### PR TITLE
feat(workflow): add Implement-Review Loop team for A-write B-review c…

### DIFF
--- a/electron/cli/conversations.ts
+++ b/electron/cli/conversations.ts
@@ -281,6 +281,10 @@ export function getMessage(id: string): ConversationMessage | undefined {
   return row ? rowToMessage(row) : undefined;
 }
 
+export function listMessage(id: string): ConversationMessage | undefined {
+  return getMessage(id);
+}
+
 export function listMessages(conversationId: string): ConversationMessage[] {
   const rows = getDb()
     .prepare(

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -31,6 +31,7 @@ import {
   deleteConversation,
   getConversation,
   listConversations,
+  listMessage,
   listMessages,
   renameConversation,
   setConversationApprovalMode,
@@ -270,6 +271,9 @@ export function registerCliIpc() {
 
   ipcMain.handle("cli:listMessages", (_e, conversationId: string) =>
     listMessages(conversationId)
+  );
+  ipcMain.handle("cli:listMessage", (_e, id: string) =>
+    listMessage(id)
   );
   ipcMain.handle("cli:appendMessage", (_e, input: AppendMessageInput) =>
     appendMessage(input)

--- a/electron/cli/workflowIpc.ts
+++ b/electron/cli/workflowIpc.ts
@@ -9,6 +9,7 @@ import { createCliStepExecutor, WorkflowRuntime } from "./workflowRuntime.js";
 import {
   getWorkflowRun,
   getWorkflowSteps,
+  listActiveWorkflowRuns,
   listWorkflowRunsByConversation
 } from "./workflows.js";
 import type {
@@ -138,6 +139,7 @@ export function registerWorkflowIpc() {
   );
 
   ipcMain.handle("workflow:getRun", (_e, runId: string) => getWorkflowRun(runId));
+  ipcMain.handle("workflow:listActiveRuns", () => listActiveWorkflowRuns());
   ipcMain.handle("workflow:getSteps", (_e, runId: string) =>
     getWorkflowSteps(runId)
   );

--- a/electron/cli/workflowIpc.ts
+++ b/electron/cli/workflowIpc.ts
@@ -113,9 +113,10 @@ export function registerWorkflowIpc() {
     ensureRuntime(event).pause(runId);
     return true;
   });
-  ipcMain.handle("workflow:resume", (event, runId: string) =>
-    ensureRuntime(event).resume(runId)
-  );
+  ipcMain.handle("workflow:resume", (event, runId: string) => {
+    void ensureRuntime(event).resume(runId);
+    return true;
+  });
   ipcMain.handle("workflow:stop", (event, runId: string) => {
     ensureRuntime(event).stop(runId);
     return true;
@@ -131,6 +132,9 @@ export function registerWorkflowIpc() {
       ensureRuntime(event).approveGate(args.runId, args.phaseId);
       return true;
     }
+  );
+  ipcMain.handle("workflow:continueImplementReview", (event, runId: string) =>
+    ensureRuntime(event).continueImplementReview(runId)
   );
 
   ipcMain.handle("workflow:getRun", (_e, runId: string) => getWorkflowRun(runId));

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -39,7 +39,9 @@ import {
   deriveStepSummary,
   ensureReviewStatusInSummary,
   extractReviewStatus,
+  findResumePhaseIndex,
   phaseGateSatisfied,
+  resumableStepRowIds,
   resolveReviewDecisionText,
   selectRunnableSteps,
   verifierHasUnresolved
@@ -196,10 +198,54 @@ export class WorkflowRuntime {
   }
 
   resume(runId: string): Promise<void> {
-    const run = this.active.get(runId);
-    if (run) run.paused = false;
+    const active = this.active.get(runId);
+    if (active) {
+      active.paused = false;
+      updateWorkflowRun(runId, { status: "running" });
+      return Promise.resolve();
+    }
+
+    const run = getWorkflowRun(runId);
+    if (!run) return Promise.resolve();
+    const plan = this.resolveWorkflowPlan(run);
+    if (run.status === "blocked") {
+      this.prepareBlockedRunForResume(runId, plan);
+    }
     updateWorkflowRun(runId, { status: "running" });
     return this.start(runId);
+  }
+
+  private prepareBlockedRunForResume(
+    runId: string,
+    plan: WorkflowPlan
+  ): void {
+    const steps = getWorkflowSteps(runId);
+    const states = steps.map((s) => ({
+      id: s.id,
+      phaseId: s.phaseId,
+      stepId: s.stepId,
+      status: s.status
+    }));
+    const phaseIndex = findResumePhaseIndex(
+      plan,
+      states.map((s) => ({
+        stepId: s.stepId,
+        phaseId: s.phaseId,
+        status: s.status
+      }))
+    );
+    const phase = plan.phases[phaseIndex];
+    if (!phase) return;
+    for (const stepRowId of resumableStepRowIds(phase.id, states)) {
+      updateWorkflowStep(stepRowId, {
+        status: "pending",
+        summary: null,
+        resultJson: null,
+        cliTaskId: null,
+        startedAt: null,
+        endedAt: null
+      });
+    }
   }
 
   stop(runId: string): void {
@@ -255,7 +301,15 @@ export class WorkflowRuntime {
     const plan = this.resolveWorkflowPlan(run);
     const state = this.active.get(runId)!;
 
-    let phaseIndex = 0;
+    const stepRows = getWorkflowSteps(runId);
+    let phaseIndex = findResumePhaseIndex(
+      plan,
+      stepRows.map((s) => ({
+        stepId: s.stepId,
+        phaseId: s.phaseId,
+        status: s.status
+      }))
+    );
     // Labeled outer loop so the Review Loop can replay review/implement/verify.
     outer: while (true) {
       while (phaseIndex < plan.phases.length) {

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -32,6 +32,7 @@ import {
   decideReviewLoop,
   deriveStepSummary,
   phaseGateSatisfied,
+  resolveReviewDecisionText,
   selectRunnableSteps,
   verifierHasUnresolved
 } from "./workflowScheduler.js";
@@ -311,14 +312,22 @@ export class WorkflowRuntime {
         const reviewer = getWorkflowSteps(runId).find(
           (s) => s.stepId === REVIEW_CHANGES_STEP_ID
         );
+        const reviewDecisionText = resolveReviewDecisionText(
+          reviewer?.summary,
+          reviewer?.resultJson
+        );
         const decision = decideImplementReviewLoop(
           reviewer?.status,
-          reviewer?.summary,
+          reviewDecisionText,
           run.loopIndex,
           run.maxLoops
         );
         if (decision === "loop") {
-          this.prepareImplementReviewLoopReplay(runId, plan, reviewer?.summary);
+          this.prepareImplementReviewLoopReplay(
+            runId,
+            plan,
+            reviewDecisionText
+          );
           state.approvedPhases.clear();
           resetWorkflowStepsForLoop(runId, IMPLEMENT_REVIEW_LOOP_PHASES);
           const implementIdx = plan.phases.findIndex((p) => p.id === "implement");

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -162,12 +162,13 @@ export class WorkflowRuntime {
     if (!run) throw new Error(`workflow run ${runId} not found`);
     if (this.active.has(runId)) return;
     const plan = JSON.parse(run.planJson) as WorkflowPlan;
+    const resolvedPlan = this.resolveWorkflowPlan(run, plan);
     this.active.set(runId, {
       paused: false,
       stopped: false,
       approvedPhases: new Set(),
       activeSessions: new Set(),
-      allowImmediateWrite: isImplementReviewLoopPlan(plan)
+      allowImmediateWrite: isImplementReviewLoopPlan(resolvedPlan)
     });
     updateWorkflowRun(runId, { status: "running" });
     try {
@@ -235,10 +236,23 @@ export class WorkflowRuntime {
     await this.start(runId);
   }
 
+  private resolveWorkflowPlan(
+    run: WorkflowRunRow,
+    plan?: WorkflowPlan
+  ): WorkflowPlan {
+    const parsed =
+      plan ?? (JSON.parse(run.planJson) as WorkflowPlan);
+    if (parsed.template) return parsed;
+    if (run.template === "implement-review-loop") {
+      return { ...parsed, template: "implement-review-loop" };
+    }
+    return parsed;
+  }
+
   private async drive(runId: string): Promise<void> {
     let run = getWorkflowRun(runId);
     if (!run) return;
-    const plan = JSON.parse(run.planJson) as WorkflowPlan;
+    const plan = this.resolveWorkflowPlan(run);
     const state = this.active.get(runId)!;
 
     let phaseIndex = 0;
@@ -324,6 +338,7 @@ export class WorkflowRuntime {
           reviewer?.summary,
           reviewer?.resultJson
         );
+        const reviewStatus = extractReviewStatus(reviewDecisionText);
         const decision = decideImplementReviewLoop(
           reviewer?.status,
           reviewDecisionText,
@@ -346,7 +361,17 @@ export class WorkflowRuntime {
           phaseIndex = implementIdx >= 0 ? implementIdx : 0;
           continue outer;
         }
-        this.finalize(runId, plan, decision === "partial" ? "partial" : "completed");
+        this.finalize(
+          runId,
+          plan,
+          decision === "partial" ? "partial" : "completed",
+          {
+            loopDecision: decision,
+            reviewStatus,
+            loopIndex: run.loopIndex,
+            maxLoops: run.maxLoops
+          }
+        );
         return;
       }
 
@@ -581,13 +606,19 @@ export class WorkflowRuntime {
   private finalize(
     runId: string,
     plan: WorkflowPlan,
-    status: WorkflowRunStatus
+    status: WorkflowRunStatus,
+    meta?: {
+      loopDecision?: string;
+      reviewStatus?: string;
+      loopIndex?: number;
+      maxLoops?: number;
+    }
   ): void {
     const run = getWorkflowRun(runId);
     if (!run) return;
     const steps = getWorkflowSteps(runId);
 
-    const summary = this.composeSummary(plan, steps, status);
+    const summary = this.composeSummary(plan, steps, status, meta);
     updateWorkflowRun(runId, {
       status,
       summary,
@@ -598,11 +629,26 @@ export class WorkflowRuntime {
   private composeSummary(
     plan: WorkflowPlan,
     steps: WorkflowStepRow[],
-    status: WorkflowRunStatus
+    status: WorkflowRunStatus,
+    meta?: {
+      loopDecision?: string;
+      reviewStatus?: string;
+      loopIndex?: number;
+      maxLoops?: number;
+    }
   ): string {
     const lines: string[] = [];
     lines.push(`Workflow ${status}: ${plan.name}`);
     lines.push(`Goal: ${plan.goal}`);
+    if (meta?.loopDecision) {
+      lines.push(
+        `Loop decision: ${meta.loopDecision}` +
+          (meta.reviewStatus ? ` (review=${meta.reviewStatus})` : "") +
+          (meta.loopIndex != null && meta.maxLoops != null
+            ? ` [round ${meta.loopIndex + 1}/${meta.maxLoops}]`
+            : "")
+      );
+    }
     for (const phase of plan.phases) {
       lines.push(`\n• ${phase.title}`);
       for (const s of steps.filter((st) => st.phaseId === phase.id)) {

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -13,6 +13,7 @@ import type {
   WorkflowPlan,
   WorkflowRunRow,
   WorkflowRunStatus,
+  WorkflowStep,
   WorkflowStepRow
 } from "./workflowTypes.js";
 import {
@@ -26,6 +27,8 @@ import {
 } from "./workflows.js";
 import { validateWorkflowPlan } from "./workflowValidate.js";
 import {
+  augmentPromptWithConsumedSummaries,
+  decideImplementReviewLoop,
   decideReviewLoop,
   deriveStepSummary,
   phaseGateSatisfied,
@@ -66,12 +69,25 @@ interface ActiveRun {
   stopped: boolean;
   approvedPhases: Set<string>;
   activeSessions: Set<string>;
+  /** Write steps may run without a prior manual gate (implement-first loops). */
+  allowImmediateWrite: boolean;
 }
 
 const REVIEW_LOOP_PHASES = ["review", "implement", "verify"];
+const IMPLEMENT_REVIEW_LOOP_PHASES = ["implement", "review"];
+const IMPLEMENT_REVIEW_STEP_ID = "implement-changes";
+const REVIEW_CHANGES_STEP_ID = "review-changes";
 
 function hasWriteApproval(state: ActiveRun): boolean {
-  return state.approvedPhases.size > 0;
+  return state.allowImmediateWrite || state.approvedPhases.size > 0;
+}
+
+function findPlanStep(plan: WorkflowPlan, stepId: string): WorkflowStep | undefined {
+  for (const phase of plan.phases) {
+    const step = phase.steps.find((s) => s.id === stepId);
+    if (step) return step;
+  }
+  return undefined;
 }
 
 export class WorkflowRuntime {
@@ -136,11 +152,13 @@ export class WorkflowRuntime {
     const run = getWorkflowRun(runId);
     if (!run) throw new Error(`workflow run ${runId} not found`);
     if (this.active.has(runId)) return;
+    const plan = JSON.parse(run.planJson) as WorkflowPlan;
     this.active.set(runId, {
       paused: false,
       stopped: false,
       approvedPhases: new Set(),
-      activeSessions: new Set()
+      activeSessions: new Set(),
+      allowImmediateWrite: plan.template === "implement-review-loop"
     });
     updateWorkflowRun(runId, { status: "running" });
     try {
@@ -289,9 +307,53 @@ export class WorkflowRuntime {
         return;
       }
 
+      if (plan.template === "implement-review-loop") {
+        const reviewer = getWorkflowSteps(runId).find(
+          (s) => s.stepId === REVIEW_CHANGES_STEP_ID
+        );
+        const decision = decideImplementReviewLoop(
+          reviewer?.status,
+          reviewer?.summary,
+          run.loopIndex,
+          run.maxLoops
+        );
+        if (decision === "loop") {
+          this.prepareImplementReviewLoopReplay(runId, plan, reviewer?.summary);
+          state.approvedPhases.clear();
+          resetWorkflowStepsForLoop(runId, IMPLEMENT_REVIEW_LOOP_PHASES);
+          const implementIdx = plan.phases.findIndex((p) => p.id === "implement");
+          updateWorkflowRun(runId, {
+            status: "running",
+            loopIndex: run.loopIndex + 1
+          });
+          phaseIndex = implementIdx >= 0 ? implementIdx : 0;
+          continue outer;
+        }
+        this.finalize(runId, plan, decision === "partial" ? "partial" : "completed");
+        return;
+      }
+
       this.finalize(runId, plan, "completed");
       return;
     }
+  }
+
+  /** Inject prior review feedback into the implement step before the next loop. */
+  private prepareImplementReviewLoopReplay(
+    runId: string,
+    plan: WorkflowPlan,
+    reviewSummary: string | undefined
+  ): void {
+    if (!reviewSummary?.trim()) return;
+    const steps = getWorkflowSteps(runId);
+    const implRow = steps.find((s) => s.stepId === IMPLEMENT_REVIEW_STEP_ID);
+    const planStep = findPlanStep(plan, IMPLEMENT_REVIEW_STEP_ID);
+    if (!implRow || !planStep) return;
+    const base = planStep.prompt;
+    const augmented =
+      `${base}\n\nAddress the following review feedback from the previous round:\n` +
+      `${reviewSummary.trim()}`;
+    updateWorkflowStep(implRow.id, { prompt: augmented });
   }
 
   private async runPhase(
@@ -331,7 +393,7 @@ export class WorkflowRuntime {
       }
 
       await Promise.all(
-        runnable.map((r) => this.executeStep(runId, run, r.stepId, state))
+        runnable.map((r) => this.executeStep(runId, run, plan, r.stepId, state))
       );
     }
   }
@@ -339,6 +401,7 @@ export class WorkflowRuntime {
   private async executeStep(
     runId: string,
     run: WorkflowRunRow,
+    plan: WorkflowPlan,
     stepId: string,
     state: ActiveRun
   ): Promise<void> {
@@ -359,6 +422,19 @@ export class WorkflowRuntime {
       updateWorkflowStep(step.id, { status: "failed", endedAt: new Date().toISOString() });
       return;
     }
+
+    const planStep = findPlanStep(plan, stepId);
+    const stepsById = new Map(
+      steps.map((s) => [
+        s.stepId,
+        { stepId: s.stepId, title: s.title, summary: s.summary }
+      ])
+    );
+    const prompt = augmentPromptWithConsumedSummaries(
+      step.prompt,
+      planStep?.consumes,
+      stepsById
+    );
 
     const sessionId = randomUUID();
     const collected: unknown[] = [];
@@ -407,7 +483,7 @@ export class WorkflowRuntime {
         adapter: resolved.adapter,
         binary: resolved.binary,
         extraArgs: resolved.extraArgs,
-        prompt: step.prompt,
+        prompt,
         cwd: run.cwd,
         onEvent: (e: CliEvent) => {
           if (e.type === "items" && e.items?.length) {

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -27,10 +27,18 @@ import {
 } from "./workflows.js";
 import { validateWorkflowPlan } from "./workflowValidate.js";
 import {
+  isImplementReviewLoopPlan,
+  IMPLEMENT_REVIEW_STEP_ID,
+  REVIEW_CHANGES_STEP_ID
+} from "./workflowTemplates.js";
+import {
   augmentPromptWithConsumedSummaries,
+  collectDecisionTextFromItems,
   decideImplementReviewLoop,
   decideReviewLoop,
   deriveStepSummary,
+  ensureReviewStatusInSummary,
+  extractReviewStatus,
   phaseGateSatisfied,
   resolveReviewDecisionText,
   selectRunnableSteps,
@@ -76,8 +84,6 @@ interface ActiveRun {
 
 const REVIEW_LOOP_PHASES = ["review", "implement", "verify"];
 const IMPLEMENT_REVIEW_LOOP_PHASES = ["implement", "review"];
-const IMPLEMENT_REVIEW_STEP_ID = "implement-changes";
-const REVIEW_CHANGES_STEP_ID = "review-changes";
 
 function hasWriteApproval(state: ActiveRun): boolean {
   return state.allowImmediateWrite || state.approvedPhases.size > 0;
@@ -111,7 +117,9 @@ export class WorkflowRuntime {
       goal: input.plan.goal,
       cwd: input.plan.cwd,
       template: input.plan.template,
-      maxLoops: input.plan.maxLoops ?? 1,
+      maxLoops: isImplementReviewLoopPlan(input.plan)
+        ? Math.max(input.plan.maxLoops ?? 5, 2)
+        : (input.plan.maxLoops ?? 1),
       planJson: JSON.stringify(input.plan)
     });
     this.seedSteps(run.id, input.plan);
@@ -159,7 +167,7 @@ export class WorkflowRuntime {
       stopped: false,
       approvedPhases: new Set(),
       activeSessions: new Set(),
-      allowImmediateWrite: plan.template === "implement-review-loop"
+      allowImmediateWrite: isImplementReviewLoopPlan(plan)
     });
     updateWorkflowRun(runId, { status: "running" });
     try {
@@ -308,7 +316,7 @@ export class WorkflowRuntime {
         return;
       }
 
-      if (plan.template === "implement-review-loop") {
+      if (isImplementReviewLoopPlan(plan)) {
         const reviewer = getWorkflowSteps(runId).find(
           (s) => s.stepId === REVIEW_CHANGES_STEP_ID
         );
@@ -521,10 +529,22 @@ export class WorkflowRuntime {
 
     if (state.stopped) return;
 
+    const decisionText = collectDecisionTextFromItems(collected);
     const failed = errored !== null || (exitCode !== null && exitCode !== 0);
-    const summary = deriveStepSummary(collected);
+    let summary = ensureReviewStatusInSummary(
+      deriveStepSummary(collected),
+      decisionText
+    );
+    let stepStatus: WorkflowStepRow["status"] = failed ? "failed" : "done";
+    if (
+      isImplementReviewLoopPlan(plan) &&
+      stepId === REVIEW_CHANGES_STEP_ID &&
+      extractReviewStatus(decisionText) !== undefined
+    ) {
+      stepStatus = "done";
+    }
     updateWorkflowStep(step.id, {
-      status: failed ? "failed" : "done",
+      status: stepStatus,
       summary,
       resultJson: JSON.stringify({ items: collected, exitCode, error: errored }),
       endedAt: new Date().toISOString()
@@ -533,7 +553,7 @@ export class WorkflowRuntime {
     if (assistantMessageId && run.conversationId) {
       updateMessage({
         id: assistantMessageId,
-        status: failed ? "failed" : "done",
+        status: stepStatus === "failed" ? "failed" : "done",
         content: JSON.stringify(collected)
       });
       this.broadcastMessageEvent({

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -208,14 +208,13 @@ export class WorkflowRuntime {
     const run = getWorkflowRun(runId);
     if (!run) return Promise.resolve();
     const plan = this.resolveWorkflowPlan(run);
-    if (run.status === "blocked") {
-      this.prepareBlockedRunForResume(runId, plan);
+    if (run.status === "blocked" || run.status === "paused" || run.status === "running") {
+      this.prepareInactiveRunForResume(runId, plan);
     }
-    updateWorkflowRun(runId, { status: "running" });
     return this.start(runId);
   }
 
-  private prepareBlockedRunForResume(
+  private prepareInactiveRunForResume(
     runId: string,
     plan: WorkflowPlan
   ): void {
@@ -280,6 +279,38 @@ export class WorkflowRuntime {
     });
     updateWorkflowRun(runId, { status: "running" });
     await this.start(runId);
+  }
+
+  continueImplementReview(runId: string): boolean {
+    const run = getWorkflowRun(runId);
+    if (!run || run.status !== "partial") return false;
+    const plan = this.resolveWorkflowPlan(run);
+    if (!isImplementReviewLoopPlan(plan)) return false;
+    const reviewer = getWorkflowSteps(runId).find(
+      (s) => s.stepId === REVIEW_CHANGES_STEP_ID
+    );
+    const reviewDecisionText = resolveReviewDecisionText(
+      reviewer?.summary,
+      reviewer?.resultJson
+    );
+    if (extractReviewStatus(reviewDecisionText) !== "FAIL") return false;
+
+    const nextMaxLoops = Math.max(run.maxLoops + 1, run.loopIndex + 2);
+    const nextPlan = {
+      ...plan,
+      maxLoops: nextMaxLoops
+    };
+    this.prepareImplementReviewLoopReplay(runId, nextPlan, reviewDecisionText);
+    resetWorkflowStepsForLoop(runId, IMPLEMENT_REVIEW_LOOP_PHASES);
+    updateWorkflowRun(runId, {
+      status: "running",
+      maxLoops: nextMaxLoops,
+      planJson: JSON.stringify(nextPlan),
+      summary: null,
+      endedAt: null
+    });
+    void this.start(runId);
+    return true;
   }
 
   private resolveWorkflowPlan(
@@ -536,6 +567,33 @@ export class WorkflowRuntime {
     const collected: unknown[] = [];
     let exitCode: number | null = null;
     let errored: string | null = null;
+    let messageFlushTimer: ReturnType<typeof setTimeout> | undefined;
+    let hasPendingMessageUpdate = false;
+
+    const flushMessageUpdate = () => {
+      if (messageFlushTimer) {
+        clearTimeout(messageFlushTimer);
+        messageFlushTimer = undefined;
+      }
+      if (!hasPendingMessageUpdate || !assistantMessageId || !run.conversationId) return;
+      hasPendingMessageUpdate = false;
+      updateMessage({
+        id: assistantMessageId,
+        content: JSON.stringify(collected)
+      });
+      this.broadcastMessageEvent({
+        type: "updated",
+        conversationId: run.conversationId,
+        messageId: assistantMessageId
+      });
+    };
+
+    const scheduleMessageUpdate = () => {
+      if (!assistantMessageId || !run.conversationId) return;
+      hasPendingMessageUpdate = true;
+      if (messageFlushTimer) return;
+      messageFlushTimer = setTimeout(flushMessageUpdate, 300);
+    };
 
     updateWorkflowStep(step.id, {
       status: "running",
@@ -584,17 +642,7 @@ export class WorkflowRuntime {
         onEvent: (e: CliEvent) => {
           if (e.type === "items" && e.items?.length) {
             collected.push(...e.items);
-            if (assistantMessageId && run.conversationId) {
-              updateMessage({
-                id: assistantMessageId,
-                content: JSON.stringify(collected)
-              });
-              this.broadcastMessageEvent({
-                type: "updated",
-                conversationId: run.conversationId,
-                messageId: assistantMessageId
-              });
-            }
+            scheduleMessageUpdate();
           }
           if (e.type === "done") exitCode = e.exitCode;
           if (e.type === "error") errored = e.message;
@@ -603,6 +651,7 @@ export class WorkflowRuntime {
     } catch (err) {
       errored = (err as Error).message;
     } finally {
+      flushMessageUpdate();
       state.activeSessions.delete(sessionId);
     }
 

--- a/electron/cli/workflowScheduler.ts
+++ b/electron/cli/workflowScheduler.ts
@@ -414,7 +414,7 @@ export function resumableStepRowIds(
     .filter(
       (s) =>
         s.phaseId === phaseId &&
-        (s.status === "failed" || s.status === "blocked")
+        (s.status === "failed" || s.status === "blocked" || s.status === "running")
     )
     .map((s) => s.id);
 }

--- a/electron/cli/workflowScheduler.ts
+++ b/electron/cli/workflowScheduler.ts
@@ -148,18 +148,31 @@ export function deriveStepSummary(items: unknown[]): string {
   return "Step completed.";
 }
 
-/** Join every assistant text chunk in order (ACP may split long replies). */
-export function collectAllTextFromItems(items: unknown[]): string {
+/** Join assistant-visible text used for workflow control markers. */
+export function collectDecisionTextFromItems(items: unknown[]): string {
   const parts: string[] = [];
   for (const raw of items) {
-    const item = raw as { kind?: string; content?: string };
+    const item = raw as {
+      kind?: string;
+      content?: string;
+      text?: string;
+    };
     if (!item || typeof item !== "object") continue;
-    if (item.kind === "text" && typeof item.content === "string") {
+    if (item.kind === "text" || item.kind === "thinking") {
+      const piece = (item.content ?? item.text ?? "").trim();
+      if (piece) parts.push(piece);
+    }
+    if (item.kind === "tool-result" && typeof item.content === "string") {
       const piece = item.content.trim();
       if (piece) parts.push(piece);
     }
   }
   return parts.join("\n");
+}
+
+/** Join every assistant text chunk in order (ACP may split long replies). */
+export function collectAllTextFromItems(items: unknown[]): string {
+  return collectDecisionTextFromItems(items);
 }
 
 /** Prefer full stream text from resultJson when deciding loop outcomes. */
@@ -170,7 +183,7 @@ export function resolveReviewDecisionText(
   if (resultJson) {
     try {
       const parsed = JSON.parse(resultJson) as { items?: unknown[] };
-      const full = collectAllTextFromItems(parsed.items ?? []).trim();
+      const full = collectDecisionTextFromItems(parsed.items ?? []).trim();
       if (full) return full;
     } catch {
       /* fall through to summary */
@@ -195,10 +208,23 @@ export function extractReviewStatus(
   text: string | undefined
 ): "PASS" | "FAIL" | undefined {
   if (!text) return undefined;
-  const matches = [...text.matchAll(/REVIEW_STATUS:\s*(PASS|FAIL)/gi)];
+  const matches = [
+    ...text.matchAll(/REVIEW[\s_-]*STATUS\s*:\s*(PASS|FAIL)/gi)
+  ];
   const last = matches.at(-1)?.[1];
   if (!last) return undefined;
   return last.toUpperCase() as "PASS" | "FAIL";
+}
+
+/** Ensure compact summaries still carry a review status marker when present in full text. */
+export function ensureReviewStatusInSummary(
+  summary: string,
+  decisionText: string
+): string {
+  const status = extractReviewStatus(decisionText);
+  if (!status) return summary;
+  if (extractReviewStatus(summary)) return summary;
+  return `${summary}\nREVIEW_STATUS: ${status}`;
 }
 
 /** Heuristic: detect "UNRESOLVED: <n>" with n > 0 in a verifier summary. */
@@ -223,10 +249,17 @@ export function decideImplementReviewLoop(
   loopIndex: number,
   maxLoops: number
 ): "loop" | "finish" | "partial" {
+  const reviewStatus = extractReviewStatus(reviewerSummary);
+  if (reviewStatus === "PASS") return "finish";
+  if (reviewStatus === "FAIL") {
+    if (reviewerStatus !== "done" && reviewerStatus !== "failed") {
+      return "partial";
+    }
+    if (loopIndex + 1 < maxLoops) return "loop";
+    return "partial";
+  }
   if (reviewerStatus !== "done") return "partial";
-  if (!reviewerHasFail(reviewerSummary)) return "finish";
-  if (loopIndex + 1 < maxLoops) return "loop";
-  return "partial";
+  return "finish";
 }
 
 export interface ConsumedStepRef {

--- a/electron/cli/workflowScheduler.ts
+++ b/electron/cli/workflowScheduler.ts
@@ -150,24 +150,145 @@ export function deriveStepSummary(items: unknown[]): string {
 
 /** Join assistant-visible text used for workflow control markers. */
 export function collectDecisionTextFromItems(items: unknown[]): string {
-  const parts: string[] = [];
-  for (const raw of items) {
-    const item = raw as {
-      kind?: string;
-      content?: string;
-      text?: string;
-    };
-    if (!item || typeof item !== "object") continue;
-    if (item.kind === "text" || item.kind === "thinking") {
-      const piece = (item.content ?? item.text ?? "").trim();
-      if (piece) parts.push(piece);
-    }
-    if (item.kind === "tool-result" && typeof item.content === "string") {
-      const piece = item.content.trim();
-      if (piece) parts.push(piece);
-    }
+  const normalized = normalizeStreamItemsForDecision(items);
+  const pieces: string[] = [];
+  for (const item of normalized) {
+    extractTextPiecesFromItem(item, pieces);
   }
-  return parts.join("\n");
+  return pieces.join("\n");
+}
+
+interface StreamLike {
+  kind?: string;
+  content?: string;
+  text?: string;
+  role?: string;
+  messageId?: string;
+  append?: boolean;
+  blockType?: string;
+  entries?: Array<{ content?: string }>;
+  output?: string;
+  toolOutputs?: StreamLike[];
+  input?: unknown;
+}
+
+function mergeStreamTextLike(prev: StreamLike, next: StreamLike): StreamLike {
+  const prevContent = String(prev.content ?? prev.text ?? "");
+  const nextContent = String(next.content ?? next.text ?? "");
+  if (next.append) {
+    return { ...prev, content: prevContent + nextContent };
+  }
+  if (nextContent === prevContent) return prev;
+  if (nextContent.startsWith(prevContent)) {
+    return { ...prev, content: nextContent };
+  }
+  return { ...next, content: nextContent };
+}
+
+/** Merge ACP append chunks the same way the chat renderer does. */
+function normalizeStreamItemsForDecision(items: unknown[]): StreamLike[] {
+  const out: StreamLike[] = [];
+  for (const raw of items) {
+    const item = raw as StreamLike;
+    if (!item || typeof item !== "object") continue;
+
+    if (item.kind === "text" || item.kind === "thinking") {
+      if (item.messageId) {
+        const idx = out.findIndex(
+          (previous) =>
+            previous.kind === item.kind &&
+            previous.messageId === item.messageId &&
+            (item.kind !== "text" || previous.role === item.role)
+        );
+        if (idx >= 0) {
+          out[idx] = mergeStreamTextLike(out[idx]!, item);
+          continue;
+        }
+      }
+      const last = out[out.length - 1];
+      if (
+        item.append &&
+        last &&
+        last.kind === item.kind &&
+        (item.kind !== "text" || last.role === item.role)
+      ) {
+        out[out.length - 1] = mergeStreamTextLike(last, item);
+        continue;
+      }
+      if (
+        last &&
+        last.kind === item.kind &&
+        (item.kind !== "text" || last.role === item.role)
+      ) {
+        const merged = mergeStreamTextLike(last, item);
+        if (merged !== last) {
+          out[out.length - 1] = merged;
+          continue;
+        }
+      }
+      out.push({ ...item, content: item.content ?? item.text ?? "" });
+      continue;
+    }
+    out.push(item);
+  }
+  return out;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function extractTextPiecesFromItem(item: StreamLike, pieces: string[]): void {
+  switch (item.kind) {
+    case "text":
+    case "thinking":
+    case "raw":
+    case "command-output": {
+      const piece = String(item.content ?? item.text ?? "").trim();
+      if (piece) pieces.push(piece);
+      return;
+    }
+    case "tool-result": {
+      const piece = String(item.content ?? "").trim();
+      if (piece) pieces.push(piece);
+      return;
+    }
+    case "tool-call": {
+      if (typeof item.output === "string" && item.output.trim()) {
+        pieces.push(item.output.trim());
+      }
+      if (item.input !== undefined) {
+        const input = stringifyUnknown(item.input).trim();
+        if (input && input !== "{}") pieces.push(input);
+      }
+      for (const nested of item.toolOutputs ?? []) {
+        extractTextPiecesFromItem(nested, pieces);
+      }
+      return;
+    }
+    case "content-block": {
+      if (item.blockType === "resource" && typeof item.text === "string") {
+        const piece = item.text.trim();
+        if (piece) pieces.push(piece);
+      }
+      return;
+    }
+    case "plan": {
+      for (const entry of item.entries ?? []) {
+        const piece = String(entry?.content ?? "").trim();
+        if (piece) pieces.push(piece);
+      }
+      return;
+    }
+    default:
+      return;
+  }
 }
 
 /** Join every assistant text chunk in order (ACP may split long replies). */
@@ -193,8 +314,8 @@ export function resolveReviewDecisionText(
 }
 
 function compactStepSummary(text: string, maxLen = 400): string {
-  const reviewMarker = [...text.matchAll(/REVIEW_STATUS:\s*(?:PASS|FAIL)/gi)]
-    .at(-1)?.[0];
+  const status = extractReviewStatus(text);
+  const reviewMarker = status ? `REVIEW_STATUS: ${status}` : undefined;
   const unresolvedMarker = text.match(/UNRESOLVED:\s*\d+/i)?.[0];
   const markers = [reviewMarker, unresolvedMarker].filter(Boolean) as string[];
   if (text.length <= maxLen) return text;
@@ -208,6 +329,10 @@ export function extractReviewStatus(
   text: string | undefined
 ): "PASS" | "FAIL" | undefined {
   if (!text) return undefined;
+  if (/<<<REVIEW_FAIL>>>/i.test(text)) return "FAIL";
+  if (/<<<REVIEW_PASS>>>/i.test(text)) return "PASS";
+  if (/\[\[REVIEW:FAIL\]\]/i.test(text)) return "FAIL";
+  if (/\[\[REVIEW:PASS\]\]/i.test(text)) return "PASS";
   const matches = [
     ...text.matchAll(/REVIEW[\s_-]*STATUS\s*:\s*(PASS|FAIL)/gi)
   ];

--- a/electron/cli/workflowScheduler.ts
+++ b/electron/cli/workflowScheduler.ts
@@ -127,27 +127,78 @@ export function decideReviewLoop(
 
 /**
  * Extract a concise summary from the final assistant stream items of a step.
- * Prefers the last assistant text; falls back to tool-action count.
+ * Concatenates all text chunks and preserves workflow control markers
+ * (REVIEW_STATUS / UNRESOLVED) even when the body is truncated.
  */
 export function deriveStepSummary(items: unknown[]): string {
-  let text = "";
+  const fullText = collectAllTextFromItems(items);
   let toolCount = 0;
   for (const raw of items) {
-    const item = raw as { kind?: string; content?: string };
+    const item = raw as { kind?: string };
     if (!item || typeof item !== "object") continue;
     if (item.kind === "tool-call" || item.kind === "tool-result") {
       toolCount += 1;
     }
-    if (item.kind === "text" && typeof item.content === "string") {
-      text = item.content;
-    }
   }
-  const trimmed = text.trim();
-  if (trimmed) return trimmed.slice(0, 400);
+  const trimmed = fullText.trim();
+  if (trimmed) return compactStepSummary(trimmed);
   if (toolCount > 0) {
     return `Completed ${toolCount} tool action${toolCount === 1 ? "" : "s"}.`;
   }
   return "Step completed.";
+}
+
+/** Join every assistant text chunk in order (ACP may split long replies). */
+export function collectAllTextFromItems(items: unknown[]): string {
+  const parts: string[] = [];
+  for (const raw of items) {
+    const item = raw as { kind?: string; content?: string };
+    if (!item || typeof item !== "object") continue;
+    if (item.kind === "text" && typeof item.content === "string") {
+      const piece = item.content.trim();
+      if (piece) parts.push(piece);
+    }
+  }
+  return parts.join("\n");
+}
+
+/** Prefer full stream text from resultJson when deciding loop outcomes. */
+export function resolveReviewDecisionText(
+  summary: string | undefined,
+  resultJson: string | undefined
+): string | undefined {
+  if (resultJson) {
+    try {
+      const parsed = JSON.parse(resultJson) as { items?: unknown[] };
+      const full = collectAllTextFromItems(parsed.items ?? []).trim();
+      if (full) return full;
+    } catch {
+      /* fall through to summary */
+    }
+  }
+  return summary;
+}
+
+function compactStepSummary(text: string, maxLen = 400): string {
+  const reviewMarker = [...text.matchAll(/REVIEW_STATUS:\s*(?:PASS|FAIL)/gi)]
+    .at(-1)?.[0];
+  const unresolvedMarker = text.match(/UNRESOLVED:\s*\d+/i)?.[0];
+  const markers = [reviewMarker, unresolvedMarker].filter(Boolean) as string[];
+  if (text.length <= maxLen) return text;
+  if (markers.length === 0) return text.slice(0, maxLen);
+  const markerBlock = markers.join("\n");
+  const budget = Math.max(80, maxLen - markerBlock.length - 2);
+  return `${text.slice(0, budget).trimEnd()}\n…\n${markerBlock}`;
+}
+
+export function extractReviewStatus(
+  text: string | undefined
+): "PASS" | "FAIL" | undefined {
+  if (!text) return undefined;
+  const matches = [...text.matchAll(/REVIEW_STATUS:\s*(PASS|FAIL)/gi)];
+  const last = matches.at(-1)?.[1];
+  if (!last) return undefined;
+  return last.toUpperCase() as "PASS" | "FAIL";
 }
 
 /** Heuristic: detect "UNRESOLVED: <n>" with n > 0 in a verifier summary. */
@@ -160,8 +211,7 @@ export function verifierHasUnresolved(summary: string | undefined): boolean {
 
 /** Heuristic: detect REVIEW_STATUS: FAIL in a reviewer summary. */
 export function reviewerHasFail(summary: string | undefined): boolean {
-  if (!summary) return false;
-  return /REVIEW_STATUS:\s*FAIL/i.test(summary);
+  return extractReviewStatus(summary) === "FAIL";
 }
 
 /**

--- a/electron/cli/workflowScheduler.ts
+++ b/electron/cli/workflowScheduler.ts
@@ -6,6 +6,7 @@ import type {
 
 export interface StepState {
   stepId: string;
+  phaseId?: string;
   status?: WorkflowStepStatus;
 }
 
@@ -385,6 +386,37 @@ export function decideImplementReviewLoop(
   }
   if (reviewerStatus !== "done") return "partial";
   return "finish";
+}
+
+/** First phase that still has steps not in done|skipped. */
+export function findResumePhaseIndex(
+  plan: WorkflowPlan,
+  states: StepState[]
+): number {
+  for (let i = 0; i < plan.phases.length; i++) {
+    const phase = plan.phases[i]!;
+    const phaseSteps = states.filter((s) => s.phaseId === phase.id);
+    if (phaseSteps.length === 0) continue;
+    const finished = phaseSteps.every(
+      (s) => s.status === "done" || s.status === "skipped"
+    );
+    if (!finished) return i;
+  }
+  return plan.phases.length;
+}
+
+/** Step row ids in a phase that should be reset before resuming after a block. */
+export function resumableStepRowIds(
+  phaseId: string,
+  states: Array<{ id: string; phaseId: string; status?: WorkflowStepStatus }>
+): string[] {
+  return states
+    .filter(
+      (s) =>
+        s.phaseId === phaseId &&
+        (s.status === "failed" || s.status === "blocked")
+    )
+    .map((s) => s.id);
 }
 
 export interface ConsumedStepRef {

--- a/electron/cli/workflowScheduler.ts
+++ b/electron/cli/workflowScheduler.ts
@@ -157,3 +157,48 @@ export function verifierHasUnresolved(summary: string | undefined): boolean {
   if (match) return Number(match[1]) > 0;
   return false;
 }
+
+/** Heuristic: detect REVIEW_STATUS: FAIL in a reviewer summary. */
+export function reviewerHasFail(summary: string | undefined): boolean {
+  if (!summary) return false;
+  return /REVIEW_STATUS:\s*FAIL/i.test(summary);
+}
+
+/**
+ * Decide the Implement-Review Loop outcome after the reviewer step completes.
+ */
+export function decideImplementReviewLoop(
+  reviewerStatus: WorkflowStepStatus | undefined,
+  reviewerSummary: string | undefined,
+  loopIndex: number,
+  maxLoops: number
+): "loop" | "finish" | "partial" {
+  if (reviewerStatus !== "done") return "partial";
+  if (!reviewerHasFail(reviewerSummary)) return "finish";
+  if (loopIndex + 1 < maxLoops) return "loop";
+  return "partial";
+}
+
+export interface ConsumedStepRef {
+  stepId: string;
+  title: string;
+  summary?: string;
+}
+
+/** Append upstream step summaries referenced by consumes ids. */
+export function augmentPromptWithConsumedSummaries(
+  basePrompt: string,
+  consumes: string[] | undefined,
+  stepsById: Map<string, ConsumedStepRef>
+): string {
+  if (!consumes?.length) return basePrompt;
+  const blocks: string[] = [];
+  for (const id of consumes) {
+    const ref = stepsById.get(id);
+    if (ref?.summary?.trim()) {
+      blocks.push(`--- ${ref.title} ---\n${ref.summary.trim()}`);
+    }
+  }
+  if (blocks.length === 0) return basePrompt;
+  return `${basePrompt}\n\nContext from prior steps:\n${blocks.join("\n\n")}`;
+}

--- a/electron/cli/workflowTeamAdapter.ts
+++ b/electron/cli/workflowTeamAdapter.ts
@@ -91,6 +91,8 @@ export function expandTeamToPlan(
   let approvalNodeCount = 0;
   let priorMode: WorkflowTemplateNodeMode | undefined;
 
+  let priorStepIds: string[] = [];
+
   for (const node of orderedNodes) {
     const role = node.roleId
       ? team.roles.find((r) => r.id === node.roleId)
@@ -147,7 +149,8 @@ export function expandTeamToPlan(
       title: node.title,
       agentId: agentRef.id,
       mode: nodeModeToStepMode(node.mode),
-      prompt: renderPrompt(node.promptTemplate, input)
+      prompt: renderPrompt(node.promptTemplate, input),
+      ...(priorStepIds.length ? { consumes: priorStepIds } : {})
     };
 
     phases.push({
@@ -167,6 +170,7 @@ export function expandTeamToPlan(
     });
 
     priorMode = node.mode;
+    priorStepIds = [step.id];
   }
 
   if (errors.length > 0) return { ok: false, errors };

--- a/electron/cli/workflowTeamAdapter.ts
+++ b/electron/cli/workflowTeamAdapter.ts
@@ -1,4 +1,8 @@
 import { builtinCliMembers } from "./members.js";
+import {
+  buildImplementReviewLoopPlan,
+  IMPLEMENT_REVIEW_LOOP_TEMPLATE_ID
+} from "./workflowTemplates.js";
 import type {
   WorkflowAgentRef,
   WorkflowGate,
@@ -53,6 +57,10 @@ export function expandTeamToPlan(
   input: TeamRunInput,
   agents: WorkflowAgentRef[]
 ): TeamPreviewResult {
+  if (team.template.id === IMPLEMENT_REVIEW_LOOP_TEMPLATE_ID) {
+    return expandImplementReviewTeamToPlan(team, input, agents);
+  }
+
   const errors: string[] = [];
 
   if (!team.enabled) {
@@ -181,6 +189,88 @@ export function expandTeamToPlan(
     routeSummary,
     writeNodeCount,
     approvalNodeCount,
+    maxLoops: team.policy.maxLoops,
+    plan
+  };
+
+  return { ok: true, preview };
+}
+
+function expandImplementReviewTeamToPlan(
+  team: WorkflowTeam,
+  input: TeamRunInput,
+  agents: WorkflowAgentRef[]
+): TeamPreviewResult {
+  const errors: string[] = [];
+  if (!team.enabled) errors.push("team is disabled");
+
+  const implementerRole = team.roles.find((r) => r.kind === "implementer");
+  const reviewerRole = team.roles.find((r) => r.kind === "reviewer");
+  if (!implementerRole) errors.push("implementer role is required");
+  if (!reviewerRole) errors.push("reviewer role is required");
+
+  const implementer = implementerRole
+    ? agents.find((a) => a.id === implementerRole.agentId)
+    : undefined;
+  const reviewer = reviewerRole
+    ? agents.find((a) => a.id === reviewerRole.agentId)
+    : undefined;
+  if (implementerRole && !implementer) {
+    errors.push(`implementer references unknown agent "${implementerRole.agentId}"`);
+  }
+  if (reviewerRole && !reviewer) {
+    errors.push(`reviewer references unknown agent "${reviewerRole.agentId}"`);
+  }
+  if (errors.length > 0 || !implementer || !reviewer) {
+    return { ok: false, errors };
+  }
+
+  const plan = buildImplementReviewLoopPlan({
+    goal: input.goal,
+    cwd: input.cwd,
+    targetPaths: input.targetPaths,
+    implementer,
+    reviewer,
+    maxLoops: team.policy.maxLoops
+  });
+
+  const roleSummary: WorkflowTeamPreview["roleSummary"] = team.roles.map((role) => {
+    const m = builtinCliMembers.find((x) => x.id === role.agentId);
+    return {
+      roleId: role.id,
+      roleLabel: role.label,
+      kind: role.kind,
+      agentId: role.agentId,
+      agentName: m?.name ?? role.agentId
+    };
+  });
+
+  const routeSummary: WorkflowTeamPreview["routeSummary"] = [
+    {
+      nodeId: "implement",
+      title: "Implement",
+      mode: "write",
+      roleLabel: implementerRole!.label,
+      agentName: implementer.name
+    },
+    {
+      nodeId: "review",
+      title: "Review",
+      mode: "review",
+      roleLabel: reviewerRole!.label,
+      agentName: reviewer.name
+    }
+  ];
+
+  const preview: WorkflowTeamPreview = {
+    teamId: team.id,
+    teamName: team.name,
+    goal: input.goal,
+    cwd: input.cwd,
+    roleSummary,
+    routeSummary,
+    writeNodeCount: 1,
+    approvalNodeCount: 0,
     maxLoops: team.policy.maxLoops,
     plan
   };

--- a/electron/cli/workflowTeamBuiltins.ts
+++ b/electron/cli/workflowTeamBuiltins.ts
@@ -63,94 +63,6 @@ export function builtinWorkflowTeams(): WorkflowTeam[] {
     updatedAt: now
   };
 
-  const reviewTeam: WorkflowTeam = {
-    id: "team-code-review",
-    name: "Code Review",
-    description: "Research, review, approve findings, implement, verify. For higher-risk tasks needing review first.",
-    icon: "team-review",
-    enabled: true,
-    source: "builtin",
-    roles: [
-      { id: "role-researcher", label: "Researcher", kind: "researcher", agentId: codex, required: true, canWrite: false },
-      { id: "role-reviewer", label: "Reviewer", kind: "reviewer", agentId: claude, required: true, canWrite: false },
-      { id: "role-implementer", label: "Implementer", kind: "implementer", agentId: claude, required: true, canWrite: true },
-      { id: "role-verifier", label: "Verifier", kind: "verifier", agentId: opencode, required: true, canWrite: false },
-      { id: "role-summarizer", label: "Summarizer", kind: "summarizer", agentId: codex, required: true, canWrite: false }
-    ],
-    template: {
-      id: "tpl-code-review",
-      name: "Code Review",
-      version: 1,
-      nodes: [
-        { id: "baseline", title: "Baseline", roleId: "role-researcher", mode: "research", promptTemplate: "Summarize the task and current state. Goal: {{goal}}. Report target files, current state, and success criteria." },
-        { id: "review", title: "Review", roleId: "role-reviewer", mode: "review", promptTemplate: "Review the current state against the goal. List concrete, actionable findings with severity." },
-        { id: "implement", title: "Implement", roleId: "role-implementer", mode: "write", promptTemplate: "Address the approved review findings for: {{goal}}. Make focused changes." },
-        { id: "verify", title: "Verify", roleId: "role-verifier", mode: "verify", promptTemplate: "Verify the changes resolve the findings. Run checks. End your response with: UNRESOLVED: <count>" },
-        { id: "summarize", title: "Summarize", roleId: "role-summarizer", mode: "summarize", promptTemplate: "Summarize what was reviewed, what was changed, and remaining issues." }
-      ],
-      edges: [
-        { id: "e1", from: "baseline", to: "review" },
-        { id: "e2", from: "review", to: "implement" },
-        { id: "e3", from: "implement", to: "verify" },
-        { id: "e4", from: "verify", to: "summarize" }
-      ],
-      startNodeIds: ["baseline"],
-      finalNodeIds: ["summarize"]
-    },
-    policy: {
-      allowWrites: true,
-      requireApprovalBeforeWrite: false,
-      requireApprovalAfterReview: true,
-      maxParallelReadSteps: 1,
-      maxParallelWriteSteps: 1,
-      maxLoops: 3,
-      stopOnVerifyFailure: true
-    },
-    createdAt: now,
-    updatedAt: now
-  };
-
-  const readonlyTeam: WorkflowTeam = {
-    id: "team-readonly-analysis",
-    name: "Read-Only Analysis",
-    description: "Research, review, summarize. No file writes allowed. For code comprehension, comparison, and reporting.",
-    icon: "team-readonly",
-    enabled: true,
-    source: "builtin",
-    roles: [
-      { id: "role-researcher", label: "Researcher", kind: "researcher", agentId: codex, required: true, canWrite: false },
-      { id: "role-reviewer", label: "Reviewer", kind: "reviewer", agentId: claude, required: true, canWrite: false },
-      { id: "role-summarizer", label: "Summarizer", kind: "summarizer", agentId: codex, required: true, canWrite: false }
-    ],
-    template: {
-      id: "tpl-readonly-analysis",
-      name: "Read-Only Analysis",
-      version: 1,
-      nodes: [
-        { id: "research-context", title: "Research context", roleId: "role-researcher", mode: "research", promptTemplate: "Explore the codebase and gather context for: {{goal}}. Report key files and findings." },
-        { id: "review-risks", title: "Review risks", roleId: "role-reviewer", mode: "review", promptTemplate: "Review the research findings. List risks, trade-offs, and recommendations for: {{goal}}." },
-        { id: "summarize", title: "Summarize", roleId: "role-summarizer", mode: "summarize", promptTemplate: "Summarize the analysis and recommendations for: {{goal}}." }
-      ],
-      edges: [
-        { id: "e1", from: "research-context", to: "review-risks" },
-        { id: "e2", from: "review-risks", to: "summarize" }
-      ],
-      startNodeIds: ["research-context"],
-      finalNodeIds: ["summarize"]
-    },
-    policy: {
-      allowWrites: false,
-      requireApprovalBeforeWrite: false,
-      requireApprovalAfterReview: false,
-      maxParallelReadSteps: 3,
-      maxParallelWriteSteps: 1,
-      maxLoops: 1,
-      stopOnVerifyFailure: false
-    },
-    createdAt: now,
-    updatedAt: now
-  };
-
   const implementReviewTeam: WorkflowTeam = {
     id: "team-implement-review-loop",
     name: "Implement-Review Loop",
@@ -214,5 +126,86 @@ export function builtinWorkflowTeams(): WorkflowTeam[] {
     updatedAt: now
   };
 
-  return [quickTeam, reviewTeam, implementReviewTeam, readonlyTeam];
+  const researchReportTeam: WorkflowTeam = {
+    id: "team-research-report",
+    name: "Research Report",
+    description:
+      "Research a non-coding topic, analyze scenarios, and produce a concise report with conclusions and confidence.",
+    icon: "team-research-report",
+    enabled: true,
+    source: "builtin",
+    roles: [
+      {
+        id: "role-researcher",
+        label: "Researcher",
+        kind: "researcher",
+        agentId: pickAgent(["cli-kimi-acp", "cli-codex-acp"]),
+        required: true,
+        canWrite: false
+      },
+      {
+        id: "role-analyst",
+        label: "Analyst",
+        kind: "reviewer",
+        agentId: codex,
+        required: true,
+        canWrite: false
+      },
+      {
+        id: "role-reporter",
+        label: "Reporter",
+        kind: "summarizer",
+        agentId: claude,
+        required: true,
+        canWrite: false
+      }
+    ],
+    template: {
+      id: "tpl-research-report",
+      name: "Research Report",
+      version: 1,
+      nodes: [
+        {
+          id: "research",
+          title: "Research",
+          roleId: "role-researcher",
+          mode: "research",
+          promptTemplate: "Research the topic: {{goal}}. Gather relevant facts, context, constraints, and uncertainties. If current information is needed, identify what should be verified and cite available evidence from your environment."
+        },
+        {
+          id: "analysis",
+          title: "Analyze",
+          roleId: "role-analyst",
+          mode: "review",
+          promptTemplate: "Analyze the research for: {{goal}}. Compare plausible scenarios, key drivers, risks, and assumptions. If predicting outcomes such as sports scores, give likely ranges and confidence instead of overclaiming certainty."
+        },
+        {
+          id: "report",
+          title: "Report",
+          roleId: "role-reporter",
+          mode: "summarize",
+          promptTemplate: "Write a concise final report for: {{goal}}. Include summary, evidence, analysis, forecast or recommendation, confidence level, and caveats."
+        }
+      ],
+      edges: [
+        { id: "e1", from: "research", to: "analysis" },
+        { id: "e2", from: "analysis", to: "report" }
+      ],
+      startNodeIds: ["research"],
+      finalNodeIds: ["report"]
+    },
+    policy: {
+      allowWrites: false,
+      requireApprovalBeforeWrite: false,
+      requireApprovalAfterReview: false,
+      maxParallelReadSteps: 1,
+      maxParallelWriteSteps: 1,
+      maxLoops: 1,
+      stopOnVerifyFailure: false
+    },
+    createdAt: now,
+    updatedAt: now
+  };
+
+  return [quickTeam, implementReviewTeam, researchReportTeam];
 }

--- a/electron/cli/workflowTeamBuiltins.ts
+++ b/electron/cli/workflowTeamBuiltins.ts
@@ -170,21 +170,21 @@ export function builtinWorkflowTeams(): WorkflowTeam[] {
           title: "Research",
           roleId: "role-researcher",
           mode: "research",
-          promptTemplate: "Research the topic: {{goal}}. Gather relevant facts, context, constraints, and uncertainties. If current information is needed, identify what should be verified and cite available evidence from your environment."
+          promptTemplate: "Research the topic: {{goal}}. Focus only on information gathering: collect relevant facts, current context, constraints, evidence, and data gaps. Do not make final judgments or forecasts. Output concise evidence bullets, note freshness/uncertainty, and list what could not be verified."
         },
         {
           id: "analysis",
           title: "Analyze",
           roleId: "role-analyst",
           mode: "review",
-          promptTemplate: "Analyze the research for: {{goal}}. Compare plausible scenarios, key drivers, risks, and assumptions. If predicting outcomes such as sports scores, give likely ranges and confidence instead of overclaiming certainty."
+          promptTemplate: "Analyze the provided research for: {{goal}}. Do not repeat the raw facts except when needed as evidence. Identify key drivers, compare plausible scenarios, assess risks and assumptions, and provide likelihood ranges or confidence levels. For sports scores or forecasts, reason from the evidence and avoid claiming certainty."
         },
         {
           id: "report",
           title: "Report",
           roleId: "role-reporter",
           mode: "summarize",
-          promptTemplate: "Write a concise final report for: {{goal}}. Include summary, evidence, analysis, forecast or recommendation, confidence level, and caveats."
+          promptTemplate: "Write a concise final report for: {{goal}}. Synthesize the research evidence and analysis into a clear answer with summary, key evidence, forecast or recommendation, confidence level, and caveats."
         }
       ],
       edges: [

--- a/electron/cli/workflowTeamBuiltins.ts
+++ b/electron/cli/workflowTeamBuiltins.ts
@@ -164,7 +164,7 @@ export function builtinWorkflowTeams(): WorkflowTeam[] {
         id: "role-implementer",
         label: "Implementer",
         kind: "implementer",
-        agentId: claude,
+        agentId: opencode,
         required: true,
         canWrite: true
       },
@@ -172,7 +172,7 @@ export function builtinWorkflowTeams(): WorkflowTeam[] {
         id: "role-reviewer",
         label: "Reviewer",
         kind: "reviewer",
-        agentId: codex,
+        agentId: pickAgent(["cli-kimi-acp", "cli-codex-acp"]),
         required: true,
         canWrite: false
       }

--- a/electron/cli/workflowTeamBuiltins.ts
+++ b/electron/cli/workflowTeamBuiltins.ts
@@ -151,5 +151,68 @@ export function builtinWorkflowTeams(): WorkflowTeam[] {
     updatedAt: now
   };
 
-  return [quickTeam, reviewTeam, readonlyTeam];
+  const implementReviewTeam: WorkflowTeam = {
+    id: "team-implement-review-loop",
+    name: "Implement-Review Loop",
+    description:
+      "Agent A implements, Agent B reviews. On FAIL, A fixes and B reviews again until PASS or max loops.",
+    icon: "team-implement-review",
+    enabled: true,
+    source: "builtin",
+    roles: [
+      {
+        id: "role-implementer",
+        label: "Implementer",
+        kind: "implementer",
+        agentId: claude,
+        required: true,
+        canWrite: true
+      },
+      {
+        id: "role-reviewer",
+        label: "Reviewer",
+        kind: "reviewer",
+        agentId: codex,
+        required: true,
+        canWrite: false
+      }
+    ],
+    template: {
+      id: "tpl-implement-review-loop",
+      name: "Implement-Review Loop",
+      version: 1,
+      nodes: [
+        {
+          id: "implement",
+          title: "Implement",
+          roleId: "role-implementer",
+          mode: "write",
+          promptTemplate: "Implement: {{goal}}"
+        },
+        {
+          id: "review",
+          title: "Review",
+          roleId: "role-reviewer",
+          mode: "review",
+          promptTemplate: "Review: {{goal}}"
+        }
+      ],
+      edges: [{ id: "e1", from: "implement", to: "review" }],
+      startNodeIds: ["implement"],
+      finalNodeIds: ["review"]
+    },
+    policy: {
+      allowWrites: true,
+      requireApprovalBeforeWrite: false,
+      requireApprovalAfterReview: false,
+      maxParallelReadSteps: 1,
+      maxParallelWriteSteps: 1,
+      maxLoops: 5,
+      stopOnVerifyFailure: false
+    },
+    createdAt: now,
+    updatedAt: now
+  };
+
+  return [quickTeam, reviewTeam, implementReviewTeam, readonlyTeam];
 }

--- a/electron/cli/workflowTeams.ts
+++ b/electron/cli/workflowTeams.ts
@@ -145,6 +145,18 @@ export function seedBuiltinWorkflowTeams(): void {
   for (const team of builtinWorkflowTeams()) {
     if (!existingIds.has(team.id)) {
       insertWorkflowTeam(team);
+      continue;
+    }
+    if (team.id === "team-implement-review-loop") {
+      updateWorkflowTeam(team.id, {
+        name: team.name,
+        description: team.description,
+        icon: team.icon,
+        enabled: team.enabled,
+        roles: team.roles,
+        template: team.template,
+        policy: team.policy
+      });
     }
   }
 }

--- a/electron/cli/workflowTeams.ts
+++ b/electron/cli/workflowTeams.ts
@@ -139,7 +139,17 @@ export function deleteWorkflowTeam(id: string): boolean {
 
 export { builtinWorkflowTeams };
 
+const removedBuiltinWorkflowTeamIds = [
+  "team-code-review",
+  "team-readonly-analysis"
+];
+
 export function seedBuiltinWorkflowTeams(): void {
+  const db = getDb();
+  for (const id of removedBuiltinWorkflowTeamIds) {
+    db.prepare("DELETE FROM workflow_teams WHERE id = ? AND source = 'builtin'").run(id);
+  }
+
   const existing = listWorkflowTeams();
   const existingIds = new Set(existing.map((t) => t.id));
   for (const team of builtinWorkflowTeams()) {
@@ -147,7 +157,7 @@ export function seedBuiltinWorkflowTeams(): void {
       insertWorkflowTeam(team);
       continue;
     }
-    if (team.id === "team-implement-review-loop") {
+    if (team.id === "team-implement-review-loop" || team.source === "builtin") {
       updateWorkflowTeam(team.id, {
         name: team.name,
         description: team.description,

--- a/electron/cli/workflowTemplates.ts
+++ b/electron/cli/workflowTemplates.ts
@@ -114,11 +114,24 @@ export interface ImplementReviewLoopInput {
 }
 
 export const IMPLEMENT_REVIEW_LOOP_TEMPLATE_ID = "tpl-implement-review-loop";
+export const IMPLEMENT_REVIEW_STEP_ID = "implement-changes";
+export const REVIEW_CHANGES_STEP_ID = "review-changes";
+
+export function isImplementReviewLoopPlan(plan: WorkflowPlan): boolean {
+  if (plan.template === "implement-review-loop") return true;
+  const stepIds = new Set(
+    plan.phases.flatMap((phase) => phase.steps.map((step) => step.id))
+  );
+  return (
+    stepIds.has(IMPLEMENT_REVIEW_STEP_ID) &&
+    stepIds.has(REVIEW_CHANGES_STEP_ID)
+  );
+}
 
 export function buildImplementReviewLoopPlan(
   input: ImplementReviewLoopInput
 ): WorkflowPlan {
-  const maxLoops = input.maxLoops ?? 5;
+  const maxLoops = Math.max(input.maxLoops ?? 5, 2);
   const target = (input.targetPaths ?? []).join(", ");
   const goalLine = `Goal: ${input.goal}.` + (target ? ` Target: ${target}.` : "");
 

--- a/electron/cli/workflowTemplates.ts
+++ b/electron/cli/workflowTemplates.ts
@@ -104,6 +104,80 @@ export function buildReviewLoopPlan(input: ReviewLoopInput): WorkflowPlan {
   };
 }
 
+export interface ImplementReviewLoopInput {
+  goal: string;
+  cwd?: string;
+  implementer: WorkflowAgentRef;
+  reviewer: WorkflowAgentRef;
+  targetPaths?: string[];
+  maxLoops?: number;
+}
+
+export const IMPLEMENT_REVIEW_LOOP_TEMPLATE_ID = "tpl-implement-review-loop";
+
+export function buildImplementReviewLoopPlan(
+  input: ImplementReviewLoopInput
+): WorkflowPlan {
+  const maxLoops = input.maxLoops ?? 5;
+  const target = (input.targetPaths ?? []).join(", ");
+  const goalLine = `Goal: ${input.goal}.` + (target ? ` Target: ${target}.` : "");
+
+  return {
+    name: "Implement-Review Loop",
+    goal: input.goal,
+    cwd: input.cwd,
+    template: "implement-review-loop",
+    maxLoops,
+    phases: [
+      {
+        id: "implement",
+        title: "Implement",
+        parallelism: 1,
+        steps: [
+          {
+            id: "implement-changes",
+            title: "Implement changes",
+            agentId: input.implementer.id,
+            mode: "write",
+            prompt:
+              `Implement the requested change. ${goalLine} ` +
+              "Make focused, minimal edits. Run quick sanity checks if appropriate.",
+            targetPaths: input.targetPaths
+          }
+        ],
+        gate: { type: "all_done" }
+      },
+      {
+        id: "review",
+        title: "Review",
+        parallelism: 1,
+        steps: [
+          {
+            id: "review-changes",
+            title: "Review changes",
+            agentId: input.reviewer.id,
+            mode: "review",
+            prompt:
+              `Review the implementation for: ${input.goal}. ` +
+              "List concrete issues if any. " +
+              "End your response with exactly one line: REVIEW_STATUS: PASS or REVIEW_STATUS: FAIL. " +
+              "If FAIL, include a FINDINGS section with actionable bullets.",
+            consumes: ["implement-changes"]
+          }
+        ],
+        gate: { type: "all_done" }
+      },
+      {
+        id: "loop_or_finish",
+        title: "Loop or Finish",
+        parallelism: 1,
+        steps: [],
+        gate: { type: "all_done" }
+      }
+    ]
+  };
+}
+
 export function reviewLoopCoordinatorPrompt(input: {
   goal: string;
   cwd?: string;

--- a/electron/cli/workflowTemplates.ts
+++ b/electron/cli/workflowTemplates.ts
@@ -172,9 +172,13 @@ export function buildImplementReviewLoopPlan(
             mode: "review",
             prompt:
               `Review the implementation for: ${input.goal}. ` +
-              "List concrete issues if any. " +
-              "End your response with exactly one line: REVIEW_STATUS: PASS or REVIEW_STATUS: FAIL. " +
-              "If FAIL, include a FINDINGS section with actionable bullets.",
+              "List concrete issues if any.\n\n" +
+              "Required machine-readable format (first AND last line of your reply):\n" +
+              "REVIEW_STATUS: PASS\n" +
+              "or\n" +
+              "REVIEW_STATUS: FAIL\n\n" +
+              "If FAIL, include a FINDINGS section with actionable bullets.\n" +
+              "You may also end with <<<REVIEW_PASS>>> or <<<REVIEW_FAIL>>>.",
             consumes: ["implement-changes"]
           }
         ],

--- a/electron/cli/workflowTypes.ts
+++ b/electron/cli/workflowTypes.ts
@@ -34,7 +34,7 @@ export interface WorkflowPlan {
   name: string;
   goal: string;
   cwd?: string;
-  template?: "review-loop" | "custom";
+  template?: "review-loop" | "implement-review-loop" | "custom";
   maxLoops?: number;
   phases: WorkflowPhase[];
 }

--- a/electron/cli/workflows.ts
+++ b/electron/cli/workflows.ts
@@ -109,7 +109,9 @@ export function createWorkflowRun(input: CreateWorkflowRunInput): WorkflowRunRow
 export interface UpdateWorkflowRunPatch {
   status?: WorkflowRunStatus;
   loopIndex?: number;
-  summary?: string;
+  maxLoops?: number;
+  planJson?: string;
+  summary?: string | null;
   endedAt?: string | null;
 }
 
@@ -126,6 +128,14 @@ export function updateWorkflowRun(
   if (patch.loopIndex !== undefined) {
     fields.push("loop_index = ?");
     params.push(patch.loopIndex);
+  }
+  if (patch.maxLoops !== undefined) {
+    fields.push("max_loops = ?");
+    params.push(patch.maxLoops);
+  }
+  if (patch.planJson !== undefined) {
+    fields.push("plan_json = ?");
+    params.push(patch.planJson);
   }
   if (patch.summary !== undefined) {
     fields.push("summary = ?");

--- a/electron/cli/workflows.ts
+++ b/electron/cli/workflows.ts
@@ -216,6 +216,7 @@ export function createWorkflowStep(input: CreateWorkflowStepInput): void {
 
 export interface UpdateWorkflowStepPatch {
   status?: WorkflowStepStatus;
+  prompt?: string;
   summary?: string | null;
   resultJson?: string | null;
   cliTaskId?: string | null;
@@ -232,6 +233,10 @@ export function updateWorkflowStep(
   if (patch.status !== undefined) {
     fields.push("status = ?");
     params.push(patch.status);
+  }
+  if (patch.prompt !== undefined) {
+    fields.push("prompt = ?");
+    params.push(patch.prompt);
   }
   if (patch.summary !== undefined) {
     fields.push("summary = ?");

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -107,6 +107,7 @@ const workflow = {
   continueImplementReview: (runId: string) =>
     ipcRenderer.invoke("workflow:continueImplementReview", runId),
   getRun: (runId: string) => ipcRenderer.invoke("workflow:getRun", runId),
+  listActiveRuns: () => ipcRenderer.invoke("workflow:listActiveRuns"),
   getSteps: (runId: string) => ipcRenderer.invoke("workflow:getSteps", runId),
   listRuns: (conversationId: string) =>
     ipcRenderer.invoke("workflow:listRuns", conversationId),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -55,6 +55,8 @@ const cli = {
   ) => ipcRenderer.invoke("cli:setConversationApprovalMode", { id, approvalMode }),
   listMessages: (conversationId: string) =>
     ipcRenderer.invoke("cli:listMessages", conversationId),
+  listMessage: (id: string) =>
+    ipcRenderer.invoke("cli:listMessage", id),
   appendMessage: (input: unknown) =>
     ipcRenderer.invoke("cli:appendMessage", input),
   updateMessage: (input: unknown) =>
@@ -102,6 +104,8 @@ const workflow = {
   retryStep: (args: unknown) => ipcRenderer.invoke("workflow:retryStep", args),
   approveGate: (args: unknown) =>
     ipcRenderer.invoke("workflow:approveGate", args),
+  continueImplementReview: (runId: string) =>
+    ipcRenderer.invoke("workflow:continueImplementReview", runId),
   getRun: (runId: string) => ipcRenderer.invoke("workflow:getRun", runId),
   getSteps: (runId: string) => ipcRenderer.invoke("workflow:getSteps", runId),
   listRuns: (conversationId: string) =>

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -13,6 +13,8 @@ import type {
   WorkflowTeamPreview
 } from "@/services/workflowTeams/types";
 import { workflowTeamName } from "@/services/workflowTeams/types";
+import { workflowFollowupAgentId } from "@/services/workflows/types";
+import { workflowClient } from "@/services/workflows/client";
 import { displayAgentName } from "@/config/agentDisplay";
 import {
   attachmentPreviewUrl,
@@ -259,8 +261,15 @@ export function ChatView() {
   const [slashIndex, setSlashIndex] = useState(0);
 
   const conv = conversations.find((c) => c.id === activeId);
-  const member = conv ? members.find((m) => m.id === conv.agentId) : undefined;
-  const agentDisplayName = displayAgentName(member?.name ?? conv?.agentName, conv?.adapter);
+  const activeRun = useWorkflowStore((s) => s.activeRun);
+  const workflowFollowupAgent =
+    activeRun && activeRun.conversationId === conv?.id
+      ? workflowFollowupAgentId(activeRun)
+      : undefined;
+  const member = conv
+    ? members.find((m) => m.id === (workflowFollowupAgent ?? conv.agentId))
+    : undefined;
+  const agentDisplayName = displayAgentName(member?.name ?? conv?.agentName, member?.cli.adapter ?? conv?.adapter);
   const running =
     live?.status === "running" || live?.status === "starting";
   const sending =
@@ -561,10 +570,21 @@ export function ChatView() {
     chatTextareaRef.current?.focus();
   };
 
+  const resolveWorkflowFollowupMember = async () => {
+    if (!conv || !workflowClient.isAvailable()) return member;
+    const run =
+      activeRun?.conversationId === conv.id
+        ? activeRun
+        : (await workflowClient.listRuns(conv.id))[0];
+    const agentId = run ? workflowFollowupAgentId(run) : undefined;
+    return members.find((m) => m.id === (agentId ?? conv.agentId));
+  };
+
   const onSend = async () => {
     const prompt = draft.trim();
     const attachmentsToSend = pendingAttachments;
-    if (!conv || !member || (!prompt && attachmentsToSend.length === 0) || sending) return;
+    const targetMember = await resolveWorkflowFollowupMember();
+    if (!conv || !targetMember || (!prompt && attachmentsToSend.length === 0) || sending) return;
     setPreflightMsg(null);
     isNearBottomRef.current = true;
     const userMessageId = nanoid();
@@ -581,7 +601,7 @@ export function ChatView() {
     setDraft("");
     setPendingAttachments([]);
     try {
-      if (!(await preflightMember(member))) {
+      if (!(await preflightMember(targetMember))) {
         setSubmitPreview(null);
         setDraft(prompt);
         setPendingAttachments(attachmentsToSend);

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -12,6 +12,7 @@ import type {
   WorkflowTeam,
   WorkflowTeamPreview
 } from "@/services/workflowTeams/types";
+import { workflowTeamName } from "@/services/workflowTeams/types";
 import { displayAgentName } from "@/config/agentDisplay";
 import {
   attachmentPreviewUrl,
@@ -178,6 +179,20 @@ function AttachmentTray({
         </div>
       ))}
     </div>
+  );
+}
+
+function teamConversationMember(
+  team: WorkflowTeam,
+  members: ReturnType<typeof useConversationStore.getState>["members"]
+) {
+  const preferredRole =
+    team.roles.find((role) => role.kind === "summarizer") ??
+    team.roles.find((role) => !role.canWrite) ??
+    team.roles[0];
+  if (!preferredRole) return members[0];
+  return (
+    members.find((member) => member.id === preferredRole.agentId) ?? members[0]
   );
 }
 
@@ -456,9 +471,7 @@ export function ChatView() {
       if (!prompt || !selectedTeamId) return;
       const team = teams.find((tt) => tt.id === selectedTeamId);
       if (!team) return;
-      const firstRoleAgentId = team.roles[0]?.agentId;
-      const teamMember =
-        members.find((m) => m.id === firstRoleAgentId) ?? members[0];
+      const teamMember = teamConversationMember(team, members);
       if (!teamMember) return;
       setPreflightMsg(null);
       try {
@@ -610,16 +623,18 @@ export function ChatView() {
   };
 
   const onCreateTeamConversation = async () => {
-    const selectedMember = members.find((m) => m.id === selectedMemberId) ?? members[0];
-    if (!selectedMember) return;
     if (!teamMode) return;
     if (!pendingTeamPreview) return;
+    const team = teams.find((tt) => tt.id === pendingTeamPreview.teamId);
+    if (!team) return;
+    const teamMember = teamConversationMember(team, members);
+    if (!teamMember) return;
     const cwd = newTaskCwd.trim() || pendingTeamPreview?.cwd;
     setPreflightMsg(null);
     try {
-      if (!(await preflightMember(selectedMember))) return;
+      if (!(await preflightMember(teamMember))) return;
       const newConv = await createConversation({
-        member: selectedMember,
+        member: teamMember,
         cwd,
         title: (pendingTeamPreview.goal || pendingTeamPreview.teamName || "").slice(0, 24),
         approvalMode: permissionMode
@@ -939,7 +954,7 @@ function NewTaskHome({
                     .filter((tt) => tt.enabled)
                     .map((tt) => (
                       <option key={tt.id} value={tt.id}>
-                        {tt.name}
+                        {workflowTeamName(tt, t)}
                       </option>
                     ))}
                 </select>

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -467,7 +467,7 @@ export function ChatView() {
         const newConv = await createConversation({
           member: teamMember,
           cwd,
-          title: (team.name + ": " + prompt).slice(0, 32),
+          title: (prompt || team.name).slice(0, 24),
           approvalMode: permissionMode
         });
         setNewTaskDraft("");
@@ -621,7 +621,7 @@ export function ChatView() {
       const newConv = await createConversation({
         member: selectedMember,
         cwd,
-        title: (pendingTeamPreview.name ?? "").slice(0, 24),
+        title: (pendingTeamPreview.goal || pendingTeamPreview.teamName || "").slice(0, 24),
         approvalMode: permissionMode
       });
       setNewTaskDraft("");
@@ -855,7 +855,7 @@ function NewTaskHome({
   cwd: string;
   permissionMode: "auto" | "ask";
   pendingAttachments: ChatAttachment[];
-  taskMode: "normal" | "workflow" | "team";
+  taskMode: "normal" | "team";
   teams: WorkflowTeam[];
   selectedTeamId: string;
   preflightMsg: string | null;
@@ -865,7 +865,7 @@ function NewTaskHome({
   onPermissionMode: (value: "auto" | "ask") => void;
   onSelectAttachments: () => void;
   onRemoveAttachment: (id: string) => void;
-  onTaskMode: (value: "normal" | "workflow" | "team") => void;
+  onTaskMode: (value: "normal" | "team") => void;
   onTeam: (id: string) => void;
   onSubmit: () => void;
 }) {

--- a/src/components/CLI/ConversationList.tsx
+++ b/src/components/CLI/ConversationList.tsx
@@ -1,5 +1,6 @@
 import { Fragment, memo, useCallback, useMemo, useState } from "react";
 import { useConversationStore } from "@/store/conversationStore";
+import { useWorkflowStore } from "@/store/workflowStore";
 import type { Conversation } from "@/services/cli/types";
 import { displayAgentName } from "@/config/agentDisplay";
 import i18next from "i18next";
@@ -198,11 +199,18 @@ export function ConversationList({
     }
     return ids.join("\n");
   });
+  const workflowRun = useWorkflowStore((s) => s.activeRun);
+  const workflowRunningConversationId =
+    workflowRun &&
+    ["running", "paused", "blocked", "pending_approval"].includes(workflowRun.status)
+      ? workflowRun.conversationId
+      : undefined;
   const remove = useConversationStore((s) => s.deleteConversation);
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
 
   const runningSet = new Set(runningSignature ? runningSignature.split("\n") : []);
+  if (workflowRunningConversationId) runningSet.add(workflowRunningConversationId);
 
   // Stable callbacks so memoized rows don't all re-render on every parent render.
   const handleSelect = useCallback(

--- a/src/components/CLI/ConversationList.tsx
+++ b/src/components/CLI/ConversationList.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useCallback, useMemo, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useConversationStore } from "@/store/conversationStore";
 import { useWorkflowStore } from "@/store/workflowStore";
 import type { Conversation } from "@/services/cli/types";
@@ -118,12 +118,14 @@ const ConversationRow = memo(function ConversationRow({
   conversation,
   isActive,
   isRunning,
+  isWorkflowRunning,
   onSelect,
   onDelete
 }: {
   conversation: Conversation;
   isActive: boolean;
   isRunning: boolean;
+  isWorkflowRunning: boolean;
   onSelect: (id: string) => void;
   onDelete: (id: string, title: string) => void;
 }) {
@@ -146,7 +148,12 @@ const ConversationRow = memo(function ConversationRow({
         }
       }}
     >
-      {isRunning && <span className="conv-running-dot" />}
+      {(isRunning || isWorkflowRunning) && (
+        <span
+          className={`conv-running-dot${isWorkflowRunning ? " workflow" : ""}`}
+          title={isWorkflowRunning ? t("workflow.runningIndicator") : t("chat.agentRunning")}
+        />
+      )}
       <div className="conv-item-main">
         <div className="conv-item-title-row">
           <strong>{conversation.title}</strong>
@@ -199,18 +206,18 @@ export function ConversationList({
     }
     return ids.join("\n");
   });
-  const workflowRun = useWorkflowStore((s) => s.activeRun);
-  const workflowRunningConversationId =
-    workflowRun &&
-    ["running", "paused", "blocked", "pending_approval"].includes(workflowRun.status)
-      ? workflowRun.conversationId
-      : undefined;
+  const workflowActiveRuns = useWorkflowStore((s) => s.activeRuns);
+  const loadWorkflowActiveRuns = useWorkflowStore((s) => s.loadActiveRuns);
   const remove = useConversationStore((s) => s.deleteConversation);
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
 
   const runningSet = new Set(runningSignature ? runningSignature.split("\n") : []);
-  if (workflowRunningConversationId) runningSet.add(workflowRunningConversationId);
+  const workflowRunningSet = new Set(
+    workflowActiveRuns
+      .map((run) => run.conversationId)
+      .filter((id): id is string => Boolean(id))
+  );
 
   // Stable callbacks so memoized rows don't all re-render on every parent render.
   const handleSelect = useCallback(
@@ -229,6 +236,11 @@ export function ConversationList({
   );
 
   const normalizedQuery = query.trim().toLowerCase();
+
+  useEffect(() => {
+    void loadWorkflowActiveRuns();
+  }, [loadWorkflowActiveRuns]);
+
   const filtered = useMemo(() => {
     if (!normalizedQuery) return conversations;
     return conversations.filter((c) => {
@@ -303,6 +315,7 @@ export function ConversationList({
                   conversation={c}
                   isActive={activeId === c.id}
                   isRunning={runningSet.has(c.id)}
+                  isWorkflowRunning={workflowRunningSet.has(c.id)}
                   onSelect={handleSelect}
                   onDelete={handleDelete}
                 />

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -374,7 +374,7 @@ function MessageAttachments({
   );
 }
 
-export function MessageBubble({
+export const MessageBubble = memo(function MessageBubble({
   message,
   adapter
 }: {
@@ -523,4 +523,4 @@ export function MessageBubble({
       </div>
     </div>
   );
-}
+});

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState, type MouseEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -232,6 +232,45 @@ function visibleBlocks(items: CliStreamItem[]): VisibleBlock[] {
   return blocks;
 }
 
+function itemText(item: CliStreamItem): string {
+  switch (item.kind) {
+    case "text":
+    case "thinking":
+    case "raw":
+      return item.content;
+    case "error":
+      return [item.message, item.details].filter(Boolean).join("\n");
+    case "command":
+      return item.command;
+    case "command-output":
+    case "tool-result":
+      return item.content;
+    case "tool-call":
+      return [
+        item.tool,
+        item.input === undefined
+          ? ""
+          : typeof item.input === "string"
+            ? item.input
+            : JSON.stringify(item.input, null, 2),
+        item.output ?? ""
+      ].filter(Boolean).join("\n");
+    case "file-edit":
+      return [item.path, item.oldText, item.newText].filter(Boolean).join("\n");
+    case "content-block":
+      return [item.title, item.name, item.text, item.uri]
+        .filter(Boolean)
+        .join("\n");
+    default:
+      return "";
+  }
+}
+
+function messageText(message: ConversationMessage, items: CliStreamItem[]): string {
+  if (message.role === "user" || message.role === "system") return message.content;
+  return items.map(itemText).filter(Boolean).join("\n\n");
+}
+
 function attachmentSummary(attachment: ChatAttachment): string {
   return [
     attachment.mimeType || attachment.extension || attachment.kind,
@@ -422,6 +461,28 @@ export const MessageBubble = memo(function MessageBubble({
       return "";
     }
   }, [message.createdAt]);
+  const [copyMenu, setCopyMenu] = useState<{ x: number; y: number } | null>(null);
+  const copyText = messageText(message, items).trim();
+  const handleContextMenu = (event: MouseEvent) => {
+    if (!copyText) return;
+    event.preventDefault();
+    setCopyMenu({ x: event.clientX, y: event.clientY });
+  };
+  const handleCopy = () => {
+    if (copyText) void navigator.clipboard?.writeText(copyText);
+    setCopyMenu(null);
+  };
+  const copyMenuNode = copyMenu ? (
+    <div
+      className="message-context-menu"
+      style={{ left: copyMenu.x, top: copyMenu.y }}
+      onMouseLeave={() => setCopyMenu(null)}
+    >
+      <button type="button" onClick={handleCopy}>
+        {t("message.copy")}
+      </button>
+    </div>
+  ) : null;
 
   if (message.role === "user") {
     const { images: imageAttachments, others: otherAttachments } =
@@ -432,7 +493,7 @@ export const MessageBubble = memo(function MessageBubble({
 
     return (
       <div className="msg msg-user">
-        <div className="msg-content-wrapper">
+        <div className="msg-content-wrapper" onContextMenu={handleContextMenu}>
           <div className="msg-header">
             <span className="msg-author">{t("message.you")}</span>
             <span className="msg-time">{timeStr}</span>
@@ -446,6 +507,7 @@ export const MessageBubble = memo(function MessageBubble({
           {imageAttachments.length > 0 && (
             <MessageImageAttachments attachments={imageAttachments} />
           )}
+          {copyMenuNode}
         </div>
         <div className="msg-avatar user-avatar">
           <span>👤</span>
@@ -457,7 +519,7 @@ export const MessageBubble = memo(function MessageBubble({
   if (message.role === "system") {
     const label = message.roleLabel ?? t("message.system");
     return (
-      <div className="msg msg-system msg-system-divider">
+      <div className="msg msg-system msg-system-divider" onContextMenu={handleContextMenu}>
         <span className="msg-system-divider-line" aria-hidden="true" />
         <span className="msg-system-divider-label">
           <span className="msg-system-role">{label}</span>
@@ -466,6 +528,7 @@ export const MessageBubble = memo(function MessageBubble({
           )}
         </span>
         <span className="msg-system-divider-line" aria-hidden="true" />
+        {copyMenuNode}
       </div>
     );
   }
@@ -482,7 +545,7 @@ export const MessageBubble = memo(function MessageBubble({
         className="msg-avatar agent-avatar"
         fallback={<span>✦</span>}
       />
-      <div className="msg-content-wrapper">
+      <div className="msg-content-wrapper" onContextMenu={handleContextMenu}>
         <div className="msg-header">
           <span className="msg-author">{agentLabel}</span>
           <span className="msg-time">{timeStr}</span>
@@ -520,6 +583,7 @@ export const MessageBubble = memo(function MessageBubble({
             <span>{t("message.thinking")}</span>
           </div>
         )}
+        {copyMenuNode}
       </div>
     </div>
   );

--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -9,15 +9,15 @@ import { WorkflowTeamsTab } from "./WorkflowTeamsTab";
 type SettingsTab = "general" | "cli" | "workflowTeams" | "about";
 
 const TABS: { key: SettingsTab; labelKey: string }[] = [
-  { key: "general", labelKey: "settings.tabs.general" },
   { key: "cli", labelKey: "settings.tabs.cli" },
   { key: "workflowTeams", labelKey: "settings.tabs.workflowTeams" },
+  { key: "general", labelKey: "settings.tabs.general" },
   { key: "about", labelKey: "settings.tabs.about" }
 ];
 
 export function SettingsModal({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+  const [activeTab, setActiveTab] = useState<SettingsTab>("cli");
 
   return (
     <div className="modal-backdrop" onClick={onClose}>

--- a/src/components/Settings/WorkflowTeamEditor.tsx
+++ b/src/components/Settings/WorkflowTeamEditor.tsx
@@ -6,6 +6,10 @@ import type {
   WorkflowTeamPolicy,
   WorkflowTeamRole
 } from "@/services/workflowTeams/types";
+import {
+  workflowTeamDescription,
+  workflowTeamName
+} from "@/services/workflowTeams/types";
 import { useWorkflowTeamStore } from "@/store/workflowTeamStore";
 import { useConversationStore } from "@/store/conversationStore";
 
@@ -62,6 +66,10 @@ export function WorkflowTeamEditor({
   const [errors, setErrors] = useState<string[]>([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const isBuiltin = team?.source === "builtin";
+  const displayName = team ? workflowTeamName(team, t) : draft.name;
+  const displayDescription = team
+    ? workflowTeamDescription(team, t)
+    : draft.description;
 
   useEffect(() => {
     setDraft(team ? structuredClone(team) : emptyTeam());
@@ -140,7 +148,7 @@ export function WorkflowTeamEditor({
           ←
         </button>
         <div className="workflow-team-editor-title">
-          <h4>{isNew ? t("workflow.newTeam") : draft.name || t("workflow.teamEditor")}</h4>
+          <h4>{isNew ? t("workflow.newTeam") : displayName || t("workflow.teamEditor")}</h4>
           {isBuiltin && (
             <span className="workflow-team-badge builtin">
               {t("workflow.builtinTeam")}
@@ -181,7 +189,7 @@ export function WorkflowTeamEditor({
           <span>{t("workflow.teamName")}</span>
           <input
             type="text"
-            value={draft.name}
+            value={isBuiltin ? displayName : draft.name}
             onChange={(e) => setDraft({ ...draft, name: e.target.value })}
             disabled={isBuiltin}
             placeholder={t("workflow.teamName")}
@@ -190,7 +198,7 @@ export function WorkflowTeamEditor({
         <label className="workflow-team-editor-field">
           <span>{t("workflow.teamDescription")}</span>
           <textarea
-            value={draft.description ?? ""}
+            value={isBuiltin ? displayDescription ?? "" : draft.description ?? ""}
             onChange={(e) =>
               setDraft({ ...draft, description: e.target.value })
             }

--- a/src/components/Settings/WorkflowTeamList.tsx
+++ b/src/components/Settings/WorkflowTeamList.tsx
@@ -1,11 +1,14 @@
 import { useTranslation } from "react-i18next";
 
 import type { WorkflowTeam } from "@/services/workflowTeams/types";
+import {
+  workflowTeamDescription,
+  workflowTeamName
+} from "@/services/workflowTeams/types";
 import { useWorkflowTeamStore } from "@/store/workflowTeamStore";
 
 export function WorkflowTeamList({
   teams,
-  onNew,
   onEdit
 }: {
   teams: WorkflowTeam[];
@@ -19,7 +22,11 @@ export function WorkflowTeamList({
   return (
     <div className="workflow-team-list">
       <div className="workflow-team-list-actions">
-        <button type="button" className="primary" onClick={onNew}>
+        <button
+          type="button"
+          className="primary"
+          onClick={() => window.alert(t("workflow.newTeamComingSoon"))}
+        >
           + {t("workflow.newTeam")}
         </button>
       </div>
@@ -27,77 +34,81 @@ export function WorkflowTeamList({
         <p className="muted">{t("workflow.noTeams")}</p>
       ) : (
         <ul className="workflow-team-list-items">
-          {teams.map((team) => (
-            <li key={team.id} className="workflow-team-card">
-              <div className="workflow-team-card-main">
-                <div className="workflow-team-card-title">
-                  <strong>{team.name}</strong>
-                  <span
-                    className={
-                      team.source === "builtin"
-                        ? "workflow-team-badge builtin"
-                        : "workflow-team-badge user"
-                    }
-                  >
-                    {team.source === "builtin"
-                      ? t("workflow.builtinTeam")
-                      : t("workflow.userTeam")}
-                  </span>
-                  {!team.enabled && (
-                    <span className="workflow-team-badge muted">
-                      {t("workflow.disableTeam")}
+          {teams.map((team) => {
+            const name = workflowTeamName(team, t);
+            const description = workflowTeamDescription(team, t);
+            return (
+              <li key={team.id} className="workflow-team-card">
+                <div className="workflow-team-card-main">
+                  <div className="workflow-team-card-title">
+                    <strong>{name}</strong>
+                    <span
+                      className={
+                        team.source === "builtin"
+                          ? "workflow-team-badge builtin"
+                          : "workflow-team-badge user"
+                      }
+                    >
+                      {team.source === "builtin"
+                        ? t("workflow.builtinTeam")
+                        : t("workflow.userTeam")}
                     </span>
+                    {!team.enabled && (
+                      <span className="workflow-team-badge muted">
+                        {t("workflow.disableTeam")}
+                      </span>
+                    )}
+                  </div>
+                  {description && (
+                    <p className="workflow-team-card-desc">{description}</p>
                   )}
+                  <div className="workflow-team-card-meta">
+                    <span>
+                      {team.roles.length} {t("workflow.teamRoles").toLowerCase()}
+                    </span>
+                    <span>·</span>
+                    <span>
+                      {team.policy.allowWrites
+                        ? t("workflow.allowWrites")
+                        : t("workflow.allowWrites") + ": " + t("workflow.denied")}
+                    </span>
+                    <span>·</span>
+                    <span>
+                      {t("workflow.maxLoops")} {team.policy.maxLoops}
+                    </span>
+                  </div>
                 </div>
-                {team.description && (
-                  <p className="workflow-team-card-desc">{team.description}</p>
-                )}
-                <div className="workflow-team-card-meta">
-                  <span>
-                    {team.roles.length} {t("workflow.teamRoles").toLowerCase()}
-                  </span>
-                  <span>·</span>
-                  <span>
-                    {team.policy.allowWrites
-                      ? t("workflow.allowWrites")
-                      : t("workflow.allowWrites") + ": " + t("workflow.denied")}
-                  </span>
-                  <span>·</span>
-                  <span>
-                    {t("workflow.maxLoops")} {team.policy.maxLoops}
-                  </span>
-                </div>
-              </div>
-              <div className="workflow-team-card-actions">
-                <button type="button" onClick={() => onEdit(team)}>
-                  {t("common.edit")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() =>
-                    void update(team.id, { enabled: !team.enabled })
-                  }
-                >
-                  {team.enabled
-                    ? t("workflow.disableTeam")
-                    : t("workflow.enableTeam")}
-                </button>
-                {team.source === "user" && (
+                <div className="workflow-team-card-actions">
+                  <button type="button" onClick={() => onEdit(team)}>
+                    {t("common.edit")}
+                  </button>
                   <button
                     type="button"
-                    className="danger"
-                    onClick={() => {
-                      if (window.confirm(t("workflow.confirmDeleteTeam"))) {
-                        void remove(team.id);
-                      }
-                    }}
+                    onClick={() =>
+                      void update(team.id, { enabled: !team.enabled })
+                    }
                   >
-                    {t("workflow.deleteTeam")}
+                    {team.enabled
+                      ? t("workflow.disableTeam")
+                      : t("workflow.enableTeam")}
                   </button>
-                )}
-              </div>
-            </li>
-          ))}
+                  {team.source === "user" && (
+                    <button
+                      type="button"
+                      className="danger"
+                      onClick={() => {
+                        if (window.confirm(t("workflow.confirmDeleteTeam"))) {
+                          void remove(team.id);
+                        }
+                      }}
+                    >
+                      {t("workflow.deleteTeam")}
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/src/components/Workflows/WorkflowPhaseList.tsx
+++ b/src/components/Workflows/WorkflowPhaseList.tsx
@@ -8,6 +8,7 @@ import type {
   WorkflowPhase,
   WorkflowStepRow as WorkflowStepRowData
 } from "@/services/workflows/types";
+import { workflowPhaseTitle, workflowStepTitle } from "@/services/workflows/types";
 import { WorkflowStepDetails } from "./WorkflowStepDetails";
 
 const STATUS_MAP: Record<string, StepsProps["status"]> = {
@@ -52,6 +53,7 @@ export function WorkflowPhaseList({
       : 0;
 
   const items: StepsProps["items"] = allSteps.map((step) => {
+    const phase = phases.find((entry) => entry.steps.some((ps) => ps.id === step.stepId));
     const agentLabel = displayAgentName(step.agentName, step.adapter);
     const isSelected = selectedStepId === step.id;
     return {
@@ -61,11 +63,16 @@ export function WorkflowPhaseList({
           onClick={onSelect ? () => onSelect(step) : undefined}
           role={onSelect ? "button" : undefined}
         >
-          {step.title}
+          {workflowStepTitle(step, t)}
         </span>
       ),
       description: (
         <span className="workflow-step-meta">
+          {phase && (
+            <span className="workflow-step-phase">
+              {workflowPhaseTitle(phase, t)}
+            </span>
+          )}
           <AgentAvatar
             adapter={step.adapter}
             className="workflow-step-agent-avatar"

--- a/src/components/Workflows/WorkflowPlanCard.tsx
+++ b/src/components/Workflows/WorkflowPlanCard.tsx
@@ -36,7 +36,13 @@ export function WorkflowPlanCard({
     <section className="workflow-plan-card">
       <header>
         <strong>{plan.name}</strong>
-        <span>{plan.template === "review-loop" ? t("workflow.reviewLoop") : ""}</span>
+        <span>
+          {plan.template === "review-loop"
+            ? t("workflow.reviewLoop")
+            : plan.template === "implement-review-loop"
+              ? t("workflow.implementReviewLoop")
+              : ""}
+        </span>
       </header>
       <p className="workflow-plan-goal">{plan.goal}</p>
       <dl className="workflow-plan-stats">

--- a/src/components/Workflows/WorkflowRunPanel.tsx
+++ b/src/components/Workflows/WorkflowRunPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { WorkflowStepRow } from "@/services/workflows/types";
+import type { WorkflowPlan, WorkflowStepRow } from "@/services/workflows/types";
 import { pendingManualGatePhaseId } from "@/services/workflows/planning";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { WorkflowPhaseList } from "./WorkflowPhaseList";
@@ -55,6 +55,16 @@ function StopIcon() {
   );
 }
 
+function workflowRunName(name: string, template: string | undefined, t: ReturnType<typeof useTranslation>["t"]) {
+  if (template === "implement-review-loop") return t("workflow.implementReviewLoop");
+  if (template === "review-loop") return t("workflow.reviewLoop");
+  if (name === "Research Report") return t("workflow.builtinTeams.team-research-report.name");
+  if (name === "Quick Implementation") return t("workflow.builtinTeams.team-quick-implement.name");
+  if (name === "Implement-Review Loop") return t("workflow.implementReviewLoop");
+  if (name === "Review Loop") return t("workflow.reviewLoop");
+  return name;
+}
+
 export function WorkflowRunPanel() {
   const { t } = useTranslation();
   const activeRun = useWorkflowStore((s) => s.activeRun);
@@ -68,10 +78,10 @@ export function WorkflowRunPanel() {
   const continueImplementReview = useWorkflowStore((s) => s.continueImplementReview);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
 
-  let plan: ReturnType<typeof JSON.parse> = null;
+  let plan: WorkflowPlan | null = null;
   if (activeRun) {
     try {
-      plan = JSON.parse(activeRun.planJson);
+      plan = JSON.parse(activeRun.planJson) as WorkflowPlan;
     } catch {
       plan = null;
     }
@@ -128,7 +138,7 @@ export function WorkflowRunPanel() {
     <section className="side-card workflow-run-panel">
       <div className="workflow-run-header">
         <div className="workflow-run-title">
-          <strong>{activeRun.name}</strong>
+          <strong>{workflowRunName(activeRun.name, plan.template ?? activeRun.template, t)}</strong>
           <span className={`workflow-run-status ${activeRun.status}`}>
             {t(`workflow.status.${activeRun.status}`)}
           </span>

--- a/src/components/Workflows/WorkflowRunPanel.tsx
+++ b/src/components/Workflows/WorkflowRunPanel.tsx
@@ -102,7 +102,13 @@ export function WorkflowRunPanel() {
     return null;
   }
 
-  const gatingPhaseId = pendingManualGatePhaseId(
+  const failedSteps = steps.filter(
+    (s) => s.status === "failed" || s.status === "blocked"
+  );
+  const resumeLabel =
+    activeRun.status === "blocked" && failedSteps.length > 0
+      ? t("workflow.resumeAfterFailure")
+      : t("workflow.resume");
     plan.phases,
     steps.map((s) => ({ stepId: s.stepId, status: s.status }))
   );

--- a/src/components/Workflows/WorkflowRunPanel.tsx
+++ b/src/components/Workflows/WorkflowRunPanel.tsx
@@ -109,6 +109,8 @@ export function WorkflowRunPanel() {
     activeRun.status === "blocked" && failedSteps.length > 0
       ? t("workflow.resumeAfterFailure")
       : t("workflow.resume");
+
+  const gatingPhaseId = pendingManualGatePhaseId(
     plan.phases,
     steps.map((s) => ({ stepId: s.stepId, status: s.status }))
   );
@@ -145,7 +147,7 @@ export function WorkflowRunPanel() {
           {(activeRun.status === "paused" ||
             activeRun.status === "blocked") && (
             <button type="button" onClick={() => void resume(activeRun.id)}>
-              <ResumeIcon /> {t("workflow.resume")}
+              <ResumeIcon /> {resumeLabel}
             </button>
           )}
           {gatingPhaseId && (

--- a/src/components/Workflows/WorkflowRunPanel.tsx
+++ b/src/components/Workflows/WorkflowRunPanel.tsx
@@ -65,6 +65,7 @@ export function WorkflowRunPanel() {
   const stop = useWorkflowStore((s) => s.stop);
   const retryStep = useWorkflowStore((s) => s.retryStep);
   const approveGate = useWorkflowStore((s) => s.approveGate);
+  const continueImplementReview = useWorkflowStore((s) => s.continueImplementReview);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
 
   let plan: ReturnType<typeof JSON.parse> = null;
@@ -114,6 +115,14 @@ export function WorkflowRunPanel() {
     plan.phases,
     steps.map((s) => ({ stepId: s.stepId, status: s.status }))
   );
+  const reviewStep = steps.find((s) => s.stepId === "review-changes");
+  const canContinueImplementReview =
+    activeRun.status === "partial" &&
+    (plan.template === "implement-review-loop" ||
+      activeRun.template === "implement-review-loop") &&
+    /(?:REVIEW_STATUS:\s*FAIL|<<<REVIEW_FAIL>>>|\[\[REVIEW:FAIL\]\])/i.test(
+      `${reviewStep?.summary ?? ""}\n${reviewStep?.resultJson ?? ""}`
+    );
 
   return (
     <section className="side-card workflow-run-panel">
@@ -137,8 +146,17 @@ export function WorkflowRunPanel() {
         </div>
       </div>
 
-      {(isLive || gatingPhaseId) && (
+      {(isLive || gatingPhaseId || canContinueImplementReview) && (
         <div className="workflow-run-actions">
+          {canContinueImplementReview && (
+            <button
+              type="button"
+              className="primary"
+              onClick={() => void continueImplementReview(activeRun.id)}
+            >
+              <ResumeIcon /> {t("workflow.continueIteration")}
+            </button>
+          )}
           {activeRun.status === "running" && (
             <button type="button" onClick={() => void pause(activeRun.id)}>
               <PauseIcon /> {t("workflow.pause")}

--- a/src/components/Workflows/WorkflowStepDetails.tsx
+++ b/src/components/Workflows/WorkflowStepDetails.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import type { WorkflowStepRow } from "@/services/workflows/types";
+import { workflowStepTitle } from "@/services/workflows/types";
 
 export function WorkflowStepDetails({
   step,
@@ -16,6 +17,7 @@ export function WorkflowStepDetails({
   return (
     <div className="workflow-step-details">
       <header>
+        <strong>{workflowStepTitle(step, t)}</strong>
         <span className={`workflow-status-pill ${step.status}`}>
           {t(`workflow.stepStatus.${step.status}`)}
         </span>

--- a/src/components/Workflows/WorkflowTeamPreviewCard.tsx
+++ b/src/components/Workflows/WorkflowTeamPreviewCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import type { WorkflowTeamPreview } from "@/services/workflowTeams/types";
+import { workflowTeamPreviewName } from "@/services/workflowTeams/types";
 
 export function WorkflowTeamPreviewCard({
   preview,
@@ -16,7 +17,7 @@ export function WorkflowTeamPreviewCard({
   return (
     <section className="workflow-team-preview-card">
       <header className="workflow-team-preview-header">
-        <strong>{preview.teamName}</strong>
+        <strong>{workflowTeamPreviewName(preview, t)}</strong>
         <span className="muted small">{t("workflow.teamPlanPreview")}</span>
       </header>
       <p className="workflow-plan-goal">{preview.goal}</p>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -152,7 +152,8 @@
   "message": {
     "you": "You",
     "thinking": "Thinking",
-    "system": "System"
+    "system": "System",
+    "copy": "Copy"
   },
   "stream": {
     "read": "Read {{target}}",
@@ -343,6 +344,33 @@
       "failed": "Failed",
       "skipped": "Skipped",
       "blocked": "Blocked"
+    },
+    "phaseTitles": {
+      "baseline": "Baseline",
+      "review": "Review",
+      "implement": "Implement",
+      "verify": "Verify",
+      "loop_or_finish": "Loop or finish",
+      "plan-task": "Plan task",
+      "summarize": "Summarize",
+      "research": "Research",
+      "analysis": "Analyze",
+      "report": "Report"
+    },
+    "stepTitles": {
+      "baseline-summarize": "Summarize task and current state",
+      "review-findings": "Produce review findings",
+      "implement-fixes": "Address approved findings",
+      "verify-changes": "Verify changes and report unresolved issues",
+      "implement-changes": "Implement changes",
+      "review-changes": "Review changes",
+      "plan-task-step": "Plan task",
+      "implement-step": "Implement",
+      "verify-step": "Verify",
+      "summarize-step": "Summarize",
+      "research-step": "Research",
+      "analysis-step": "Analyze",
+      "report-step": "Report"
     },
     "invalidPlan": "The generated plan is invalid",
     "summary": "Workflow summary",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -302,6 +302,7 @@
     "approveGate": "Approve & continue",
     "pause": "Pause",
     "resume": "Resume",
+    "resumeAfterFailure": "Retry & continue",
     "stop": "Stop",
     "retry": "Retry step",
     "progress": "Progress",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -290,6 +290,7 @@
     "modeTabsAria": "Task mode",
     "modeHint": "Plan with multiple agents, then run as a workflow",
     "reviewLoop": "Review Loop",
+    "implementReviewLoop": "Implement-Review Loop",
     "generatePlan": "Generate plan",
     "planPreview": "Workflow plan",
     "phases": "Phases",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -325,6 +325,7 @@
     "gates": "Gates",
     "noGates": "No manual gates",
     "noActiveRun": "No active workflow",
+    "runningIndicator": "Workflow is running",
     "status": {
       "pending_approval": "Awaiting approval",
       "running": "Running",
@@ -370,6 +371,7 @@
     "allowed": "Allowed",
     "denied": "Denied",
     "newTeam": "New team",
+    "newTeamComingSoon": "Custom teams are coming soon.",
     "teamName": "Team name",
     "teamDescription": "Description",
     "teamSource": "Source",
@@ -400,7 +402,21 @@
     "advancedGraph": "Advanced graph",
     "graphViewer": "Graph viewer",
     "startNodes": "Start nodes",
-    "finalNodes": "Final nodes"
+    "finalNodes": "Final nodes",
+    "builtinTeams": {
+      "team-quick-implement": {
+        "name": "Quick Implementation",
+        "description": "Plan, implement, verify, summarize. Small focused changes with one approval gate before writing."
+      },
+      "team-implement-review-loop": {
+        "name": "Implement-Review Loop",
+        "description": "Agent A implements, Agent B reviews. On FAIL, A fixes and B reviews again until PASS or max loops."
+      },
+      "team-research-report": {
+        "name": "Research Report",
+        "description": "Research a non-coding topic, analyze scenarios, and produce a concise report with conclusions and confidence."
+      }
+    }
   },
   "updater": {
     "appTitle": "Application",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -313,6 +313,7 @@
     "pause": "Pause",
     "resume": "Resume",
     "resumeAfterFailure": "Retry & continue",
+    "continueIteration": "Continue iteration",
     "stop": "Stop",
     "retry": "Retry step",
     "progress": "Progress",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -312,6 +312,7 @@
     "pause": "暂停",
     "resume": "继续",
     "resumeAfterFailure": "重试并继续",
+    "continueIteration": "继续迭代",
     "stop": "停止",
     "retry": "重试步骤",
     "progress": "进度",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -324,6 +324,7 @@
     "gates": "关卡",
     "noGates": "没有人工关卡",
     "noActiveRun": "没有进行中的工作流",
+    "runningIndicator": "工作流正在运行",
     "status": {
       "pending_approval": "等待批准",
       "running": "运行中",
@@ -369,6 +370,7 @@
     "allowed": "允许",
     "denied": "禁止",
     "newTeam": "新建团队",
+    "newTeamComingSoon": "自定义团队即将推出。",
     "teamName": "团队名称",
     "teamDescription": "描述",
     "teamSource": "来源",
@@ -399,7 +401,21 @@
     "advancedGraph": "高级图计划",
     "graphViewer": "图查看器",
     "startNodes": "起始节点",
-    "finalNodes": "结束节点"
+    "finalNodes": "结束节点",
+    "builtinTeams": {
+      "team-quick-implement": {
+        "name": "快速实现",
+        "description": "规划、实现、验证并总结。适合小而聚焦的改动，写入前有一次审批。"
+      },
+      "team-implement-review-loop": {
+        "name": "实现-审查循环",
+        "description": "Agent A 负责实现，Agent B 负责审查。失败时 A 修复、B 复审，直到通过或达到最大循环次数。"
+      },
+      "team-research-report": {
+        "name": "分析调研报告",
+        "description": "调研非开发类主题，分析不同情景，并输出带结论和置信度的简洁报告。"
+      }
+    }
   },
   "updater": {
     "appTitle": "应用",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -289,6 +289,7 @@
     "modeTabsAria": "任务模式",
     "modeHint": "使用多个 Agent 规划并作为工作流运行",
     "reviewLoop": "评审循环",
+    "implementReviewLoop": "实现-审查循环",
     "generatePlan": "生成计划",
     "planPreview": "工作流计划",
     "phases": "阶段",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -149,10 +149,11 @@
     "createToBegin": "创建会话以开始",
     "sessionConfig": "会话配置"
   },
-"message": {
+  "message": {
     "you": "你",
     "thinking": "思考中",
-    "system": "系统"
+    "system": "系统",
+    "copy": "复制"
   },
   "stream": {
     "read": "读取 {{target}}",
@@ -342,6 +343,33 @@
       "failed": "已失败",
       "skipped": "已跳过",
       "blocked": "已阻塞"
+    },
+    "phaseTitles": {
+      "baseline": "基线",
+      "review": "审查",
+      "implement": "实现",
+      "verify": "验证",
+      "loop_or_finish": "循环或结束",
+      "plan-task": "规划任务",
+      "summarize": "总结",
+      "research": "调研",
+      "analysis": "分析",
+      "report": "报告"
+    },
+    "stepTitles": {
+      "baseline-summarize": "总结任务和当前状态",
+      "review-findings": "生成审查结论",
+      "implement-fixes": "处理已批准的问题",
+      "verify-changes": "验证改动并报告未解决问题",
+      "implement-changes": "实现改动",
+      "review-changes": "审查改动",
+      "plan-task-step": "规划任务",
+      "implement-step": "实现",
+      "verify-step": "验证",
+      "summarize-step": "总结",
+      "research-step": "调研",
+      "analysis-step": "分析",
+      "report-step": "报告"
     },
     "invalidPlan": "生成的计划无效",
     "summary": "工作流总结",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -301,6 +301,7 @@
     "approveGate": "批准并继续",
     "pause": "暂停",
     "resume": "继续",
+    "resumeAfterFailure": "重试并继续",
     "stop": "停止",
     "retry": "重试步骤",
     "progress": "进度",

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -136,6 +136,9 @@ export const cliClient = {
   listMessages(conversationId: string): Promise<ConversationMessage[]> {
     return api().listMessages(conversationId);
   },
+  listMessage(id: string): Promise<ConversationMessage | undefined> {
+    return api().listMessage(id);
+  },
   appendMessage(input: AppendMessageInput): Promise<ConversationMessage> {
     return api().appendMessage(input);
   },

--- a/src/services/workflowTeams/types.ts
+++ b/src/services/workflowTeams/types.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from "i18next";
 import type { WorkflowPlan } from "@/services/workflows/types";
 
 export type WorkflowTeamRoleKind =
@@ -88,6 +89,31 @@ export interface WorkflowTeam {
   policy: WorkflowTeamPolicy;
   createdAt: string;
   updatedAt: string;
+}
+
+export function workflowTeamName(team: WorkflowTeam, t: TFunction): string {
+  return team.source === "builtin"
+    ? t(`workflow.builtinTeams.${team.id}.name`, { defaultValue: team.name })
+    : team.name;
+}
+
+export function workflowTeamDescription(
+  team: WorkflowTeam,
+  t: TFunction
+): string | undefined {
+  if (team.source !== "builtin") return team.description;
+  return t(`workflow.builtinTeams.${team.id}.description`, {
+    defaultValue: team.description ?? ""
+  });
+}
+
+export function workflowTeamPreviewName(
+  preview: WorkflowTeamPreview,
+  t: TFunction
+): string {
+  return t(`workflow.builtinTeams.${preview.teamId}.name`, {
+    defaultValue: preview.teamName
+  });
 }
 
 export interface WorkflowTeamPreview {

--- a/src/services/workflows/client.ts
+++ b/src/services/workflows/client.ts
@@ -59,6 +59,9 @@ export const workflowClient = {
   getRun(runId: string): Promise<WorkflowRunRow | undefined> {
     return api().getRun(runId);
   },
+  listActiveRuns(): Promise<WorkflowRunRow[]> {
+    return api().listActiveRuns();
+  },
   getSteps(runId: string): Promise<WorkflowStepRow[]> {
     return api().getSteps(runId);
   },

--- a/src/services/workflows/client.ts
+++ b/src/services/workflows/client.ts
@@ -53,6 +53,9 @@ export const workflowClient = {
   approveGate(args: { runId: string; phaseId: string }): Promise<boolean> {
     return api().approveGate(args);
   },
+  continueImplementReview(runId: string): Promise<boolean> {
+    return api().continueImplementReview(runId);
+  },
   getRun(runId: string): Promise<WorkflowRunRow | undefined> {
     return api().getRun(runId);
   },

--- a/src/services/workflows/types.ts
+++ b/src/services/workflows/types.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from "i18next";
+
 export type WorkflowStepMode =
   | "research"
   | "review"
@@ -100,6 +102,14 @@ export interface WorkflowStepRow {
 export interface WorkflowValidationResult {
   ok: boolean;
   errors: string[];
+}
+
+export function workflowPhaseTitle(phase: Pick<WorkflowPhase, "id" | "title">, t: TFunction): string {
+  return t(`workflow.phaseTitles.${phase.id}`, { defaultValue: phase.title });
+}
+
+export function workflowStepTitle(step: Pick<WorkflowStepRow, "stepId" | "title">, t: TFunction): string {
+  return t(`workflow.stepTitles.${step.stepId}`, { defaultValue: step.title });
 }
 
 export function workflowFollowupAgentId(run: Pick<WorkflowRunRow, "planJson">): string | undefined {

--- a/src/services/workflows/types.ts
+++ b/src/services/workflows/types.ts
@@ -101,3 +101,30 @@ export interface WorkflowValidationResult {
   ok: boolean;
   errors: string[];
 }
+
+export function workflowFollowupAgentId(run: Pick<WorkflowRunRow, "planJson">): string | undefined {
+  let plan: WorkflowPlan;
+  try {
+    plan = JSON.parse(run.planJson) as WorkflowPlan;
+  } catch {
+    return undefined;
+  }
+
+  for (let i = plan.phases.length - 1; i >= 0; i -= 1) {
+    const phase = plan.phases[i];
+    for (let j = phase.steps.length - 1; j >= 0; j -= 1) {
+      const step = phase.steps[j];
+      if (step.mode === "summarize") return step.agentId;
+    }
+  }
+
+  for (let i = plan.phases.length - 1; i >= 0; i -= 1) {
+    const phase = plan.phases[i];
+    for (let j = phase.steps.length - 1; j >= 0; j -= 1) {
+      const step = phase.steps[j];
+      if (step.mode !== "write") return step.agentId;
+    }
+  }
+
+  return undefined;
+}

--- a/src/services/workflows/types.ts
+++ b/src/services/workflows/types.ts
@@ -34,7 +34,7 @@ export interface WorkflowPlan {
   name: string;
   goal: string;
   cwd?: string;
-  template?: "review-loop" | "custom";
+  template?: "review-loop" | "implement-review-loop" | "custom";
   maxLoops?: number;
   phases: WorkflowPhase[];
 }

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -50,7 +50,7 @@ export interface ConversationState {
 
   load(): Promise<void>;
   setActive(id: string | undefined): Promise<void>;
-  loadMessages(id: string): Promise<void>;
+  loadMessages(id: string, messageIds?: string[]): Promise<void>;
 
   newConversation(input: {
     member: CLIMember;
@@ -91,10 +91,11 @@ export const runCtxMap = new Map<string, RunCtx>();
 let workflowMessageUnsubscribe: (() => void) | null = null;
 let workflowMessageConversationId: string | null = null;
 let workflowRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+const workflowPendingMessageIds = new Set<string>();
 
 function ensureWorkflowMessageSubscription(
   conversationId: string | undefined,
-  refresh: (id: string) => Promise<void>
+  refresh: (id: string, messageIds?: string[]) => Promise<void>
 ) {
   const fb = (globalThis as any).freebuddy;
   const api = fb?.workflow;
@@ -112,18 +113,18 @@ function ensureWorkflowMessageSubscription(
     clearTimeout(workflowRefreshTimer);
     workflowRefreshTimer = null;
   }
+  workflowPendingMessageIds.clear();
   workflowMessageConversationId = conversationId ?? null;
   if (!conversationId) return;
-  workflowMessageUnsubscribe = api.onStepMessage(conversationId, () => {
-    // Workflow steps (especially parallel ones) can emit many message
-    // updates in quick succession. Each reload pulls every message and
-    // re-parses every assistant content blob, so coalesce the burst into
-    // a single trailing reload (~one per 150ms during continuous activity).
+  workflowMessageUnsubscribe = api.onStepMessage(conversationId, (event: { messageId?: string }) => {
+    if (event.messageId) workflowPendingMessageIds.add(event.messageId);
     if (workflowRefreshTimer) return;
     workflowRefreshTimer = setTimeout(() => {
       workflowRefreshTimer = null;
-      void refresh(conversationId);
-    }, 150);
+      const ids = [...workflowPendingMessageIds];
+      workflowPendingMessageIds.clear();
+      void refresh(conversationId, ids.length ? ids : undefined);
+    }, 300);
   });
 }
 
@@ -169,8 +170,8 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     if (active && !get().messages[active]) {
       await get().loadMessages(active);
     }
-    ensureWorkflowMessageSubscription(active, async (cid) => {
-      await get().loadMessages(cid);
+    ensureWorkflowMessageSubscription(active, async (cid, messageIds) => {
+      await get().loadMessages(cid, messageIds);
     });
   },
 
@@ -179,13 +180,29 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     if (id && !get().messages[id]) {
       await get().loadMessages(id);
     }
-    ensureWorkflowMessageSubscription(id, async (cid) => {
-      await get().loadMessages(cid);
+    ensureWorkflowMessageSubscription(id, async (cid, messageIds) => {
+      await get().loadMessages(cid, messageIds);
     });
   },
 
-  async loadMessages(id) {
+  async loadMessages(id, messageIds) {
     if (!cliClient.isAvailable()) return;
+    if (messageIds?.length) {
+      const loaded = (
+        await Promise.all(messageIds.map((messageId) => cliClient.listMessage(messageId)))
+      ).filter((message): message is ConversationMessage =>
+        Boolean(message && message.conversationId === id)
+      );
+      if (!loaded.length) return;
+      set((s) => ({
+        messages: {
+          ...s.messages,
+          [id]: mergeConversationMessages(s.messages[id] ?? [], loaded)
+        }
+      }));
+      return;
+    }
+
     const list = await cliClient.listMessages(id);
     set((s) => {
       const sessionInfo = latestSessionInfoFromMessages(list);
@@ -227,8 +244,8 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       messages: { ...s.messages, [conv.id]: [] },
       pendingFreshContext: { ...s.pendingFreshContext, [conv.id]: true }
     }));
-    ensureWorkflowMessageSubscription(conv.id, async (cid) => {
-      await get().loadMessages(cid);
+    ensureWorkflowMessageSubscription(conv.id, async (cid, messageIds) => {
+      await get().loadMessages(cid, messageIds);
     });
     return conv;
   },

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -16,6 +16,9 @@ import type {
   Conversation,
   ConversationMessage
 } from "@/services/cli/types";
+import type { WorkflowRunRow } from "@/services/workflows/types";
+import { workflowFollowupAgentId } from "@/services/workflows/types";
+import { workflowClient } from "@/services/workflows/client";
 import { composeMessageWithAttachments } from "@/utils/chatAttachments";
 
 import { useCliExecutorStore } from "./cliExecutorStore";
@@ -146,6 +149,23 @@ function latestSessionIdFromMessages(messages: ConversationMessage[]): string | 
     }
   }
   return undefined;
+}
+
+async function workflowRunForConversation(
+  conversationId: string
+): Promise<WorkflowRunRow | undefined> {
+  if (!workflowClient.isAvailable()) return undefined;
+  const runs = await workflowClient.listRuns(conversationId);
+  return runs[0];
+}
+
+function memberForWorkflowFollowup(
+  run: WorkflowRunRow | undefined,
+  members: CLIMember[]
+): CLIMember | undefined {
+  const agentId = run ? workflowFollowupAgentId(run) : undefined;
+  if (!agentId) return undefined;
+  return members.find((member) => member.id === agentId);
 }
 
 export const useConversationStore = create<ConversationState>((set, get) => ({
@@ -322,7 +342,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
 
     const conv = get().conversations.find((c) => c.id === conversationId);
     if (!conv) return;
-    const member = get().members.find((m) => m.id === conv.agentId);
+    const workflowRun = await workflowRunForConversation(conversationId);
+    const member =
+      memberForWorkflowFollowup(workflowRun, get().members) ??
+      get().members.find((m) => m.id === conv.agentId);
     if (!member) throw new Error(`Member ${conv.agentId} not found`);
 
     const userMsgId = userMessageId ?? nanoid();
@@ -404,7 +427,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       ...(resolved?.extraArgs ?? []),
       ...(member.cli.extraArgs ?? [])
     ];
-    const toolSessionScope = conv.cwd ?? `conversation:${conv.id}`;
+    const toolSessionScope = workflowRun
+      ? `workflow:${workflowRun.id}:${member.id}`
+      : conv.cwd ?? `conversation:${conv.id}`;
 
     let resumedFromSessionId: string | undefined;
     if (!wantFresh) {

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -410,20 +410,35 @@ export function mergeConversationMessages(
   loaded: ConversationMessage[]
 ): ConversationMessage[] {
   const byId = new Map<string, ConversationMessage>();
-  for (const message of loaded) {
+  let changed = false;
+  for (const message of existing) {
     byId.set(message.id, message);
   }
-  for (const message of existing) {
-    const persisted = byId.get(message.id);
-    if (!persisted) {
+  for (const message of loaded) {
+    const previous = byId.get(message.id);
+    if (!previous) {
       byId.set(message.id, message);
+      changed = true;
+      continue;
+    }
+    const attachments = mergeMessageAttachments(message, previous);
+    if (
+      previous.status === message.status &&
+      previous.content === message.content &&
+      previous.updatedAt === message.updatedAt &&
+      previous.attachments === attachments
+    ) {
       continue;
     }
     byId.set(message.id, {
-      ...persisted,
-      attachments: mergeMessageAttachments(persisted, message)
+      ...previous,
+      ...message,
+      attachments
     });
+    changed = true;
   }
+  if (!changed && byId.size !== existing.length) changed = true;
+  if (!changed) return existing;
   return Array.from(byId.values()).sort((a, b) =>
     a.createdAt.localeCompare(b.createdAt)
   );

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -13,9 +13,11 @@ interface State {
   pendingPlan: WorkflowPlan | null;
   pendingErrors: string[];
   activeRun: WorkflowRunRow | null;
+  activeRuns: WorkflowRunRow[];
   steps: WorkflowStepRow[];
 
   loadForConversation(conversationId: string): Promise<void>;
+  loadActiveRuns(): Promise<void>;
   previewReviewLoop(input: {
     goal: string;
     cwd?: string;
@@ -47,6 +49,7 @@ export const useWorkflowStore = create<State>((set, get) => ({
   pendingPlan: null,
   pendingErrors: [],
   activeRun: null,
+  activeRuns: [],
   steps: [],
 
   async loadForConversation(conversationId) {
@@ -68,6 +71,13 @@ export const useWorkflowStore = create<State>((set, get) => ({
         steps: []
       });
     }
+    void get().loadActiveRuns();
+  },
+
+  async loadActiveRuns() {
+    if (!workflowClient.isAvailable()) return;
+    const activeRuns = await workflowClient.listActiveRuns();
+    set({ activeRuns });
   },
 
   async previewReviewLoop(input) {
@@ -92,6 +102,7 @@ export const useWorkflowStore = create<State>((set, get) => ({
       return false;
     }
     set({ pendingPlan: null, pendingErrors: [], activeRun: res.run, steps: [] });
+    await get().loadActiveRuns();
     await workflowClient.start(res.run.id);
     await get().refresh(res.run.id);
     return true;
@@ -105,6 +116,7 @@ export const useWorkflowStore = create<State>((set, get) => ({
       return false;
     }
     set({ pendingPlan: null, pendingErrors: [], activeRun: res.run, steps: [] });
+    await get().loadActiveRuns();
     await workflowClient.start(res.run.id);
     await get().refresh(res.run.id);
     return true;
@@ -117,6 +129,7 @@ export const useWorkflowStore = create<State>((set, get) => ({
       workflowClient.getSteps(runId)
     ]);
     if (run) set({ activeRun: run, steps });
+    void get().loadActiveRuns();
   },
 
   async pause(runId) {

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -39,6 +39,7 @@ interface State {
   stop(runId: string): Promise<void>;
   retryStep(runId: string, stepRowId: string): Promise<void>;
   approveGate(runId: string, phaseId: string): Promise<void>;
+  continueImplementReview(runId: string): Promise<void>;
   validate(plan: WorkflowPlan): Promise<WorkflowValidationResult>;
 }
 
@@ -136,6 +137,10 @@ export const useWorkflowStore = create<State>((set, get) => ({
   },
   async approveGate(runId, phaseId) {
     await workflowClient.approveGate({ runId, phaseId });
+    await get().refresh(runId);
+  },
+  async continueImplementReview(runId) {
+    await workflowClient.continueImplementReview(runId);
     await get().refresh(runId);
   },
   async validate(plan) {

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -97,6 +97,7 @@ declare global {
     ): Promise<void>;
 
     listMessages(conversationId: string): Promise<ConversationMessage[]>;
+    listMessage(id: string): Promise<ConversationMessage | undefined>;
     appendMessage(input: AppendMessageInput): Promise<ConversationMessage>;
     updateMessage(input: UpdateMessageInput): Promise<void>;
 
@@ -143,6 +144,7 @@ declare global {
     stop(runId: string): Promise<boolean>;
     retryStep(args: { runId: string; stepRowId: string }): Promise<void>;
     approveGate(args: { runId: string; phaseId: string }): Promise<boolean>;
+    continueImplementReview(runId: string): Promise<boolean>;
     getRun(runId: string): Promise<WorkflowRunRow | undefined>;
     getSteps(runId: string): Promise<WorkflowStepRow[]>;
     listRuns(conversationId: string): Promise<WorkflowRunRow[]>;

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -146,6 +146,7 @@ declare global {
     approveGate(args: { runId: string; phaseId: string }): Promise<boolean>;
     continueImplementReview(runId: string): Promise<boolean>;
     getRun(runId: string): Promise<WorkflowRunRow | undefined>;
+    listActiveRuns(): Promise<WorkflowRunRow[]>;
     getSteps(runId: string): Promise<WorkflowStepRow[]>;
     listRuns(conversationId: string): Promise<WorkflowRunRow[]>;
     previewTeamRun(input: {

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,8 @@
   --fb-active-fg: #ffffff;
   --fb-brand: #10b981;
   --fb-brand-glow: rgba(16, 185, 129, 0.12);
+  --fb-workflow: #8b5cf6;
+  --fb-workflow-glow: rgba(139, 92, 246, 0.16);
   --fb-brand-gradient: linear-gradient(135deg, #10b981 0%, #06b6d4 100%);
   --fb-danger: #e11d48;
   --fb-warning: #f59e0b;
@@ -3228,6 +3230,14 @@ button {
   background: var(--fb-brand);
   box-shadow: 0 0 0 3px var(--fb-brand-glow);
   animation: pulse-glow 2s infinite;
+}
+
+.conv-running-dot.workflow {
+  width: 8px;
+  height: 8px;
+  border-radius: 3px;
+  background: var(--fb-workflow);
+  box-shadow: 0 0 0 3px var(--fb-workflow-glow);
 }
 
 .conv-item:hover {

--- a/styles.css
+++ b/styles.css
@@ -2384,6 +2384,36 @@ button {
   box-shadow: var(--fb-shadow);
 }
 
+.message-context-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 112px;
+  padding: 6px;
+  border: 1px solid var(--fb-border);
+  border-radius: 8px;
+  background: var(--fb-panel-bg);
+  box-shadow: var(--fb-shadow);
+}
+
+.message-context-menu button {
+  display: block;
+  width: 100%;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fb-text-primary);
+  text-align: left;
+}
+
+.message-context-menu button:hover {
+  background: var(--fb-hover);
+}
+
+.msg-system-divider .message-context-menu {
+  text-align: left;
+}
+
 .msg-user .msg-bubble {
   border-color: transparent;
   background: var(--fb-brand-gradient);

--- a/tests/workflow-implement-review-loop.test.mjs
+++ b/tests/workflow-implement-review-loop.test.mjs
@@ -209,12 +209,52 @@ test("expandTeamToPlan uses implement-review-loop template for loop team", async
   assert.equal(result.preview.plan.phases.length, 3);
 });
 
-test("runtime handles implement-review-loop template", () => {
+test("findResumePhaseIndex skips finished phases", async () => {
+  const { findResumePhaseIndex } = await import(
+    "../dist-electron/cli/workflowScheduler.js"
+  );
+  const plan = {
+    name: "p",
+    goal: "g",
+    phases: [
+      {
+        id: "implement",
+        title: "Implement",
+        parallelism: 1,
+        steps: [{ id: "implement-changes", title: "i", agentId: "a", mode: "write", prompt: "p" }]
+      },
+      {
+        id: "review",
+        title: "Review",
+        parallelism: 1,
+        steps: [{ id: "review-changes", title: "r", agentId: "a", mode: "review", prompt: "p" }]
+      }
+    ]
+  };
+  const idx = findResumePhaseIndex(plan, [
+    { stepId: "implement-changes", phaseId: "implement", status: "done" },
+    { stepId: "review-changes", phaseId: "review", status: "failed" }
+  ]);
+  assert.equal(idx, 1);
+});
+
+test("resumableStepRowIds returns failed and blocked steps in phase", async () => {
+  const { resumableStepRowIds } = await import(
+    "../dist-electron/cli/workflowScheduler.js"
+  );
+  const ids = resumableStepRowIds("review", [
+    { id: "row-1", phaseId: "implement", status: "done" },
+    { id: "row-2", phaseId: "review", status: "failed" },
+    { id: "row-3", phaseId: "review", status: "blocked" }
+  ]);
+  assert.deepEqual(ids, ["row-2", "row-3"]);
+});
+
+test("runtime prepares blocked runs before resume", () => {
   const src = fs.readFileSync(
     new URL("../electron/cli/workflowRuntime.ts", import.meta.url),
     "utf8"
   );
-  assert.match(src, /isImplementReviewLoopPlan/);
-  assert.match(src, /decideImplementReviewLoop/);
-  assert.match(src, /IMPLEMENT_REVIEW_LOOP_PHASES/);
+  assert.match(src, /prepareBlockedRunForResume/);
+  assert.match(src, /findResumePhaseIndex/);
 });

--- a/tests/workflow-implement-review-loop.test.mjs
+++ b/tests/workflow-implement-review-loop.test.mjs
@@ -186,6 +186,16 @@ test("augmentPromptWithConsumedSummaries appends upstream summaries", () => {
   assert.match(out, /Fix error handling/);
 });
 
+test("runtime exposes continueImplementReview for max-loop FAIL follow-up", () => {
+  const src = fs.readFileSync(
+    new URL("../electron/cli/workflowRuntime.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(src, /continueImplementReview/);
+  assert.match(src, /maxLoops: nextMaxLoops/);
+  assert.match(src, /resetWorkflowStepsForLoop\(runId, IMPLEMENT_REVIEW_LOOP_PHASES\)/);
+});
+
 test("expandTeamToPlan uses implement-review-loop template for loop team", async () => {
   const { builtinWorkflowTeams } = await import(
     "../dist-electron/cli/workflowTeamBuiltins.js"
@@ -238,16 +248,17 @@ test("findResumePhaseIndex skips finished phases", async () => {
   assert.equal(idx, 1);
 });
 
-test("resumableStepRowIds returns failed and blocked steps in phase", async () => {
+test("resumableStepRowIds returns failed, blocked, and stale running steps in phase", async () => {
   const { resumableStepRowIds } = await import(
     "../dist-electron/cli/workflowScheduler.js"
   );
   const ids = resumableStepRowIds("review", [
     { id: "row-1", phaseId: "implement", status: "done" },
     { id: "row-2", phaseId: "review", status: "failed" },
-    { id: "row-3", phaseId: "review", status: "blocked" }
+    { id: "row-3", phaseId: "review", status: "blocked" },
+    { id: "row-4", phaseId: "review", status: "running" }
   ]);
-  assert.deepEqual(ids, ["row-2", "row-3"]);
+  assert.deepEqual(ids, ["row-2", "row-3", "row-4"]);
 });
 
 test("runtime prepares blocked runs before resume", () => {
@@ -255,6 +266,6 @@ test("runtime prepares blocked runs before resume", () => {
     new URL("../electron/cli/workflowRuntime.ts", import.meta.url),
     "utf8"
   );
-  assert.match(src, /prepareBlockedRunForResume/);
+  assert.match(src, /prepareInactiveRunForResume/);
   assert.match(src, /findResumePhaseIndex/);
 });

--- a/tests/workflow-implement-review-loop.test.mjs
+++ b/tests/workflow-implement-review-loop.test.mjs
@@ -56,6 +56,34 @@ test("reviewerHasFail detects FAIL marker", () => {
   assert.equal(reviewerHasFail(undefined), false);
 });
 
+test("deriveStepSummary preserves REVIEW_STATUS FAIL when body is truncated", async () => {
+  const { deriveStepSummary } = scheduler;
+  const long = `${"issue ".repeat(120)}REVIEW_STATUS: FAIL`;
+  const summary = deriveStepSummary([{ kind: "text", content: long }]);
+  assert.match(summary, /REVIEW_STATUS:\s*FAIL/i);
+  assert.equal(decideImplementReviewLoop("done", summary, 0, 5), "loop");
+});
+
+test("deriveStepSummary scans all text chunks for review status", async () => {
+  const { deriveStepSummary } = scheduler;
+  const summary = deriveStepSummary([
+    { kind: "text", content: "Long findings paragraph. " },
+    { kind: "tool-call" },
+    { kind: "text", content: "REVIEW_STATUS: FAIL" }
+  ]);
+  assert.match(summary, /REVIEW_STATUS:\s*FAIL/i);
+  assert.equal(decideImplementReviewLoop("done", summary, 0, 5), "loop");
+});
+
+test("resolveReviewDecisionText prefers full resultJson over truncated summary", async () => {
+  const { resolveReviewDecisionText } = scheduler;
+  const text = resolveReviewDecisionText("truncated…", JSON.stringify({
+    items: [{ kind: "text", content: `${"x".repeat(600)}\nREVIEW_STATUS: FAIL` }]
+  }));
+  assert.match(text ?? "", /REVIEW_STATUS:\s*FAIL/i);
+  assert.equal(decideImplementReviewLoop("done", text, 0, 5), "loop");
+});
+
 test("decideImplementReviewLoop finishes on PASS", () => {
   assert.equal(
     decideImplementReviewLoop("done", "REVIEW_STATUS: PASS", 0, 5),

--- a/tests/workflow-implement-review-loop.test.mjs
+++ b/tests/workflow-implement-review-loop.test.mjs
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const scheduler = await import("../dist-electron/cli/workflowScheduler.js");
+const {
+  decideImplementReviewLoop,
+  reviewerHasFail,
+  augmentPromptWithConsumedSummaries
+} = scheduler;
+
+const { buildImplementReviewLoopPlan } = await import(
+  "../dist-electron/cli/workflowTemplates.js"
+);
+
+const agents = {
+  implementer: {
+    id: "cli-claude-agent-acp",
+    name: "ClaudeCode",
+    adapter: "claude-agent-acp",
+    enabled: true
+  },
+  reviewer: {
+    id: "cli-codex-acp",
+    name: "Codex",
+    adapter: "codex-acp",
+    enabled: true
+  }
+};
+
+test("buildImplementReviewLoopPlan produces implement → review → loop_or_finish", () => {
+  const p = buildImplementReviewLoopPlan({
+    goal: "add retry",
+    implementer: agents.implementer,
+    reviewer: agents.reviewer
+  });
+  assert.equal(p.template, "implement-review-loop");
+  assert.equal(p.maxLoops, 5);
+  assert.deepEqual(
+    p.phases.map((ph) => ph.id),
+    ["implement", "review", "loop_or_finish"]
+  );
+  const impl = p.phases.find((ph) => ph.id === "implement");
+  const review = p.phases.find((ph) => ph.id === "review");
+  assert.equal(impl.steps[0].agentId, agents.implementer.id);
+  assert.equal(impl.steps[0].mode, "write");
+  assert.equal(review.steps[0].agentId, agents.reviewer.id);
+  assert.equal(review.steps[0].mode, "review");
+  assert.match(review.steps[0].prompt, /REVIEW_STATUS: PASS/);
+  assert.match(review.steps[0].prompt, /REVIEW_STATUS: FAIL/);
+});
+
+test("reviewerHasFail detects FAIL marker", () => {
+  assert.equal(reviewerHasFail("Looks good\nREVIEW_STATUS: PASS"), false);
+  assert.equal(reviewerHasFail("Issues found\nREVIEW_STATUS: FAIL"), true);
+  assert.equal(reviewerHasFail(undefined), false);
+});
+
+test("decideImplementReviewLoop finishes on PASS", () => {
+  assert.equal(
+    decideImplementReviewLoop("done", "REVIEW_STATUS: PASS", 0, 5),
+    "finish"
+  );
+});
+
+test("decideImplementReviewLoop loops on FAIL while under maxLoops", () => {
+  assert.equal(
+    decideImplementReviewLoop("done", "REVIEW_STATUS: FAIL", 0, 5),
+    "loop"
+  );
+  assert.equal(
+    decideImplementReviewLoop("done", "REVIEW_STATUS: FAIL", 4, 5),
+    "partial"
+  );
+});
+
+test("decideImplementReviewLoop returns partial when reviewer failed", () => {
+  assert.equal(
+    decideImplementReviewLoop("failed", "REVIEW_STATUS: FAIL", 0, 5),
+    "partial"
+  );
+});
+
+test("augmentPromptWithConsumedSummaries appends upstream summaries", () => {
+  const out = augmentPromptWithConsumedSummaries(
+    "Implement the change.",
+    ["review-changes"],
+    new Map([
+      [
+        "review-changes",
+        { stepId: "review-changes", title: "Review", summary: "Fix error handling" }
+      ]
+    ])
+  );
+  assert.match(out, /Implement the change/);
+  assert.match(out, /Fix error handling/);
+});
+
+test("expandTeamToPlan uses implement-review-loop template for loop team", async () => {
+  const { builtinWorkflowTeams } = await import(
+    "../dist-electron/cli/workflowTeamBuiltins.js"
+  );
+  const { expandTeamToPlan } = await import(
+    "../dist-electron/cli/workflowTeamAdapter.js"
+  );
+  const team = builtinWorkflowTeams().find(
+    (t) => t.id === "team-implement-review-loop"
+  );
+  assert.ok(team);
+  const agentRefs = team.roles.map((r) => ({
+    id: r.agentId,
+    name: r.agentId,
+    adapter: "stub-acp",
+    enabled: true
+  }));
+  const result = expandTeamToPlan(team, { goal: "fix auth" }, agentRefs);
+  assert.equal(result.ok, true);
+  assert.equal(result.preview.plan.template, "implement-review-loop");
+  assert.equal(result.preview.plan.phases.length, 3);
+});
+
+test("runtime handles implement-review-loop template", () => {
+  const src = fs.readFileSync(
+    new URL("../electron/cli/workflowRuntime.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(src, /implement-review-loop/);
+  assert.match(src, /decideImplementReviewLoop/);
+  assert.match(src, /IMPLEMENT_REVIEW_LOOP_PHASES/);
+});

--- a/tests/workflow-implement-review-loop.test.mjs
+++ b/tests/workflow-implement-review-loop.test.mjs
@@ -127,12 +127,39 @@ test("decideImplementReviewLoop requires maxLoops >= 2 for a retry", () => {
   );
 });
 
-test("extractReviewStatus reads markers from thinking chunks", async () => {
+test("extractReviewStatus reads markers from fragmented append chunks", async () => {
   const { collectDecisionTextFromItems, extractReviewStatus } = scheduler;
   const text = collectDecisionTextFromItems([
-    { kind: "thinking", content: "Checking files..." },
-    { kind: "text", content: "Found issues." },
-    { kind: "thinking", content: "REVIEW_STATUS: FAIL" }
+    { kind: "text", content: "RE", append: true, messageId: "m1", role: "assistant" },
+    { kind: "text", content: "VIEW_STATUS: ", append: true, messageId: "m1", role: "assistant" },
+    { kind: "text", content: "FAIL", append: true, messageId: "m1", role: "assistant" }
+  ]);
+  assert.equal(extractReviewStatus(text), "FAIL");
+  assert.equal(decideImplementReviewLoop("done", text, 0, 5), "loop");
+});
+
+test("extractReviewStatus supports alternate markers for tool-heavy agents", async () => {
+  const { extractReviewStatus } = scheduler;
+  assert.equal(extractReviewStatus("done <<<REVIEW_FAIL>>>"), "FAIL");
+  assert.equal(extractReviewStatus("ok [[REVIEW:PASS]]"), "PASS");
+});
+
+test("collectDecisionTextFromItems reads content-block and tool-call output", async () => {
+  const { collectDecisionTextFromItems, extractReviewStatus } = scheduler;
+  const text = collectDecisionTextFromItems([
+    {
+      kind: "tool-call",
+      id: "t1",
+      tool: "review",
+      output: "Issues found",
+      toolOutputs: [
+        {
+          kind: "content-block",
+          blockType: "resource",
+          text: "REVIEW_STATUS: FAIL"
+        }
+      ]
+    }
   ]);
   assert.equal(extractReviewStatus(text), "FAIL");
 });

--- a/tests/workflow-implement-review-loop.test.mjs
+++ b/tests/workflow-implement-review-loop.test.mjs
@@ -28,6 +28,16 @@ const agents = {
   }
 };
 
+test("buildImplementReviewLoopPlan enforces at least two cycles", () => {
+  const p = buildImplementReviewLoopPlan({
+    goal: "x",
+    implementer: agents.implementer,
+    reviewer: agents.reviewer,
+    maxLoops: 1
+  });
+  assert.equal(p.maxLoops, 2);
+});
+
 test("buildImplementReviewLoopPlan produces implement → review → loop_or_finish", () => {
   const p = buildImplementReviewLoopPlan({
     goal: "add retry",
@@ -97,14 +107,39 @@ test("decideImplementReviewLoop loops on FAIL while under maxLoops", () => {
     "loop"
   );
   assert.equal(
+    decideImplementReviewLoop("failed", "REVIEW_STATUS: FAIL", 0, 5),
+    "loop"
+  );
+  assert.equal(
     decideImplementReviewLoop("done", "REVIEW_STATUS: FAIL", 4, 5),
     "partial"
   );
 });
 
-test("decideImplementReviewLoop returns partial when reviewer failed", () => {
+test("decideImplementReviewLoop requires maxLoops >= 2 for a retry", () => {
   assert.equal(
-    decideImplementReviewLoop("failed", "REVIEW_STATUS: FAIL", 0, 5),
+    decideImplementReviewLoop("done", "REVIEW_STATUS: FAIL", 0, 1),
+    "partial"
+  );
+  assert.equal(
+    decideImplementReviewLoop("done", "REVIEW_STATUS: FAIL", 0, 2),
+    "loop"
+  );
+});
+
+test("extractReviewStatus reads markers from thinking chunks", async () => {
+  const { collectDecisionTextFromItems, extractReviewStatus } = scheduler;
+  const text = collectDecisionTextFromItems([
+    { kind: "thinking", content: "Checking files..." },
+    { kind: "text", content: "Found issues." },
+    { kind: "thinking", content: "REVIEW_STATUS: FAIL" }
+  ]);
+  assert.equal(extractReviewStatus(text), "FAIL");
+});
+
+test("decideImplementReviewLoop returns partial when reviewer failed without status", () => {
+  assert.equal(
+    decideImplementReviewLoop("failed", "Tool error", 0, 5),
     "partial"
   );
 });
@@ -152,7 +187,7 @@ test("runtime handles implement-review-loop template", () => {
     new URL("../electron/cli/workflowRuntime.ts", import.meta.url),
     "utf8"
   );
-  assert.match(src, /implement-review-loop/);
+  assert.match(src, /isImplementReviewLoopPlan/);
   assert.match(src, /decideImplementReviewLoop/);
   assert.match(src, /IMPLEMENT_REVIEW_LOOP_PHASES/);
 });

--- a/tests/workflow-scheduler.test.mjs
+++ b/tests/workflow-scheduler.test.mjs
@@ -151,13 +151,13 @@ test("decideReviewLoop returns partial when verifier did not finish", () => {
   assert.equal(decideReviewLoop("failed", true, 0, 3), "partial");
 });
 
-test("deriveStepSummary prefers the last assistant text", () => {
+test("deriveStepSummary concatenates assistant text chunks", () => {
   const s = deriveStepSummary([
     { kind: "text", content: "first" },
     { kind: "tool-call" },
     { kind: "text", content: "  final answer here  " }
   ]);
-  assert.equal(s, "final answer here");
+  assert.equal(s, "first\nfinal answer here");
 });
 
 test("deriveStepSummary falls back to tool count", () => {

--- a/tests/workflow-teams.test.mjs
+++ b/tests/workflow-teams.test.mjs
@@ -95,6 +95,12 @@ test("research report team expands to a read-only plan", async () => {
   assert.equal(result.preview.teamId, "team-research-report");
   assert.equal(result.preview.writeNodeCount, 0);
   assert.equal(result.preview.plan.phases.length, 3);
+  const [research, analysis, reportPhase] = result.preview.plan.phases;
+  assert.equal(research.steps[0].consumes, undefined);
+  assert.deepEqual(analysis.steps[0].consumes, [research.steps[0].id]);
+  assert.deepEqual(reportPhase.steps[0].consumes, [analysis.steps[0].id]);
+  assert.match(research.steps[0].prompt, /Do not make final judgments or forecasts/);
+  assert.match(analysis.steps[0].prompt, /Do not repeat the raw facts/);
   for (const phase of result.preview.plan.phases) {
     for (const step of phase.steps) {
       assert.notEqual(step.mode, "write");

--- a/tests/workflow-teams.test.mjs
+++ b/tests/workflow-teams.test.mjs
@@ -5,6 +5,7 @@ import fs from "node:fs";
 const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
 
 const TEAM_METHODS = ["list", "get", "create", "update", "delete", "seedBuiltins"];
+const WORKFLOW_METHODS = ["listActiveRuns"];
 
 test("workflow team IPC handlers are registered", () => {
   const ipc = read("../electron/cli/workflowIpc.ts");
@@ -13,6 +14,9 @@ test("workflow team IPC handlers are registered", () => {
   }
   assert.match(ipc, /workflow:previewTeamRun/);
   assert.match(ipc, /workflow:createTeamRun/);
+  for (const m of WORKFLOW_METHODS) {
+    assert.match(ipc, new RegExp(`workflow:${m}`));
+  }
 });
 
 test("preload exposes the workflowTeams client object", () => {
@@ -22,12 +26,16 @@ test("preload exposes the workflowTeams client object", () => {
     assert.match(preload, new RegExp(`${m}\\s*:`));
   }
   assert.match(preload, /workflowTeams,/);
+  for (const m of WORKFLOW_METHODS) {
+    assert.match(preload, new RegExp(`${m}\\s*:`));
+  }
 });
 
 test("renderer types declare the FreebuddyWorkflowTeams interface", () => {
   const types = read("../src/types/freebuddy.d.ts");
   assert.match(types, /interface FreebuddyWorkflowTeams \{/);
   assert.match(types, /workflowTeams:\s*FreebuddyWorkflowTeams/);
+  assert.match(types, /listActiveRuns\(\): Promise<WorkflowRunRow\[]>/);
 });
 
 test("expandTeamToPlan produces a workflow plan for the quick team", async () => {
@@ -55,7 +63,18 @@ test("expandTeamToPlan produces a workflow plan for the quick team", async () =>
   assert.ok(result.preview.writeNodeCount >= 1);
 });
 
-test("readonly team rejects expansion when policy disallows writes", async () => {
+test("builtin workflow teams include the three default teams", async () => {
+  const { builtinWorkflowTeams } = await import(
+    "../dist-electron/cli/workflowTeamBuiltins.js"
+  );
+  const teams = builtinWorkflowTeams();
+  assert.deepEqual(
+    teams.map((t) => t.id),
+    ["team-quick-implement", "team-implement-review-loop", "team-research-report"]
+  );
+});
+
+test("research report team expands to a read-only plan", async () => {
   const { builtinWorkflowTeams } = await import(
     "../dist-electron/cli/workflowTeamBuiltins.js"
   );
@@ -63,22 +82,32 @@ test("readonly team rejects expansion when policy disallows writes", async () =>
     "../dist-electron/cli/workflowTeamAdapter.js"
   );
   const teams = builtinWorkflowTeams();
-  const readonly = teams.find((t) => t.id === "team-readonly-analysis");
-  assert.ok(readonly);
-  const agents = readonly.roles.map((r) => ({
+  const report = teams.find((t) => t.id === "team-research-report");
+  assert.ok(report);
+  const agents = report.roles.map((r) => ({
     id: r.agentId,
     name: r.agentId,
     adapter: "stub-acp",
     enabled: true
   }));
-  const result = expandTeamToPlan(readonly, { goal: "audit" }, agents);
+  const result = expandTeamToPlan(report, { goal: "analyze tomorrow World Cup matches and scores" }, agents);
   assert.equal(result.ok, true);
+  assert.equal(result.preview.teamId, "team-research-report");
   assert.equal(result.preview.writeNodeCount, 0);
+  assert.equal(result.preview.plan.phases.length, 3);
   for (const phase of result.preview.plan.phases) {
     for (const step of phase.steps) {
       assert.notEqual(step.mode, "write");
     }
   }
+});
+
+test("seeding removes retired builtin workflow teams", () => {
+  const src = read("../electron/cli/workflowTeams.ts");
+  assert.match(src, /removedBuiltinWorkflowTeamIds/);
+  assert.match(src, /team-code-review/);
+  assert.match(src, /team-readonly-analysis/);
+  assert.match(src, /DELETE FROM workflow_teams WHERE id = \? AND source = 'builtin'/);
 });
 
 test("validateWorkflowTeam rejects unknown agent on required role", async () => {
@@ -106,17 +135,36 @@ test("team i18n keys exist in both locales", () => {
     "teamPolicy",
     "newTeam",
     "allowWrites",
-    "requireApprovalBeforeWrite"
+    "requireApprovalBeforeWrite",
+    "newTeamComingSoon"
   ]) {
     assert.ok(en.workflow?.[key], `missing en workflow.${key}`);
     assert.ok(zh.workflow?.[key], `missing zh-CN workflow.${key}`);
   }
 });
 
+test("new team button shows coming soon instead of opening editor", () => {
+  const src = read("../src/components/Settings/WorkflowTeamList.tsx");
+  assert.match(src, /workflow\.newTeamComingSoon/);
+  assert.match(src, /window\.alert/);
+  assert.doesNotMatch(src, /onClick=\{onNew\}/);
+});
+
 test("Settings modal mounts the WorkflowTeamsTab", () => {
   const src = read("../src/components/Settings/SettingsModal.tsx");
   assert.match(src, /<WorkflowTeamsTab/);
   assert.match(src, /import \{ WorkflowTeamsTab \}/);
+});
+
+test("ChatView uses a non-writing summary role for team follow-up conversations", () => {
+  const src = read("../src/components/CLI/ChatView.tsx");
+  assert.match(src, /function teamConversationMember/);
+  assert.match(src, /role\.kind === "summarizer"/);
+  assert.match(src, /!role\.canWrite/);
+  assert.doesNotMatch(src, /team\.roles\[0\]\?\.agentId/);
+  assert.match(src, /const teamMember = teamConversationMember\(team, members\)/);
+  assert.match(src, /teams\.find\(\(tt\) => tt\.id === pendingTeamPreview\.teamId\)/);
+  assert.match(src, /member: teamMember/);
 });
 
 test("new task page exposes a team selector and send button for team mode", () => {

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -120,15 +120,19 @@ test("workflow i18n keys exist in both locales", () => {
   assert.ok(zh.workflow.stepStatus?.failed);
 });
 
-test("workflow team UI translates builtin team names", () => {
-  const list = read("../src/components/Settings/WorkflowTeamList.tsx");
-  const editor = read("../src/components/Settings/WorkflowTeamEditor.tsx");
-  const preview = read("../src/components/Workflows/WorkflowTeamPreviewCard.tsx");
+test("conversationStore routes workflow follow-ups to the workflow summary agent", () => {
+  const src = read("../src/store/conversationStore.ts");
   const chat = read("../src/components/CLI/ChatView.tsx");
-  assert.match(list, /workflowTeamName\(team, t\)/);
-  assert.match(list, /workflowTeamDescription\(team, t\)/);
-  assert.match(editor, /workflowTeamName\(team, t\)/);
-  assert.match(editor, /workflowTeamDescription\(team, t\)/);
-  assert.match(preview, /workflowTeamPreviewName\(preview, t\)/);
-  assert.match(chat, /workflowTeamName\(tt, t\)/);
+  const types = read("../src/services/workflows/types.ts");
+  assert.match(types, /function workflowFollowupAgentId/);
+  assert.match(types, /step\.mode === "summarize"/);
+  assert.match(types, /step\.mode !== "write"/);
+  assert.match(src, /workflowRunForConversation/);
+  assert.match(src, /memberForWorkflowFollowup\(workflowRun, get\(\)\.members\)/);
+  assert.match(src, /workflow:\$\{workflowRun\.id\}:\$\{member\.id\}/);
+  assert.match(chat, /workflowFollowupAgentId\(activeRun\)/);
+  assert.match(chat, /workflowFollowupAgent \?\? conv\.agentId/);
+  assert.match(chat, /resolveWorkflowFollowupMember/);
+  assert.match(chat, /await workflowClient\.listRuns\(conv\.id\)/);
+  assert.match(chat, /preflightMember\(targetMember\)/);
 });

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -40,12 +40,15 @@ test("WorkflowPhaseList renders inline step details for the selected step", () =
   const src = read("../src/components/Workflows/WorkflowPhaseList.tsx");
   assert.match(src, /WorkflowStepDetails/);
   assert.match(src, /selectedStepId/);
+  assert.match(src, /workflowPhaseTitle\(phase, t\)/);
+  assert.match(src, /workflowStepTitle\(step, t\)/);
 });
 
 test("WorkflowStepDetails renders failed-state retry", () => {
   const src = read("../src/components/Workflows/WorkflowStepDetails.tsx");
   assert.match(src, /step\.status === "failed"/);
   assert.match(src, /workflow-retry-button/);
+  assert.match(src, /workflowStepTitle\(step, t\)/);
 });
 
 test("ReviewLoopSummary renders final status text", () => {
@@ -104,7 +107,7 @@ test("ChatView titles team workflow conversations from the prompt", () => {
 test("workflow i18n keys exist in both locales", () => {
   const en = JSON.parse(read("../src/locales/en.json"));
   const zh = JSON.parse(read("../src/locales/zh-CN.json"));
-  for (const key of ["mode", "normalMode", "run", "cancel", "summary", "progress", "gates", "risk", "runningIndicator"]) {
+  for (const key of ["mode", "normalMode", "run", "cancel", "summary", "progress", "gates", "risk", "runningIndicator", "phaseTitles", "stepTitles"]) {
     assert.ok(en.workflow?.[key], `missing en workflow.${key}`);
     assert.ok(zh.workflow?.[key], `missing zh-CN workflow.${key}`);
   }
@@ -118,6 +121,28 @@ test("workflow i18n keys exist in both locales", () => {
   assert.ok(zh.workflow.status?.running);
   assert.ok(en.workflow.stepStatus?.failed);
   assert.ok(zh.workflow.stepStatus?.failed);
+});
+
+test("WorkflowRunPanel translates workflow run names", () => {
+  const src = read("../src/components/Workflows/WorkflowRunPanel.tsx");
+  assert.match(src, /workflowRunName/);
+  assert.match(src, /workflow\.builtinTeams\.team-research-report\.name/);
+  assert.match(src, /workflow\.implementReviewLoop/);
+});
+
+test("Settings modal opens with CLI agents before General", () => {
+  const src = read("../src/components/Settings/SettingsModal.tsx");
+  assert.match(src, /useState<SettingsTab>\("cli"\)/);
+  assert.match(src, /const TABS[\s\S]*key: "cli"[\s\S]*key: "workflowTeams"[\s\S]*key: "general"/);
+});
+
+test("MessageBubble supports right-click copy", () => {
+  const src = read("../src/components/CLI/MessageBubble.tsx");
+  const css = read("../styles.css");
+  assert.match(src, /onContextMenu=\{handleContextMenu\}/);
+  assert.match(src, /navigator\.clipboard\?\.writeText\(copyText\)/);
+  assert.match(src, /message\.copy/);
+  assert.match(css, /\.message-context-menu/);
 });
 
 test("conversationStore routes workflow follow-ups to the workflow summary agent", () => {

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -84,9 +84,15 @@ test("new-task page exposes mode tabs and team submit", () => {
 
 test("ConversationList includes workflow runs in the running indicator set", () => {
   const src = read("../src/components/CLI/ConversationList.tsx");
+  const css = read("../styles.css");
   assert.match(src, /useWorkflowStore/);
-  assert.match(src, /workflowRunningConversationId/);
-  assert.match(src, /runningSet\.add\(workflowRunningConversationId\)/);
+  assert.match(src, /workflowActiveRuns/);
+  assert.match(src, /loadWorkflowActiveRuns/);
+  assert.match(src, /workflowRunningSet\.has\(c\.id\)/);
+  assert.match(src, /isWorkflowRunning=\{workflowRunningSet\.has\(c\.id\)\}/);
+  assert.match(src, /conv-running-dot\$\{isWorkflowRunning \? " workflow" : ""\}/);
+  assert.match(css, /\.conv-running-dot\.workflow/);
+  assert.match(css, /--fb-workflow/);
 });
 
 test("ChatView titles team workflow conversations from the prompt", () => {
@@ -98,12 +104,31 @@ test("ChatView titles team workflow conversations from the prompt", () => {
 test("workflow i18n keys exist in both locales", () => {
   const en = JSON.parse(read("../src/locales/en.json"));
   const zh = JSON.parse(read("../src/locales/zh-CN.json"));
-  for (const key of ["mode", "normalMode", "run", "cancel", "summary", "progress", "gates", "risk"]) {
+  for (const key of ["mode", "normalMode", "run", "cancel", "summary", "progress", "gates", "risk", "runningIndicator"]) {
     assert.ok(en.workflow?.[key], `missing en workflow.${key}`);
     assert.ok(zh.workflow?.[key], `missing zh-CN workflow.${key}`);
+  }
+  for (const teamId of ["team-quick-implement", "team-implement-review-loop", "team-research-report"]) {
+    assert.ok(en.workflow.builtinTeams?.[teamId]?.name, `missing en workflow.builtinTeams.${teamId}.name`);
+    assert.ok(en.workflow.builtinTeams?.[teamId]?.description, `missing en workflow.builtinTeams.${teamId}.description`);
+    assert.ok(zh.workflow.builtinTeams?.[teamId]?.name, `missing zh-CN workflow.builtinTeams.${teamId}.name`);
+    assert.ok(zh.workflow.builtinTeams?.[teamId]?.description, `missing zh-CN workflow.builtinTeams.${teamId}.description`);
   }
   assert.ok(en.workflow.status?.running);
   assert.ok(zh.workflow.status?.running);
   assert.ok(en.workflow.stepStatus?.failed);
   assert.ok(zh.workflow.stepStatus?.failed);
+});
+
+test("workflow team UI translates builtin team names", () => {
+  const list = read("../src/components/Settings/WorkflowTeamList.tsx");
+  const editor = read("../src/components/Settings/WorkflowTeamEditor.tsx");
+  const preview = read("../src/components/Workflows/WorkflowTeamPreviewCard.tsx");
+  const chat = read("../src/components/CLI/ChatView.tsx");
+  assert.match(list, /workflowTeamName\(team, t\)/);
+  assert.match(list, /workflowTeamDescription\(team, t\)/);
+  assert.match(editor, /workflowTeamName\(team, t\)/);
+  assert.match(editor, /workflowTeamDescription\(team, t\)/);
+  assert.match(preview, /workflowTeamPreviewName\(preview, t\)/);
+  assert.match(chat, /workflowTeamName\(tt, t\)/);
 });

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -82,6 +82,19 @@ test("new-task page exposes mode tabs and team submit", () => {
   assert.match(src, /new-task-mode-tabs/);
 });
 
+test("ConversationList includes workflow runs in the running indicator set", () => {
+  const src = read("../src/components/CLI/ConversationList.tsx");
+  assert.match(src, /useWorkflowStore/);
+  assert.match(src, /workflowRunningConversationId/);
+  assert.match(src, /runningSet\.add\(workflowRunningConversationId\)/);
+});
+
+test("ChatView titles team workflow conversations from the prompt", () => {
+  const src = read("../src/components/CLI/ChatView.tsx");
+  assert.match(src, /title: \(prompt \|\| team\.name\)\.slice\(0, 24\)/);
+  assert.match(src, /title: \(pendingTeamPreview\.goal \|\| pendingTeamPreview\.teamName/);
+});
+
 test("workflow i18n keys exist in both locales", () => {
   const en = JSON.parse(read("../src/locales/en.json"));
   const zh = JSON.parse(read("../src/locales/zh-CN.json"));


### PR DESCRIPTION
…ycles

Introduce a two-agent workflow template where an implementer writes code, a reviewer checks it, and the loop continues on REVIEW_STATUS: FAIL until PASS or maxLoops is reached.

- Add buildImplementReviewLoopPlan and scheduler decision helpers
- Extend WorkflowRuntime with loop replay and consumed-summary prompts
- Add builtin team-implement-review-loop and team adapter expansion
- Add tests and i18n for the new template