### PR TITLE
feat: add internationalization (English + 简体中文)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-i18n.md
+++ b/docs/superpowers/plans/2026-06-19-i18n.md
@@ -1,0 +1,1333 @@
+# FreeBuddy i18n Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add English + 简体中文 internationalization to FreeBuddy with auto-detection, a persisted manual override, and full coverage of all user-facing strings.
+
+**Architecture:** `react-i18next` in the renderer with `src/locales/{en,zh-CN}.json` resources; a new persisted settings layer (SQLite `app_settings` table → IPC → Zustand `settingsStore`) that drives `i18next.changeLanguage()`; the Electron main process uses a small inline dictionary and rebuilds its menu when the language changes.
+
+**Tech Stack:** React 19, i18next + react-i18next, Zustand, better-sqlite3, Electron 39, Vite. Tests: `node --test` (source-grep wiring tests + functional tests importing compiled `dist-electron`).
+
+**Testing convention note:** This repo tests `src/` via source-string assertions (see `tests/settings-ui.test.mjs`, `attachments-integration.test.mjs`) and tests pure electron logic functionally via `dist-electron` (see `acp.test.mjs`). This plan follows that convention: source-grep tests for wiring, one functional test where pure electron code allows.
+
+**Spec refinement (build constraint):** `tsconfig.electron.json` pins `rootDir: "electron"` and lacks `resolveJsonModule`, so the Electron main process cannot cleanly import `src/locales/*.json`. Because main needs only ~7 strings, it uses a tiny inline dictionary instead of i18next+shared JSON.
+
+---
+
+## File Structure
+
+### New files
+| Path | Responsibility |
+|---|---|
+| `src/utils/detectLocale.ts` | Pure `detectLocale(tag) → "en" \| "zh-CN"` + `SUPPORTED_LOCALES`. |
+| `src/i18n/index.ts` | Initialize i18next + react-i18next; load JSON resources; default `lng`. |
+| `src/locales/en.json` | English translations (single source of truth for renderer). |
+| `src/locales/zh-CN.json` | Simplified Chinese translations. |
+| `src/store/settingsStore.ts` | Zustand store: `language`, load/setLanguage, drives i18next + persists. |
+| `src/components/Settings/GeneralTab.tsx` | Language selector UI. |
+| `electron/cli/settings.ts` | `getSetting`/`setSetting`/`getLanguage` over `app_settings`. |
+| `electron/cli/i18n.ts` | Tiny inline dictionary + `tMain(key, lang)` for main-process strings. |
+| `electron/menu.ts` | `buildAppMenu(lang)` + `setApplicationMenuForLanguage(lang)` (avoids main↔ipc cycle). |
+| `electron/app-meta.ts` | Shared `APP_NAME` constant. |
+| `tests/i18n-detect.test.mjs` | detectLocale source-grep test. |
+| `tests/i18n-settings.test.mjs` | Settings persistence wiring source-grep test. |
+| `tests/i18n-strings.test.mjs` | Asserts no leftover hardcoded UI strings after migration. |
+
+### Modified files
+| Path | Change |
+|---|---|
+| `package.json` | Add `i18next`, `react-i18next`. |
+| `src/main.tsx` | Import `./i18n` before `<App/>`. |
+| `src/App.tsx` | labels/aria/breadcrumb → `t()`; reactive `document.documentElement.lang`. |
+| `index.html` | `lang="zh-CN"` → `lang="en"` (runtime overrides). |
+| `src/components/CLI/ConversationList.tsx` | `t()` + wire `Intl.DateTimeFormat` to `i18next.language`. |
+| `src/components/CLI/ChatView.tsx` | `t()` for ~40 strings; starter prompts → keys. |
+| `src/components/CLI/WorkspacePanel.tsx` | `t()` for ~30 labels + statuses. |
+| `src/components/CLI/MessageBubble.tsx` | "You", "正在思考", aria, statuses. |
+| `src/components/CLI/StreamItem.tsx` | tool verbs → keyed; "结果"/"思考过程"/"查看原始日志". |
+| `src/components/CLI/PermissionDialog.tsx` | `t()` + plural (`morePending`). |
+| `src/components/CLI/ImageLightbox.tsx` | aria labels. |
+| `src/components/Settings/SettingsModal.tsx` | Add `<GeneralTab/>` section. |
+| `src/components/Settings/CLIAdaptersTab.tsx` | `t()` for ~22 strings + `alert()`. |
+| `src/components/Settings/AvatarPicker.tsx` | GROUPS array → keys; placeholders. |
+| `src/store/conversationHandlers.ts` | Chinese error summaries → `i18next.t`. |
+| `src/utils/chatAttachments.ts` | prompt template strings → `i18next.t`. |
+| `src/services/cli/client.ts` | "CLI bridge unavailable" → `i18next.t`. |
+| `src/types/freebuddy.d.ts` | Add `FreebuddySettings` interface + `settings` on `FreebuddyApi`. |
+| `electron/cli/db.ts` | Add `app_settings` table to migration. |
+| `electron/cli/ipc.ts` | `settings:get`/`settings:set` handlers; translate dialog filter names; rebuild menu on language change. |
+| `electron/preload.ts` | Expose `settings.get/set`. |
+| `electron/main.ts` | Use `electron/menu.ts`; translate error body via `tMain`. |
+
+---
+
+## Task 1: Locale detection helper
+
+**Files:**
+- Create: `src/utils/detectLocale.ts`
+- Test: `tests/i18n-detect.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// tests/i18n-detect.test.mjs
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const src = fs.readFileSync(
+  new URL("../src/utils/detectLocale.ts", import.meta.url),
+  "utf8"
+);
+
+test("detectLocale exports supported locales and maps zh-prefix to zh-CN", () => {
+  assert.match(src, /export type AppLocale = "en" \| "zh-CN"/);
+  assert.match(src, /export const SUPPORTED_LOCALES/);
+  assert.match(src, /export function detectLocale\(tag: string \| undefined\)/);
+  assert.match(src, /\.toLowerCase\(\)/);
+  assert.match(src, /startsWith\("zh"\)/);
+  assert.match(src, /return "zh-CN"/);
+  assert.match(src, /return "en"/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/i18n-detect.test.mjs`
+Expected: FAIL (file not found / no matches).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/utils/detectLocale.ts
+export type AppLocale = "en" | "zh-CN";
+
+export const SUPPORTED_LOCALES: AppLocale[] = ["en", "zh-CN"];
+
+export function detectLocale(tag: string | undefined): AppLocale {
+  if (!tag) return "en";
+  return tag.toLowerCase().startsWith("zh") ? "zh-CN" : "en";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/i18n-detect.test.mjs`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/detectLocale.ts tests/i18n-detect.test.mjs
+git commit -m "feat(i18n): add locale detection helper"
+```
+
+---
+
+## Task 2: Dependencies + locale resource skeletons
+
+**Files:**
+- Modify: `package.json`
+- Create: `src/locales/en.json`, `src/locales/zh-CN.json`
+
+- [ ] **Step 1: Install i18n dependencies**
+
+Run: `npm install i18next react-i18next`
+Expected: both added to `dependencies` in `package.json`.
+
+- [ ] **Step 2: Create the English resource file (shared/common keys only for now; domain keys added in migration tasks)**
+
+```json
+{
+  "common": {
+    "cancel": "Cancel",
+    "close": "Close",
+    "settings": "Settings",
+    "delete": "Delete",
+    "save": "Save",
+    "reset": "Reset",
+    "edit": "Edit",
+    "check": "Check",
+    "install": "Install",
+    "installing": "Installing…",
+    "search": "Search"
+  },
+  "status": {
+    "running": "Running",
+    "starting": "Starting",
+    "done": "Done",
+    "failed": "Failed",
+    "killed": "Killed"
+  },
+  "general": {
+    "languageLabel": "Language",
+    "languageEn": "English",
+    "languageZhCN": "简体中文"
+  }
+}
+```
+
+- [ ] **Step 3: Create the Chinese resource file (same keys)**
+
+```json
+{
+  "common": {
+    "cancel": "取消",
+    "close": "关闭",
+    "settings": "设置",
+    "delete": "删除",
+    "save": "保存",
+    "reset": "重置",
+    "edit": "编辑",
+    "check": "检查",
+    "install": "安装",
+    "installing": "安装中…",
+    "search": "搜索"
+  },
+  "status": {
+    "running": "运行中",
+    "starting": "启动中",
+    "done": "已完成",
+    "failed": "已失败",
+    "killed": "已中断"
+  },
+  "general": {
+    "languageLabel": "语言",
+    "languageEn": "English",
+    "languageZhCN": "简体中文"
+  }
+}
+```
+
+- [ ] **Step 4: Verify typecheck still passes (JSON modules resolve)**
+
+Run: `npm run typecheck`
+Expected: PASS (no output).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json src/locales/en.json src/locales/zh-CN.json
+git commit -m "feat(i18n): add i18next deps and locale skeletons"
+```
+
+---
+
+## Task 3: Renderer i18n initialization
+
+**Files:**
+- Create: `src/i18n/index.ts`
+- Modify: `src/main.tsx`
+
+- [ ] **Step 1: Create the i18n init module**
+
+```ts
+// src/i18n/index.ts
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "@/locales/en.json";
+import zhCN from "@/locales/zh-CN.json";
+import { detectLocale } from "@/utils/detectLocale";
+
+const initial = detectLocale(
+  typeof navigator !== "undefined" ? navigator.language : undefined
+);
+
+void i18next.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    "zh-CN": { translation: zhCN }
+  },
+  lng: initial,
+  fallbackLng: "en",
+  interpolation: { escapeValue: false }
+});
+
+export default i18next;
+```
+
+- [ ] **Step 2: Wire into the renderer entrypoint**
+
+```tsx
+// src/main.tsx
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./i18n";
+import "../styles.css";
+
+createRoot(document.getElementById("root") as HTMLElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+```
+
+- [ ] **Step 3: Verify typecheck + build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: both PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/i18n/index.ts src/main.tsx
+git commit -m "feat(i18n): initialize react-i18next in renderer"
+```
+
+---
+
+## Task 4: Settings persistence backend
+
+**Files:**
+- Modify: `electron/cli/db.ts` (add table in `migrate`)
+- Create: `electron/cli/settings.ts`
+- Modify: `electron/cli/ipc.ts` (add handlers)
+- Modify: `electron/preload.ts` (expose API)
+- Modify: `src/types/freebuddy.d.ts` (add types)
+- Modify: `src/services/cli/client.ts` (add method)
+- Test: `tests/i18n-settings.test.mjs`
+
+- [ ] **Step 1: Write the failing wiring test**
+
+```js
+// tests/i18n-settings.test.mjs
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
+const db = read("../electron/cli/db.ts");
+const ipc = read("../electron/cli/ipc.ts");
+const preload = read("../electron/preload.ts");
+const types = read("../src/types/freebuddy.d.ts");
+const client = read("../src/services/cli/client.ts");
+const settings = read("../electron/cli/settings.ts");
+
+test("app_settings table is created on migration", () => {
+  assert.match(db, /CREATE TABLE IF NOT EXISTS app_settings/);
+  assert.match(db, /key TEXT PRIMARY KEY/);
+  assert.match(db, /value TEXT NOT NULL/);
+});
+
+test("settings store module exposes get/set + language resolution", () => {
+  assert.match(settings, /export function getSetting\(key: string\): string \| null/);
+  assert.match(settings, /export function setSetting\(key: string, value: string\)/);
+  assert.match(settings, /export function getLanguage\(\)/);
+  assert.match(settings, /detectLocale/);
+  assert.match(settings, /app\.getLocale\(\)/);
+});
+
+test("settings IPC handlers are registered", () => {
+  assert.match(ipc, /"settings:get"/);
+  assert.match(ipc, /"settings:set"/);
+});
+
+test("preload exposes settings get/set", () => {
+  assert.match(preload, /getSetting:\s*\(key\)\s*=>\s*ipcRenderer\.invoke\("settings:get"/);
+  assert.match(preload, /setSetting:\s*\(key, value\)\s*=>\s*ipcRenderer\.invoke\("settings:set"/);
+});
+
+test("global types declare settings API", () => {
+  assert.match(types, /interface FreebuddySettings/);
+  assert.match(types, /getSetting\(key: string\): Promise<string \| null>/);
+  assert.match(types, /setSetting\(key: string, value: string\): Promise<void>/);
+  assert.match(types, /settings: FreebuddySettings/);
+});
+
+test("cli client exposes settings methods", () => {
+  assert.match(client, /getSetting\(key: string\)/);
+  assert.match(client, /setSetting\(key: string, value: string\)/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/i18n-settings.test.mjs`
+Expected: FAIL (no matches).
+
+- [ ] **Step 3: Add the `app_settings` table to the migration**
+
+In `electron/cli/db.ts`, inside `migrate(db)` add at the end of the `db.exec(\`...\`)` template (before the closing backtick, after the `conversation_messages` block):
+
+```sql
+    CREATE TABLE IF NOT EXISTS app_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+```
+
+- [ ] **Step 4: Create the settings store module**
+
+```ts
+// electron/cli/settings.ts
+import { app } from "electron";
+import { getDb } from "./db.js";
+
+type AppLocale = "en" | "zh-CN";
+
+function detectLocale(tag: string | undefined): AppLocale {
+  if (!tag) return "en";
+  return tag.toLowerCase().startsWith("zh") ? "zh-CN" : "en";
+}
+
+export function getSetting(key: string): string | null {
+  const row = getDb()
+    .prepare("SELECT value FROM app_settings WHERE key = ?")
+    .get(key) as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+export function setSetting(key: string, value: string): void {
+  getDb()
+    .prepare(
+      "INSERT INTO app_settings (key, value) VALUES (?, ?) " +
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+    )
+    .run(key, value);
+}
+
+export function getLanguage(): AppLocale {
+  const stored = getSetting("language");
+  if (stored === "en" || stored === "zh-CN") return stored;
+  return detectLocale(app.getLocale());
+}
+```
+
+- [ ] **Step 5: Add IPC handlers in `electron/cli/ipc.ts`**
+
+Add import at top:
+```ts
+import { getSetting, setSetting } from "./settings.js";
+```
+Inside `registerCliIpc()`, add:
+```ts
+  ipcMain.handle("settings:get", (_e, key: string) => getSetting(key));
+  ipcMain.handle("settings:set", (_e, args: { key: string; value: string }) => {
+    setSetting(args.key, args.value);
+  });
+```
+(Menu rebuild on language change is wired in Task 7 once `electron/menu.ts` exists.)
+
+- [ ] **Step 6: Expose via preload**
+
+In `electron/preload.ts`, add a `settings` object and expose it. After the `window` const and before `contextBridge.exposeInMainWorld(...)`:
+
+```ts
+const settings = {
+  getSetting: (key: string) => ipcRenderer.invoke("settings:get", key),
+  setSetting: (key: string, value: string) =>
+    ipcRenderer.invoke("settings:set", { key, value })
+};
+```
+Then add `settings,` to the exposed object (next to `cli,` and `window,`).
+
+- [ ] **Step 7: Add global types**
+
+In `src/types/freebuddy.d.ts`, add inside `declare global`:
+```ts
+  interface FreebuddySettings {
+    getSetting(key: string): Promise<string | null>;
+    setSetting(key: string, value: string): Promise<void>;
+  }
+```
+And in `FreebuddyApi` add:
+```ts
+    settings: FreebuddySettings;
+```
+
+- [ ] **Step 8: Add client methods**
+
+In `src/services/cli/client.ts`, add to the `cliClient` object:
+```ts
+  getSetting(key: string): Promise<string | null> {
+    const api = window.freebuddy;
+    if (!api) return Promise.resolve(null);
+    return api.settings.getSetting(key);
+  },
+  setSetting(key: string, value: string): Promise<void> {
+    const api = window.freebuddy;
+    if (!api) return Promise.resolve();
+    return api.settings.setSetting(key, value);
+  },
+```
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `node --test tests/i18n-settings.test.mjs`
+Expected: PASS (6 tests).
+
+- [ ] **Step 10: Verify full build + test**
+
+Run: `npm run build:electron && npm test`
+Expected: all tests PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add electron/cli/db.ts electron/cli/settings.ts electron/cli/ipc.ts \
+        electron/preload.ts src/types/freebuddy.d.ts src/services/cli/client.ts \
+        tests/i18n-settings.test.mjs
+git commit -m "feat(settings): add persisted app_settings store with IPC + preload"
+```
+
+---
+
+## Task 5: Settings Zustand store + i18n wiring
+
+**Files:**
+- Create: `src/store/settingsStore.ts`
+- Modify: `src/App.tsx` (load on startup, reactive `<html lang>`)
+- Modify: `index.html`
+
+- [ ] **Step 1: Create the settings store**
+
+```ts
+// src/store/settingsStore.ts
+import { create } from "zustand";
+import i18next from "i18next";
+import { cliClient } from "@/services/cli/client";
+import { detectLocale, type AppLocale } from "@/utils/detectLocale";
+
+interface SettingsState {
+  loaded: boolean;
+  language: AppLocale;
+  load(): Promise<void>;
+  setLanguage(lng: AppLocale): Promise<void>;
+}
+
+export const useSettingsStore = create<SettingsState>((set) => ({
+  loaded: false,
+  language: "en",
+
+  async load() {
+    if (!cliClient.isAvailable()) {
+      const fallback = detectLocale(navigator.language);
+      await i18next.changeLanguage(fallback);
+      set({ loaded: true, language: fallback });
+      return;
+    }
+    const stored = await cliClient.getSetting("language");
+    const lng: AppLocale =
+      stored === "zh-CN" || stored === "en"
+        ? stored
+        : detectLocale(navigator.language);
+    await i18next.changeLanguage(lng);
+    set({ loaded: true, language: lng });
+  },
+
+  async setLanguage(lng) {
+    await i18next.changeLanguage(lng);
+    set({ language: lng });
+    if (cliClient.isAvailable()) {
+      await cliClient.setSetting("language", lng);
+    }
+  }
+}));
+```
+
+- [ ] **Step 2: Load on startup + reactive `<html lang>` in `App.tsx`**
+
+Near the other store hooks in `App.tsx` (after the `useCliExecutorStore`/`useConversationStore` imports), add import:
+```ts
+import { useSettingsStore } from "./store/settingsStore";
+import i18next from "i18next";
+import { useTranslation } from "react-i18next";
+```
+Inside the `App` component, add (alongside existing `useEffect` blocks):
+```tsx
+  const { t } = useTranslation();
+  const loadSettings = useSettingsStore((s) => s.load);
+  useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  useEffect(() => {
+    document.documentElement.lang = i18next.language ?? "en";
+    const handler = (lng: string) => {
+      document.documentElement.lang = lng;
+    };
+    i18next.on("languageChanged", handler);
+    return () => i18next.off("languageChanged", handler);
+  }, []);
+```
+(The `t` will be used in Task 8 to replace App.tsx's inline strings.)
+
+- [ ] **Step 3: Fix `index.html` default lang**
+
+Change `<html lang="zh-CN">` → `<html lang="en">` (runtime overrides it reactively).
+
+- [ ] **Step 4: Verify build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/settingsStore.ts src/App.tsx index.html
+git commit -m "feat(i18n): add settings store and wire language to i18next + html lang"
+```
+
+---
+
+## Task 6: Settings UI — General tab (language selector)
+
+**Files:**
+- Create: `src/components/Settings/GeneralTab.tsx`
+- Modify: `src/components/Settings/SettingsModal.tsx`
+
+- [ ] **Step 1: Create GeneralTab**
+
+```tsx
+// src/components/Settings/GeneralTab.tsx
+import { useTranslation } from "react-i18next";
+import { useSettingsStore } from "@/store/settingsStore";
+import { SUPPORTED_LOCALES, type AppLocale } from "@/utils/detectLocale";
+
+const LABEL_KEY: Record<AppLocale, string> = {
+  en: "general.languageEn",
+  "zh-CN": "general.languageZhCN"
+};
+
+export function GeneralTab() {
+  const { t } = useTranslation();
+  const language = useSettingsStore((s) => s.language);
+  const setLanguage = useSettingsStore((s) => s.setLanguage);
+
+  return (
+    <section className="settings-section">
+      <h3>{t("general.languageLabel")}</h3>
+      <select
+        value={language}
+        onChange={(e) => void setLanguage(e.target.value as AppLocale)}
+      >
+        {SUPPORTED_LOCALES.map((lng) => (
+          <option key={lng} value={lng}>
+            {t(LABEL_KEY[lng])}
+          </option>
+        ))}
+      </select>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Render GeneralTab in SettingsModal**
+
+```tsx
+// src/components/Settings/SettingsModal.tsx
+import { useTranslation } from "react-i18next";
+import { CLIAdaptersTab } from "./CLIAdaptersTab";
+import { GeneralTab } from "./GeneralTab";
+
+export function SettingsModal({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal modal-wide" onClick={(e) => e.stopPropagation()}>
+        <header className="modal-header">
+          <h2>{t("common.settings")}</h2>
+          <button className="icon-btn" onClick={onClose} aria-label={t("common.close")}>
+            ✕
+          </button>
+        </header>
+        <div className="settings-body">
+          <GeneralTab />
+          <CLIAdaptersTab />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add minimal style (if `.settings-section` lacks styling)**
+
+Check `styles.css` for `.settings-section`; if absent, append:
+```css
+.settings-section { padding: 12px 0; border-bottom: 1px solid var(--border, #e5e7eb); }
+.settings-section h3 { margin: 0 0 8px; font-size: 13px; }
+.settings-section select { padding: 6px 8px; border-radius: 6px; }
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Settings/GeneralTab.tsx src/components/Settings/SettingsModal.tsx styles.css
+git commit -m "feat(i18n): add language selector in Settings General tab"
+```
+
+---
+
+## Task 7: Electron main-process i18n + menu rebuild
+
+**Files:**
+- Create: `electron/cli/i18n.ts` (main dictionary)
+- Create: `electron/menu.ts` (menu builder, cycle-free)
+- Create: `electron/app-meta.ts`
+- Modify: `electron/main.ts` (use menu.ts, translate error body)
+- Modify: `electron/cli/ipc.ts` (translate dialog filters; rebuild menu on language change)
+
+- [ ] **Step 1: Create main i18n dictionary**
+
+```ts
+// electron/cli/i18n.ts
+type AppLocale = "en" | "zh-CN";
+
+const DICT: Record<string, Record<AppLocale, string>> = {
+  "menu.edit": { en: "Edit", "zh-CN": "编辑" },
+  "menu.view": { en: "View", "zh-CN": "视图" },
+  "menu.window": { en: "Window", "zh-CN": "窗口" },
+  "dialog.supportedAttachments": { en: "Supported attachments", "zh-CN": "支持的附件" },
+  "dialog.allFiles": { en: "All files", "zh-CN": "所有文件" },
+  "main.fileLoadFailed": { en: "Failed to load file: {{message}}", "zh-CN": "加载文件失败：{{message}}" }
+};
+
+export function tMain(key: string, lang: AppLocale, vars?: Record<string, string>): string {
+  const entry = DICT[key]?.[lang] ?? DICT[key]?.en ?? key;
+  if (!vars) return entry;
+  return entry.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? "");
+}
+```
+
+- [ ] **Step 2: Create app-meta module**
+
+```ts
+// electron/app-meta.ts
+export const APP_NAME = "FreeBuddy";
+```
+
+- [ ] **Step 3: Create menu builder module**
+
+```ts
+// electron/menu.ts
+import { Menu } from "electron";
+import { tMain } from "./cli/i18n.js";
+import { getLanguage } from "./cli/settings.js";
+import { APP_NAME } from "./app-meta.js";
+
+export function buildAppMenu(lang: "en" | "zh-CN") {
+  return Menu.buildFromTemplate([
+    {
+      label: APP_NAME,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" }
+      ]
+    },
+    {
+      label: tMain("menu.edit", lang),
+      submenu: [
+        { role: "undo" }, { role: "redo" }, { type: "separator" },
+        { role: "cut" }, { role: "copy" }, { role: "paste" }, { role: "selectAll" }
+      ]
+    },
+    {
+      label: tMain("menu.view", lang),
+      submenu: [
+        { role: "reload" }, { role: "toggleDevTools" }, { type: "separator" },
+        { role: "resetZoom" }, { role: "zoomIn" }, { role: "zoomOut" }, { type: "separator" },
+        { role: "togglefullscreen" }
+      ]
+    },
+    {
+      label: tMain("menu.window", lang),
+      submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }]
+    }
+  ]);
+}
+
+export function setApplicationMenuForLanguage(lang: "en" | "zh-CN") {
+  Menu.setApplicationMenu(buildAppMenu(lang));
+}
+
+export function initApplicationMenu() {
+  setApplicationMenuForLanguage(getLanguage());
+}
+```
+
+- [ ] **Step 4: Update `electron/main.ts`**
+
+- Replace `const APP_NAME = "FreeBuddy";` with `import { APP_NAME } from "./app-meta.js";` (remove the local const).
+- Add `import { initApplicationMenu } from "./menu.js";`, `import { tMain } from "./cli/i18n.js";`, `import { getLanguage } from "./cli/settings.js";`.
+- Remove the local `createMenu()` function entirely.
+- Replace `Menu.setApplicationMenu(createMenu());` in `createWindow()` with `initApplicationMenu();`.
+- In `registerLocalFileProtocol`, translate the error body:
+```ts
+      return new Response(
+        tMain("main.fileLoadFailed", getLanguage(), {
+          message: (error as Error).message
+        }),
+        { status: 404 }
+      );
+```
+
+- [ ] **Step 5: Translate dialog filters + rebuild menu on language change in `ipc.ts`**
+
+Add imports:
+```ts
+import { tMain } from "./i18n.js";
+import { getLanguage } from "./settings.js";
+import { setApplicationMenuForLanguage } from "../menu.js";
+```
+In the `cli:selectAttachments` handler, replace the `filters` array:
+```ts
+      filters: [
+        { name: tMain("dialog.supportedAttachments", getLanguage()), extensions: ATTACHMENT_EXTENSIONS },
+        { name: tMain("dialog.allFiles", getLanguage()), extensions: ["*"] }
+      ]
+```
+In the `settings:set` handler (from Task 4), rebuild the menu when the language changes:
+```ts
+  ipcMain.handle("settings:set", (_e, args: { key: string; value: string }) => {
+    setSetting(args.key, args.value);
+    if (args.key === "language" && (args.value === "en" || args.value === "zh-CN")) {
+      setApplicationMenuForLanguage(args.value);
+    }
+  });
+```
+
+- [ ] **Step 6: Verify electron build + tests**
+
+Run: `npm run build:electron && npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add electron/cli/i18n.ts electron/menu.ts electron/app-meta.ts \
+        electron/main.ts electron/cli/ipc.ts
+git commit -m "feat(i18n): localize electron menu/dialogs and rebuild on language change"
+```
+
+---
+
+## Task 8: Migrate App.tsx + ConversationList (+ Intl locale)
+
+**Files:** `src/App.tsx`, `src/components/CLI/ConversationList.tsx`, `src/locales/*.json`
+
+- [ ] **Step 1: Add keys to both locale files**
+
+en.json `app`/`sidebar`/`conversations` sections:
+```json
+  "app": { "brand": "FreeBuddy", "chat": "Chat" },
+  "sidebar": {
+    "expand": "Expand sidebar",
+    "collapse": "Collapse sidebar",
+    "toggleTheme": "Toggle theme"
+  },
+  "conversations": {
+    "title": "Conversations",
+    "new": "+ New",
+    "empty": "No conversations yet.",
+    "deleteConfirm": "Delete \"{{title}}\"?"
+  }
+```
+zh-CN.json:
+```json
+  "app": { "brand": "FreeBuddy", "chat": "聊天" },
+  "sidebar": {
+    "expand": "展开侧边栏",
+    "collapse": "收起侧边栏",
+    "toggleTheme": "切换主题"
+  },
+  "conversations": {
+    "title": "会话",
+    "new": "+ 新建",
+    "empty": "暂无会话。",
+    "deleteConfirm": "删除“{{title}}”?"
+  }
+```
+
+- [ ] **Step 2: Replace inline strings in `src/App.tsx`**
+
+Targets (from current file): `<h1>FreeBuddy</h1>` → `{t("app.brand")}`; the "Chat" breadcrumb label → `{t("app.chat")}`; `title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}` and its `aria-label` → `t(sidebarCollapsed ? "sidebar.expand" : "sidebar.collapse")`; the theme toggle `title="Toggle theme"` / aria → `t("sidebar.toggleTheme")`. (The `t` and `useEffect` imports were added in Task 5.)
+
+- [ ] **Step 3: Replace inline strings + wire Intl locale in `ConversationList.tsx`**
+
+Add imports:
+```ts
+import { useTranslation } from "react-i18next";
+import i18next from "i18next";
+```
+In the component, `const { t } = useTranslation();` and replace the four `new Intl.DateTimeFormat(undefined, …)` calls with `new Intl.DateTimeFormat(i18next.language, …)`.
+Targets: `<h2>Conversations</h2>` → `{t("conversations.title")}`; `+ New` → `{t("conversations.new")}`; `No conversations yet.` → `{t("conversations.empty")}`; `title="Delete"` → `t("common.delete")`; `window.confirm(\`Delete "${c.title}"?\`)` → `window.confirm(t("conversations.deleteConfirm", { title: c.title }))`.
+
+- [ ] **Step 4: Verify typecheck + build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/App.tsx src/components/CLI/ConversationList.tsx src/locales/en.json src/locales/zh-CN.json
+git commit -m "feat(i18n): localize App and ConversationList, wire Intl to active language"
+```
+
+---
+
+## Task 9: Migrate ChatView + chatAttachments
+
+**Files:** `src/components/CLI/ChatView.tsx`, `src/utils/chatAttachments.ts`, `src/locales/*.json`
+
+- [ ] **Step 1: Add `chat` + `errors` keys to both locale files**
+
+en.json:
+```json
+  "chat": {
+    "inputPlaceholder": "Type freely",
+    "attachFile": "Attach file",
+    "permission": "Permission",
+    "approvalAuto": "Auto",
+    "approvalAsk": "Ask each time",
+    "enterHint": "Enter to send · Shift+Enter for newline",
+    "agentRunning": "Agent is running…",
+    "send": "Send",
+    "stop": "Stop",
+    "selectCwd": "Select working directory",
+    "cwdPlaceholder": "Select a working directory",
+    "heroTitle": "Local CLI Agent Workspace",
+    "newAgentChat": "New Agent Chat",
+    "starter": {
+      "one": "Analyze the current project structure and suggest next steps",
+      "two": "Check recent changes for UI/UX issues",
+      "three": "Implement a small feature and explain how to verify it"
+    }
+  },
+  "errors": {
+    "attachmentLimit": "Add at most {{count}} attachments per message.",
+    "attachmentTooLarge": "{{name}} exceeds the 50 MB attachment limit.",
+    "attachmentType": "{{name}} is not a supported attachment type.",
+    "attachmentDesktopOnly": "Attachments require the Electron desktop app.",
+    "attachmentSelectFailed": "Failed to select attachments: {{err}}",
+    "cliBridgeUnavailable": "FreeBuddy CLI bridge is unavailable. Please run the Electron desktop app.",
+    "agentNotInstalled": "{{agent}} is not installed. Open Settings → Cli Agents to install.",
+    "checkFailed": "Check failed: {{err}}",
+    "taskFailed": "Task failed: {{err}}",
+    "sendFailed": "Send failed: {{err}}"
+  }
+```
+zh-CN.json (translate each value):
+```json
+  "chat": {
+    "inputPlaceholder": "随心输入",
+    "attachFile": "添加附件",
+    "permission": "权限",
+    "approvalAuto": "自动",
+    "approvalAsk": "每次询问",
+    "enterHint": "Enter 发送 · Shift+Enter 换行",
+    "agentRunning": "Agent 正在运行…",
+    "send": "发送",
+    "stop": "停止",
+    "selectCwd": "选择工作目录",
+    "cwdPlaceholder": "选择一个工作目录",
+    "heroTitle": "本地 CLI Agent 工作台",
+    "newAgentChat": "新建 Agent 对话",
+    "starter": {
+      "one": "先分析当前项目结构，给我下一步实现建议",
+      "two": "检查刚才的改动有没有 UI/UX 问题",
+      "three": "帮我实现一个小功能，并说明验证步骤"
+    }
+  },
+  "errors": {
+    "attachmentLimit": "每条消息最多添加 {{count}} 个附件。",
+    "attachmentTooLarge": "{{name}} 超过 50 MB 附件大小限制。",
+    "attachmentType": "{{name}} 不是支持的附件类型。",
+    "attachmentDesktopOnly": "附件功能需要在 Electron 桌面端使用。",
+    "attachmentSelectFailed": "选择附件失败：{{err}}",
+    "cliBridgeUnavailable": "FreeBuddy CLI 桥接不可用。请在 Electron 桌面端运行。",
+    "agentNotInstalled": "{{agent}} 未安装。请在“设置 → Cli Agents”中安装。",
+    "checkFailed": "检查失败：{{err}}",
+    "taskFailed": "任务失败：{{err}}",
+    "sendFailed": "发送失败：{{err}}"
+  }
+```
+
+- [ ] **Step 2: Migrate `ChatView.tsx`**
+
+Add `import { useTranslation } from "react-i18next";` and `const { t } = useTranslation();` in both `ChatView` and `NewTaskHome`.
+- `starterPrompts` array (lines ~19–28) → `[t("chat.starter.one"), t("chat.starter.two"), t("chat.starter.three")]` computed inside the component.
+- Replace every listed literal with `t(...)`: `"随心输入"`→`t("chat.inputPlaceholder")`; `"Attach file"`→`t("chat.attachFile")`; `"权限"`→`t("chat.permission")`; `"自动"`/`"每次询问"`→`t("chat.approvalAuto")`/`t("chat.approvalAsk")`; the Enter hint→`t("chat.enterHint")`; `"Agent 正在运行…"`→`t("chat.agentRunning")`; send/stop titles→`t("chat.send")`/`t("chat.stop")`; `"选择工作目录"`→`t("chat.selectCwd")`; cwd placeholder→`t("chat.cwdPlaceholder")`; `"本地 CLI Agent 工作台"`→`t("chat.heroTitle")`; `"New Agent Chat"`→`t("chat.newAgentChat")`.
+- Error/preflight messages with interpolation (lines ~250, 260, 261, 275, 292, 308, 317, 323, 355, 400) → `t("errors.<key>", { name/count/err/agent })`.
+
+- [ ] **Step 3: Migrate `chatAttachments.ts`**
+
+`chatAttachments.ts` is plain TS (not a React component), so use the `i18next` instance directly:
+```ts
+import i18next from "i18next";
+```
+Add `attachments` keys to locale files:
+en: `"attachments": { "review": "Please review these attachments.", "userMessage": "User message:", "attached": "Attachments:" }`
+zh: `"attachments": { "review": "请查看这些附件。", "userMessage": "用户消息：", "attached": "附件：" }`
+Replace lines ~190–191 with `i18next.t("attachments.review")`, `i18next.t("attachments.userMessage")`, `i18next.t("attachments.attached")`.
+
+- [ ] **Step 4: Verify typecheck + build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/CLI/ChatView.tsx src/utils/chatAttachments.ts src/locales/*.json
+git commit -m "feat(i18n): localize ChatView, starter prompts, and attachment prompt templates"
+```
+
+---
+
+## Task 10: Migrate WorkspacePanel + MessageBubble + StreamItem
+
+**Files:** `src/components/CLI/WorkspacePanel.tsx`, `src/components/CLI/MessageBubble.tsx`, `src/components/CLI/StreamItem.tsx`, `src/locales/*.json`
+
+- [ ] **Step 1: Add `workspace`/`message`/`stream` keys to both locale files**
+
+en.json:
+```json
+  "workspace": {
+    "activeAgent": "Active Agent",
+    "runState": "Run State",
+    "workspace": "Workspace",
+    "sessionId": "Session ID",
+    "messages": "Messages",
+    "agentTurns": "Agent turns",
+    "context": "Context",
+    "cost": "Cost",
+    "executionQueue": "Execution Queue",
+    "noConversation": "No conversation",
+    "localAgent": "Local coding agent",
+    "createToBegin": "Create a conversation to begin",
+    "noSession": "No session captured yet",
+    "copied": "Copied",
+    "notCaptured": "Not captured"
+  },
+  "message": { "you": "You", "thinking": "Thinking" },
+  "stream": {
+    "read": "Read", "edit": "Edit", "exec": "Execute",
+    "result": "{{tool}} result",
+    "thinking": "Thinking process",
+    "viewRawLog": "View raw log ({{count}})"
+  }
+```
+zh-CN.json:
+```json
+  "workspace": {
+    "activeAgent": "当前 Agent",
+    "runState": "运行状态",
+    "workspace": "工作区",
+    "sessionId": "会话 ID",
+    "messages": "消息数",
+    "agentTurns": "Agent 轮次",
+    "context": "上下文",
+    "cost": "成本",
+    "executionQueue": "执行队列",
+    "noConversation": "无会话",
+    "localAgent": "本地编码 Agent",
+    "createToBegin": "创建会话以开始",
+    "noSession": "尚未捕获会话",
+    "copied": "已复制",
+    "notCaptured": "未捕获"
+  },
+  "message": { "you": "你", "thinking": "正在思考" },
+  "stream": {
+    "read": "读取", "edit": "修改", "exec": "执行",
+    "result": "{{tool}} 结果",
+    "thinking": "思考过程",
+    "viewRawLog": "查看原始日志 ({{count}})"
+  }
+```
+
+- [ ] **Step 2: Migrate `WorkspacePanel.tsx`**
+
+Add `const { t } = useTranslation();`. Map each label (~30, lines 83–201) to `t("workspace.<key>")`, and render `message.status`/run-state via `t(\`status.${value}\`)` (e.g. line 84). For the `N live`/`idle` statuses (line ~106) add `"status": { ..., "idle": "Idle" }` / `"空闲"` if needed.
+
+- [ ] **Step 3: Migrate `MessageBubble.tsx`**
+
+`const { t } = useTranslation();`. `"You"` (line ~390) → `t("message.you")`; `正在思考` (line ~448) → `t("message.thinking")`; the `message.status` render (line ~423) → `t(\`status.${message.status}\`)`; aria labels → keys.
+
+- [ ] **Step 4: Migrate `StreamItem.tsx` (verbs as parameters)**
+
+`const { t } = useTranslation();`. The action-verb block (lines ~289–296) currently hardcodes "读取/修改/执行 {{target}}". Refactor: compute a verb key from the action (`read`/`edit`/`exec`) and render `t(\`stream.${verbKey}\`, { target })`. Replace `"{{tool}} 结果"` (lines ~371/413/422) → `t("stream.result", { tool })`; `"思考过程"` (line ~397) → `t("stream.thinking")`; `"查看原始日志 (N)"` (line ~493) → `t("stream.viewRawLog", { count })`.
+
+- [ ] **Step 5: Verify typecheck + build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/CLI/WorkspacePanel.tsx src/components/CLI/MessageBubble.tsx \
+        src/components/CLI/StreamItem.tsx src/locales/*.json
+git commit -m "feat(i18n): localize Workspace, MessageBubble, and StreamItem tool verbs"
+```
+
+---
+
+## Task 11: Migrate PermissionDialog (plural) + ImageLightbox
+
+**Files:** `src/components/CLI/PermissionDialog.tsx`, `src/components/CLI/ImageLightbox.tsx`, `src/locales/*.json`
+
+- [ ] **Step 1: Add keys (with i18next plural `one`/`other`)**
+
+en.json:
+```json
+  "permission": {
+    "title": "Permission required",
+    "input": "Input",
+    "help": "This action requires your approval. Choose how to proceed.",
+    "cancel": "Cancel",
+    "morePending_one": "+{{count}} more pending request",
+    "morePending_other": "+{{count}} more pending requests"
+  },
+  "lightbox": {
+    "preview": "Image preview",
+    "close": "Close preview"
+  }
+```
+zh-CN.json (Chinese has no singular/plural distinction; provide a single `_other` form — i18next falls back to `morePending_other`):
+```json
+  "permission": {
+    "title": "需要权限",
+    "input": "输入",
+    "help": "此操作需要您的确认，请选择处理方式。",
+    "cancel": "取消",
+    "morePending_other": "还有 {{count}} 个待处理请求"
+  },
+  "lightbox": {
+    "preview": "图片预览",
+    "close": "关闭预览"
+  }
+```
+
+- [ ] **Step 2: Migrate `PermissionDialog.tsx`**
+
+`const { t } = useTranslation();`. Targets: `"Permission required"`→`t("permission.title")`; `"Input"`→`t("permission.input")`; help paragraph→`t("permission.help")`; `"Cancel"`→`t("permission.cancel")`; the `+N more pending request(s)` (lines ~123–124) → `t("permission.morePending", { count })` (i18next auto-selects `_one`/`_other`).
+
+- [ ] **Step 3: Migrate `ImageLightbox.tsx`**
+
+`const { t } = useTranslation();`. `"Image preview"`→`t("lightbox.preview")`; `"Close preview"`→`t("lightbox.close")`.
+
+- [ ] **Step 4: Verify typecheck + build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/CLI/PermissionDialog.tsx src/components/CLI/ImageLightbox.tsx src/locales/*.json
+git commit -m "feat(i18n): localize PermissionDialog (plural) and ImageLightbox"
+```
+
+---
+
+## Task 12: Migrate Settings components + config
+
+**Files:** `src/components/Settings/CLIAdaptersTab.tsx`, `src/components/Settings/AvatarPicker.tsx`, `src/config/aiMembers.ts`, `src/config/cliAdapters.ts`, `src/locales/*.json`
+
+- [ ] **Step 1: Add `settings.cli` + `avatar` keys to both locale files**
+
+en.json:
+```json
+  "settings": {
+    "cli": {
+      "title": "Cli Agents",
+      "description": "Configure the local cli agents available in FreeBuddy.",
+      "commandOverride": "Command override",
+      "model": "Model",
+      "extraArgs": "Extra args (one per line)",
+      "environment": "Environment (KEY=value per line)",
+      "docs": "Docs:",
+      "setupGuide": "Setup guide",
+      "useDefault": "Use default",
+      "useAgentDefault": "Use agent default",
+      "avatar": "Avatar",
+      "searchPlaceholder": "Search icons (DeepSeek, Qwen, Cursor…)",
+      "noIcons": "No matching icons.",
+      "iconsFrom": "Icons from",
+      "installFailed": "Install failed (exit {{code}}):\n{{output}}"
+    },
+    "avatar": { "groups": { "all": "All", "models": "Models", "providers": "Providers", "apps": "Apps" } }
+  }
+```
+zh-CN.json:
+```json
+  "settings": {
+    "cli": {
+      "title": "Cli Agents",
+      "description": "配置 FreeBuddy 中可用的本地 CLI Agent。",
+      "commandOverride": "命令覆盖",
+      "model": "模型",
+      "extraArgs": "附加参数（每行一个）",
+      "environment": "环境变量（每行 KEY=value）",
+      "docs": "文档：",
+      "setupGuide": "安装指南",
+      "useDefault": "使用默认",
+      "useAgentDefault": "使用 Agent 默认",
+      "avatar": "头像",
+      "searchPlaceholder": "搜索图标（DeepSeek、Qwen、Cursor…）",
+      "noIcons": "没有匹配的图标。",
+      "iconsFrom": "图标来自",
+      "installFailed": "安装失败（退出码 {{code}}）：\n{{output}}"
+    },
+    "avatar": { "groups": { "all": "全部", "models": "模型", "providers": "提供商", "apps": "应用" } }
+  }
+```
+
+- [ ] **Step 2: Migrate `CLIAdaptersTab.tsx`**
+
+`const { t } = useTranslation();`. Replace: `"Cli Agents"` (64/76)→`t("settings.cli.title")`; description (78)→`t("settings.cli.description")`; `"Check"`→`t("common.check")`; `"Install"`/`"Installing…"`→`t("common.install")`/`t("common.installing")`; `"Edit"`→`t("common.edit")`; `"Reset"/"Cancel"/"Save"`→`t("common.reset")`/`t("common.cancel")`/`t("common.save")`; `"Command override"`→`t("settings.cli.commandOverride")`; `"Model"`→`t("settings.cli.model")`; `"Extra args (one per line)"`→`t("settings.cli.extraArgs")`; `"Environment (KEY=value per line)"`→`t("settings.cli.environment")`; `"Docs:"`→`t("settings.cli.docs")`; `"Setup guide"`→`t("settings.cli.setupGuide")`; placeholders `"Use default"`/`"Use agent default"`→`t("settings.cli.useDefault")`/`t("settings.cli.useAgentDefault")`; `"Avatar"`→`t("settings.cli.avatar")`. The `alert(\`Install failed (exit ${r.exitCode}):\n${r.stderr || r.stdout}\`)` (line ~95) → `alert(t("settings.cli.installFailed", { code: r.exitCode, output: r.stderr || r.stdout }))`.
+
+- [ ] **Step 3: Migrate `AvatarPicker.tsx`**
+
+`const { t } = useTranslation();`. Replace the `GROUPS = ["All","Models","Providers","Apps"]` array with `const GROUP_KEYS = ["all","models","providers","apps"] as const;` and render `t(\`settings.avatar.groups.${g}\`)`. Replace search placeholder→`t("settings.cli.searchPlaceholder")`; `"Use default"`→`t("settings.cli.useDefault")`; `"No matching icons."`→`t("settings.cli.noIcons")`; `"Icons from"`→`t("settings.cli.iconsFrom")`.
+
+- [ ] **Step 4: Handle config `label`/`description` fields**
+
+- `src/config/cliAdapters.ts` `label` values are brand names ("Codex", "Claude") — **leave as-is** (not translated).
+- `src/config/aiMembers.ts` `description` fields (e.g. "Local Codex coding agent."): add an `agents.*` key per member and resolve via `t()` at the call site (wherever `description` is rendered) rather than in the config. If descriptions are only shown in `WorkspacePanel`/`ChatView`, map `description: t(\`agents.${member.id}\`)` there. (Confirm the render site during implementation; brand names in titles stay.)
+
+- [ ] **Step 5: Verify typecheck + build**
+
+Run: `npm run typecheck && npm run build:renderer`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Settings/CLIAdaptersTab.tsx src/components/Settings/AvatarPicker.tsx \
+        src/config/aiMembers.ts src/locales/*.json
+git commit -m "feat(i18n): localize Settings tabs and avatar picker"
+```
+
+---
+
+## Task 13: Migrate store error strings + client message
+
+**Files:** `src/store/conversationHandlers.ts`, `src/services/cli/client.ts`, `src/locales/*.json`
+
+- [ ] **Step 1: Add agent-error keys to both locale files**
+
+en.json `errors`:
+```json
+    "agentInterrupted": "Agent run interrupted.",
+    "agentFailed": "Agent run failed with exit code {{code}}.{{detail}}",
+    "rawLogCollapsed": "Raw CLI log collapsed for easier debugging.",
+    "cliNoStructured": "The CLI returned no parseable structured content."
+```
+zh-CN.json `errors`:
+```json
+    "agentInterrupted": "Agent 运行已中断。",
+    "agentFailed": "Agent 运行失败，退出码 {{code}}。{{detail}}",
+    "rawLogCollapsed": "已收起原始 CLI 日志，方便排查。",
+    "cliNoStructured": "CLI 没有返回可解析的结构化内容。"
+```
+
+- [ ] **Step 2: Migrate `conversationHandlers.ts`**
+
+These run in a non-React reducer, so use the `i18next` instance directly:
+```ts
+import i18next from "i18next";
+```
+Replace lines 29–34: `exitCode === 130 ? i18next.t("errors.agentInterrupted") : i18next.t("errors.agentFailed", { code: exitCode, detail: … })`; `"已收起原始 CLI 日志，方便排查。"`→`i18next.t("errors.rawLogCollapsed")`; `"CLI 没有返回可解析的结构化内容。"`→`i18next.t("errors.cliNoStructured")`.
+
+- [ ] **Step 3: Migrate `client.ts`**
+
+```ts
+import i18next from "i18next";
+```
+Replace the `throw new Error("FreeBuddy CLI bridge is unavailable. Are you running outside Electron?")` (line ~25) → `throw new Error(i18next.t("errors.cliBridgeUnavailable"))`. Align wording with Task 9's `errors.cliBridgeUnavailable` key.
+
+- [ ] **Step 4: Verify typecheck + build + tests**
+
+Run: `npm run typecheck && npm run build:renderer && npm test`
+Expected: PASS (existing tests still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/conversationHandlers.ts src/services/cli/client.ts src/locales/*.json
+git commit -m "feat(i18n): localize store error summaries and client message"
+```
+
+---
+
+## Task 14: Leftover-string guard test + final verification
+
+**Files:** `tests/i18n-strings.test.mjs`
+
+- [ ] **Step 1: Write a guard test asserting no Chinese literals remain in migrated files**
+
+```js
+// tests/i18n-strings.test.mjs
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
+const files = [
+  "../src/App.tsx",
+  "../src/components/CLI/ChatView.tsx",
+  "../src/components/CLI/ConversationList.tsx",
+  "../src/components/CLI/WorkspacePanel.tsx",
+  "../src/components/CLI/MessageBubble.tsx",
+  "../src/components/CLI/StreamItem.tsx",
+  "../src/components/CLI/PermissionDialog.tsx",
+  "../src/components/CLI/ImageLightbox.tsx",
+  "../src/components/Settings/SettingsModal.tsx",
+  "../src/components/Settings/CLIAdaptersTab.tsx",
+  "../src/components/Settings/AvatarPicker.tsx"
+];
+
+test("no CJK literals remain in migrated components", () => {
+  for (const f of files) {
+    const src = read(f);
+    assert.equal(/[\u4e00-\u9fff]/.test(src), false, `CJK found in ${f}`);
+  }
+});
+
+test("migrated components use the translation hook", () => {
+  for (const f of files) {
+    const src = read(f);
+    if (/Conversations|Settings|Permission|ChatView|Workspace/.test(f)) {
+      assert.match(src, /useTranslation\(\)|i18next\.t\(/, `${f} should use t()`);
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run the guard test**
+
+Run: `node --test tests/i18n-strings.test.mjs`
+Expected: PASS. If CJK remains (e.g. a missed string), fix it and re-run.
+
+- [ ] **Step 3: Full verification**
+
+Run: `npm run typecheck && npm run build && npm test`
+Expected: typecheck PASS, build PASS, all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/i18n-strings.test.mjs
+git commit -m "test(i18n): guard against leftover hardcoded UI strings"
+```
+
+- [ ] **Step 5: Manual QA matrix**
+
+1. Fresh launch (no stored language) on a `zh` OS locale → UI renders in 简体中文; on `en` → English. `<html lang>` matches.
+2. Settings → General → switch language → Chat / Workspace / Settings / Permission dialog / Electron menu / file-dialog filter names update immediately.
+3. Quit & relaunch → language choice persists; Electron menu stays in chosen language.
+4. Trigger an agent error (e.g. stop a run, or run an uninstalled agent) → error summary appears in the active language.

--- a/docs/superpowers/specs/2026-06-19-i18n-design.md
+++ b/docs/superpowers/specs/2026-06-19-i18n-design.md
@@ -53,12 +53,14 @@ and `index.html` declares `lang="zh-CN"` despite most of the UI being English.
      on first run, before a choice is persisted).
    - Imported once in `src/main.tsx` before `<App />` mounts.
 
-2. **i18n layer (Electron main)** — `src/i18n/main.ts`
-   - Initializes **core `i18next`** (non-React) with the **same shared JSON** resources.
-   - Language read from the `app_settings` table at startup.
+2. **i18n layer (Electron main)** — `electron/cli/i18n.ts` (refined during implementation)
+   - Uses a small **inline dictionary** (`tMain(key, lang, vars?)`) rather than core i18next +
+     shared JSON. Rationale: `tsconfig.electron.json` pins `rootDir: "electron"`, so the main
+     process cannot import `src/locales/*.json` without build changes; main needs only ~7 strings.
+   - Language read from the `app_settings` table at startup (`electron/cli/settings.ts:getLanguage`).
    - Covers: custom menu labels, HTTP error body in `electron/main.ts`, dialog filter names in
      `electron/cli/ipc.ts`.
-   - The menu is rebuilt when the language changes.
+   - The menu is rebuilt when the language changes (menu builder lives in `electron/menu.ts`).
 
 3. **Settings store + persistence (NEW)** — `src/store/settingsStore.ts`
    - Zustand store holding `language`.

--- a/electron/app-meta.ts
+++ b/electron/app-meta.ts
@@ -1,0 +1,1 @@
+export const APP_NAME = "FreeBuddy";

--- a/electron/cli/db.ts
+++ b/electron/cli/db.ts
@@ -121,6 +121,11 @@ function migrate(db: DB) {
     );
     CREATE INDEX IF NOT EXISTS idx_messages_conv_time
       ON conversation_messages(conversation_id, created_at);
+
+    CREATE TABLE IF NOT EXISTS app_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
   `);
 
   const overrideCols = db

--- a/electron/cli/i18n.ts
+++ b/electron/cli/i18n.ts
@@ -1,0 +1,16 @@
+type AppLocale = "en" | "zh-CN";
+
+const DICT: Record<string, Record<AppLocale, string>> = {
+  "menu.edit": { en: "Edit", "zh-CN": "编辑" },
+  "menu.view": { en: "View", "zh-CN": "视图" },
+  "menu.window": { en: "Window", "zh-CN": "窗口" },
+  "dialog.supportedAttachments": { en: "Supported attachments", "zh-CN": "支持的附件" },
+  "dialog.allFiles": { en: "All files", "zh-CN": "所有文件" },
+  "main.fileLoadFailed": { en: "Failed to load file: {{message}}", "zh-CN": "加载文件失败：{{message}}" }
+};
+
+export function tMain(key: string, lang: AppLocale, vars?: Record<string, string>): string {
+  const entry = DICT[key]?.[lang] ?? DICT[key]?.en ?? key;
+  if (!vars) return entry;
+  return entry.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? "");
+}

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -40,6 +40,7 @@ import {
   type ListConversationsArgs,
   type UpdateMessageInput
 } from "./conversations.js";
+import { getSetting, setSetting } from "./settings.js";
 
 function senderWindow(event: IpcMainInvokeEvent): BrowserWindow | null {
   return BrowserWindow.fromWebContents(event.sender);
@@ -270,4 +271,9 @@ export function registerCliIpc() {
   ipcMain.handle("cli:updateMessage", (_e, input: UpdateMessageInput) =>
     updateMessage(input)
   );
+
+  ipcMain.handle("settings:get", (_e, key: string) => getSetting(key));
+  ipcMain.handle("settings:set", (_e, args: { key: string; value: string }) => {
+    setSetting(args.key, args.value);
+  });
 }

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -40,7 +40,9 @@ import {
   type ListConversationsArgs,
   type UpdateMessageInput
 } from "./conversations.js";
-import { getSetting, setSetting } from "./settings.js";
+import { getSetting, setSetting, getLanguage } from "./settings.js";
+import { tMain } from "./i18n.js";
+import { setApplicationMenuForLanguage } from "../menu.js";
 
 function senderWindow(event: IpcMainInvokeEvent): BrowserWindow | null {
   return BrowserWindow.fromWebContents(event.sender);
@@ -130,8 +132,8 @@ export function registerCliIpc() {
     const { canceled, filePaths } = await dialog.showOpenDialog(win, {
       properties: ["openFile", "multiSelections"],
       filters: [
-        { name: "Supported attachments", extensions: ATTACHMENT_EXTENSIONS },
-        { name: "All files", extensions: ["*"] }
+        { name: tMain("dialog.supportedAttachments", getLanguage()), extensions: ATTACHMENT_EXTENSIONS },
+        { name: tMain("dialog.allFiles", getLanguage()), extensions: ["*"] }
       ]
     });
     if (canceled) return [];
@@ -275,5 +277,8 @@ export function registerCliIpc() {
   ipcMain.handle("settings:get", (_e, key: string) => getSetting(key));
   ipcMain.handle("settings:set", (_e, args: { key: string; value: string }) => {
     setSetting(args.key, args.value);
+    if (args.key === "language" && (args.value === "en" || args.value === "zh-CN")) {
+      setApplicationMenuForLanguage(args.value);
+    }
   });
 }

--- a/electron/cli/settings.ts
+++ b/electron/cli/settings.ts
@@ -1,0 +1,31 @@
+import { app } from "electron";
+import { getDb } from "./db.js";
+
+type AppLocale = "en" | "zh-CN";
+
+function detectLocale(tag: string | undefined): AppLocale {
+  if (!tag) return "en";
+  return tag.toLowerCase().startsWith("zh") ? "zh-CN" : "en";
+}
+
+export function getSetting(key: string): string | null {
+  const row = getDb()
+    .prepare("SELECT value FROM app_settings WHERE key = ?")
+    .get(key) as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+export function setSetting(key: string, value: string): void {
+  getDb()
+    .prepare(
+      "INSERT INTO app_settings (key, value) VALUES (?, ?) " +
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+    )
+    .run(key, value);
+}
+
+export function getLanguage(): AppLocale {
+  const stored = getSetting("language");
+  if (stored === "en" || stored === "zh-CN") return stored;
+  return detectLocale(app.getLocale());
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,14 +1,17 @@
-import { app, BrowserWindow, Menu, nativeImage, net, protocol, shell } from "electron";
+import { app, BrowserWindow, nativeImage, net, protocol, shell } from "electron";
 import path from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { shellEnv } from "shell-env";
 
 import { registerCliIpc } from "./cli/ipc.js";
 import { getDb } from "./cli/db.js";
+import { initApplicationMenu } from "./menu.js";
+import { tMain } from "./cli/i18n.js";
+import { getLanguage } from "./cli/settings.js";
+import { APP_NAME } from "./app-meta.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isDev = Boolean(process.env.VITE_DEV_SERVER_URL);
-const APP_NAME = "FreeBuddy";
 
 app.setName(APP_NAME);
 app.setAboutPanelOptions({ applicationName: APP_NAME });
@@ -46,9 +49,12 @@ function registerLocalFileProtocol() {
       const absolute = path.isAbsolute(decoded) ? decoded : `/${decoded}`;
       return await net.fetch(pathToFileURL(absolute).toString());
     } catch (error) {
-      return new Response(`Failed to load file: ${(error as Error).message}`, {
-        status: 404
-      });
+      return new Response(
+        tMain("main.fileLoadFailed", getLanguage(), {
+          message: (error as Error).message
+        }),
+        { status: 404 }
+      );
     }
   });
 }
@@ -91,7 +97,7 @@ function createWindow() {
     }
   });
 
-  Menu.setApplicationMenu(createMenu());
+  initApplicationMenu();
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
@@ -113,52 +119,6 @@ function createWindow() {
   } else {
     void mainWindow.loadFile(path.join(__dirname, "../dist/index.html"));
   }
-}
-
-function createMenu() {
-  return Menu.buildFromTemplate([
-    {
-      label: APP_NAME,
-      submenu: [
-        { role: "about" },
-        { type: "separator" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "unhide" },
-        { type: "separator" },
-        { role: "quit" }
-      ]
-    },
-    {
-      label: "Edit",
-      submenu: [
-        { role: "undo" },
-        { role: "redo" },
-        { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectAll" }
-      ]
-    },
-    {
-      label: "View",
-      submenu: [
-        { role: "reload" },
-        { role: "toggleDevTools" },
-        { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
-        { type: "separator" },
-        { role: "togglefullscreen" }
-      ]
-    },
-    {
-      label: "Window",
-      submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }]
-    }
-  ]);
 }
 
 app.whenReady().then(async () => {

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -1,0 +1,48 @@
+import { Menu } from "electron";
+import { tMain } from "./cli/i18n.js";
+import { getLanguage } from "./cli/settings.js";
+import { APP_NAME } from "./app-meta.js";
+
+export function buildAppMenu(lang: "en" | "zh-CN") {
+  return Menu.buildFromTemplate([
+    {
+      label: APP_NAME,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" }
+      ]
+    },
+    {
+      label: tMain("menu.edit", lang),
+      submenu: [
+        { role: "undo" }, { role: "redo" }, { type: "separator" },
+        { role: "cut" }, { role: "copy" }, { role: "paste" }, { role: "selectAll" }
+      ]
+    },
+    {
+      label: tMain("menu.view", lang),
+      submenu: [
+        { role: "reload" }, { role: "toggleDevTools" }, { type: "separator" },
+        { role: "resetZoom" }, { role: "zoomIn" }, { role: "zoomOut" }, { type: "separator" },
+        { role: "togglefullscreen" }
+      ]
+    },
+    {
+      label: tMain("menu.window", lang),
+      submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }]
+    }
+  ]);
+}
+
+export function setApplicationMenuForLanguage(lang: "en" | "zh-CN") {
+  Menu.setApplicationMenu(buildAppMenu(lang));
+}
+
+export function initApplicationMenu() {
+  setApplicationMenuForLanguage(getLanguage());
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -66,6 +66,15 @@ const window = {
   }
 };
 
+const settings: {
+  getSetting: (key: string) => Promise<unknown>;
+  setSetting: (key: string, value: string) => Promise<unknown>;
+} = {
+  getSetting: (key) => ipcRenderer.invoke("settings:get", key),
+  setSetting: (key, value) =>
+    ipcRenderer.invoke("settings:set", { key, value })
+};
+
 contextBridge.exposeInMainWorld("freebuddy", {
   platform: process.platform,
   versions: {
@@ -74,5 +83,6 @@ contextBridge.exposeInMainWorld("freebuddy", {
     node: process.versions.node
   },
   cli,
+  settings,
   window
 });

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "@lobehub/icons": "^5.10.0",
         "better-sqlite3": "^12.11.1",
+        "i18next": "^26.3.1",
         "nanoid": "^5.1.11",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "react-i18next": "^17.0.8",
         "shell-env": "^4.0.3",
         "zustand": "^5.0.14"
       },
@@ -8433,6 +8435,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -8511,6 +8522,34 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.3.1",
+      "resolved": "https://registry.npmmirror.com/i18next/-/i18next-26.3.1.tgz",
+      "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -11843,6 +11882,33 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmmirror.com/react-i18next/-/react-i18next-17.0.8.tgz",
+      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-18.3.1.tgz",
@@ -13446,7 +13512,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13721,7 +13787,6 @@
       "resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -13907,6 +13972,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/web-namespaces": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   "dependencies": {
     "@lobehub/icons": "^5.10.0",
     "better-sqlite3": "^12.11.1",
+    "i18next": "^26.3.1",
     "nanoid": "^5.1.11",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-i18next": "^17.0.8",
     "shell-env": "^4.0.3",
     "zustand": "^5.0.14"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,8 +153,8 @@ function App() {
     <button
       type="button"
       className={`sidebar-toggle${extraClass ? ` ${extraClass}` : ""}`}
-      title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-      aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+      title={t(sidebarCollapsed ? "sidebar.expand" : "sidebar.collapse")}
+      aria-label={t(sidebarCollapsed ? "sidebar.expand" : "sidebar.collapse")}
       aria-expanded={!sidebarCollapsed}
       onClick={() => setSidebarCollapsed((v) => !v)}
     >
@@ -174,7 +174,7 @@ function App() {
           <div className="sidebar-brand">
             <BrandMark />
             <div className="sidebar-brand-text">
-              <h1>FreeBuddy</h1>
+              <h1>{t("app.brand")}</h1>
             </div>
           </div>
           {renderToggleButton()}
@@ -188,12 +188,12 @@ function App() {
             onClick={() => setSettingsOpen(true)}
           >
             <GearIcon />
-            Settings
+            {t("common.settings")}
           </button>
           <button
             className="footer-toggle"
-            title="Toggle theme"
-            aria-label="Toggle theme"
+            title={t("sidebar.toggleTheme")}
+            aria-label={t("sidebar.toggleTheme")}
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
           >
             {theme === "dark" ? <SunIcon /> : <MoonIcon />}
@@ -204,12 +204,12 @@ function App() {
       <main className="workspace">
         <header className="titlebar">
           <div className="breadcrumb">
-            <strong>{activeConversation?.title ?? "Chat"}</strong>
+            <strong>{activeConversation?.title ?? t("app.chat")}</strong>
           </div>
 
         </header>
 
-        <section className="chat-section" aria-label="Chat">
+        <section className="chat-section" aria-label={t("app.chat")}>
           <ChatView />
         </section>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import { WorkspacePanel } from "./components/CLI/WorkspacePanel";
 import { SettingsModal } from "./components/Settings/SettingsModal";
 import { useCliExecutorStore } from "./store/cliExecutorStore";
 import { useConversationStore } from "./store/conversationStore";
+import { useSettingsStore } from "./store/settingsStore";
+import i18next from "i18next";
+import { useTranslation } from "react-i18next";
 
 type Theme = "light" | "dark";
 
@@ -119,6 +122,21 @@ function App() {
     return () => {
       off?.();
     };
+  }, []);
+
+  const { t } = useTranslation();
+  const loadSettings = useSettingsStore((s) => s.load);
+  useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  useEffect(() => {
+    document.documentElement.lang = i18next.language ?? "en";
+    const handler = (lng: string) => {
+      document.documentElement.lang = lng;
+    };
+    i18next.on("languageChanged", handler);
+    return () => i18next.off("languageChanged", handler);
   }, []);
 
   const conversations = useConversationStore((s) => s.conversations);

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { nanoid } from "nanoid";
+import { useTranslation } from "react-i18next";
 
 import { useConversationStore } from "@/store/conversationStore";
 import { useCliExecutorStore } from "@/store/cliExecutorStore";
@@ -16,16 +17,6 @@ import {
 import { MessageBubble } from "./MessageBubble";
 
 const EMPTY_MESSAGES: never[] = [];
-const starterPrompts = [
-  "先分析当前项目结构，给我下一步实现建议",
-  "检查刚才的改动有没有 UI/UX 问题",
-  "帮我实现一个小功能，并说明验证步骤"
-];
-const newTaskPrompts = [
-  ["分析项目", "先分析当前项目结构，告诉我可以先做什么"],
-  ["修改代码", "根据我的需求修改代码，并给出验证步骤"],
-  ["代码审查", "检查当前改动的风险、问题和可改进点"]
-];
 
 function attachmentSummary(attachment: ChatAttachment): string {
   return [
@@ -77,10 +68,11 @@ function AttachmentTray({
   attachments: ChatAttachment[];
   onRemove: (id: string) => void;
 }) {
+  const { t } = useTranslation();
   if (attachments.length === 0) return null;
 
   return (
-    <div className="attachment-tray" aria-label="Pending attachments">
+    <div className="attachment-tray" aria-label={t("chat.pendingAttachmentsAria")}>
       {attachments.map((attachment) => (
         <div className="attachment-chip" key={attachment.id} title={attachment.path}>
           <span className="attachment-chip-icon">
@@ -118,7 +110,7 @@ function AttachmentTray({
           <button
             type="button"
             className="attachment-chip-remove"
-            aria-label={`Remove ${attachment.name}`}
+            aria-label={t("chat.removeAttachmentAria", { name: attachment.name })}
             onClick={() => onRemove(attachment.id)}
           >
             x
@@ -130,6 +122,7 @@ function AttachmentTray({
 }
 
 export function ChatView() {
+  const { t } = useTranslation();
   const activeId = useConversationStore((s) => s.activeId);
   const conversations = useConversationStore((s) => s.conversations);
   const members = useConversationStore((s) => s.members);
@@ -179,6 +172,11 @@ export function ChatView() {
   const sending =
     running ||
     (submitPreview?.conversationId === conv?.id);
+  const starterPrompts = [
+    t("chat.starter.one"),
+    t("chat.starter.two"),
+    t("chat.starter.three")
+  ];
 
   const previewMessages = useMemo<ConversationMessage[]>(() => {
     if (!conv || submitPreview?.conversationId !== conv.id) return [];
@@ -247,7 +245,7 @@ export function ChatView() {
 
     for (const candidate of selected) {
       if (byPath.size >= MAX_ATTACHMENTS_PER_MESSAGE) {
-        warnings.push(`每条消息最多添加 ${MAX_ATTACHMENTS_PER_MESSAGE} 个附件。`);
+        warnings.push(t("errors.attachmentLimit", { count: MAX_ATTACHMENTS_PER_MESSAGE }));
         break;
       }
 
@@ -257,8 +255,8 @@ export function ChatView() {
         const name = candidate.name || candidate.path;
         warnings.push(
           validation.reason === "file_too_large"
-            ? `${name} 超过 50 MB 附件大小限制。`
-            : `${name} 不是支持的附件类型。`
+            ? t("errors.attachmentTooLarge", { name })
+            : t("errors.attachmentType", { name })
         );
         continue;
       }
@@ -272,7 +270,7 @@ export function ChatView() {
   const handleSelectAttachments = async (target: "chat" | "new") => {
     if (sending) return;
     if (!cliClient.isAvailable()) {
-      setPreflightMsg("附件功能需要在 Electron 桌面端使用。");
+      setPreflightMsg(t("errors.attachmentDesktopOnly"));
       return;
     }
 
@@ -289,7 +287,7 @@ export function ChatView() {
       }
       setPreflightMsg(warnings[0] ?? null);
     } catch (error) {
-      setPreflightMsg(`选择附件失败：${error instanceof Error ? error.message : String(error)}`);
+      setPreflightMsg(t("errors.attachmentSelectFailed", { err: error instanceof Error ? error.message : String(error) }));
     }
   };
 
@@ -305,7 +303,7 @@ export function ChatView() {
 
   const preflightMember = async (targetMember: typeof members[number]) => {
     if (!cliClient.isAvailable()) {
-      setPreflightMsg("FreeBuddy CLI bridge is unavailable. Please run the Electron desktop app.");
+      setPreflightMsg(t("errors.cliBridgeUnavailable"));
       return false;
     }
     try {
@@ -314,13 +312,13 @@ export function ChatView() {
       if (!r.installed) {
         const resolved = resolve(targetMember.cli.adapter);
         setPreflightMsg(
-          `${resolved?.label ?? "Agent"} is not installed. Open Settings -> Cli Agents to install.`
+          t("errors.agentNotInstalled", { agent: resolved?.label ?? t("chat.agent") })
         );
         return false;
       }
       return true;
     } catch (err) {
-      setPreflightMsg(`Check failed: ${err instanceof Error ? err.message : String(err)}`);
+      setPreflightMsg(t("errors.checkFailed", { err: err instanceof Error ? err.message : String(err) }));
       return false;
     }
   };
@@ -338,7 +336,7 @@ export function ChatView() {
       const newConv = await createConversation({
         member: selectedMember,
         cwd: newTaskCwd.trim() || undefined,
-        title: (prompt || attachmentsToSend[0]?.name || "附件").slice(0, 24),
+        title: (prompt || attachmentsToSend[0]?.name || t("chat.defaultAttachmentTitle")).slice(0, 24),
         approvalMode: permissionMode
       });
       setNewTaskDraft("");
@@ -352,7 +350,7 @@ export function ChatView() {
     } catch (e) {
       setNewTaskDraft(prompt);
       setNewTaskPendingAttachments(attachmentsToSend);
-      setPreflightMsg(`Task failed: ${e instanceof Error ? e.message : String(e)}`);
+      setPreflightMsg(t("errors.taskFailed", { err: e instanceof Error ? e.message : String(e) }));
     }
   };
 
@@ -397,7 +395,7 @@ export function ChatView() {
       setSubmitPreview(null);
       setDraft(prompt);
       setPendingAttachments(attachmentsToSend);
-      setPreflightMsg(`Send failed: ${e instanceof Error ? e.message : String(e)}`);
+      setPreflightMsg(t("errors.sendFailed", { err: e instanceof Error ? e.message : String(e) }));
     }
   };
 
@@ -430,10 +428,10 @@ export function ChatView() {
       <div className="chat-scroll" ref={scrollRef} onScroll={handleScroll}>
         {messages.length === 0 && (
           <div className="chat-empty chat-empty-hero">
-            <p className="eyebrow">New Agent Chat</p>
-            <h2>What should {member?.name} work on?</h2>
+            <p className="eyebrow">{t("chat.newAgentChat")}</p>
+            <h2>{t("chat.emptyHeroHeading", { name: member?.name ?? "" })}</h2>
             <p className="muted">
-              Use this thread for coding tasks, project inspection, and focused fixes.
+              {t("chat.emptyHeroBody")}
             </p>
             <div className="starter-prompts">
               {starterPrompts.map((prompt) => (
@@ -457,7 +455,7 @@ export function ChatView() {
       <div className="chat-composer">
         <div className="composer-context-row">
           <span>{agentDisplayName}</span>
-          <span>{conv.cwd ? conv.cwd : "No workspace selected"}</span>
+          <span>{conv.cwd ? conv.cwd : t("chat.noWorkspace")}</span>
         </div>
         <AttachmentTray
           attachments={pendingAttachments}
@@ -470,8 +468,8 @@ export function ChatView() {
           disabled={sending}
           placeholder={
             sending
-              ? "Agent 正在运行…"
-              : "随心输入"
+              ? t("chat.agentRunning")
+              : t("chat.inputPlaceholder")
           }
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
@@ -486,18 +484,18 @@ export function ChatView() {
             <button
               className="composer-tool-chip"
               type="button"
-              title="Attach file"
+              title={t("chat.attachFile")}
               disabled={sending || pendingAttachments.length >= MAX_ATTACHMENTS_PER_MESSAGE}
               onClick={() => void handleSelectAttachments("chat")}
             >
               <PaperclipIcon />
-              <span>Attach</span>
+              <span>{t("chat.attach")}</span>
             </button>
             <label
               className="composer-permission"
-              title="Permission mode for tool execution"
+              title={t("chat.permissionHint")}
             >
-              <span className="composer-permission-label">权限</span>
+              <span className="composer-permission-label">{t("chat.permission")}</span>
               <select
                 className="composer-permission-select"
                 value={permissionMode}
@@ -508,20 +506,20 @@ export function ChatView() {
                   if (conv?.id) void setApprovalMode(conv.id, next);
                 }}
               >
-                <option value="auto">自动</option>
-                <option value="ask">每次询问</option>
+                <option value="auto">{t("chat.approvalAuto")}</option>
+                <option value="ask">{t("chat.approvalAsk")}</option>
               </select>
             </label>
           </div>
           <div className="composer-tail">
-            <span className="composer-hint">Enter 发送 · Shift+Enter 换行</span>
+            <span className="composer-hint">{t("chat.enterHint")}</span>
             {sending ? (
               <button
                 className="danger stop-icon-button"
                 type="button"
                 disabled={!running}
-                title={running ? "停止" : "启动中"}
-                aria-label={running ? "停止运行" : "正在启动"}
+                title={running ? t("chat.stop") : t("status.starting")}
+                aria-label={running ? t("chat.stopAria") : t("chat.startingAria")}
                 onClick={() => void stopActive(conv.id)}
               >
                 {running ? "■" : "…"}
@@ -531,8 +529,8 @@ export function ChatView() {
                 className="primary send-icon-button"
                 type="button"
                 disabled={!(draft.trim() || pendingAttachments.length > 0)}
-                title="发送"
-                aria-label="发送消息"
+                title={t("chat.send")}
+                aria-label={t("chat.sendAria")}
                 onClick={onSend}
               >
                 ↑
@@ -578,21 +576,27 @@ function NewTaskHome({
   onPrompt: (value: string) => void;
   onSubmit: () => void;
 }) {
+  const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const newTaskPrompts = [
+    { label: t("chat.newTaskPrompts.analyze.label"), prompt: t("chat.newTaskPrompts.analyze.prompt") },
+    { label: t("chat.newTaskPrompts.modify.label"), prompt: t("chat.newTaskPrompts.modify.prompt") },
+    { label: t("chat.newTaskPrompts.review.label"), prompt: t("chat.newTaskPrompts.review.prompt") }
+  ];
 
   return (
     <div className="new-task-view">
-      <section className="new-task-hero" aria-label="New task">
+      <section className="new-task-hero" aria-label={t("chat.newTaskAria")}>
         <h1>
           FreeBuddy
-          <span>本地 CLI Agent 工作台</span>
+          <span>{t("chat.heroTitle")}</span>
         </h1>
         <p className="new-task-subtitle">
-          选择一个本地 agent，给它一个工作目录，然后开始编码、检查或改造项目。
+          {t("chat.heroSubtitle")}
         </p>
 
-        <div className="new-task-chips" aria-label="Common tasks">
-          {newTaskPrompts.map(([label, prompt]) => (
+        <div className="new-task-chips" aria-label={t("chat.commonTasksAria")}>
+          {newTaskPrompts.map(({ label, prompt }) => (
             <button
               key={label}
               onClick={() => {
@@ -615,7 +619,7 @@ function NewTaskHome({
             autoFocus
             rows={4}
             value={draft}
-            placeholder="随心输入"
+            placeholder={t("chat.inputPlaceholder")}
             onChange={(event) => onDraft(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "Enter" && !event.shiftKey) {
@@ -627,7 +631,7 @@ function NewTaskHome({
 
           <div className="new-task-toolbar">
             <label>
-              <span>Agent</span>
+              <span>{t("chat.agent")}</span>
               <select value={selectedMemberId} onChange={(event) => onMember(event.target.value)}>
                 {members.map((member) => (
                   <option key={member.id} value={member.id}>
@@ -637,18 +641,18 @@ function NewTaskHome({
               </select>
             </label>
             <label>
-              <span>权限</span>
+              <span>{t("chat.permission")}</span>
               <select value={permissionMode} onChange={(event) => onPermissionMode(event.target.value as "auto" | "ask")}>
-                <option value="auto">自动</option>
-                <option value="ask">每次询问</option>
+                <option value="auto">{t("chat.approvalAuto")}</option>
+                <option value="ask">{t("chat.approvalAsk")}</option>
               </select>
             </label>
             <button
               className="new-task-send send-icon-button"
               type="button"
               disabled={!(draft.trim() || pendingAttachments.length > 0) || members.length === 0}
-              title="开始任务"
-              aria-label="开始任务"
+              title={t("chat.startTask")}
+              aria-label={t("chat.startTask")}
               onClick={onSubmit}
             >
               ↑
@@ -660,17 +664,17 @@ function NewTaskHome({
               <button
                 className="composer-tool-chip"
                 type="button"
-                title="Attach file"
+                title={t("chat.attachFile")}
                 disabled={pendingAttachments.length >= MAX_ATTACHMENTS_PER_MESSAGE}
                 onClick={onSelectAttachments}
               >
                 <PaperclipIcon />
-                <span>Attach</span>
+                <span>{t("chat.attach")}</span>
               </button>
               <button
                 className="composer-tool-chip"
                 type="button"
-                title="选择工作目录"
+                title={t("chat.selectCwd")}
                 onClick={async () => {
                   try {
                     const path = await cliClient.selectDirectory();
@@ -681,12 +685,12 @@ function NewTaskHome({
                 }}
               >
                 <FolderIcon />
-                <span>Workspace</span>
+                <span>{t("chat.workspace")}</span>
               </button>
             </div>
             <input
               value={cwd}
-              placeholder="/absolute/path，可选；不填则使用默认运行目录"
+              placeholder={t("chat.cwdPlaceholder")}
               onChange={(event) => onCwd(event.target.value)}
             />
           </div>

--- a/src/components/CLI/ConversationList.tsx
+++ b/src/components/CLI/ConversationList.tsx
@@ -1,6 +1,8 @@
 import { useConversationStore } from "@/store/conversationStore";
 import type { Conversation } from "@/services/cli/types";
 import { displayAgentName } from "@/config/agentDisplay";
+import i18next from "i18next";
+import { useTranslation } from "react-i18next";
 
 function conversationTimeValue(conversation: Conversation) {
   return conversation.lastMessageAt ?? conversation.updatedAt ?? conversation.createdAt;
@@ -17,20 +19,20 @@ function formatConversationTime(value: string) {
     date.getDate() === now.getDate();
 
   if (sameDay) {
-    return new Intl.DateTimeFormat(undefined, {
+    return new Intl.DateTimeFormat(i18next.language, {
       hour: "2-digit",
       minute: "2-digit"
     }).format(date);
   }
 
   if (date.getFullYear() === now.getFullYear()) {
-    return new Intl.DateTimeFormat(undefined, {
+    return new Intl.DateTimeFormat(i18next.language, {
       month: "2-digit",
       day: "2-digit"
     }).format(date);
   }
 
-  return new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat(i18next.language, {
     year: "numeric",
     month: "2-digit",
     day: "2-digit"
@@ -40,7 +42,7 @@ function formatConversationTime(value: string) {
 function formatConversationTimeTitle(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
-  return new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat(i18next.language, {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -59,18 +61,19 @@ export function ConversationList({
   const setActive = useConversationStore((s) => s.setActive);
   const live = useConversationStore((s) => s.live);
   const remove = useConversationStore((s) => s.deleteConversation);
+  const { t } = useTranslation();
 
   return (
     <div className="conv-list">
       <div className="conv-list-header">
-        <h2>Conversations</h2>
+        <h2>{t("conversations.title")}</h2>
         <button className="ghost" onClick={onNew}>
-          + New
+          {t("conversations.new")}
         </button>
       </div>
       <ul>
         {conversations.length === 0 && (
-          <li className="conv-empty muted">No conversations yet.</li>
+          <li className="conv-empty muted">{t("conversations.empty")}</li>
         )}
         {conversations.map((c) => {
           const running =
@@ -105,10 +108,10 @@ export function ConversationList({
               <div className="conv-item-side">
                 <button
                   className="icon-btn danger"
-                  title="Delete"
+                  title={t("common.delete")}
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (window.confirm(`Delete "${c.title}"?`))
+                    if (window.confirm(t("conversations.deleteConfirm", { title: c.title })))
                       void remove(c.id);
                   }}
                 >

--- a/src/components/CLI/ImageLightbox.tsx
+++ b/src/components/CLI/ImageLightbox.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
 interface LightboxState {
   src: string;
@@ -14,6 +15,7 @@ const LightboxContext = createContext<LightboxContextValue | null>(null);
 
 export function ImageLightboxProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<LightboxState | null>(null);
+  const { t } = useTranslation();
 
   const open = useCallback((next: LightboxState) => setState(next), []);
   const close = useCallback(() => setState(null), []);
@@ -40,13 +42,13 @@ export function ImageLightboxProvider({ children }: { children: ReactNode }) {
           className="image-lightbox-backdrop"
           role="dialog"
           aria-modal="true"
-          aria-label={state.alt || "Image preview"}
+          aria-label={state.alt || t("lightbox.preview")}
           onClick={close}
         >
           <button
             type="button"
             className="image-lightbox-close"
-            aria-label="Close preview"
+            aria-label={t("lightbox.close")}
             onClick={(event) => {
               event.stopPropagation();
               close();

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from "react";
 
+import { useTranslation } from "react-i18next";
+
 import { displayAgentName } from "@/config/agentDisplay";
 import type { ChatAttachment, ConversationMessage } from "@/services/cli/types";
 import type { CliStreamItem } from "@/services/cli/parsers";
@@ -231,13 +233,14 @@ function MessageImageAttachments({
 }: {
   attachments: ChatAttachment[];
 }) {
+  const { t } = useTranslation();
   const { open } = useImageLightbox();
   if (!attachments.length) return null;
 
   return (
     <div
       className="message-image-attachments"
-      aria-label="Message image attachments"
+      aria-label={t("attachments.imagesAria")}
     >
       {attachments.map((attachment) => {
         const src = attachmentPreviewUrl(attachment.path);
@@ -247,7 +250,7 @@ function MessageImageAttachments({
             type="button"
             className="message-image-attachment"
             title={attachment.path}
-            aria-label={`Preview ${attachment.name}`}
+            aria-label={t("attachments.previewName", { name: attachment.name })}
             onClick={() => open({ src, alt: attachment.name })}
           >
             <img
@@ -273,11 +276,12 @@ function MessageAttachments({
 }: {
   attachments?: ChatAttachment[];
 }) {
+  const { t } = useTranslation();
   const { open } = useImageLightbox();
   if (!attachments?.length) return null;
 
   return (
-    <div className="message-attachments attachment-list" aria-label="Message attachments">
+    <div className="message-attachments attachment-list" aria-label={t("attachments.listAria")}>
       {attachments.map((attachment) => {
         const isImage = attachment.kind === "image";
         const previewSrc = isImage ? attachmentPreviewUrl(attachment.path) : null;
@@ -302,10 +306,10 @@ function MessageAttachments({
               style={isImage ? { display: "none" } : undefined}
             >
               {isImage
-                ? "IMG"
+                ? t("attachments.kindImage")
                 : attachment.kind === "code"
-                  ? "CODE"
-                  : "FILE"}
+                  ? t("attachments.kindCode")
+                  : t("attachments.kindFile")}
             </span>
           </span>
         );
@@ -316,7 +320,7 @@ function MessageAttachments({
                 type="button"
                 className="message-attachment-thumb-button"
                 onClick={() => open({ src: previewSrc, alt: attachment.name })}
-                aria-label={`Preview ${attachment.name}`}
+                aria-label={t("attachments.previewName", { name: attachment.name })}
               >
                 {thumb}
               </button>
@@ -344,6 +348,7 @@ export function MessageBubble({
   message: ConversationMessage;
   adapter?: string;
 }) {
+  const { t } = useTranslation();
   const items = useMemo<CliStreamItem[]>(() => {
     if (message.role !== "assistant") return [];
     try {
@@ -387,7 +392,7 @@ export function MessageBubble({
       <div className="msg msg-user">
         <div className="msg-content-wrapper">
           <div className="msg-header">
-            <span className="msg-author">You</span>
+            <span className="msg-author">{t("message.you")}</span>
             <span className="msg-time">{timeStr}</span>
           </div>
           {showBubble && (
@@ -420,7 +425,7 @@ export function MessageBubble({
           <span className="msg-time">{timeStr}</span>
           {message.status !== "ready" && (
             <span className={`status-pill ${message.status}`}>
-              {message.status}
+              {t(`status.${message.status}`)}
             </span>
           )}
         </div>
@@ -445,7 +450,7 @@ export function MessageBubble({
         {isWaitingForAgent && (
           <div className="msg-loading">
             <span className="loading-dots">●●●</span>
-            <span>正在思考</span>
+            <span>{t("message.thinking")}</span>
           </div>
         )}
       </div>

--- a/src/components/CLI/PermissionDialog.tsx
+++ b/src/components/CLI/PermissionDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { CliPermissionOption } from "@/services/cli/types";
 import { usePermissionStore } from "@/store/permissionStore";
@@ -27,6 +28,7 @@ export function PermissionDialog() {
   const queue = usePermissionStore((s) => s.queue);
   const decide = usePermissionStore((s) => s.decide);
   const current = queue[0];
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!current) return;
@@ -54,7 +56,7 @@ export function PermissionDialog() {
   const title =
     current.toolCall?.title ||
     current.toolCall?.kind ||
-    "Tool execution permission";
+    t("permission.fallbackTitle");
   const subtitle =
     current.toolCall?.title && current.toolCall?.kind
       ? current.toolCall.kind
@@ -67,7 +69,7 @@ export function PermissionDialog() {
         onClick={(event) => event.stopPropagation()}
       >
         <header className="permission-header">
-          <span className="permission-eyebrow">Permission required</span>
+          <span className="permission-eyebrow">{t("permission.title")}</span>
           <h2 className="permission-title">{title}</h2>
           {subtitle ? (
             <span className="permission-subtitle">{subtitle}</span>
@@ -76,15 +78,12 @@ export function PermissionDialog() {
 
         {inputText ? (
           <div className="permission-section">
-            <span className="permission-label">Input</span>
+            <span className="permission-label">{t("permission.input")}</span>
             <pre className="permission-input">{inputText}</pre>
           </div>
         ) : null}
 
-        <p className="permission-help">
-          The agent is asking for permission to run the action above. Choose
-          how to respond — you can allow once, allow always, or reject.
-        </p>
+        <p className="permission-help">{t("permission.help")}</p>
 
         <div className="permission-actions">
           {current.options.map((option) => {
@@ -114,14 +113,13 @@ export function PermissionDialog() {
               void decide(current.requestId, { outcome: "cancelled" })
             }
           >
-            Cancel
+            {t("common.cancel")}
           </button>
         </div>
 
         {queue.length > 1 ? (
           <div className="permission-queue">
-            +{queue.length - 1} more pending request
-            {queue.length - 1 === 1 ? "" : "s"}
+            {t("permission.morePending", { count: queue.length - 1 })}
           </div>
         ) : null}
       </div>

--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
 
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+
 import type { CliStreamItem } from "@/services/cli/parsers";
 import { dedupeCommands, dedupeToolResults } from "@/store/conversationUtils";
 import { attachmentPreviewUrl } from "@/utils/chatAttachments";
@@ -99,6 +102,7 @@ function collectInlineImages(text: string): InlineImageRef[] {
 }
 
 function MessageImage({ src, alt }: { alt: string; src: string }) {
+  const { t } = useTranslation();
   const { open } = useImageLightbox();
   return (
     <figure className="markdown-image-figure">
@@ -106,7 +110,7 @@ function MessageImage({ src, alt }: { alt: string; src: string }) {
         type="button"
         className="markdown-image-button"
         onClick={() => open({ src, alt })}
-        aria-label={alt ? `Preview ${alt}` : "Preview image"}
+        aria-label={alt ? t("attachments.previewName", { name: alt }) : t("attachments.previewImage")}
       >
         <img
           src={src}
@@ -283,15 +287,20 @@ function truncate(value: string, max = 96) {
   return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
 }
 
-function toolActionLabel(item: Extract<CliStreamItem, { kind: "tool-call" }>) {
+function toolActionLabel(
+  item: Extract<CliStreamItem, { kind: "tool-call" }>,
+  t: TFunction
+) {
   const tool = item.tool.toLowerCase();
   const target = truncate(summarizeValue(item.input));
-  if (tool.includes("read") || tool.includes("open")) return `读取 ${target || item.tool}`;
+  if (tool.includes("read") || tool.includes("open")) {
+    return t("stream.read", { target: target || item.tool });
+  }
   if (tool.includes("write") || tool.includes("edit") || tool.includes("patch")) {
-    return `修改 ${target || item.tool}`;
+    return t("stream.edit", { target: target || item.tool });
   }
   if (tool.includes("command") || tool.includes("exec") || tool.includes("shell")) {
-    return `执行 ${target || item.tool}`;
+    return t("stream.exec", { target: target || item.tool });
   }
   return target ? `${item.tool} ${target}` : item.tool;
 }
@@ -317,10 +326,13 @@ function formatValue(value: unknown): string {
   }
 }
 
-function toolGroupLabel(item: Extract<CliStreamItem, { kind: "tool-call" }>) {
+function toolGroupLabel(
+  item: Extract<CliStreamItem, { kind: "tool-call" }>,
+  t: TFunction
+) {
   const tool = item.tool.toLowerCase();
   if (tool.includes("search") || tool.includes("fetch")) return item.tool;
-  return toolActionLabel(item);
+  return toolActionLabel(item, t);
 }
 
 export function StreamToolInvocation({
@@ -336,31 +348,32 @@ export function StreamToolInvocation({
   const visibleCommands = dedupeCommands(commands);
   const hasError = visibleResults.some((result) => result.isError);
   const input = formatValue(call.input);
+  const { t } = useTranslation();
 
   return (
     <details className={`stream-tool-invocation${hasError ? " error" : ""}`}>
       <summary>
         <span className="stream-step-icon">⌁</span>
-        <span className="stream-tool-summary-main">{toolGroupLabel(call)}</span>
+        <span className="stream-tool-summary-main">{toolGroupLabel(call, t)}</span>
         {(visibleResults.length > 0 || visibleCommands.length > 0) && (
           <span className="stream-tool-summary-meta">
             {visibleResults.some((result) => hasVisibleContent(result.content)) ||
             visibleCommands.length > 0
-              ? "result"
-              : "done"}
+              ? t("stream.summaryResult")
+              : t("stream.summaryDone")}
           </span>
         )}
       </summary>
       <div className="stream-tool-body">
         {input && (
           <div className="stream-tool-section">
-            <span className="stream-label">Input</span>
+            <span className="stream-label">{t("stream.input")}</span>
             <pre>{input}</pre>
           </div>
         )}
         {visibleCommands.map((command, index) => (
           <div className="stream-tool-section" key={`command-${index}`}>
-            <span className="stream-label">Command</span>
+            <span className="stream-label">{t("stream.command")}</span>
             <pre>{command.command}</pre>
             {command.cwd && <div className="stream-tool-empty">{command.cwd}</div>}
           </div>
@@ -368,13 +381,13 @@ export function StreamToolInvocation({
         {visibleResults.map((result, index) => (
           <div className="stream-tool-section" key={`${result.id ?? "result"}-${index}`}>
             <span className="stream-label">
-              {result.tool} 结果
-              {result.isError ? " error" : ""}
+              {t("stream.result", { tool: result.tool })}
+              {result.isError ? ` ${t("stream.errorTag")}` : ""}
             </span>
             {hasVisibleContent(result.content) ? (
               <pre>{result.content}</pre>
             ) : (
-              <div className="stream-tool-empty">No output</div>
+              <div className="stream-tool-empty">{t("stream.noOutput")}</div>
             )}
           </div>
         ))}
@@ -384,6 +397,7 @@ export function StreamToolInvocation({
 }
 
 export function StreamItem({ item }: { item: CliStreamItem }) {
+  const { t } = useTranslation();
   switch (item.kind) {
     case "text":
       return (
@@ -394,7 +408,7 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
     case "thinking":
       return (
         <details className="stream-thinking">
-          <summary>思考过程</summary>
+          <summary>{t("stream.thinking")}</summary>
           <MarkdownText content={item.content} />
         </details>
       );
@@ -402,7 +416,7 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
       return (
         <div className="stream-step stream-tool-call">
           <span className="stream-step-icon">⌁</span>
-          <span>{toolActionLabel(item)}</span>
+          <span>{toolActionLabel(item, t)}</span>
         </div>
       );
     case "tool-result":
@@ -410,8 +424,8 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
         return (
           <div className={`stream-step stream-tool-result-empty${item.isError ? " error" : ""}`}>
             <span className="stream-step-icon">↳</span>
-            <span className="stream-label">{item.tool} 结果</span>
-            {item.isError && <span className="stream-error-suffix">error</span>}
+            <span className="stream-label">{t("stream.result", { tool: item.tool })}</span>
+            {item.isError && <span className="stream-error-suffix">{t("stream.errorTag")}</span>}
           </div>
         );
       }
@@ -419,9 +433,9 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
         <details className={`stream-tool-result${item.isError ? " error" : ""}`}>
           <summary>
             <span className="stream-label stream-summary-label">
-              {item.tool} 结果
+              {t("stream.result", { tool: item.tool })}
             </span>
-            {item.isError && <span className="stream-error-suffix">error</span>}
+            {item.isError && <span className="stream-error-suffix">{t("stream.errorTag")}</span>}
           </summary>
           <pre>{item.content}</pre>
         </details>
@@ -429,7 +443,7 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
     case "command":
       return (
         <div className="stream-command">
-          <span className="stream-label">⟩ Terminal</span>
+          <span className="stream-label">{t("stream.terminal")}</span>
           <code>{item.command}</code>
           {item.cwd && <span className="cwd">{item.cwd}</span>}
         </div>
@@ -450,7 +464,7 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
     case "session":
       return (
         <div className="stream-meta session-meta">
-          <span className="stream-label">Session</span>{" "}
+          <span className="stream-label">{t("stream.sessionLabel")}</span>{" "}
           <code>{item.sessionId}</code>
           {item.title ? ` — ${item.title}` : ""}
         </div>
@@ -458,19 +472,19 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
     case "usage": {
       const hasContext =
         item.contextUsed != null || item.contextSize != null;
+      const used = item.contextUsed != null ? formatTokens(item.contextUsed) : "–";
+      const total = item.contextSize != null ? ` / ${formatTokens(item.contextSize)}` : "";
       return (
         <div className="stream-meta">
-          <span className="stream-label">Usage</span>
+          <span className="stream-label">{t("stream.usageLabel")}</span>
           {hasContext ? (
-            <span>
-              ctx: {item.contextUsed != null ? formatTokens(item.contextUsed) : "–"}
-              {item.contextSize != null
-                ? ` / ${formatTokens(item.contextSize)}`
-                : ""}
-            </span>
+            <span>{t("stream.contextUsage", { used, total })}</span>
           ) : (
             <span>
-              in: {item.inputTokens ?? "–"} · out: {item.outputTokens ?? "–"}
+              {t("stream.tokenUsage", {
+                input: item.inputTokens ?? "–",
+                output: item.outputTokens ?? "–"
+              })}
             </span>
           )}
           {item.costAmount != null && (
@@ -486,11 +500,11 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
       return (
         <div className="stream-error">
           <div>
-            <span className="stream-label">Error</span> {item.message}
+            <span className="stream-label">{t("stream.errorLabel")}</span> {item.message}
           </div>
           {item.details?.length ? (
             <details className="stream-error-details">
-              <summary>查看原始日志 ({item.details.length})</summary>
+              <summary>{t("stream.viewRawLog", { count: item.details.length })}</summary>
               <pre>{item.details.join("\n")}</pre>
             </details>
           ) : null}
@@ -500,9 +514,11 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
       return (
         <div className={`stream-meta done${item.exitCode && item.exitCode !== 0 ? " failed" : ""}`}>
           <span className="stream-label">
-            {item.exitCode && item.exitCode !== 0 ? "Exit" : "✓ Done"}
+            {item.exitCode && item.exitCode !== 0 ? t("stream.exitLabel") : t("stream.doneOk")}
           </span>
-          {item.exitCode != null && <span> (exit {item.exitCode})</span>}
+          {item.exitCode != null && (
+            <span> {t("stream.exitCode", { code: item.exitCode })}</span>
+          )}
         </div>
       );
     case "raw":

--- a/src/components/CLI/WorkspacePanel.tsx
+++ b/src/components/CLI/WorkspacePanel.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from "react";
 
+import { useTranslation } from "react-i18next";
+
 import { displayAgentName } from "@/config/agentDisplay";
 import { useConversationStore } from "@/store/conversationStore";
 import { AgentAvatar } from "./AgentAvatar";
@@ -9,6 +11,7 @@ export function WorkspacePanel({
 }: {
   runningCount: number;
 }) {
+  const { t } = useTranslation();
   const activeId = useConversationStore((s) => s.activeId);
   const conversations = useConversationStore((s) => s.conversations);
   const messagesMap = useConversationStore((s) => s.messages);
@@ -77,11 +80,11 @@ export function WorkspacePanel({
   }, [messages]);
 
   return (
-    <aside className="details-panel workspace-panel" aria-label="Workspace panel">
+    <aside className="details-panel workspace-panel" aria-label={t("workspace.panelAria")}>
       <section className="side-card active-agent-card">
         <div className="side-card-header">
-          <span>Active Agent</span>
-          <strong>{status}</strong>
+          <span>{t("workspace.activeAgent")}</span>
+          <strong>{t(`status.${status}`)}</strong>
         </div>
         <div className="agent-lockup">
           <AgentAvatar
@@ -94,30 +97,38 @@ export function WorkspacePanel({
             }
           />
           <div>
-            <strong>{active ? activeAgentName : "No conversation"}</strong>
-            <small>{active ? "Local coding agent" : "Create a conversation to begin"}</small>
+            <strong>{active ? activeAgentName : t("workspace.noConversation")}</strong>
+            <small>{active ? t("workspace.localAgent") : t("workspace.createToBegin")}</small>
           </div>
         </div>
       </section>
 
       <section className="side-card">
         <div className="side-card-header">
-          <span>Run State</span>
-          <strong>{runningCount > 0 ? `${runningCount} live` : "idle"}</strong>
+          <span>{t("workspace.runState")}</span>
+          <strong>
+            {runningCount > 0
+              ? t("workspace.liveCount", { count: runningCount })
+              : t("status.idle")}
+          </strong>
         </div>
         <dl className="compact-dl">
           <div>
-            <dt>Workspace</dt>
-            <dd>{active?.cwd ? shortPath(active.cwd) : "Not set"}</dd>
+            <dt>{t("workspace.workspace")}</dt>
+            <dd>{active?.cwd ? shortPath(active.cwd) : t("workspace.notSet")}</dd>
           </div>
           <div>
-            <dt>Session ID</dt>
+            <dt>{t("workspace.sessionId")}</dt>
             <dd>
               <button
                 className="session-id-copy"
                 type="button"
                 disabled={!latestSessionId}
-                title={latestSessionId ? `Copy ${latestSessionId}` : "No session captured yet"}
+                title={
+                  latestSessionId
+                    ? t("workspace.copySession", { id: latestSessionId })
+                    : t("workspace.noSession")
+                }
                 onClick={() => {
                   if (!latestSessionId) return;
                   void navigator.clipboard.writeText(latestSessionId);
@@ -126,24 +137,24 @@ export function WorkspacePanel({
                 }}
               >
                 {copiedSession
-                  ? "Copied"
+                  ? t("workspace.copied")
                   : latestSessionId
                     ? shortSessionId(latestSessionId)
-                    : "Not captured"}
+                    : t("workspace.notCaptured")}
               </button>
             </dd>
           </div>
           <div>
-            <dt>Messages</dt>
+            <dt>{t("workspace.messages")}</dt>
             <dd>{messages.length}</dd>
           </div>
           <div>
-            <dt>Agent turns</dt>
+            <dt>{t("workspace.agentTurns")}</dt>
             <dd>{assistantTurns}</dd>
           </div>
           {latestUsage?.contextUsed != null && (
             <div>
-              <dt>Context</dt>
+              <dt>{t("workspace.context")}</dt>
               <dd>
                 {formatTokens(latestUsage.contextUsed)}
                 {latestUsage.contextSize != null
@@ -154,7 +165,7 @@ export function WorkspacePanel({
           )}
           {latestUsage?.costAmount != null && (
             <div>
-              <dt>Cost</dt>
+              <dt>{t("workspace.cost")}</dt>
               <dd>{formatCost(latestUsage.costAmount, latestUsage.costCurrency)}</dd>
             </div>
           )}
@@ -163,10 +174,12 @@ export function WorkspacePanel({
             (latestUsage?.inputTokens != null ||
               latestUsage?.outputTokens != null) && (
               <div>
-                <dt>Tokens</dt>
+                <dt>{t("workspace.tokens")}</dt>
                 <dd>
-                  in {latestUsage.inputTokens ?? "–"} · out{" "}
-                  {latestUsage.outputTokens ?? "–"}
+                  {t("workspace.tokenBreakdown", {
+                    input: latestUsage.inputTokens ?? "–",
+                    output: latestUsage.outputTokens ?? "–"
+                  })}
                 </dd>
               </div>
             )}
@@ -175,28 +188,28 @@ export function WorkspacePanel({
 
       <section className="side-card run-queue-card">
         <div className="side-card-header">
-          <span>Execution Queue</span>
-          <strong>{status}</strong>
+          <span>{t("workspace.executionQueue")}</span>
+          <strong>{t(`status.${status}`)}</strong>
         </div>
         <article className="queue-row">
           <span className={`queue-icon ${live ? "running" : ""}`} />
           <div>
-            <strong>{live ? "CLI response stream" : "Waiting for prompt"}</strong>
-            <p>{live?.pid ? `pid ${live.pid}` : "Send a message to start a run"}</p>
+            <strong>{live ? t("workspace.cliStream") : t("workspace.waitingPrompt")}</strong>
+            <p>{live?.pid ? t("workspace.pid", { pid: live.pid }) : t("workspace.sendToStart")}</p>
           </div>
         </article>
         <article className="queue-row">
           <span className="queue-icon" />
           <div>
-            <strong>Tool session</strong>
-            <p>{live?.resumedFromSessionId ? "resumed context" : "fresh or saved context"}</p>
+            <strong>{t("workspace.toolSession")}</strong>
+            <p>{live?.resumedFromSessionId ? t("workspace.resumedContext") : t("workspace.freshContext")}</p>
           </div>
         </article>
         <article className="queue-row">
           <span className="queue-icon" />
           <div>
-            <strong>Message snapshot</strong>
-            <p>{messages.length ? "persisted locally" : "no history yet"}</p>
+            <strong>{t("workspace.messageSnapshot")}</strong>
+            <p>{messages.length ? t("workspace.persistedLocally") : t("workspace.noHistory")}</p>
           </div>
         </article>
       </section>

--- a/src/components/Settings/AvatarPicker.tsx
+++ b/src/components/Settings/AvatarPicker.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { toc, type IconToc } from "@lobehub/icons";
 
 import { getAgentIconId } from "@/config/agentIcon";
@@ -10,11 +11,11 @@ import {
 
 type IconGroup = IconToc["group"] | "all";
 
-const GROUPS: { value: IconGroup; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "model", label: "Models" },
-  { value: "provider", label: "Providers" },
-  { value: "application", label: "Apps" }
+const GROUPS: { value: IconGroup; key: string }[] = [
+  { value: "all", key: "all" },
+  { value: "model", key: "models" },
+  { value: "provider", key: "providers" },
+  { value: "application", key: "apps" }
 ];
 
 function matches(item: IconToc, query: string): boolean {
@@ -38,6 +39,7 @@ export function AvatarPicker({
   defaultAdapter,
   defaultLabel
 }: AvatarPickerProps) {
+  const { t } = useTranslation();
   const [query, setQuery] = useState("");
   const [group, setGroup] = useState<IconGroup>("all");
 
@@ -58,7 +60,7 @@ export function AvatarPicker({
       <div className="avatar-picker-controls">
         <input
           className="avatar-picker-search"
-          placeholder="Search icons (DeepSeek, Qwen, Cursor…)"
+          placeholder={t("settings.cli.searchPlaceholder")}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
@@ -70,7 +72,7 @@ export function AvatarPicker({
               className={`avatar-picker-group${group === g.value ? " active" : ""}`}
               onClick={() => setGroup(g.value)}
             >
-              {g.label}
+              {t(`settings.avatar.groups.${g.key}`)}
             </button>
           ))}
         </div>
@@ -80,13 +82,13 @@ export function AvatarPicker({
         <button
           type="button"
           className={`avatar-picker-tile${value === "" ? " selected" : ""}`}
-          title="Use default"
+          title={t("settings.cli.useDefault")}
           onClick={() => onChange("")}
         >
           {defaultIconId ? (
             <img
               src={lobehubAvatarUrl(defaultIconId)}
-              alt="Default"
+              alt={t("settings.avatar.defaultAlt")}
               loading="lazy"
               className="avatar-picker-img"
             />
@@ -113,11 +115,11 @@ export function AvatarPicker({
           </button>
         ))}
         {filtered.length === 0 && (
-          <div className="avatar-picker-empty">No matching icons.</div>
+          <div className="avatar-picker-empty">{t("settings.cli.noIcons")}</div>
         )}
       </div>
       <div className="avatar-picker-source">
-        Icons from{" "}
+        {t("settings.cli.iconsFrom")}{" "}
         <a href="https://lobehub.com/icons" target="_blank" rel="noreferrer">
           LobeHub Icons
         </a>

--- a/src/components/Settings/CLIAdaptersTab.tsx
+++ b/src/components/Settings/CLIAdaptersTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useCliExecutorStore, type ResolvedExecutor } from "@/store/cliExecutorStore";
 import { cliClient } from "@/services/cli/client";
@@ -32,6 +33,7 @@ function withModelArg(args: string[], model: string): string[] {
 }
 
 export function CLIAdaptersTab() {
+  const { t } = useTranslation();
   const loaded = useCliExecutorStore((s) => s.loaded);
   const load = useCliExecutorStore((s) => s.load);
   const adapters = useCliExecutorStore((s) => s.adapters);
@@ -61,9 +63,9 @@ export function CLIAdaptersTab() {
     return (
       <div className="settings-tab">
         <div className="settings-section-heading">
-          <h3 className="settings-section-title">Cli Agents</h3>
+          <h3 className="settings-section-title">{t("settings.cli.title")}</h3>
           <span className="settings-section-desc">
-            Agent management is unavailable. Run the desktop app to manage local agents.
+            {t("settings.cli.unavailable")}
           </span>
         </div>
       </div>
@@ -73,9 +75,9 @@ export function CLIAdaptersTab() {
   return (
     <div className="settings-tab">
       <div className="settings-section-heading">
-        <h3 className="settings-section-title">Cli Agents</h3>
+        <h3 className="settings-section-title">{t("settings.cli.title")}</h3>
         <span className="settings-section-desc">
-          Configure the local cli agents available in FreeBuddy.
+          {t("settings.cli.description")}
         </span>
       </div>
 
@@ -92,7 +94,7 @@ export function CLIAdaptersTab() {
               try {
                 const r = await cliClient.install(ex.installHint);
                 if (!r.success) {
-                  alert(`Install failed (exit ${r.exitCode}):\n${r.stderr || r.stdout}`);
+                  alert(t("settings.cli.installFailed", { code: r.exitCode, output: r.stderr || r.stdout }));
                 } else {
                   await check(ex.id);
                 }
@@ -128,6 +130,7 @@ function AdapterRow({
   onInstall: () => void;
   installing: boolean;
 }) {
+  const { t } = useTranslation();
   const rt = ex.runtime;
   const parsedExtraArgs = extractModelArg(ex.extraArgs);
   const model = parsedExtraArgs.model;
@@ -145,28 +148,28 @@ function AdapterRow({
         <div className="adapter-row-meta">
           {rt?.installed ? (
             <span className="adapter-status ok">
-              ✓ installed {rt.version ? `(${rt.version})` : ""}
+              {t("settings.cli.installed")} {rt.version ? `(${rt.version})` : ""}
             </span>
           ) : rt ? (
-            <span className="adapter-status warn">not installed</span>
+            <span className="adapter-status warn">{t("settings.cli.notInstalled")}</span>
           ) : (
-            <span className="adapter-status muted">not checked</span>
+            <span className="adapter-status muted">{t("settings.cli.notChecked")}</span>
           )}
           {model && (
             <span className="muted">
-              model: <code>{model}</code>
+              {t("settings.cli.modelLabel")}: <code>{model}</code>
             </span>
           )}
         </div>
       </div>
       <div className="adapter-row-actions">
-        <button onClick={onCheck}>Check</button>
+        <button onClick={onCheck}>{t("common.check")}</button>
         {!rt?.installed && ex.installHint && (
           <button onClick={onInstall} disabled={installing}>
-            {installing ? "Installing…" : "Install"}
+            {installing ? t("common.installing") : t("common.install")}
           </button>
         )}
-        <button onClick={onEdit}>Edit</button>
+        <button onClick={onEdit}>{t("common.edit")}</button>
       </div>
     </div>
   );
@@ -179,6 +182,7 @@ function EditOverrideDialog({
   executorId: string;
   onClose: () => void;
 }) {
+  const { t } = useTranslation();
   const resolve = useCliExecutorStore((s) => s.resolve);
   const override = useCliExecutorStore((s) => s.overrides[executorId]);
   const ex = resolve(executorId);
@@ -243,14 +247,14 @@ function EditOverrideDialog({
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <header className="modal-header">
-          <h2>Edit {ex.label}</h2>
-          <button className="icon-btn" onClick={onClose} aria-label="Close">
+          <h2>{t("settings.cli.editTitle", { label: ex.label })}</h2>
+          <button className="icon-btn" onClick={onClose} aria-label={t("common.close")}>
             ✕
           </button>
         </header>
 
         <div className="icon-picker-field">
-          <span className="icon-picker-label">Avatar</span>
+          <span className="icon-picker-label">{t("settings.cli.avatar")}</span>
           <AvatarPicker
             value={icon}
             onChange={setIcon}
@@ -260,25 +264,25 @@ function EditOverrideDialog({
         </div>
 
         <label>
-          Command override
+          {t("settings.cli.commandOverride")}
           <input
             value={binary}
-            placeholder="Use default"
+            placeholder={t("settings.cli.useDefault")}
             onChange={(e) => setBinary(e.target.value)}
           />
         </label>
 
         <label>
-          Model
+          {t("settings.cli.model")}
           <input
             value={model}
-            placeholder="Use agent default"
+            placeholder={t("settings.cli.useAgentDefault")}
             onChange={(e) => setModel(e.target.value)}
           />
         </label>
 
         <label>
-          Extra args (one per line)
+          {t("settings.cli.extraArgs")}
           <textarea
             rows={4}
             value={extraArgs}
@@ -287,7 +291,7 @@ function EditOverrideDialog({
         </label>
 
         <label>
-          Environment (KEY=value per line)
+          {t("settings.cli.environment")}
           <textarea
             rows={4}
             value={envText}
@@ -297,18 +301,18 @@ function EditOverrideDialog({
 
         {ex.docsUrl && (
           <p className="muted">
-            Docs:{" "}
+            {t("settings.cli.docs")}{" "}
             <a href={ex.docsUrl} target="_blank" rel="noreferrer">
-              Setup guide
+              {t("settings.cli.setupGuide")}
             </a>
           </p>
         )}
 
         <div className="modal-actions">
-          <button onClick={onReset}>Reset</button>
-          <button onClick={onClose}>Cancel</button>
+          <button onClick={onReset}>{t("common.reset")}</button>
+          <button onClick={onClose}>{t("common.cancel")}</button>
           <button className="primary" onClick={onSave}>
-            Save
+            {t("common.save")}
           </button>
         </div>
       </div>

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from "react-i18next";
+import { useSettingsStore } from "@/store/settingsStore";
+import { SUPPORTED_LOCALES, type AppLocale } from "@/utils/detectLocale";
+
+const LABEL_KEY: Record<AppLocale, string> = {
+  en: "general.languageEn",
+  "zh-CN": "general.languageZhCN"
+};
+
+export function GeneralTab() {
+  const { t } = useTranslation();
+  const language = useSettingsStore((s) => s.language);
+  const setLanguage = useSettingsStore((s) => s.setLanguage);
+
+  return (
+    <section className="settings-section">
+      <h3>{t("general.languageLabel")}</h3>
+      <select
+        value={language}
+        onChange={(e) => void setLanguage(e.target.value as AppLocale)}
+      >
+        {SUPPORTED_LOCALES.map((lng) => (
+          <option key={lng} value={lng}>
+            {t(LABEL_KEY[lng])}
+          </option>
+        ))}
+      </select>
+    </section>
+  );
+}

--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -1,16 +1,20 @@
+import { useTranslation } from "react-i18next";
 import { CLIAdaptersTab } from "./CLIAdaptersTab";
+import { GeneralTab } from "./GeneralTab";
 
 export function SettingsModal({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
   return (
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal modal-wide" onClick={(e) => e.stopPropagation()}>
         <header className="modal-header">
-          <h2>Settings</h2>
-          <button className="icon-btn" onClick={onClose} aria-label="Close">
+          <h2>{t("common.settings")}</h2>
+          <button className="icon-btn" onClick={onClose} aria-label={t("common.close")}>
             ✕
           </button>
         </header>
         <div className="settings-body">
+          <GeneralTab />
           <CLIAdaptersTab />
         </div>
       </div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,21 @@
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "@/locales/en.json";
+import zhCN from "@/locales/zh-CN.json";
+import { detectLocale } from "@/utils/detectLocale";
+
+const initial = detectLocale(
+  typeof navigator !== "undefined" ? navigator.language : undefined
+);
+
+void i18next.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    "zh-CN": { translation: zhCN }
+  },
+  lng: initial,
+  fallbackLng: "en",
+  interpolation: { escapeValue: false }
+});
+
+export default i18next;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,8 +9,7 @@
     "edit": "Edit",
     "check": "Check",
     "install": "Install",
-    "installing": "Installing…",
-    "search": "Search"
+    "installing": "Installing…"
   },
   "status": {
     "running": "Running",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -160,7 +160,11 @@
     "agentNotInstalled": "{{agent}} is not installed. Open Settings → Cli Agents to install.",
     "checkFailed": "Check failed: {{err}}",
     "taskFailed": "Task failed: {{err}}",
-    "sendFailed": "Send failed: {{err}}"
+    "sendFailed": "Send failed: {{err}}",
+    "agentInterrupted": "Agent run interrupted.",
+    "agentFailed": "Agent run failed with exit code {{code}}.{{detail}}",
+    "rawLogCollapsed": "Raw CLI log collapsed for easier debugging.",
+    "cliNoStructured": "The CLI returned no parseable structured content."
   },
   "attachments": {
     "review": "Please review these attachments.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,5 +35,73 @@
     "new": "+ New",
     "empty": "No conversations yet.",
     "deleteConfirm": "Delete \"{{title}}\"?"
+  },
+  "chat": {
+    "inputPlaceholder": "Type freely",
+    "attachFile": "Attach file",
+    "permission": "Permission",
+    "approvalAuto": "Auto",
+    "approvalAsk": "Ask each time",
+    "enterHint": "Enter to send · Shift+Enter for newline",
+    "agentRunning": "Agent is running…",
+    "send": "Send",
+    "stop": "Stop",
+    "selectCwd": "Select working directory",
+    "cwdPlaceholder": "/absolute/path (optional; defaults to the default working directory)",
+    "heroTitle": "Local CLI Agent Workspace",
+    "newAgentChat": "New Agent Chat",
+    "attach": "Attach",
+    "workspace": "Workspace",
+    "noWorkspace": "No workspace selected",
+    "emptyHeroHeading": "What should {{name}} work on?",
+    "emptyHeroBody": "Use this thread for coding tasks, project inspection, and focused fixes.",
+    "heroSubtitle": "Pick a local agent, give it a working directory, then start coding, inspecting, or reshaping the project.",
+    "startTask": "Start task",
+    "agent": "Agent",
+    "stopAria": "Stop running",
+    "startingAria": "Starting",
+    "sendAria": "Send message",
+    "permissionHint": "Permission mode for tool execution",
+    "defaultAttachmentTitle": "Attachment",
+    "pendingAttachmentsAria": "Pending attachments",
+    "removeAttachmentAria": "Remove {{name}}",
+    "newTaskAria": "New task",
+    "commonTasksAria": "Common tasks",
+    "starter": {
+      "one": "Analyze the current project structure and suggest next steps",
+      "two": "Check recent changes for UI/UX issues",
+      "three": "Implement a small feature and explain how to verify it"
+    },
+    "newTaskPrompts": {
+      "analyze": {
+        "label": "Analyze project",
+        "prompt": "Analyze the current project structure and tell me what I can do first"
+      },
+      "modify": {
+        "label": "Edit code",
+        "prompt": "Modify code based on my needs and provide verification steps"
+      },
+      "review": {
+        "label": "Code review",
+        "prompt": "Review the risks, issues, and improvements in the current changes"
+      }
+    }
+  },
+  "errors": {
+    "attachmentLimit": "Add at most {{count}} attachments per message.",
+    "attachmentTooLarge": "{{name}} exceeds the 50 MB attachment size limit.",
+    "attachmentType": "{{name}} is not a supported attachment type.",
+    "attachmentDesktopOnly": "Attachments require the Electron desktop app.",
+    "attachmentSelectFailed": "Failed to select attachments: {{err}}",
+    "cliBridgeUnavailable": "FreeBuddy CLI bridge is unavailable. Please run the Electron desktop app.",
+    "agentNotInstalled": "{{agent}} is not installed. Open Settings → Cli Agents to install.",
+    "checkFailed": "Check failed: {{err}}",
+    "taskFailed": "Task failed: {{err}}",
+    "sendFailed": "Send failed: {{err}}"
+  },
+  "attachments": {
+    "review": "Please review these attachments.",
+    "userMessage": "User message:",
+    "attached": "Attachments:"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,27 @@
+{
+  "common": {
+    "cancel": "Cancel",
+    "close": "Close",
+    "settings": "Settings",
+    "delete": "Delete",
+    "save": "Save",
+    "reset": "Reset",
+    "edit": "Edit",
+    "check": "Check",
+    "install": "Install",
+    "installing": "Installing…",
+    "search": "Search"
+  },
+  "status": {
+    "running": "Running",
+    "starting": "Starting",
+    "done": "Done",
+    "failed": "Failed",
+    "killed": "Killed"
+  },
+  "general": {
+    "languageLabel": "Language",
+    "languageEn": "English",
+    "languageZhCN": "简体中文"
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,10 @@
     "starting": "Starting",
     "done": "Done",
     "failed": "Failed",
-    "killed": "Killed"
+    "killed": "Killed",
+    "idle": "Idle",
+    "ready": "Ready",
+    "sent": "Sent"
   },
   "general": {
     "languageLabel": "Language",
@@ -87,6 +90,66 @@
       }
     }
   },
+  "workspace": {
+    "panelAria": "Workspace panel",
+    "activeAgent": "Active Agent",
+    "runState": "Run State",
+    "workspace": "Workspace",
+    "notSet": "Not set",
+    "sessionId": "Session ID",
+    "copySession": "Copy {{id}}",
+    "noSession": "No session captured yet",
+    "copied": "Copied",
+    "notCaptured": "Not captured",
+    "messages": "Messages",
+    "agentTurns": "Agent turns",
+    "context": "Context",
+    "cost": "Cost",
+    "tokens": "Tokens",
+    "tokenBreakdown": "in {{input}} · out {{output}}",
+    "liveCount": "{{count}} live",
+    "executionQueue": "Execution Queue",
+    "cliStream": "CLI response stream",
+    "waitingPrompt": "Waiting for prompt",
+    "pid": "pid {{pid}}",
+    "sendToStart": "Send a message to start a run",
+    "toolSession": "Tool session",
+    "resumedContext": "resumed context",
+    "freshContext": "fresh or saved context",
+    "messageSnapshot": "Message snapshot",
+    "persistedLocally": "persisted locally",
+    "noHistory": "no history yet",
+    "noConversation": "No conversation",
+    "localAgent": "Local coding agent",
+    "createToBegin": "Create a conversation to begin"
+  },
+  "message": {
+    "you": "You",
+    "thinking": "Thinking"
+  },
+  "stream": {
+    "read": "Read {{target}}",
+    "edit": "Edit {{target}}",
+    "exec": "Execute {{target}}",
+    "result": "{{tool}} result",
+    "thinking": "Thinking process",
+    "viewRawLog": "View raw log ({{count}})",
+    "summaryResult": "result",
+    "summaryDone": "done",
+    "input": "Input",
+    "command": "Command",
+    "noOutput": "No output",
+    "errorTag": "error",
+    "terminal": "⟩ Terminal",
+    "sessionLabel": "Session",
+    "usageLabel": "Usage",
+    "contextUsage": "ctx: {{used}}{{total}}",
+    "tokenUsage": "in: {{input}} · out: {{output}}",
+    "errorLabel": "Error",
+    "exitLabel": "Exit",
+    "doneOk": "✓ Done",
+    "exitCode": "(exit {{code}})"
+  },
   "errors": {
     "attachmentLimit": "Add at most {{count}} attachments per message.",
     "attachmentTooLarge": "{{name}} exceeds the 50 MB attachment size limit.",
@@ -102,6 +165,13 @@
   "attachments": {
     "review": "Please review these attachments.",
     "userMessage": "User message:",
-    "attached": "Attachments:"
+    "attached": "Attachments:",
+    "imagesAria": "Message image attachments",
+    "listAria": "Message attachments",
+    "previewName": "Preview {{name}}",
+    "previewImage": "Preview image",
+    "kindImage": "IMG",
+    "kindCode": "CODE",
+    "kindFile": "FILE"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -185,5 +185,39 @@
   "lightbox": {
     "preview": "Image preview",
     "close": "Close preview"
+  },
+  "settings": {
+    "cli": {
+      "title": "Cli Agents",
+      "description": "Configure the local cli agents available in FreeBuddy.",
+      "commandOverride": "Command override",
+      "model": "Model",
+      "extraArgs": "Extra args (one per line)",
+      "environment": "Environment (KEY=value per line)",
+      "docs": "Docs:",
+      "setupGuide": "Setup guide",
+      "useDefault": "Use default",
+      "useAgentDefault": "Use agent default",
+      "avatar": "Avatar",
+      "searchPlaceholder": "Search icons (DeepSeek, Qwen, Cursor…)",
+      "noIcons": "No matching icons.",
+      "iconsFrom": "Icons from",
+      "installFailed": "Install failed (exit {{code}}):\n{{output}}",
+      "editTitle": "Edit {{label}}",
+      "unavailable": "Agent management is unavailable. Run the desktop app to manage local agents.",
+      "installed": "✓ installed",
+      "notInstalled": "not installed",
+      "notChecked": "not checked",
+      "modelLabel": "model"
+    },
+    "avatar": {
+      "groups": {
+        "all": "All",
+        "models": "Models",
+        "providers": "Providers",
+        "apps": "Apps"
+      },
+      "defaultAlt": "Default"
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -173,5 +173,17 @@
     "kindImage": "IMG",
     "kindCode": "CODE",
     "kindFile": "FILE"
+  },
+  "permission": {
+    "title": "Permission required",
+    "fallbackTitle": "Tool execution permission",
+    "input": "Input",
+    "help": "The agent is asking for permission to run the action above. Choose how to respond — you can allow once, allow always, or reject.",
+    "morePending_one": "+{{count}} more pending request",
+    "morePending_other": "+{{count}} more pending requests"
+  },
+  "lightbox": {
+    "preview": "Image preview",
+    "close": "Close preview"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,5 +23,17 @@
     "languageLabel": "Language",
     "languageEn": "English",
     "languageZhCN": "简体中文"
+  },
+  "app": { "brand": "FreeBuddy", "chat": "Chat" },
+  "sidebar": {
+    "expand": "Expand sidebar",
+    "collapse": "Collapse sidebar",
+    "toggleTheme": "Toggle theme"
+  },
+  "conversations": {
+    "title": "Conversations",
+    "new": "+ New",
+    "empty": "No conversations yet.",
+    "deleteConfirm": "Delete \"{{title}}\"?"
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -9,8 +9,7 @@
     "edit": "编辑",
     "check": "检查",
     "install": "安装",
-    "installing": "安装中…",
-    "search": "搜索"
+    "installing": "安装中…"
   },
   "status": {
     "running": "运行中",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -23,5 +23,17 @@
     "languageLabel": "语言",
     "languageEn": "English",
     "languageZhCN": "简体中文"
+  },
+  "app": { "brand": "FreeBuddy", "chat": "聊天" },
+  "sidebar": {
+    "expand": "展开侧边栏",
+    "collapse": "收起侧边栏",
+    "toggleTheme": "切换主题"
+  },
+  "conversations": {
+    "title": "会话",
+    "new": "+ 新建",
+    "empty": "暂无会话。",
+    "deleteConfirm": "删除“{{title}}”?"
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -160,7 +160,11 @@
     "agentNotInstalled": "{{agent}} 未安装。请在“设置 → Cli Agents”中安装。",
     "checkFailed": "检查失败：{{err}}",
     "taskFailed": "任务失败：{{err}}",
-    "sendFailed": "发送失败：{{err}}"
+    "sendFailed": "发送失败：{{err}}",
+    "agentInterrupted": "Agent 运行已中断。",
+    "agentFailed": "Agent 运行失败，退出码 {{code}}。{{detail}}",
+    "rawLogCollapsed": "已收起原始 CLI 日志，方便排查。",
+    "cliNoStructured": "CLI 没有返回可解析的结构化内容。"
   },
   "attachments": {
     "review": "请查看这些附件。",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -35,5 +35,73 @@
     "new": "+ 新建",
     "empty": "暂无会话。",
     "deleteConfirm": "删除“{{title}}”?"
+  },
+  "chat": {
+    "inputPlaceholder": "随心输入",
+    "attachFile": "添加附件",
+    "permission": "权限",
+    "approvalAuto": "自动",
+    "approvalAsk": "每次询问",
+    "enterHint": "Enter 发送 · Shift+Enter 换行",
+    "agentRunning": "Agent 正在运行…",
+    "send": "发送",
+    "stop": "停止",
+    "selectCwd": "选择工作目录",
+    "cwdPlaceholder": "/absolute/path，可选；不填则使用默认运行目录",
+    "heroTitle": "本地 CLI Agent 工作台",
+    "newAgentChat": "新建 Agent 对话",
+    "attach": "添加",
+    "workspace": "工作目录",
+    "noWorkspace": "未选择工作目录",
+    "emptyHeroHeading": "{{name}} 可以做些什么？",
+    "emptyHeroBody": "用这个会话来编码、检查项目或聚焦修复问题。",
+    "heroSubtitle": "选择一个本地 agent，给它一个工作目录，然后开始编码、检查或改造项目。",
+    "startTask": "开始任务",
+    "agent": "Agent",
+    "stopAria": "停止运行",
+    "startingAria": "正在启动",
+    "sendAria": "发送消息",
+    "permissionHint": "工具执行的权限模式",
+    "defaultAttachmentTitle": "附件",
+    "pendingAttachmentsAria": "待发送附件",
+    "removeAttachmentAria": "移除 {{name}}",
+    "newTaskAria": "新建任务",
+    "commonTasksAria": "常用任务",
+    "starter": {
+      "one": "先分析当前项目结构，给我下一步实现建议",
+      "two": "检查刚才的改动有没有 UI/UX 问题",
+      "three": "帮我实现一个小功能，并说明验证步骤"
+    },
+    "newTaskPrompts": {
+      "analyze": {
+        "label": "分析项目",
+        "prompt": "先分析当前项目结构，告诉我可以先做什么"
+      },
+      "modify": {
+        "label": "修改代码",
+        "prompt": "根据我的需求修改代码，并给出验证步骤"
+      },
+      "review": {
+        "label": "代码审查",
+        "prompt": "检查当前改动的风险、问题和可改进点"
+      }
+    }
+  },
+  "errors": {
+    "attachmentLimit": "每条消息最多添加 {{count}} 个附件。",
+    "attachmentTooLarge": "{{name}} 超过 50 MB 附件大小限制。",
+    "attachmentType": "{{name}} 不是支持的附件类型。",
+    "attachmentDesktopOnly": "附件功能需要在 Electron 桌面端使用。",
+    "attachmentSelectFailed": "选择附件失败：{{err}}",
+    "cliBridgeUnavailable": "FreeBuddy CLI 桥接不可用。请在 Electron 桌面端运行。",
+    "agentNotInstalled": "{{agent}} 未安装。请在“设置 → Cli Agents”中安装。",
+    "checkFailed": "检查失败：{{err}}",
+    "taskFailed": "任务失败：{{err}}",
+    "sendFailed": "发送失败：{{err}}"
+  },
+  "attachments": {
+    "review": "请查看这些附件。",
+    "userMessage": "用户消息：",
+    "attached": "附件："
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -173,5 +173,16 @@
     "kindImage": "图片",
     "kindCode": "代码",
     "kindFile": "文件"
+  },
+  "permission": {
+    "title": "需要权限",
+    "fallbackTitle": "工具执行权限",
+    "input": "输入",
+    "help": "Agent 正在请求执行上述操作。请选择处理方式 —— 可允许一次、始终允许或拒绝。",
+    "morePending_other": "还有 {{count}} 个待处理请求"
+  },
+  "lightbox": {
+    "preview": "图片预览",
+    "close": "关闭预览"
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -184,5 +184,39 @@
   "lightbox": {
     "preview": "图片预览",
     "close": "关闭预览"
+  },
+  "settings": {
+    "cli": {
+      "title": "Cli Agents",
+      "description": "配置 FreeBuddy 中可用的本地 CLI Agent。",
+      "commandOverride": "命令覆盖",
+      "model": "模型",
+      "extraArgs": "附加参数（每行一个）",
+      "environment": "环境变量（每行 KEY=value）",
+      "docs": "文档：",
+      "setupGuide": "安装指南",
+      "useDefault": "使用默认",
+      "useAgentDefault": "使用 Agent 默认",
+      "avatar": "头像",
+      "searchPlaceholder": "搜索图标（DeepSeek、Qwen、Cursor…）",
+      "noIcons": "没有匹配的图标。",
+      "iconsFrom": "图标来自",
+      "installFailed": "安装失败（退出码 {{code}}）：\n{{output}}",
+      "editTitle": "编辑 {{label}}",
+      "unavailable": "Agent 管理不可用。请运行桌面端以管理本地 Agent。",
+      "installed": "✓ 已安装",
+      "notInstalled": "未安装",
+      "notChecked": "未检查",
+      "modelLabel": "模型"
+    },
+    "avatar": {
+      "groups": {
+        "all": "全部",
+        "models": "模型",
+        "providers": "提供商",
+        "apps": "应用"
+      },
+      "defaultAlt": "默认"
+    }
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1,0 +1,27 @@
+{
+  "common": {
+    "cancel": "取消",
+    "close": "关闭",
+    "settings": "设置",
+    "delete": "删除",
+    "save": "保存",
+    "reset": "重置",
+    "edit": "编辑",
+    "check": "检查",
+    "install": "安装",
+    "installing": "安装中…",
+    "search": "搜索"
+  },
+  "status": {
+    "running": "运行中",
+    "starting": "启动中",
+    "done": "已完成",
+    "failed": "已失败",
+    "killed": "已中断"
+  },
+  "general": {
+    "languageLabel": "语言",
+    "languageEn": "English",
+    "languageZhCN": "简体中文"
+  }
+}

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -17,7 +17,10 @@
     "starting": "启动中",
     "done": "已完成",
     "failed": "已失败",
-    "killed": "已中断"
+    "killed": "已中断",
+    "idle": "空闲",
+    "ready": "就绪",
+    "sent": "已发送"
   },
   "general": {
     "languageLabel": "语言",
@@ -87,6 +90,66 @@
       }
     }
   },
+  "workspace": {
+    "panelAria": "工作区面板",
+    "activeAgent": "当前 Agent",
+    "runState": "运行状态",
+    "workspace": "工作区",
+    "notSet": "未设置",
+    "sessionId": "会话 ID",
+    "copySession": "复制 {{id}}",
+    "noSession": "尚未捕获会话",
+    "copied": "已复制",
+    "notCaptured": "未捕获",
+    "messages": "消息数",
+    "agentTurns": "Agent 轮次",
+    "context": "上下文",
+    "cost": "成本",
+    "tokens": "Token",
+    "tokenBreakdown": "输入 {{input}} · 输出 {{output}}",
+    "liveCount": "{{count}} 活跃",
+    "executionQueue": "执行队列",
+    "cliStream": "CLI 响应流",
+    "waitingPrompt": "等待输入",
+    "pid": "pid {{pid}}",
+    "sendToStart": "发送消息以开始运行",
+    "toolSession": "工具会话",
+    "resumedContext": "已恢复上下文",
+    "freshContext": "全新或已保存上下文",
+    "messageSnapshot": "消息快照",
+    "persistedLocally": "已本地保存",
+    "noHistory": "暂无历史",
+    "noConversation": "无会话",
+    "localAgent": "本地编码 Agent",
+    "createToBegin": "创建会话以开始"
+  },
+  "message": {
+    "you": "你",
+    "thinking": "正在思考"
+  },
+  "stream": {
+    "read": "读取 {{target}}",
+    "edit": "修改 {{target}}",
+    "exec": "执行 {{target}}",
+    "result": "{{tool}} 结果",
+    "thinking": "思考过程",
+    "viewRawLog": "查看原始日志 ({{count}})",
+    "summaryResult": "结果",
+    "summaryDone": "完成",
+    "input": "输入",
+    "command": "命令",
+    "noOutput": "无输出",
+    "errorTag": "错误",
+    "terminal": "⟩ 终端",
+    "sessionLabel": "会话",
+    "usageLabel": "用量",
+    "contextUsage": "上下文: {{used}}{{total}}",
+    "tokenUsage": "输入: {{input}} · 输出: {{output}}",
+    "errorLabel": "错误",
+    "exitLabel": "退出",
+    "doneOk": "✓ 完成",
+    "exitCode": "(退出码 {{code}})"
+  },
   "errors": {
     "attachmentLimit": "每条消息最多添加 {{count}} 个附件。",
     "attachmentTooLarge": "{{name}} 超过 50 MB 附件大小限制。",
@@ -102,6 +165,13 @@
   "attachments": {
     "review": "请查看这些附件。",
     "userMessage": "用户消息：",
-    "attached": "附件："
+    "attached": "附件：",
+    "imagesAria": "消息图片附件",
+    "listAria": "消息附件",
+    "previewName": "预览 {{name}}",
+    "previewImage": "预览图片",
+    "kindImage": "图片",
+    "kindCode": "代码",
+    "kindFile": "文件"
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import "./i18n";
 import "../styles.css";
 
 createRoot(document.getElementById("root") as HTMLElement).render(

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import type {
   CLIExecutorOverride,
   CliCheckResult,
@@ -22,9 +23,7 @@ import type { CLIAdapterDefinition, CLIAdapterId } from "@/config/cliAdapters";
 function api() {
   const cli = window.freebuddy?.cli;
   if (!cli) {
-    throw new Error(
-      "FreeBuddy CLI bridge is unavailable. Are you running outside Electron?"
-    );
+    throw new Error(i18next.t("errors.cliBridgeUnavailable"));
   }
   return cli;
 }

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -144,6 +144,17 @@ export const cliClient = {
     return api().selectAttachments();
   },
 
+  getSetting(key: string): Promise<string | null> {
+    const api = window.freebuddy;
+    if (!api) return Promise.resolve(null);
+    return api.settings.getSetting(key);
+  },
+  setSetting(key: string, value: string): Promise<void> {
+    const api = window.freebuddy;
+    if (!api) return Promise.resolve();
+    return api.settings.setSetting(key, value);
+  },
+
   onEvent(sessionId: string, cb: (e: CliEvent) => void): () => void {
     return api().onEvent(sessionId, cb as (e: unknown) => void);
   }

--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import type { CliEvent } from "@/services/cli/types";
 import type {
   CliStreamItem,
@@ -26,12 +27,13 @@ function failureSummaryFor(exitCode: number, parseCtx: ParseContext): CliStreamI
     kind: "error",
     message:
       exitCode === 130
-        ? "Agent 运行已中断。"
-        : `Agent 运行失败，退出码 ${exitCode}。${
-            details?.length
-              ? "已收起原始 CLI 日志，方便排查。"
-              : "CLI 没有返回可解析的结构化内容。"
-          }`,
+        ? i18next.t("errors.agentInterrupted")
+        : i18next.t("errors.agentFailed", {
+            code: exitCode,
+            detail: details?.length
+              ? i18next.t("errors.rawLogCollapsed")
+              : i18next.t("errors.cliNoStructured")
+          }),
     details
   };
 }

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import i18next from "i18next";
+import { cliClient } from "@/services/cli/client";
+import { detectLocale, type AppLocale } from "@/utils/detectLocale";
+
+interface SettingsState {
+  loaded: boolean;
+  language: AppLocale;
+  load(): Promise<void>;
+  setLanguage(lng: AppLocale): Promise<void>;
+}
+
+export const useSettingsStore = create<SettingsState>((set) => ({
+  loaded: false,
+  language: "en",
+
+  async load() {
+    if (!cliClient.isAvailable()) {
+      const fallback = detectLocale(navigator.language);
+      await i18next.changeLanguage(fallback);
+      set({ loaded: true, language: fallback });
+      return;
+    }
+    const stored = await cliClient.getSetting("language");
+    const lng: AppLocale =
+      stored === "zh-CN" || stored === "en"
+        ? stored
+        : detectLocale(navigator.language);
+    await i18next.changeLanguage(lng);
+    set({ loaded: true, language: lng });
+  },
+
+  async setLanguage(lng) {
+    await i18next.changeLanguage(lng);
+    set({ language: lng });
+    if (cliClient.isAvailable()) {
+      await cliClient.setSetting("language", lng);
+    }
+  }
+}));

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -93,6 +93,11 @@ declare global {
     onChromeVisible(cb: (visible: boolean) => void): () => void;
   }
 
+  interface FreebuddySettings {
+    getSetting(key: string): Promise<string | null>;
+    setSetting(key: string, value: string): Promise<void>;
+  }
+
   interface FreebuddyApi {
     platform: string;
     versions: {
@@ -101,6 +106,7 @@ declare global {
       node?: string;
     };
     cli: FreebuddyCli;
+    settings: FreebuddySettings;
     window: FreebuddyWindow;
   }
 

--- a/src/utils/chatAttachments.ts
+++ b/src/utils/chatAttachments.ts
@@ -1,3 +1,5 @@
+import i18next from "i18next";
+
 export const MAX_ATTACHMENTS_PER_MESSAGE = 10;
 export const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 
@@ -187,8 +189,8 @@ export function composeMessageWithAttachments(
   const text = content.trim();
   if (attachments.length === 0) return text;
 
-  const body = text || "请查看这些附件。";
-  return `用户消息：\n${body}\n\n附件：\n${attachments.map(formatAttachmentForPrompt).join("\n")}`;
+  const body = text || i18next.t("attachments.review");
+  return `${i18next.t("attachments.userMessage")}\n${body}\n\n${i18next.t("attachments.attached")}\n${attachments.map(formatAttachmentForPrompt).join("\n")}`;
 }
 
 /**

--- a/src/utils/detectLocale.ts
+++ b/src/utils/detectLocale.ts
@@ -1,0 +1,11 @@
+export type AppLocale = "en" | "zh-CN";
+
+export const SUPPORTED_LOCALES: AppLocale[] = ["en", "zh-CN"];
+
+export function detectLocale(tag: string | undefined): AppLocale {
+  if (!tag) return "en";
+  if (tag.toLowerCase().startsWith("zh")) {
+    return "zh-CN";
+  }
+  return "en";
+}

--- a/styles.css
+++ b/styles.css
@@ -4559,3 +4559,7 @@ button.ghost:focus-visible,
 [data-theme="dark"] .permission-btn-ghost:hover:not(:disabled) {
   background: rgba(148, 163, 184, 0.16);
 }
+
+.settings-section { padding: 12px 0; border-bottom: 1px solid var(--border, #e5e7eb); }
+.settings-section h3 { margin: 0 0 8px; font-size: 13px; }
+.settings-section select { padding: 6px 8px; border-radius: 6px; }

--- a/tests/chat-attachments.test.mjs
+++ b/tests/chat-attachments.test.mjs
@@ -8,12 +8,16 @@ async function loadModule() {
     new URL("../src/utils/chatAttachments.ts", import.meta.url),
     "utf8"
   );
-  const output = ts.transpileModule(source, {
+  const transpiled = ts.transpileModule(source, {
     compilerOptions: {
       module: ts.ModuleKind.ES2022,
       target: ts.ScriptTarget.ES2022
     }
   }).outputText;
+  const output = transpiled.replace(
+    /^import i18next from "i18next";\s*$/m,
+    'const i18next = { t: (k) => k };'
+  );
   return import(`data:text/javascript;base64,${Buffer.from(output).toString("base64")}`);
 }
 
@@ -105,10 +109,10 @@ test("formats attachments for agent prompts", async () => {
   );
   assert.equal(
     composeMessageWithAttachments("请分析", [image]),
-    "用户消息：\n请分析\n\n附件：\n- screen.png (image/png, 1.5 KB): /Users/me/Desktop/screen.png"
+    "attachments.userMessage\n请分析\n\nattachments.attached\n- screen.png (image/png, 1.5 KB): /Users/me/Desktop/screen.png"
   );
   assert.equal(
     composeMessageWithAttachments("", [image]),
-    "用户消息：\n请查看这些附件。\n\n附件：\n- screen.png (image/png, 1.5 KB): /Users/me/Desktop/screen.png"
+    "attachments.userMessage\nattachments.review\n\nattachments.attached\n- screen.png (image/png, 1.5 KB): /Users/me/Desktop/screen.png"
   );
 });

--- a/tests/i18n-detect.test.mjs
+++ b/tests/i18n-detect.test.mjs
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const src = fs.readFileSync(
+  new URL("../src/utils/detectLocale.ts", import.meta.url),
+  "utf8"
+);
+
+test("detectLocale exports supported locales and maps zh-prefix to zh-CN", () => {
+  assert.match(src, /export type AppLocale = "en" \| "zh-CN"/);
+  assert.match(src, /export const SUPPORTED_LOCALES/);
+  assert.match(src, /export function detectLocale\(tag: string \| undefined\)/);
+  assert.match(src, /\.toLowerCase\(\)/);
+  assert.match(src, /startsWith\("zh"\)/);
+  assert.match(src, /return "zh-CN"/);
+  assert.match(src, /return "en"/);
+});

--- a/tests/i18n-settings.test.mjs
+++ b/tests/i18n-settings.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
+const db = read("../electron/cli/db.ts");
+const ipc = read("../electron/cli/ipc.ts");
+const preload = read("../electron/preload.ts");
+const types = read("../src/types/freebuddy.d.ts");
+const client = read("../src/services/cli/client.ts");
+const settings = read("../electron/cli/settings.ts");
+
+test("app_settings table is created on migration", () => {
+  assert.match(db, /CREATE TABLE IF NOT EXISTS app_settings/);
+  assert.match(db, /key TEXT PRIMARY KEY/);
+  assert.match(db, /value TEXT NOT NULL/);
+});
+
+test("settings store module exposes get/set + language resolution", () => {
+  assert.match(settings, /export function getSetting\(key: string\): string \| null/);
+  assert.match(settings, /export function setSetting\(key: string, value: string\)/);
+  assert.match(settings, /ON CONFLICT\(key\) DO UPDATE SET value = excluded\.value/);
+  assert.match(settings, /export function getLanguage\(\)/);
+  assert.match(settings, /detectLocale/);
+  assert.match(settings, /app\.getLocale\(\)/);
+});
+
+test("settings IPC handlers are registered", () => {
+  assert.match(ipc, /"settings:get"/);
+  assert.match(ipc, /"settings:set"/);
+});
+
+test("preload exposes settings get/set", () => {
+  assert.match(preload, /getSetting:\s*\(key\)\s*=>\s*ipcRenderer\.invoke\("settings:get"/);
+  assert.match(preload, /setSetting:\s*\(key, value\)\s*=>\s*ipcRenderer\.invoke\("settings:set"/);
+});
+
+test("global types declare settings API", () => {
+  assert.match(types, /interface FreebuddySettings/);
+  assert.match(types, /getSetting\(key: string\): Promise<string \| null>/);
+  assert.match(types, /setSetting\(key: string, value: string\): Promise<void>/);
+  assert.match(types, /settings: FreebuddySettings/);
+});
+
+test("cli client exposes settings methods", () => {
+  assert.match(client, /getSetting\(key: string\)/);
+  assert.match(client, /setSetting\(key: string, value: string\)/);
+});

--- a/tests/i18n-strings.test.mjs
+++ b/tests/i18n-strings.test.mjs
@@ -1,9 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import path from "node:path";
 
 const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
-const files = [
+
+function listSourceFiles(dir) {
+  const root = new URL(dir, import.meta.url);
+  const out = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(entry.parentPath, entry.name);
+    if (entry.isDirectory()) out.push(...listSourceFiles(new URL(`${entry.name}/`, root)));
+    else if (/\.(ts|tsx)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+const migratedFiles = [
   "../src/App.tsx",
   "../src/components/CLI/ChatView.tsx",
   "../src/components/CLI/ConversationList.tsx",
@@ -17,15 +30,15 @@ const files = [
   "../src/components/Settings/AvatarPicker.tsx"
 ];
 
-test("no CJK literals remain in migrated components", () => {
-  for (const f of files) {
-    const src = read(f);
-    assert.equal(/[\u4e00-\u9fff]/.test(src), false, `CJK found in ${f}`);
+test("no CJK literals remain anywhere in src/", () => {
+  for (const file of listSourceFiles("../src/")) {
+    const src = fs.readFileSync(file, "utf8");
+    assert.equal(/[\u4e00-\u9fff]/.test(src), false, `CJK found in ${file}`);
   }
 });
 
 test("migrated components use the translation hook", () => {
-  for (const f of files) {
+  for (const f of migratedFiles) {
     const src = read(f);
     if (/Conversations|Settings|Permission|ChatView|Workspace/.test(f)) {
       assert.match(src, /useTranslation\(\)|i18next\.t\(/, `${f} should use t()`);

--- a/tests/i18n-strings.test.mjs
+++ b/tests/i18n-strings.test.mjs
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
+const files = [
+  "../src/App.tsx",
+  "../src/components/CLI/ChatView.tsx",
+  "../src/components/CLI/ConversationList.tsx",
+  "../src/components/CLI/WorkspacePanel.tsx",
+  "../src/components/CLI/MessageBubble.tsx",
+  "../src/components/CLI/StreamItem.tsx",
+  "../src/components/CLI/PermissionDialog.tsx",
+  "../src/components/CLI/ImageLightbox.tsx",
+  "../src/components/Settings/SettingsModal.tsx",
+  "../src/components/Settings/CLIAdaptersTab.tsx",
+  "../src/components/Settings/AvatarPicker.tsx"
+];
+
+test("no CJK literals remain in migrated components", () => {
+  for (const f of files) {
+    const src = read(f);
+    assert.equal(/[\u4e00-\u9fff]/.test(src), false, `CJK found in ${f}`);
+  }
+});
+
+test("migrated components use the translation hook", () => {
+  for (const f of files) {
+    const src = read(f);
+    if (/Conversations|Settings|Permission|ChatView|Workspace/.test(f)) {
+      assert.match(src, /useTranslation\(\)|i18next\.t\(/, `${f} should use t()`);
+    }
+  }
+});

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -11,5 +11,5 @@
     "rootDir": "electron",
     "types": ["node"]
   },
-  "include": ["electron/main.ts", "electron/cli/**/*.ts"]
+  "include": ["electron/main.ts", "electron/menu.ts", "electron/app-meta.ts", "electron/cli/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Add full i18n support with `react-i18next` and two locales (`en` source/default, `zh-CN`), ~180 nested keys in `src/locales/{en,zh-CN}.json`.
- New persisted settings layer: SQLite `app_settings` table → IPC → Zustand `settingsStore` → `i18next.changeLanguage`. OS-locale auto-detect on first run + manual override in a new Settings → General tab; choice survives restart. Reactive `<html lang>`.
- Localize all user-facing strings across renderer and Electron main: UI labels, errors, placeholders, tooltips/aria, status enums via `t(\`status.${value}\`)`, StreamItem tool verbs, AI-prompt templates, and the PermissionDialog plural. Main process uses a small inline dictionary and rebuilds its menu live on language change (built-in `role:` menu items stay OS-localized).
- Spec refinement: main process uses an inline dictionary instead of shared JSON, because `tsconfig.electron.json` pins `rootDir: "electron"` (can't import `src/locales/*.json`). Documented in the design doc.

## Test plan
- [ ] `npm run typecheck && npm run build && npm test` → 60/60 pass
- [ ] Fresh launch on a `zh` OS locale → UI in 简体中文; on `en` → English; `<html lang>` matches
- [ ] Settings → General → switch language → Chat / Workspace / Settings / Permission / Electron menu / file-dialog filters update live
- [ ] Quit & relaunch → language persists; Electron menu stays localized
- [ ] Trigger an agent error (e.g. stop a run) → summary appears in the active language

Spec: `docs/superpowers/specs/2026-06-19-i18n-design.md`
Plan: `docs/superpowers/plans/2026-06-19-i18n.md`