### PR TITLE
perf(conversations): throttle multi-session UI and add search + grouping

### DIFF
--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -32,6 +32,59 @@ export type { CliEvent, CliRunArgs } from "./runtimeShared.js";
 const running = new Map<string, Running>();
 const capturedSessions = new Map<string, string>();
 
+type StreamItemEntry = Extract<CliEvent, { type: "items" }>["items"][number];
+
+/**
+ * Coalesce consecutive high-frequency `items` events (ACP agent_message
+ * chunks, tool calls, ...) into a single event flushed on a short timer or
+ * before any non-items event. ACP agents can emit hundreds of small updates
+ * per second; without batching every chunk triggers a renderer state update,
+ * a JSON.stringify of the whole turn, a React render, and (in workflow mode)
+ * a synchronous DB write + full-message reload. Batching caps that to ~60
+ * flushes/sec while preserving ordering relative to permission/done/error.
+ */
+function createItemsBatchingEmit(
+  send: (e: CliEvent) => void
+): (e: CliEvent) => void {
+  const FLUSH_MS = 16;
+  const MAX_BUFFER = 200;
+  let buffer: StreamItemEntry[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const flush = () => {
+    timer = null;
+    if (buffer.length === 0) return;
+    const items = buffer;
+    buffer = [];
+    send({ type: "items", items });
+  };
+
+  return (e: CliEvent) => {
+    if (e.type === "items" && e.items.length) {
+      for (const it of e.items) buffer.push(it);
+      if (buffer.length >= MAX_BUFFER) {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        flush();
+      } else if (timer === null) {
+        timer = setTimeout(flush, FLUSH_MS);
+      }
+      return;
+    }
+    // Preserve ordering: flush pending items before a non-items event
+    // (permission / done / error / started) so the renderer observes them
+    // first, and so finalizeRun sees the complete item set on `done`.
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (buffer.length > 0) flush();
+    send(e);
+  };
+}
+
 function mergeJsonEnvValue(current: string | undefined, patch: string) {
   if (!current) return patch;
   try {
@@ -65,10 +118,10 @@ export async function cliRun(
   onEvent?: (e: CliEvent) => void
 ): Promise<void> {
   const channel = channelName(args.sessionId);
-  const emit = (e: CliEvent) => {
+  const emit = createItemsBatchingEmit((e) => {
     if (onEvent) onEvent(e);
     if (!webContents.isDestroyed()) webContents.send(channel, e);
-  };
+  });
 
   const logFile = path.join(getLogDir(), `${args.sessionId}.jsonl`);
   let logStream: fs.WriteStream | null = null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,14 +151,22 @@ function App() {
   }, []);
 
   const conversations = useConversationStore((s) => s.conversations);
-  const live = useConversationStore((s) => s.live);
   const activeId = useConversationStore((s) => s.activeId);
   const setActive = useConversationStore((s) => s.setActive);
   const activeConversation = conversations.find((c) => c.id === activeId);
   const isNewTask = !activeConversation;
-  const runningCount = conversations.filter(
-    (c) => live[c.id]?.status === "running" || live[c.id]?.status === "starting"
-  ).length;
+  // Select the running *count* rather than the whole live map: App (the root)
+  // re-renders only when the number of running conversations changes, not on
+  // every streaming chunk. Otherwise every background event would re-render
+  // the entire tree.
+  const runningCount = useConversationStore((s) => {
+    let n = 0;
+    for (const c of s.conversations) {
+      const st = s.live[c.id]?.status;
+      if (st === "running" || st === "starting") n += 1;
+    }
+    return n;
+  });
 
   const renderToggleButton = (extraClass = "") => (
     <button

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -186,20 +186,21 @@ export function ChatView() {
   const activeId = useConversationStore((s) => s.activeId);
   const conversations = useConversationStore((s) => s.conversations);
   const members = useConversationStore((s) => s.members);
-  const messagesMap = useConversationStore((s) => s.messages);
-  const liveMap = useConversationStore((s) => s.live);
+  // Select only the active conversation's slices so a background conversation
+  // streaming events (which always rebuilds the messages/live maps) does not
+  // re-render this component.
+  const messages = useConversationStore((s) =>
+    s.activeId ? s.messages[s.activeId] ?? EMPTY_MESSAGES : EMPTY_MESSAGES
+  );
+  const live = useConversationStore((s) =>
+    s.activeId ? s.live[s.activeId] : undefined
+  );
   const createConversation = useConversationStore((s) => s.newConversation);
   const sendMessage = useConversationStore((s) => s.sendMessage);
   const stopActive = useConversationStore((s) => s.stopActive);
   const setApprovalMode = useConversationStore(
     (s) => s.setConversationApprovalMode
   );
-
-  const messages = useMemo(
-    () => (activeId ? messagesMap[activeId] ?? EMPTY_MESSAGES : EMPTY_MESSAGES),
-    [activeId, messagesMap]
-  );
-  const live = activeId ? liveMap[activeId] : undefined;
 
   const [taskMode, setTaskMode] = useState<"normal" | "team">(
     "normal"

--- a/src/components/CLI/ConversationList.tsx
+++ b/src/components/CLI/ConversationList.tsx
@@ -1,3 +1,4 @@
+import { Fragment, memo, useCallback, useMemo, useState } from "react";
 import { useConversationStore } from "@/store/conversationStore";
 import type { Conversation } from "@/services/cli/types";
 import { displayAgentName } from "@/config/agentDisplay";
@@ -8,48 +9,175 @@ function conversationTimeValue(conversation: Conversation) {
   return conversation.lastMessageAt ?? conversation.updatedAt ?? conversation.createdAt;
 }
 
+type TimeFormatVariant = "time" | "md" | "ymd" | "full";
+
+// Intl.DateTimeFormat construction is expensive; cache one formatter per
+// (language, variant). Previously the list rebuilt up to 4*N formatter
+// objects on every render of the sidebar.
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+function dateTimeFormatter(lang: string, variant: TimeFormatVariant): Intl.DateTimeFormat {
+  const key = `${lang}|${variant}`;
+  const cached = formatterCache.get(key);
+  if (cached) return cached;
+  const options: Intl.DateTimeFormatOptions =
+    variant === "time"
+      ? { hour: "2-digit", minute: "2-digit" }
+      : variant === "md"
+        ? { month: "2-digit", day: "2-digit" }
+        : variant === "ymd"
+          ? { year: "numeric", month: "2-digit", day: "2-digit" }
+          : {
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit"
+            };
+  const formatter = new Intl.DateTimeFormat(lang, options);
+  formatterCache.set(key, formatter);
+  return formatter;
+}
+
 function formatConversationTime(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
-
+  const lang = i18next.language || "en";
   const now = new Date();
   const sameDay =
     date.getFullYear() === now.getFullYear() &&
     date.getMonth() === now.getMonth() &&
     date.getDate() === now.getDate();
-
-  if (sameDay) {
-    return new Intl.DateTimeFormat(i18next.language, {
-      hour: "2-digit",
-      minute: "2-digit"
-    }).format(date);
-  }
-
-  if (date.getFullYear() === now.getFullYear()) {
-    return new Intl.DateTimeFormat(i18next.language, {
-      month: "2-digit",
-      day: "2-digit"
-    }).format(date);
-  }
-
-  return new Intl.DateTimeFormat(i18next.language, {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit"
-  }).format(date);
+  if (sameDay) return dateTimeFormatter(lang, "time").format(date);
+  if (date.getFullYear() === now.getFullYear())
+    return dateTimeFormatter(lang, "md").format(date);
+  return dateTimeFormatter(lang, "ymd").format(date);
 }
 
 function formatConversationTimeTitle(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
-  return new Intl.DateTimeFormat(i18next.language, {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit"
-  }).format(date);
+  return dateTimeFormatter(i18next.language || "en", "full").format(date);
 }
+
+function shortCwd(cwd: string) {
+  return cwd.split(/[/\\]/).slice(-2).join("/");
+}
+
+interface ConvSection {
+  key: string;
+  label: string;
+  items: Conversation[];
+}
+
+const SECTION_ORDER = ["today", "yesterday", "last7", "last30", "earlier"] as const;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Bucket conversations into ordered recency sections. Items arrive pre-sorted
+ * by recency (DESC) from the DB, so each bucket preserves that order.
+ */
+function groupConversationsByDate(
+  items: Conversation[],
+  labels: Record<string, string>
+): ConvSection[] {
+  const now = new Date();
+  const startToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate()
+  ).getTime();
+  const buckets: Record<string, Conversation[]> = {
+    today: [],
+    yesterday: [],
+    last7: [],
+    last30: [],
+    earlier: []
+  };
+  for (const c of items) {
+    const ts = Date.parse(conversationTimeValue(c));
+    let key: string;
+    if (!Number.isFinite(ts)) key = "earlier";
+    else if (ts >= startToday) key = "today";
+    else if (ts >= startToday - DAY_MS) key = "yesterday";
+    else if (ts >= startToday - 7 * DAY_MS) key = "last7";
+    else if (ts >= startToday - 30 * DAY_MS) key = "last30";
+    else key = "earlier";
+    buckets[key].push(c);
+  }
+  const sections: ConvSection[] = [];
+  for (const key of SECTION_ORDER) {
+    if (buckets[key].length > 0) {
+      sections.push({ key, label: labels[key], items: buckets[key] });
+    }
+  }
+  return sections;
+}
+
+const ConversationRow = memo(function ConversationRow({
+  conversation,
+  isActive,
+  isRunning,
+  onSelect,
+  onDelete
+}: {
+  conversation: Conversation;
+  isActive: boolean;
+  isRunning: boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string, title: string) => void;
+}) {
+  const { t } = useTranslation();
+  const timeValue = conversationTimeValue(conversation);
+  const timeLabel = formatConversationTime(timeValue);
+  const agentName = displayAgentName(conversation.agentName, conversation.adapter);
+
+  return (
+    <li
+      className={`conv-item${isActive ? " active" : ""}`}
+      role="button"
+      tabIndex={0}
+      aria-current={isActive ? "true" : undefined}
+      onClick={() => onSelect(conversation.id)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect(conversation.id);
+        }
+      }}
+    >
+      {isRunning && <span className="conv-running-dot" />}
+      <div className="conv-item-main">
+        <div className="conv-item-title-row">
+          <strong>{conversation.title}</strong>
+        </div>
+        <small>
+          {agentName}
+          {conversation.cwd ? ` · ${shortCwd(conversation.cwd)}` : ""}
+          {timeLabel && (
+            <>
+              {" · "}
+              <time dateTime={timeValue} title={formatConversationTimeTitle(timeValue)}>
+                {timeLabel}
+              </time>
+            </>
+          )}
+        </small>
+      </div>
+      <div className="conv-item-side">
+        <button
+          className="icon-btn danger"
+          title={t("common.delete")}
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete(conversation.id, conversation.title);
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </li>
+  );
+});
 
 export function ConversationList({
   onNew
@@ -59,9 +187,60 @@ export function ConversationList({
   const conversations = useConversationStore((s) => s.conversations);
   const activeId = useConversationStore((s) => s.activeId);
   const setActive = useConversationStore((s) => s.setActive);
-  const live = useConversationStore((s) => s.live);
+  // Subscribe to a stable signature of the running set instead of the whole
+  // live map: this list re-renders only when a conversation starts or stops,
+  // not on every streaming chunk emitted by an already-running agent.
+  const runningSignature = useConversationStore((s) => {
+    const ids: string[] = [];
+    for (const c of s.conversations) {
+      const st = s.live[c.id]?.status;
+      if (st === "running" || st === "starting") ids.push(c.id);
+    }
+    return ids.join("\n");
+  });
   const remove = useConversationStore((s) => s.deleteConversation);
   const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+
+  const runningSet = new Set(runningSignature ? runningSignature.split("\n") : []);
+
+  // Stable callbacks so memoized rows don't all re-render on every parent render.
+  const handleSelect = useCallback(
+    (id: string) => {
+      void setActive(id);
+    },
+    [setActive]
+  );
+  const handleDelete = useCallback(
+    (id: string, title: string) => {
+      if (window.confirm(i18next.t("conversations.deleteConfirm", { title }))) {
+        void remove(id);
+      }
+    },
+    [remove]
+  );
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    if (!normalizedQuery) return conversations;
+    return conversations.filter((c) => {
+      if (c.title.toLowerCase().includes(normalizedQuery)) return true;
+      return displayAgentName(c.agentName, c.adapter)
+        .toLowerCase()
+        .includes(normalizedQuery);
+    });
+  }, [conversations, normalizedQuery]);
+
+  const sections = useMemo(() => {
+    const labels: Record<string, string> = {
+      today: t("conversations.group.today"),
+      yesterday: t("conversations.group.yesterday"),
+      last7: t("conversations.group.last7Days"),
+      last30: t("conversations.group.last30Days"),
+      earlier: t("conversations.group.earlier")
+    };
+    return groupConversationsByDate(filtered, labels);
+  }, [filtered, t]);
 
   return (
     <div className="conv-list">
@@ -71,56 +250,58 @@ export function ConversationList({
           {t("conversations.new")}
         </button>
       </div>
-      <ul>
-        {conversations.length === 0 && (
-          <li className="conv-empty muted">{t("conversations.empty")}</li>
+      <div className="conv-search">
+        <input
+          type="text"
+          value={query}
+          enterKeyHint="search"
+          placeholder={t("conversations.searchPlaceholder")}
+          aria-label={t("conversations.searchPlaceholder")}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              setQuery("");
+            }
+          }}
+        />
+        {query && (
+          <button
+            type="button"
+            className="conv-search-clear"
+            aria-label={t("conversations.clearSearchAria")}
+            onClick={() => setQuery("")}
+          >
+            ×
+          </button>
         )}
-        {conversations.map((c) => {
-          const running =
-            live[c.id]?.status === "running" || live[c.id]?.status === "starting";
-          const timeValue = conversationTimeValue(c);
-          const timeLabel = formatConversationTime(timeValue);
-          const agentName = displayAgentName(c.agentName, c.adapter);
-          return (
-            <li
-              key={c.id}
-              className={`conv-item${activeId === c.id ? " active" : ""}`}
-              onClick={() => void setActive(c.id)}
-            >
-              {running && <span className="conv-running-dot" />}
-              <div className="conv-item-main">
-                <div className="conv-item-title-row">
-                  <strong>{c.title}</strong>
-                </div>
-                <small>
-                  {agentName}
-                  {c.cwd ? ` · ${c.cwd.split(/[/\\]/).slice(-2).join("/")}` : ""}
-                  {timeLabel && (
-                    <>
-                      {" · "}
-                      <time dateTime={timeValue} title={formatConversationTimeTitle(timeValue)}>
-                        {timeLabel}
-                      </time>
-                    </>
-                  )}
-                </small>
-              </div>
-              <div className="conv-item-side">
-                <button
-                  className="icon-btn danger"
-                  title={t("common.delete")}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (window.confirm(t("conversations.deleteConfirm", { title: c.title })))
-                      void remove(c.id);
-                  }}
-                >
-                  ✕
-                </button>
-              </div>
-            </li>
-          );
-        })}
+      </div>
+      <ul>
+        {sections.length === 0 ? (
+          <li className="conv-empty muted">
+            {normalizedQuery
+              ? t("conversations.noResults")
+              : t("conversations.empty")}
+          </li>
+        ) : (
+          sections.map((section) => (
+            <Fragment key={section.key}>
+              <li className="conv-group-header">
+                <span>{section.label}</span>
+              </li>
+              {section.items.map((c) => (
+                <ConversationRow
+                  key={c.id}
+                  conversation={c}
+                  isActive={activeId === c.id}
+                  isRunning={runningSet.has(c.id)}
+                  onSelect={handleSelect}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </Fragment>
+          ))
+        )}
       </ul>
     </div>
   );

--- a/src/components/CLI/WorkspacePanel.tsx
+++ b/src/components/CLI/WorkspacePanel.tsx
@@ -17,6 +17,10 @@ import {
 type PlanItem = Extract<CliStreamItem, { kind: "plan" }>;
 type PlanEntry = PlanItem["entries"][number];
 
+// Stable empty array so the active-slice selectors below return a constant
+// reference when there is no active conversation (avoids re-renders).
+const EMPTY_MESSAGES: ConversationMessage[] = [];
+
 export function WorkspacePanel({
   runningCount
 }: {
@@ -25,8 +29,14 @@ export function WorkspacePanel({
   const { t } = useTranslation();
   const activeId = useConversationStore((s) => s.activeId);
   const conversations = useConversationStore((s) => s.conversations);
-  const messagesMap = useConversationStore((s) => s.messages);
-  const liveMap = useConversationStore((s) => s.live);
+  // Subscribe only to the active conversation's slices so background
+  // conversations streaming events don't re-render this panel.
+  const messages = useConversationStore((s) =>
+    s.activeId ? s.messages[s.activeId] ?? EMPTY_MESSAGES : EMPTY_MESSAGES
+  );
+  const live = useConversationStore((s) =>
+    s.activeId ? s.live[s.activeId] : undefined
+  );
   const [copiedSession, setCopiedSession] = useState(false);
   const [now, setNow] = useState(() => Date.now());
   const loadWorkflowForConversation = useWorkflowStore((s) => s.loadForConversation);
@@ -40,8 +50,6 @@ export function WorkspacePanel({
 
   const active = conversations.find((c) => c.id === activeId);
   const activeAgentName = displayAgentName(active?.agentName, active?.adapter);
-  const messages = activeId ? messagesMap[activeId] ?? [] : [];
-  const live = activeId ? liveMap[activeId] : undefined;
 
   const status = live?.status ?? "ready";
   const isLive = status === "running" || status === "starting";

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,7 +36,17 @@
     "title": "Conversations",
     "new": "+ New",
     "empty": "No conversations yet.",
-    "deleteConfirm": "Delete \"{{title}}\"?"
+    "deleteConfirm": "Delete \"{{title}}\"?",
+    "searchPlaceholder": "Search conversations",
+    "clearSearchAria": "Clear search",
+    "noResults": "No matching conversations.",
+    "group": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "last7Days": "Last 7 days",
+      "last30Days": "Last 30 days",
+      "earlier": "Earlier"
+    }
   },
   "chat": {
     "inputPlaceholder": "Type freely",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -36,7 +36,17 @@
     "title": "会话",
     "new": "+ 新建",
     "empty": "暂无会话。",
-    "deleteConfirm": "删除“{{title}}”?"
+    "deleteConfirm": "删除“{{title}}”?",
+    "searchPlaceholder": "搜索会话",
+    "clearSearchAria": "清除搜索",
+    "noResults": "没有匹配的会话。",
+    "group": {
+      "today": "今天",
+      "yesterday": "昨天",
+      "last7Days": "近 7 天",
+      "last30Days": "近 30 天",
+      "earlier": "更早"
+    }
   },
   "chat": {
     "inputPlaceholder": "随心输入",

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -90,6 +90,7 @@ export const runCtxMap = new Map<string, RunCtx>();
 
 let workflowMessageUnsubscribe: (() => void) | null = null;
 let workflowMessageConversationId: string | null = null;
+let workflowRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
 function ensureWorkflowMessageSubscription(
   conversationId: string | undefined,
@@ -107,10 +108,22 @@ function ensureWorkflowMessageSubscription(
     }
     workflowMessageUnsubscribe = null;
   }
+  if (workflowRefreshTimer) {
+    clearTimeout(workflowRefreshTimer);
+    workflowRefreshTimer = null;
+  }
   workflowMessageConversationId = conversationId ?? null;
   if (!conversationId) return;
   workflowMessageUnsubscribe = api.onStepMessage(conversationId, () => {
-    void refresh(conversationId);
+    // Workflow steps (especially parallel ones) can emit many message
+    // updates in quick succession. Each reload pulls every message and
+    // re-parses every assistant content blob, so coalesce the burst into
+    // a single trailing reload (~one per 150ms during continuous activity).
+    if (workflowRefreshTimer) return;
+    workflowRefreshTimer = setTimeout(() => {
+      workflowRefreshTimer = null;
+      void refresh(conversationId);
+    }, 150);
   });
 }
 
@@ -230,6 +243,16 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
   },
 
   async deleteConversation(id) {
+    // Stop any in-flight agent run before removing the conversation so the
+    // child process and its IPC event subscription don't keep running
+    // orphaned. The eventual "done" event finalizes and cleans up runCtxMap.
+    if (get().isRunning(id)) {
+      try {
+        await get().stopActive(id);
+      } catch {
+        /* best-effort: still remove the conversation */
+      }
+    }
     await cliClient.deleteConversation(id);
     set((s) => {
       const next = s.conversations.filter((c) => c.id !== id);

--- a/styles.css
+++ b/styles.css
@@ -3141,6 +3141,68 @@ button {
   color: var(--fb-text-primary);
 }
 
+.conv-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 0 4px 6px;
+}
+
+.conv-search input {
+  flex: 1;
+  min-width: 0;
+  height: 30px;
+  padding: 0 30px 0 10px;
+  border: 1px solid var(--fb-border);
+  border-radius: 8px;
+  background: var(--fb-panel-bg);
+  color: var(--fb-text-primary);
+  font-size: 12px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.conv-search input:focus {
+  outline: none;
+  border-color: var(--fb-brand);
+  box-shadow: 0 0 0 2px var(--fb-brand-glow);
+}
+
+.conv-search input::placeholder {
+  color: var(--fb-text-tertiary);
+}
+
+.conv-search-clear {
+  position: absolute;
+  right: 10px;
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--fb-text-tertiary);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.conv-search-clear:hover {
+  background: var(--fb-hover);
+  color: var(--fb-text-primary);
+}
+
+.conv-group-header {
+  padding: 10px 6px 4px;
+  color: var(--fb-text-tertiary);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
 .conv-item {
   display: flex;
   align-items: center;
@@ -3150,7 +3212,11 @@ button {
   border-radius: 10px;
   cursor: pointer;
   border: 1px solid transparent;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Only transition properties that actually change on hover/active. Avoid
+     `transition: all` (and never transform the item itself on :hover) so the
+     hit box stays put and the cursor can't oscillate in/out at the edges. */
+  transition: background-color 0.15s ease, box-shadow 0.15s ease,
+    border-color 0.15s ease;
   margin-bottom: 2px;
 }
 
@@ -3166,7 +3232,6 @@ button {
 
 .conv-item:hover {
   background: var(--fb-hover);
-  transform: translateX(2px);
 }
 
 .conv-item.active {


### PR DESCRIPTION
- main: coalesce high-frequency ACP items events (16ms / 200-item flush) to cap IPC traffic, per-chunk DB writes and React renders
- renderer: scope ChatView/WorkspacePanel/App/ConversationList subscriptions to active-slice / running-count / running-set so background conversations no longer re-render the UI while streaming
- store: throttle workflow full-message reloads (150ms) and kill the running task before deleting a conversation (fixes orphaned child process + listener leak)
- list: memoized rows, cached Intl.DateTimeFormat, search box (title/agent), date grouping (today / yesterday / last 7 / last 30 / earlier)
- fix list-item hover jitter caused by transform: translateX(2px) on :hover