### PR TITLE
feat(workspace): show agent run duration in WorkspacePanel

### DIFF
--- a/src/components/CLI/WorkspacePanel.tsx
+++ b/src/components/CLI/WorkspacePanel.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 
 import { displayAgentName } from "@/config/agentDisplay";
 import { useConversationStore } from "@/store/conversationStore";
+import { formatDuration } from "@/utils/duration";
 import { AgentAvatar } from "./AgentAvatar";
 
 export function WorkspacePanel({
@@ -17,6 +18,7 @@ export function WorkspacePanel({
   const messagesMap = useConversationStore((s) => s.messages);
   const liveMap = useConversationStore((s) => s.live);
   const [copiedSession, setCopiedSession] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
 
   const active = conversations.find((c) => c.id === activeId);
   const activeAgentName = displayAgentName(active?.agentName, active?.adapter);
@@ -24,6 +26,13 @@ export function WorkspacePanel({
   const live = activeId ? liveMap[activeId] : undefined;
 
   const status = live?.status ?? "ready";
+  const isLive = status === "running" || status === "starting";
+
+  useEffect(() => {
+    if (!isLive) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [isLive]);
   const assistantTurns = useMemo(
     () => messages.filter((m) => m.role === "assistant").length,
     [messages]
@@ -78,6 +87,19 @@ export function WorkspacePanel({
     }
     return undefined;
   }, [messages]);
+
+  const durationMs = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const message = messages[i];
+      if (message.role !== "assistant") continue;
+      const start = Date.parse(message.createdAt);
+      const end = isLive ? now : Date.parse(message.updatedAt);
+      if (!Number.isFinite(start) || !Number.isFinite(end)) return undefined;
+      const ms = end - start;
+      return ms >= 0 ? ms : undefined;
+    }
+    return undefined;
+  }, [messages, isLive, now]);
 
   return (
     <aside className="details-panel workspace-panel" aria-label={t("workspace.panelAria")}>
@@ -152,6 +174,12 @@ export function WorkspacePanel({
             <dt>{t("workspace.agentTurns")}</dt>
             <dd>{assistantTurns}</dd>
           </div>
+          {durationMs != null && (
+            <div>
+              <dt>{t("workspace.duration")}</dt>
+              <dd>{formatDuration(durationMs)}</dd>
+            </div>
+          )}
           {latestUsage?.contextUsed != null && (
             <div>
               <dt>{t("workspace.context")}</dt>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -102,6 +102,7 @@
     "notCaptured": "Not captured",
     "messages": "Messages",
     "agentTurns": "Agent turns",
+    "duration": "Duration",
     "context": "Context",
     "cost": "Cost",
     "tokens": "Tokens",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -102,6 +102,7 @@
     "notCaptured": "未捕获",
     "messages": "消息数",
     "agentTurns": "Agent 轮次",
+    "duration": "耗时",
     "context": "上下文",
     "cost": "成本",
     "tokens": "Token",

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -1,0 +1,10 @@
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) return `${totalMinutes}m ${seconds}s`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+}

--- a/tests/duration.test.mjs
+++ b/tests/duration.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+async function loadModule() {
+  const source = fs.readFileSync(
+    new URL("../src/utils/duration.ts", import.meta.url),
+    "utf8"
+  );
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(`data:text/javascript;base64,${Buffer.from(output).toString("base64")}`);
+}
+
+test("formatDuration formats milliseconds into a compact human duration", async () => {
+  const { formatDuration } = await loadModule();
+
+  assert.equal(formatDuration(0), "0s");
+  assert.equal(formatDuration(500), "0s");
+  assert.equal(formatDuration(59_000), "59s");
+  assert.equal(formatDuration(60_000), "1m 0s");
+  assert.equal(formatDuration(125_000), "2m 5s");
+  assert.equal(formatDuration(3_661_000), "1h 1m");
+});


### PR DESCRIPTION
## Summary
- Show the agent run's elapsed time (耗时 / Duration) in the WorkspacePanel metrics, next to Agent turns.
- Derived purely from existing message timestamps — **no schema/DB/ACP changes**: assistant message `createdAt` is set once at run start, `updatedAt` refreshes on every stream event.
  - While running: `Date.now() - createdAt`, ticking every 1s.
  - When finished: frozen to `updatedAt - createdAt`, survives reload.
- Works for **all** agents (including cursor, which doesn't report ACP usage) — duration is measured client-side, independent of usage reporting.
- New pure helper `src/utils/duration.ts:formatDuration` (covered by a real functional test, transpiled like `chat-attachments.test.mjs`). New locale key `workspace.duration`.

## Test plan
- [ ] `npm run typecheck && npm run build && npm test` → 60/60 pass (new `tests/duration.test.mjs`)
- [ ] Run any agent → WorkspacePanel shows 耗时 ticking each second while running, then frozen at the final value after it finishes

Stacked on #2 (i18n) — rebase/retarget to `main` once that merges.