### PR TITLE
fix(release): publish latest-mac.yml so macOS auto-update works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,49 @@ jobs:
           ${{ matrix.assets }}
           ASSETS
 
+      - name: Upload macOS update metadata (per-arch latest-mac.yml)
+        if: matrix.platform == 'macos-latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          tag="${{ github.ref_name }}"
+          repo="${{ github.repository }}"
+          yml=$(find release -name latest-mac.yml -type f | head -1)
+          if [ -z "$yml" ]; then
+            echo "No latest-mac.yml found; skipping"
+            exit 0
+          fi
+          # Rewrite native artifact names to the friendly download names
+          # that we actually uploaded above.
+          sed -i.bak \
+            -e 's#FreeBuddy-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}-mac-arm64\.dmg#FreeBuddy_macOS-Apple-Silicon.dmg#g' \
+            -e 's#FreeBuddy-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}-mac-x64\.dmg#FreeBuddy_macOS-Intel.dmg#g' \
+            "$yml"
+          # Tag the yml with the arch so the two matrix jobs don't clobber
+          # each other. A follow-up job merges them into latest-mac.yml.
+          if echo "${{ matrix.builder_args }}" | grep -q -- '--arm64'; then
+            arch_tag="arm64"
+          else
+            arch_tag="x64"
+          fi
+          cp "$yml" "latest-mac-${arch_tag}.yml"
+          gh release upload "$tag" "latest-mac-${arch_tag}.yml" \
+            --repo "$repo" --clobber
+          # Also upload the blockmap so delta updates work.
+          blockmap=$(find release -name "*.dmg.blockmap" -type f | head -1)
+          if [ -n "$blockmap" ]; then
+            if [ "$arch_tag" = "arm64" ]; then
+              cp "$blockmap" "FreeBuddy_macOS-Apple-Silicon.dmg.blockmap"
+              gh release upload "$tag" "FreeBuddy_macOS-Apple-Silicon.dmg.blockmap" \
+                --repo "$repo" --clobber
+            else
+              cp "$blockmap" "FreeBuddy_macOS-Intel.dmg.blockmap"
+              gh release upload "$tag" "FreeBuddy_macOS-Intel.dmg.blockmap" \
+                --repo "$repo" --clobber
+            fi
+          fi
+
       - name: Upload renamed assets (Windows)
         if: matrix.platform == 'windows-latest'
         env:
@@ -157,8 +200,43 @@ jobs:
             gh release upload $tag FreeBuddy_Windows_x64.exe.blockmap --repo $repo --clobber
           }
 
-  publish-release:
+  merge-mac-metadata:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Merge per-arch latest-mac.yml into latest-mac.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ github.ref_name }}"
+          repo="${{ github.repository }}"
+          mkdir -p _mac_meta
+          gh release download "$tag" --repo "$repo" \
+            --dir _mac_meta \
+            --pattern 'latest-mac-arm64.yml' \
+            --pattern 'latest-mac-x64.yml' || true
+          if [ ! -f _mac_meta/latest-mac-arm64.yml ] && [ ! -f _mac_meta/latest-mac-x64.yml ]; then
+            echo "No per-arch mac yml found; skipping merge"
+            exit 0
+          fi
+          node scripts/merge-mac-latest-yml.mjs \
+            _mac_meta/latest-mac-arm64.yml \
+            _mac_meta/latest-mac-x64.yml \
+            latest-mac.yml
+          gh release upload "$tag" latest-mac.yml --repo "$repo" --clobber
+
+  publish-release:
+    needs: merge-mac-metadata
     runs-on: ubuntu-latest
     steps:
       - name: Publish release

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -128,6 +128,23 @@ function createWindow() {
   mainWindow.on("maximize", sendChromeVisible);
   mainWindow.on("unmaximize", sendChromeVisible);
 
+  // The app menu is hidden (Menu.setApplicationMenu(null)) and we use
+  // titleBarStyle: "hiddenInset", so macOS' default Esc-to-leave-fullscreen
+  // shortcut has no menu item to bind to. Restore it manually.
+  mainWindow.webContents.on("before-input-event", (_event, input) => {
+    if (
+      input.type === "keyDown" &&
+      input.key === "Escape" &&
+      !input.alt &&
+      !input.control &&
+      !input.meta &&
+      !input.shift &&
+      mainWindow?.isFullScreen()
+    ) {
+      mainWindow.setFullScreen(false);
+    }
+  });
+
   if (isDev) {
     void mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL as string);
     mainWindow.webContents.openDevTools({ mode: "detach" });

--- a/scripts/merge-mac-latest-yml.mjs
+++ b/scripts/merge-mac-latest-yml.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Merges two per-arch electron-updater metadata files (latest-mac-arm64.yml
+// and latest-mac-x64.yml) into a single latest-mac.yml whose `files` list
+// covers both architectures. electron-updater on macOS reads latest-mac.yml
+// and picks the matching arch entry automatically.
+
+import fs from "node:fs";
+import path from "node:path";
+
+function parseYml(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  const text = fs.readFileSync(filePath, "utf8");
+  const lines = text.split(/\r?\n/);
+  const top = {};
+  const files = [];
+  let cur = null;
+  let inFiles = false;
+
+  for (const line of lines) {
+    if (line.startsWith("files:")) {
+      inFiles = true;
+      continue;
+    }
+    if (inFiles) {
+      const mItem = line.match(/^\s*-\s*url:\s*(.+)$/);
+      const mKv = line.match(/^\s{4,}([a-zA-Z0-9_-]+):\s*(.+)$/);
+      if (mItem) {
+        if (cur) files.push(cur);
+        cur = { url: mItem[1].trim() };
+        continue;
+      }
+      if (mKv && cur) {
+        cur[mKv[1]] = mKv[2].trim();
+        continue;
+      }
+      if (/^[a-zA-Z]/.test(line)) {
+        if (cur) {
+          files.push(cur);
+          cur = null;
+        }
+        inFiles = false;
+      }
+    }
+    if (!inFiles) {
+      const m = line.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
+      if (m) top[m[1]] = m[2];
+    }
+  }
+  if (cur) files.push(cur);
+  return { top, files };
+}
+
+function dumpYml(doc) {
+  const order = ["version", "files", "path", "sha512", "releaseDate"];
+  const lines = [];
+  for (const key of order) {
+    if (key === "files") {
+      lines.push("files:");
+      for (const f of doc.files) {
+        lines.push(`  - url: ${f.url}`);
+        for (const k of Object.keys(f)) {
+          if (k === "url") continue;
+          lines.push(`    ${k}: ${f[k]}`);
+        }
+      }
+      continue;
+    }
+    const v = doc.top[key];
+    if (v !== undefined && v !== "") lines.push(`${key}: ${v}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+const [armPath, x64Path, outPath] = process.argv.slice(2);
+if (!outPath) {
+  console.error("usage: merge-mac-latest-yml.mjs <arm64.yml> <x64.yml> <out.yml>");
+  process.exit(2);
+}
+
+const arm = parseYml(armPath);
+const x64 = parseYml(x64Path);
+
+if (!arm && !x64) {
+  console.error("Neither arm64 nor x64 yml found; nothing to merge.");
+  process.exit(1);
+}
+
+const base = arm ?? x64;
+const merged = { top: { ...base.top }, files: [...base.files] };
+const other = arm ? x64 : null;
+if (other) {
+  for (const f of other.files) {
+    if (!merged.files.some((x) => x.url === f.url)) merged.files.push(f);
+  }
+}
+
+fs.mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true });
+fs.writeFileSync(outPath, dumpYml(merged));
+process.stdout.write(fs.readFileSync(outPath, "utf8"));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,7 +197,6 @@ function App() {
       className={`app-shell${isElectron ? " electron-shell" : ""}${isNewTask ? " new-task-mode" : ""}${sidebarCollapsed ? " sidebar-collapsed" : ""}${!chromeVisible ? " chrome-hidden" : ""}${platform ? ` platform-${platform}` : ""}`}
       data-theme={theme}
     >
-      {sidebarCollapsed && renderToggleButton("floating")}
       <aside className="sidebar">
         <div className="sidebar-header">
           <div className="sidebar-brand">
@@ -234,6 +233,7 @@ function App() {
 
       <main className="workspace">
         <header className="titlebar">
+          {sidebarCollapsed && renderToggleButton("floating")}
           <div className="breadcrumb">
             <strong>{activeConversation?.title ?? t("app.chat")}</strong>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,7 @@ button {
   justify-content: space-between;
   gap: 12px;
   padding: 18px 16px 14px;
+  position: relative;
 }
 .electron-shell .sidebar-header {
   -webkit-app-region: drag;
@@ -233,29 +234,35 @@ button {
   color: var(--fb-text-primary);
 }
 
-/* macOS traffic lights visible: lift the toggle into the top-left system-button row */
+/* macOS traffic lights visible: lift the in-header toggle into the
+   top-left system-button row, anchored to .sidebar-header (which sets
+   position: relative above). */
 .electron-shell.platform-darwin:not(.chrome-hidden) .sidebar-header > .sidebar-toggle {
   position: absolute;
-  top: 8px;
-  left: 74px;
+  top: 10px;
+  left: 82px;
   z-index: 40;
+  -webkit-app-region: no-drag;
 }
 
-/* Floating toggle used only when the sidebar is collapsed */
+/* Floating toggle used only when the sidebar is collapsed.
+   It is rendered inside .titlebar (which has -webkit-app-region: drag),
+   so it can safely opt out of the drag region as a child element. */
 .sidebar-toggle.floating {
   position: absolute;
   top: 8px;
   left: 8px;
   z-index: 40;
+  -webkit-app-region: no-drag;
 }
 
-/* Electron titlebar is taller (52px + 8px padding) → align with its breadcrumb center */
+/* Electron titlebar has a top padding of 8px → match it for vertical centering. */
 .electron-shell .sidebar-toggle.floating {
   top: 16px;
 }
 
 .electron-shell.platform-darwin:not(.chrome-hidden) .sidebar-toggle.floating {
-  left: 74px;
+  left: 82px;
 }
 
 .electron-shell.chrome-hidden.sidebar-collapsed .titlebar {
@@ -444,6 +451,7 @@ button {
 
 .titlebar {
   display: flex;
+  position: relative;
   height: 44px;
   flex: 0 0 auto;
   align-items: center;


### PR DESCRIPTION
## 背景

macOS 客户端检查更新时报 404：

```
Cannot find latest-mac.yml in the latest release artifacts
(https://github.com/maojindao55/freebuddy/releases/download/v0.0.12/latest-mac.yml)
```

## 根因

现有 release 工作流只为 Windows 上传了 `latest.yml`，没有为 macOS 上传 electron-updater 必需的 `latest-mac.yml`。即便上传，由于 dmg 在工作流中被重命名为 `FreeBuddy_macOS-Apple-Silicon.dmg` / `FreeBuddy_macOS-Intel.dmg`，而 electron-builder 自动生成的 yml 仍指向原始 `FreeBuddy-x.y.z-mac-<arch>.dmg`，下载也会失败。

## 改动

**`.github/workflows/release.yml`**

- macOS 矩阵新增 *Upload macOS update metadata* 步骤：
  - 将 yml 中 dmg 文件名重写为友好名
  - 按架构上传 `latest-mac-arm64.yml` / `latest-mac-x64.yml`
  - 同时上传带友好名的 `.dmg.blockmap`（支持差量更新）
- 新增 `merge-mac-metadata` job：下载两份 per-arch yml，合并为单一 `latest-mac.yml`（其 `files` 列表覆盖两种架构），上传到 release
- `publish-release` 改为依赖 `merge-mac-metadata`，确保 yml 就位后再把 release 转正

**`scripts/merge-mac-latest-yml.mjs`（新增）**

零依赖的合并工具，已用样例本地验证。

## 兼容性

- 旧 v0.0.12 的 mac 用户客户端是去 GitHub 最新 release 拉 `latest-mac.yml`，因此**下一个新版本按此工作流发布后，旧用户即可正常收到更新提示**，无需手工回填 v0.0.12 的资产
- Windows 与 Linux 的发布流程不受影响