### PR TITLE
feat(draft): add web preview canvas and agent bridge

### DIFF
--- a/docs/agent-bridge.md
+++ b/docs/agent-bridge.md
@@ -1,0 +1,77 @@
+# Agent Bridge — FreeBuddy ↔ Agent 双向通道
+
+FreeBuddy 与所运行的 coding agent 之间,有一套**不依赖 MCP/ACP 工具注入、零 agent 端适配**的双向交互层。它只借助 agent 自带的两个通用能力:**读取 workspace 指令文件** + **执行命令**。
+
+## 总览
+
+| 方向 | 机制 | 载体 |
+| --- | --- | --- |
+| FreeBuddy → agent(注入提示词/上下文) | workspace 指令文件 | `AGENTS.md` / `CLAUDE.md` / `.cursorrules` |
+| agent → FreeBuddy(调用能力) | 本地 loopback HTTP | `http://127.0.0.1:<port>/freebuddy/<action>` |
+
+## 1. 注入方向(FreeBuddy → agent)
+
+新建带 `cwd` 的会话时,`ensureAgentGuides`(主进程)在 workspace 根目录写入指令文件:
+
+- `AGENTS.md`(codex / opencode 读取)
+- `CLAUDE.md`(claude 读取)
+- `.cursorrules`(cursor 读取)
+
+内容含:环境说明、产出规范(可预览 web 产物)、以及**从 action 注册表自动生成的能力清单**(见下)。agent 启动时自动读进上下文,等价于注入了 system 提示词,绕过了「FreeBuddy 无 systemPrompt 注入入口」的限制。
+
+更新策略:
+- 含 `auto-created by FreeBuddy` 标记的文件会被自动更新(随端口/能力变化保持最新)。
+- 用户自己编辑过(无标记)的文件永不覆盖。
+- FreeBuddy 重启后端口变化,下次写指令文件时自动更新为新端口。
+
+## 2. 回调方向(agent → FreeBuddy)
+
+FreeBuddy 在 app ready 时启动一个仅监听 `127.0.0.1` 的本地 HTTP server(`previewServer.ts`),端口由 OS 动态分配。agent 用它的 execute 工具执行 `curl` 即可调用:
+
+```
+curl -s "http://127.0.0.1:<port>/freebuddy/<action>?<params>"
+```
+
+请求经 `parseBridgeRequest` 解析,通过 IPC `freebuddy://bridge` 转发到 renderer,由 `AgentBridgeListener` 按 `action` 分发到对应 store。
+
+> 端口写入指令文件(具体端口号),agent 直接照抄 curl 命令即可,无需自行发现端口。
+
+### 当前 actions
+
+单一事实来源:`BRIDGE_ACTIONS`(`electron/agentBridge.ts`)。它同时驱动 HTTP 路由校验与指令文件的能力清单生成。
+
+| action | 作用 | 参数 |
+| --- | --- | --- |
+| `preview` | 切到 Draft web 预览面板 | — |
+| `navigate` | 预览跳转到指定 workspace 相对路径 | `to`(必填) |
+| `notify` | 在 FreeBuddy 弹一条 toast 提示 | `text`(必填) |
+
+示例:
+```sh
+curl -s "http://127.0.0.1:<port>/freebuddy/preview"
+curl -s "http://127.0.0.1:<port>/freebuddy/navigate?to=about.html"
+curl -s "http://127.0.0.1:<port>/freebuddy/notify?text=done"
+```
+
+(向后兼容:旧的 `/preview` 仍被识别为 `preview`。)
+
+## 3. 扩展一个新 action
+
+只需三步,HTTP 路由与指令清单会自动跟进:
+
+1. 在 `electron/agentGuides... agentBridge.ts` 的 `BRIDGE_ACTIONS` 加一项:`{ name, summary, description, params? }`。
+2. 在 `previewServer.ts` 的请求处理里无需改动(已用 `isKnownBridgeAction` 自动放行);IPC 载荷 `{ action, params }` 透传。
+3. 在 `src/components/AgentBridge/AgentBridgeListener.tsx` 的分发 switch 里加一个 `case`,调用相应 store。
+
+指令文件会在下次 `ensureAgentGuides` 时把新 action 的 curl 示例与参数说明自动写进能力清单。
+
+## 4. OS scheme(可选,仅打包)
+
+`main.ts` 还注册了 `freebuddy://` scheme(`app.isPackaged` 守卫,仅打包生效):打包后 `open "freebuddy://preview"` 也会经同一 `onBridge` 入口触发。dev 模式不注册(避免 LaunchServices 报错),改由本地 HTTP 承担。
+
+## 设计要点
+
+- **零 agent 适配**:只用 agent 通用的「读指令文件」+「执行命令」,不要求 agent 支持 MCP/自定义工具。
+- **单一事实来源**:`BRIDGE_ACTIONS` 一处定义,路由 + 文档 + 注入清单都从它派生。
+- **本地 loopback**:HTTP 只绑 `127.0.0.1`,不暴露网络;端口动态,避免冲突。
+- **非破坏**:指令文件可编辑/可删,scheme 仅打包,HTTP 失败不影响手动操作预览。

--- a/docs/draft-preview-design.md
+++ b/docs/draft-preview-design.md
@@ -1,0 +1,230 @@
+# Draft — 第三列 Web 预览画布 设计
+
+- 状态:Draft / 待评审
+- 版本:v1
+- 分支:`feature/conversation-drafts`(基于 `cursor/implement-review-loop-41c1`)
+- 关联文件:`src/App.tsx`、`src/components/CLI/WorkspacePanel.tsx`、`src/services/cli/streamParser.ts`、`electron/main.ts`、`electron/freebuddyFileProtocol.ts`
+
+> 说明:本期的「Draft」指**第三列的 web 预览画布**(类似 v0/bolt/Cursor preview),用于实时预览 agent 在工作区里生成的 web 产物,**不是**输入框草稿。
+
+## 1. 概述
+
+在主聊天区右侧第三列放入一个 webview 画布。它把当前会话 `cwd` 下 agent 刚写入/修改的 web 产物(HTML/CSS/JS/资源)当作一个真实网站直接渲染;每当流里出现 `file-edit` 事件就自动刷新。第三列顶部改为 **Tab 容器**,在「概览」(现有 `WorkspacePanel`,状态/usage/plan)与「Draft 预览」之间**自由切换**,两者并存、信息均保留。
+
+## 2. 背景与动机
+
+- coding agent 最常见的产出是「一个能跑的 web 页面」。当前 FreeBuddy 只能在消息流里看到文件被改的 diff,看不到渲染结果,用户得手动切到浏览器/编辑器预览,打断「让 agent 改 → 看效果 → 再改」的循环。
+- 产物是真实落在 `cwd` 磁盘上的多文件(HTML 引用相对的 CSS/JS/图片),需要相对路径与模块加载都可用,不能只用 `iframe srcdoc`。
+
+## 3. 目标 / 非目标
+
+**目标**
+- G1 第三列直接渲染 `cwd` 下的 web 入口(默认 `index.html`),相对资源、CSS、JS、ESM、fetch 都正常工作。
+- G2 监听 agent 流式产物,出现 `file-edit` 即自动防抖刷新(无需手动 F5)。
+- G3 第三列改为 Tab 容器,`WorkspacePanel`(概览)与 `DraftCanvas`(预览)**自由切换**,两者并存、信息均保留。
+- G4 沙盒安全:预览内容无法触及 Electron / FreeBuddy 运行时;协议只读且限定在 `cwd` 子树内。
+- G5 复用现有分层与协议范式,不引入新框架/新依赖。
+
+**非目标**
+- N1 不做 dev server 代理 / `localhost` 转发(本期只预览**静态产物**;需要打包/起服务的项目由用户自行构建后再预览)。
+- N2 不做多入口 tab / 多画布(单画布,入口可手动指定)。
+- N3 不做代码与预览的联动高亮、不做元素检查器(后续增强)。
+- N4 不做跨设备/云同步。
+
+## 4. 现状与关键集成点
+
+| 事实 | 位置 | 用途 |
+| --- | --- | --- |
+| 第三列挂载 | `App.tsx:257-259` `{activeConversation && <WorkspacePanel/>}` | 替换为 `<DraftCanvas/>` |
+| `file-edit` 事件结构 | `streamParser.ts:62-69` `{ kind:"file-edit"; path; action; patch?; oldText?; newText? }` | 刷新信号源 |
+| 各 parser 都发 file-edit | codex `parsers/codex.ts:216`、opencode `parsers/opencode.ts:92`、claude | 跨 agent 通用 |
+| 自定义协议注册范式 | `main.ts:36-51` `registerSchemesAsPrivileged` + `protocol.handle` | 新协议照搬 |
+| `Request/Response` handler 写法 | `freebuddyFileProtocol.ts:58` `handleFreebuddyFileRequest` | 新 handler 仿写 |
+| 会话 cwd 来源 | `conversation.cwd`(`WorkspacePanel.tsx:221` 已使用) | 确定 web 根 |
+| 实时流 items | `conversationStore.live[activeId].items` | 实时刷新监听 |
+| 历史流 items | assistant message.content(JSON 数组) | 切回/重启后回放 |
+
+## 5. 整体架构
+
+```
+agent 写盘 ─> CLI stdout ─> parser ─> file-edit item
+                                        │
+              ┌─────────────────────────┴─────────────────────────┐
+              ▼(live items / message items)                        ▼
+   useDraftPreviewStore 订阅 active 会话 items            entry 探测器(cwd 下找 index.html)
+              │ path ∈ webRoot ?                                │
+              ▼ debounce 300ms                                  │
+        重载 iframe ───────────────────────────────────────────► iframe.src
+                                                              = freebuddy-draft:///<rel>?root=<cwd>
+                                                                    │
+                                                                    ▼(主进程)
+                                                         handleDraftRequest()
+                                                            只读 serve cwd 子树
+```
+
+## 6. 技术方案
+
+### 6.1 webview 容器:iframe + sandbox(主方案)
+- 用普通 `<iframe>` 放在第三列,布局随 React/antd 栅格自然流动,**无需**像 `WebContentsView` 那样手动同步窗口坐标(第三列尺寸随窗口/侧栏伸缩变化)。
+- `sandbox="allow-scripts allow-forms allow-popups allow-modals"`(刻意**不带** `allow-same-origin`):脚本可跑,但被隔离为唯一 opaque origin,拿不到 FreeBuddy 的 DOM / storage / Electron。
+- 刷新:优先 `iframe.contentWindow.location.reload()`;跨 origin 不可访问时退化为重置 `src`(带 `?v=<ts>` 防缓存)。
+- **备选(进阶)**:主进程 `WebContentsView` + ResizeObserver 坐标同步,换取独立 devtools / 更强隔离 / 原生路由。本期不采用,留待 §12。
+
+### 6.2 产物加载:新增 `freebuddy-draft` 自定义协议
+仿 `freebuddy-file`(`main.ts:36-51`、`freebuddyFileProtocol.ts`)新增第二套:
+
+注册(app ready 前):
+```ts
+protocol.registerSchemesAsPrivileged([
+  { scheme: "freebuddy-draft",
+    privileges: { standard: true, secure: true, supportFetchAPI: true,
+                  bypassCSP: true, stream: true } }
+]);
+```
+URL 形态:`freebuddy-draft://render/<relPath>?root=<encodeURIComponent(cwd)>`
+- 例:入口 `freebuddy-draft://render/index.html?root=D%3A%5Cwww%5Cdemo`
+- HTML 内 `<link href="styles.css">`、`<script src="main.js">`、`fetch("./api.json")` 都按同协议解析为 `freebuddy-draft://render/styles.css?root=...`,自动复用同一 `root`。
+
+Handler(`handleDraftRequest`)职责:
+1. 解析 `root`(绝对路径,校验 `path.isAbsolute`)与 `relPath`。
+2. `path.resolve(root, relPath)` 后**校验结果仍以 `root` 开头**(防 `../../etc/passwd` 目录穿越),否则 403。
+3. 仅 `fs.readFile`(只读),MIME 按扩展名查表(扩展 `freebuddyFileProtocol.ts` 的表,补 `html/css/js/mjs/map/wasm/ico/woff2...`);目录请求自动追加 `index.html`。
+4. 错误返回 404 页面。
+
+> 复用点:MIME 表与只读读取范式直接借鉴 `freebuddyFileProtocol.ts:53-73`;不复用其「任意绝对路径」语义——draft 必须**锁定 root 子树**。
+
+### 6.3 入口探测
+无显式入口时,按序找第一个存在的文件作为 `entryRel`:
+1. 用户手设(地址栏输入,持久化到 store)
+2. `index.html`
+3. `public/index.html`、`dist/index.html`、`build/index.html`
+4. 最近一次 `file-edit` 里路径以 `.html` 结尾者
+
+探测由 store 调用一次新 IPC `cli:resolveDraftEntry`(主进程 `fs.exists` 检查,避免 renderer 越权读盘)。
+
+### 6.4 实时刷新
+- `useDraftPreviewStore` 用 selector 订阅当前会话的 `messages` + `live.items`,聚合成一个「最近 file-edit 路径 + 序号」的派生值。
+- 派生值变化 → 若路径在 webRoot 下 → `setTimeout` 300ms 防抖 → 触发 `reload()`。
+- 切换会话/`cwd` 变化 → 重算 webRoot + 入口 → 整体替换 `src`。
+- agent 正在跑(流式中)也持续刷新;完成时再刷新一次确保最终态。
+
+## 7. 分层改动清单
+
+**主进程**
+- `electron/main.ts`:注册 `freebuddy-draft` privileged scheme(`main.ts:36` 附近);app ready 后 `protocol.handle("freebuddy-draft", handleDraftRequest)`(仿 `main.ts:50`)。
+- 新建 `electron/draftProtocol.ts`:`handleDraftRequest` + MIME 表 + root 子树校验 + 目录穿越防护 + IPC `resolveDraftEntry`/`draftStat`。
+- `electron/cli/ipc.ts`:新增 `cli:resolveDraftEntry`、`cli:draftStat`(返回入口是否存在/最近修改时间)。
+
+**Preload / 类型 / 客户端**
+- `electron/preload.ts`:`cli.resolveDraftEntry / draftStat`。
+- `src/types/freebuddy.d.ts`:`FreebuddyCli` 补两方法签名。
+- `src/services/cli/client.ts`:`cliClient.resolveDraftEntry / draftStat`。
+
+**状态层**
+- 新建 `src/store/draftPreviewStore.ts`(zustand):
+  ```
+  state: { byConv: Record<convId, { cwd, webRoot, entryRel?, manualEntry?, url, lastEditPath?, ready }>; }
+  actions: ensureFor(convId, cwd); setEntry(convId, rel); reload(convId);
+           onItems(convId, items)  // 由 conversationHandlers/订阅调用,内部防抖 reload
+  ```
+
+**UI**
+- 新建 `src/components/Draft/DraftCanvas.tsx`(预览 Tab 主体):地址栏(协议相对路径,可编辑)+ 刷新 + 在系统浏览器打开 + 入口下拉 + iframe。空态(cwd 未设 / 无 HTML)给引导。
+- 新建 `src/components/Draft/DraftToolbar.tsx`:工具条。
+- 新建第三列 Tab 容器 `src/components/CLI/DetailColumn.tsx`:顶部两 Tab「概览 / 预览」,内容分别渲染 `<WorkspacePanel/>` 与 `<DraftCanvas/>`;按会话记忆上次所选 Tab。
+- `src/App.tsx:257-259`:把 `<WorkspacePanel/>` 替换为 `<DetailColumn/>`(内部承载两个面板)。
+
+**样式**:`styles.css` 新增 `.draft-canvas / .draft-toolbar / .draft-frame`(尺寸 100% 第三列,圆角 `--fb-rounded-lg`,边框 `rgba(148,163,184,.24)`,暗色背景 `#0b0f19`)。
+
+**i18n**:`locales/{en,zh-CN}.json` 新增 `draft` 命名空间(`title / refresh / openExternal / entry / emptyNoWorkspace / emptyNoEntry / loading / unsupported / tabOverview / tabPreview / previewBadge` 等)。
+
+## 8. 数据流(时序)
+
+**A. 进入有产物的会话**
+```
+setActive(id) → store.ensureFor(id, conv.cwd)
+              → IPC resolveDraftEntry(cwd) → entryRel="index.html"
+              → url = freebuddy-draft://render/index.html?root=<cwd>
+              → iframe 加载 → 首屏渲染
+```
+
+**B. agent 实时改文件**
+```
+parser 产 file-edit(path) → live.items 更新
+  → store.onItems 过滤 path ∈ webRoot → debounce 300ms → iframe.reload()
+```
+
+**C. 切换会话 / cwd 变**
+```
+activeId 变 → ensureFor(newId) → 若 cwd 变则重算 entry → 替换 iframe.src
+```
+
+**D. 重启后回看**
+```
+load 会话 → 取最近 file-edit(历史 message items)→ ensureFor → 首屏即最终态
+```
+
+## 9. 安全模型
+
+- 协议 `freebuddy-draft` 只读、锁定 `root=cwd` 子树,目录穿越被 `path.resolve` + 前缀校验拦截。
+- iframe `sandbox` 不含 `allow-same-origin` → agent 写的 JS 在隔离 origin,无法访问 `window.parent`(FreeBuddy UI)、localStorage、cookie,也无法触发导航逃逸(不带 `allow-top-navigation`)。
+- 协议 `secure: true` 保证 ESM / 现代 web API 可用,同时仍是 opaque origin。
+- 不向渲染进程暴露任意路径读盘能力;`resolveDraftEntry` 只返回**相对入口名**,不泄漏绝对路径之外的文件系统信息。
+
+## 10. UI / UX
+
+- 顶部一条工具栏:入口路径(可编辑回车)+ 刷新按钮(带加载态)+ 「在浏览器打开」+ 入口快速切换(若有多个 `.html`)。
+- 主区:iframe 占满。空态分两种:`cwd 未设置` / `cwd 下找不到 HTML`,各自给文案与(若适用)引导去新建会话选目录。
+- 暗色模式:iframe 外层给暗色衬底,避免白屏闪。
+- 首次进入有产物的会话自动加载;agent 跑动时持续刷新(工具栏显示一个「自动刷新中」微指示)。
+- **Tab 切换**:第三列顶部两 Tab「概览」/「预览」。默认「概览」;当 cwd 下存在 web 入口或出现首个 `file-edit` 时,「预览」Tab 出现可用徽标(不强切,避免打断)。每个会话在内存里记忆上次所选 Tab,切回时恢复。
+
+## 11. 关键决策与备选
+
+| 决策点 | 选择 | 理由 | 备选(未采用) |
+| --- | --- | --- | --- |
+| 容器 | renderer `<iframe sandbox>` | 布局随栅格自然、刷新最简单、隔离充分 | 主进程 `WebContentsView`(坐标同步复杂)、`<webview>`(官方 deprecated) |
+| 产物加载 | 自定义 privileged 协议 serve cwd | 相对路径/ESM/fetch 全可用;只读+锁子树安全 | `file://`(ESM/fetch 受限、跨平台路径丑)、起本地 http server(多端口、生命周期复杂) |
+| 刷新信号 | 监听 `file-edit` item | 跨 agent 通用、已有结构 | 监听磁盘 fs.watch(噪声大、跨平台不稳) |
+| 刷新策略 | 300ms 防抖 reload | 平衡实时性与性能 | 每次 item 立即 reload(抖动) |
+| 第三列承载 | Tab 容器,概览/预览自由切换 | 遵循需求:两者信息都要保留,用户按需切换 | 整体替换(信息丢失)、纯 status chip(信息降级) |
+
+## 12. 边界情况
+
+- **cwd 未设**:显示空态「请选择工作区目录」。
+- **多文件路由(SPA)**:hash/history 路由在 reload 时可能复位——history 路由刷新后会回根路径,属可接受降级。
+- **产物需打包/起服务**(如纯 `.tsx`/vite 项目无 `index.html` 产物):本期不支持,空态提示「请先构建」(N1)。
+- **大资源/死循环脚本**:iframe 内卡死不影响主 UI(隔离进程/沙盒);提供手动刷新与「在浏览器打开」逃生口。
+- **跨平台路径**:Windows 反斜杠统一 `encodeURIComponent` 进 `root`,`relPath` 用正斜杠。
+- **无 file-edit 的纯静态会话**:也能加载入口,只是不自动刷新(手动刷新可用)。
+
+## 13. 风险与未决
+
+- **R1(已解决)**:第三列改为 Tab 切换,`WorkspacePanel` 全部信息卡(session/usage/cost/plan/config/agent 状态)保留,与 Draft 预览并存,无信息丢失。
+- **R2** sandbox 不带 `allow-same-origin` 时,部分依赖 `localStorage`/`indexedDB` 的页面会异常——若目标用户常用此类产物,需评估是否对「可信 cwd」放宽(带来安全权衡)。
+- **R3** ESM + bare import(没 build 的源码直接引用 `react`)无法在协议下解析;属 N1 范畴,空态引导构建。
+- **R4** 第三列在窄窗口下可能被挤压;需给 iframe 一个最小可用宽度并允许整列折叠(沿用现有 `sidebar-collapsed` 类思路)。
+
+## 14. 实现拆解(建议提交顺序)
+
+1. **协议层**:`draftProtocol.ts` + `main.ts` 注册;`resolveDraftEntry` IPC。单测:目录穿越拦截、MIME、目录→index.html。
+2. **打通调用链**:preload / `freebuddy.d.ts` / `client.ts`。
+3. **store**:`draftPreviewStore.ts`(ensureFor / onItems 防抖 / reload / 入口缓存)。
+4. **UI 主体**:`DraftCanvas` + `DraftToolbar` + 空态;新增第三列 Tab 容器 `DetailColumn`;`App.tsx` 用 `DetailColumn` 承载 `WorkspacePanel` 与 `DraftCanvas`。
+5. **实时刷新接线**:在 `conversationHandlers` 或 store 订阅里把 file-edit 喂给 `onItems`。
+6. **样式 + i18n + 暗色**。
+7. **Tab 记忆与徽标**:按会话在内存(可选 `app_settings`)记忆上次 Tab;预览可用时给徽标。
+8. **验证**:`typecheck` + `test` + Electron 实跑(新建/切换/cwd 变/agent 改文件自动刷新/目录穿越拦截)。
+
+## 15. 验证与测试
+
+- **单测**:`draftProtocol.ts` 的穿越拦截(`../`、绝对路径、符号链接不跟随)、MIME 映射、目录请求补 `index.html`、403/404。
+- **手测清单**:
+  - [ ] 有 `index.html` 的会话,进入即见首屏,相对 CSS/JS/图片/ESM 正常。
+  - [ ] agent 改 `index.html` 或 `style.css` 后 ~300ms 自动刷新。
+  - [ ] 切换会话 / 切到不同 cwd,画布随之换站。
+  - [ ] 概览/预览 Tab 自由切换;切走再切回会话,恢复上次 Tab;预览可用时 Tab 有徽标。
+  - [ ] 地址栏输入相对路径回车可跳转;「在浏览器打开」可用。
+  - [ ] cwd 未设 / 无 HTML 时空态正确。
+  - [ ] 构造 `freebuddy-draft://render/../../etc/passwd?root=...` 返回 403。
+  - [ ] iframe 无法 `parent.postMessage` 触达 FreeBuddy(隔离验证)。

--- a/electron/agentBridge.ts
+++ b/electron/agentBridge.ts
@@ -1,0 +1,121 @@
+export interface BridgeActionParam {
+  name: string;
+  description: string;
+  required?: boolean;
+}
+
+export interface BridgeAction {
+  name: string;
+  summary: string;
+  description: string;
+  params?: BridgeActionParam[];
+}
+
+/**
+ * The catalog of actions FreeBuddy exposes to agents over the local HTTP
+ * bridge. This single source of truth drives:
+ *  - HTTP routing (previewServer.ts -> parseBridgeRequest)
+ *  - the capability list injected into workspace guide files (agentGuides.ts)
+ */
+export const BRIDGE_PORT = 17878;
+
+export const BRIDGE_ACTIONS: BridgeAction[] = [
+  {
+    name: "preview",
+    summary: "Open the web preview panel.",
+    description:
+      "Switch the side panel to the Draft web preview for this workspace."
+  },
+  {
+    name: "navigate",
+    summary: "Point the preview at a workspace-relative path.",
+    description:
+      "Re-target the preview iframe to a different entry file (e.g. another page).",
+    params: [
+      {
+        name: "to",
+        description: "Workspace-relative path, e.g. about.html",
+        required: true
+      }
+    ]
+  },
+  {
+    name: "notify",
+    summary: "Show a short toast message to the user.",
+    description: "Surface a brief, non-blocking message in the FreeBuddy UI.",
+    params: [
+      { name: "text", description: "The message to display", required: true }
+    ]
+  }
+];
+
+export interface ParsedBridgeRequest {
+  action: string;
+  params: Record<string, string>;
+}
+
+export function parseBridgeRequest(
+  requestUrl: string
+): ParsedBridgeRequest | null {
+  let url: URL;
+  try {
+    url = new URL(requestUrl, "http://localhost");
+  } catch {
+    return null;
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+
+  // Canonical: /freebuddy/<action>?<params>
+  if (parts.length >= 2 && parts[0] === "freebuddy") {
+    const action = parts[1];
+    const params: Record<string, string> = {};
+    url.searchParams.forEach((value, key) => {
+      params[key] = value;
+    });
+    return { action, params };
+  }
+
+  // Legacy: /preview
+  if (parts.length === 1 && parts[0] === "preview") {
+    return { action: "preview", params: {} };
+  }
+
+  return null;
+}
+
+export function isKnownBridgeAction(action: string): boolean {
+  return BRIDGE_ACTIONS.some((a) => a.name === action);
+}
+
+export function buildBridgeSection(port: number): string {
+  const lines: string[] = [
+    "## FreeBuddy bridge",
+    "",
+    "You can talk back to FreeBuddy over a local HTTP bridge while it is running.",
+    "Run any of these from the project root:",
+    ""
+  ];
+  for (const action of BRIDGE_ACTIONS) {
+    const params = action.params ?? [];
+    const query = params.length
+      ? "?" + params.map((p) => `${p.name}=<value>`).join("&")
+      : "";
+    lines.push(`### ${action.name}`);
+    lines.push(`${action.summary} ${action.description}`);
+    lines.push("```sh");
+    lines.push(
+      `curl -s "http://127.0.0.1:${port}/freebuddy/${action.name}${query}"`
+    );
+    lines.push("```");
+    if (params.length) {
+      lines.push("Parameters:");
+      for (const p of params) {
+        lines.push(
+          `- \`${p.name}\`${p.required ? " (required)" : ""}: ${p.description}`
+        );
+      }
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/electron/agentGuides.ts
+++ b/electron/agentGuides.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { BRIDGE_PORT, buildBridgeSection } from "./agentBridge.js";
+
+const GUIDE_FILES = ["AGENTS.md", "CLAUDE.md", ".cursorrules"];
+const FB_SIGNATURE = "auto-created by FreeBuddy";
+
+function buildGuideContent(): string {
+  const bridge = buildBridgeSection(BRIDGE_PORT);
+  return `# FreeBuddy Workspace Guide
+
+You are working inside **FreeBuddy**, a local-first desktop app that runs you
+as a coding agent and streams your work to the user in real time.
+
+## Environment
+- This directory is the user's project root.
+- File edits and creates you make are tracked and shown live to the user.
+- The user can preview web output (HTML/CSS/JS) in a side panel.
+
+## Producing previewable web output
+When the task involves building or changing a web page:
+- Write a self-contained \`index.html\` at the project root (or under \`dist/\`).
+- Use **relative paths** for CSS/JS/assets so they load inside the preview.
+- Plain HTML/CSS/JS renders directly. Projects that need a dev server or a
+  build step will NOT preview until built to static files.
+
+${bridge}
+
+> This file was ${FB_SIGNATURE} and is safe to edit or delete.
+`;
+}
+
+export async function ensureAgentGuides(
+  cwd: string
+): Promise<string[]> {
+  const written: string[] = [];
+  if (!cwd || !path.isAbsolute(cwd)) return written;
+
+  const content = buildGuideContent();
+  for (const name of GUIDE_FILES) {
+    const full = path.join(cwd, name);
+    let exists = false;
+    try {
+      await fs.access(full);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      // Update only files FreeBuddy previously generated; leave user edits alone.
+      try {
+        const current = await fs.readFile(full, "utf8");
+        if (current.includes(FB_SIGNATURE)) {
+          await fs.writeFile(full, content, "utf8");
+        }
+      } catch {
+        // ignore read/write errors
+      }
+    } else {
+      try {
+        await fs.writeFile(full, content, "utf8");
+        written.push(name);
+      } catch {
+        // ignore write errors (permissions, read-only, etc.)
+      }
+    }
+  }
+
+  return written;
+}

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -42,6 +42,8 @@ import {
   type UpdateMessageInput
 } from "./conversations.js";
 import { getSetting, setSetting, getLanguage } from "./settings.js";
+import { resolveDraftEntry } from "../draftProtocol.js";
+import { ensureAgentGuides } from "../agentGuides.js";
 import { tMain } from "./i18n.js";
 import { setApplicationMenuForLanguage } from "../menu.js";
 import { registerWorkflowIpc } from "./workflowIpc.js";
@@ -237,6 +239,14 @@ export function registerCliIpc() {
         args.sessionId,
         args.title
       )
+  );
+
+  ipcMain.handle("cli:resolveDraftEntry", (_e, cwd: string) =>
+    resolveDraftEntry(cwd ?? "")
+  );
+
+  ipcMain.handle("cli:ensureAgentGuides", (_e, cwd: string) =>
+    ensureAgentGuides(cwd ?? "")
   );
 
   // ---- Conversations -----------------------------------------------------

--- a/electron/draftProtocol.ts
+++ b/electron/draftProtocol.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const MIME_BY_EXT: Record<string, string> = {
+  html: "text/html; charset=utf-8",
+  htm: "text/html; charset=utf-8",
+  css: "text/css; charset=utf-8",
+  js: "text/javascript; charset=utf-8",
+  mjs: "text/javascript; charset=utf-8",
+  cjs: "text/javascript; charset=utf-8",
+  jsx: "text/javascript; charset=utf-8",
+  ts: "text/plain; charset=utf-8",
+  tsx: "text/plain; charset=utf-8",
+  json: "application/json; charset=utf-8",
+  map: "application/json; charset=utf-8",
+  svg: "image/svg+xml",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  gif: "image/gif",
+  ico: "image/x-icon",
+  bmp: "image/bmp",
+  avif: "image/avif",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  ttf: "font/ttf",
+  otf: "font/otf",
+  eot: "application/vnd.ms-fontobject",
+  wasm: "application/wasm",
+  txt: "text/plain; charset=utf-8",
+  md: "text/markdown; charset=utf-8",
+  xml: "application/xml; charset=utf-8",
+  csv: "text/csv; charset=utf-8",
+  pdf: "application/pdf"
+};
+
+const ENTRY_CANDIDATES = [
+  "index.html",
+  "public/index.html",
+  "dist/index.html",
+  "build/index.html"
+];
+
+function mimeForPath(filePath: string): string {
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  return MIME_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+export function isWithinRoot(target: string, root: string): boolean {
+  if (target === root) return true;
+  return target.startsWith(root + path.sep);
+}
+
+export interface DraftRequestParams {
+  root: string;
+  rel: string;
+}
+
+export function parseDraftUrl(requestUrl: string): DraftRequestParams {
+  const url = new URL(requestUrl);
+  const rootRaw = url.searchParams.get("root");
+  if (!rootRaw) throw new Error("Missing root");
+  const root = path.resolve(decodeURIComponent(rootRaw));
+  if (!path.isAbsolute(root)) throw new Error("root must be absolute");
+
+  const relRaw = decodeURIComponent(url.pathname.replace(/^\//, ""));
+  const rel = relRaw === "" ? "index.html" : relRaw;
+  return { root, rel };
+}
+
+export async function handleDraftRequest(
+  request: Request
+): Promise<Response> {
+  try {
+    const { root, rel } = parseDraftUrl(request.url);
+    const abs = path.resolve(root, rel);
+    if (!isWithinRoot(abs, root)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    let stat;
+    try {
+      stat = await fs.stat(abs);
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+
+    let filePath = abs;
+    if (stat.isDirectory()) {
+      filePath = path.join(abs, "index.html");
+      try {
+        await fs.stat(filePath);
+      } catch {
+        return new Response("Not found", { status: 404 });
+      }
+    }
+
+    const data = await fs.readFile(filePath);
+    return new Response(data, {
+      headers: {
+        "Content-Type": mimeForPath(filePath),
+        "Cache-Control": "no-cache"
+      }
+    });
+  } catch (error) {
+    return new Response((error as Error).message, { status: 500 });
+  }
+}
+
+export async function resolveDraftEntry(
+  cwd: string
+): Promise<string | null> {
+  if (!cwd || !path.isAbsolute(cwd)) return null;
+  for (const candidate of ENTRY_CANDIDATES) {
+    try {
+      const full = path.join(cwd, candidate);
+      const stat = await fs.stat(full);
+      if (stat.isFile()) return candidate;
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,6 +5,8 @@ import { shellEnv } from "shell-env";
 
 import { registerCliIpc } from "./cli/ipc.js";
 import { handleFreebuddyFileRequest } from "./freebuddyFileProtocol.js";
+import { handleDraftRequest } from "./draftProtocol.js";
+import { startPreviewServer } from "./previewServer.js";
 import { getDb } from "./cli/db.js";
 import { seedBuiltinWorkflowTeams } from "./cli/workflowTeams.js";
 import { initApplicationMenu } from "./menu.js";
@@ -20,6 +22,38 @@ app.setAboutPanelOptions({
   applicationName: APP_NAME,
   applicationVersion: APP_VERSION,
   version: APP_VERSION
+});
+
+const PROTOCOL = "freebuddy";
+
+function handleSchemeUrl(raw: string) {
+  try {
+    const parsed = new URL(raw);
+    const action = parsed.hostname || parsed.pathname.replace(/^\//, "");
+    if (action === "preview" && mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("freebuddy://bridge", { action: "preview", params: {} });
+    }
+  } catch {
+    // ignore malformed scheme urls
+  }
+}
+
+if (app.isPackaged && !app.isDefaultProtocolClient(PROTOCOL)) {
+  app.setAsDefaultProtocolClient(PROTOCOL);
+}
+
+if (!app.requestSingleInstanceLock()) {
+  app.quit();
+}
+
+app.on("open-url", (event, url) => {
+  event.preventDefault();
+  handleSchemeUrl(url);
+});
+
+app.on("second-instance", (_event, argv) => {
+  const url = argv.find((arg) => arg.startsWith(`${PROTOCOL}://`));
+  if (url) handleSchemeUrl(url);
 });
 
 function resolveAppIconPath() {
@@ -43,11 +77,25 @@ protocol.registerSchemesAsPrivileged([
       bypassCSP: true,
       stream: true
     }
+  },
+  {
+    scheme: "freebuddy-draft",
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      bypassCSP: true,
+      stream: true
+    }
   }
 ]);
 
 function registerLocalFileProtocol() {
   protocol.handle("freebuddy-file", handleFreebuddyFileRequest);
+}
+
+function registerDraftProtocol() {
+  protocol.handle("freebuddy-draft", handleDraftRequest);
 }
 
 async function injectShellPath() {
@@ -140,6 +188,10 @@ function createWindow() {
 app.whenReady().then(async () => {
   await injectShellPath();
   registerLocalFileProtocol();
+  registerDraftProtocol();
+  startPreviewServer(() =>
+    mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null
+  );
   getDb();
   seedBuiltinWorkflowTeams();
   registerCliIpc();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -65,6 +65,12 @@ const cli = {
   selectDirectory: () => ipcRenderer.invoke("cli:selectDirectory"),
   selectAttachments: () => ipcRenderer.invoke("cli:selectAttachments"),
 
+  resolveDraftEntry: (cwd: string) =>
+    ipcRenderer.invoke("cli:resolveDraftEntry", cwd),
+
+  ensureAgentGuides: (cwd: string) =>
+    ipcRenderer.invoke("cli:ensureAgentGuides", cwd),
+
   onEvent(sessionId: string, cb: (event: unknown) => void): () => void {
     const channel = `cli://${sessionId}`;
     const handler = (_e: IpcRendererEvent, payload: unknown) => cb(payload);
@@ -78,6 +84,16 @@ const window = {
     const handler = (_e: IpcRendererEvent, visible: boolean) => cb(visible);
     ipcRenderer.on("window:chrome", handler);
     return () => ipcRenderer.off("window:chrome", handler);
+  },
+  onBridge(
+    cb: (event: { action: string; params: Record<string, string> }) => void
+  ): () => void {
+    const handler = (
+      _e: IpcRendererEvent,
+      payload: { action: string; params: Record<string, string> }
+    ) => cb(payload);
+    ipcRenderer.on("freebuddy://bridge", handler);
+    return () => ipcRenderer.off("freebuddy://bridge", handler);
   }
 };
 

--- a/electron/previewServer.ts
+++ b/electron/previewServer.ts
@@ -1,0 +1,32 @@
+import http from "node:http";
+import type { WebContents } from "electron";
+
+import { BRIDGE_PORT, isKnownBridgeAction, parseBridgeRequest } from "./agentBridge.js";
+
+let previewServer: http.Server | null = null;
+
+export function startPreviewServer(
+  getWebContents: () => WebContents | null
+): void {
+  if (previewServer) return;
+  const server = http.createServer((req, res) => {
+    const parsed = parseBridgeRequest(req.url || "");
+    if (parsed && isKnownBridgeAction(parsed.action)) {
+      const wc = getWebContents();
+      if (wc && !wc.isDestroyed()) {
+        wc.send("freebuddy://bridge", parsed);
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, action: parsed.action }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("not found");
+  });
+  server.on("error", () => {
+    // listen failed (port in use) — bridge unavailable; actions fall back to manual UI
+  });
+  server.listen(BRIDGE_PORT, "127.0.0.1", () => {
+    previewServer = server;
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { ConfigProvider, theme as antdTheme } from "antd";
 
 import sidebarLogoUrl from "../assets/sidebar-logo.png";
@@ -6,13 +6,16 @@ import { ChatView } from "./components/CLI/ChatView";
 import { ConversationList } from "./components/CLI/ConversationList";
 import { ImageLightboxProvider } from "./components/CLI/ImageLightbox";
 import { PermissionDialog } from "./components/CLI/PermissionDialog";
-import { WorkspacePanel } from "./components/CLI/WorkspacePanel";
+import { DetailColumn } from "./components/CLI/DetailColumn";
+import { AgentBridgeListener } from "./components/AgentBridge/AgentBridgeListener";
+import { AgentBridgeToasts } from "./components/AgentBridge/AgentBridgeToasts";
 import { SettingsModal } from "./components/Settings/SettingsModal";
 import { CliInstallPanelHost } from "./components/Settings/CliInstallPanelHost";
 import { useCliExecutorStore } from "./store/cliExecutorStore";
 import { useConversationStore } from "./store/conversationStore";
 import { useSettingsStore } from "./store/settingsStore";
 import { useUpdaterStore } from "./store/updaterStore";
+import { useDetailLayoutStore, selectDetailWidth, DETAIL_MIN_WIDTH } from "./store/detailLayoutStore";
 import i18next from "i18next";
 import { useTranslation } from "react-i18next";
 
@@ -138,6 +141,25 @@ function App() {
   useEffect(() => {
     void loadUpdater();
   }, [loadUpdater]);
+  const loadDetailLayout = useDetailLayoutStore((s) => s.load);
+  const detailWidth = useDetailLayoutStore(selectDetailWidth);
+  useEffect(() => {
+    void loadDetailLayout();
+  }, [loadDetailLayout]);
+
+  const [winWidth, setWinWidth] = useState(() =>
+    typeof window !== "undefined" ? window.innerWidth : 1280
+  );
+  useEffect(() => {
+    const onResize = () => setWinWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  const sidebarWidth = sidebarCollapsed ? 0 : 272;
+  const effectiveDetailWidth = Math.min(
+    detailWidth,
+    Math.max(DETAIL_MIN_WIDTH, winWidth - sidebarWidth - 420 - 8)
+  );
   const updateReady = useUpdaterStore((s) => s.status === "downloaded");
   const appVersion = useUpdaterStore((s) => s.appVersion);
 
@@ -205,6 +227,7 @@ function App() {
     <div
       className={`app-shell${isElectron ? " electron-shell" : ""}${isNewTask ? " new-task-mode" : ""}${sidebarCollapsed ? " sidebar-collapsed" : ""}${!chromeVisible ? " chrome-hidden" : ""}${platform ? ` platform-${platform}` : ""}`}
       data-theme={theme}
+      style={{ "--fb-detail-width": `${effectiveDetailWidth}px` } as CSSProperties}
     >
       <aside className="sidebar">
         <div className="sidebar-header">
@@ -255,12 +278,14 @@ function App() {
       </main>
 
       {activeConversation && (
-        <WorkspacePanel runningCount={runningCount} />
+        <DetailColumn runningCount={runningCount} />
       )}
 
       {settingsOpen && <SettingsModal onClose={() => setSettingsOpen(false)} />}
       <CliInstallPanelHost />
       <PermissionDialog />
+      <AgentBridgeListener />
+      <AgentBridgeToasts />
     </div>
     </ImageLightboxProvider>
     </ConfigProvider>

--- a/src/components/AgentBridge/AgentBridgeListener.tsx
+++ b/src/components/AgentBridge/AgentBridgeListener.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+import { useAgentBridgeStore } from "@/store/agentBridgeStore";
+import { useConversationStore } from "@/store/conversationStore";
+import { useDetailLayoutStore } from "@/store/detailLayoutStore";
+import { useDraftPreviewStore } from "@/store/draftPreviewStore";
+
+/**
+ * Listens for agent -> FreeBuddy bridge events (local HTTP / OS scheme) and
+ * dispatches them to the right store. Mounted once at the app root.
+ */
+export function AgentBridgeListener() {
+  const notify = useAgentBridgeStore((s) => s.notify);
+
+  useEffect(() => {
+    const off = window.freebuddy?.window?.onBridge?.((event) => {
+      const { action, params } = event;
+      if (action === "preview") {
+        useDetailLayoutStore.getState().setActiveTab("preview");
+        return;
+      }
+      if (action === "navigate") {
+        const to = params?.to;
+        const convId = useConversationStore.getState().activeId;
+        if (to && convId) {
+          useDraftPreviewStore.getState().setManualEntry(convId, to);
+          useDetailLayoutStore.getState().setActiveTab("preview");
+        }
+        return;
+      }
+      if (action === "notify") {
+        const text = params?.text;
+        if (text) notify(text);
+        return;
+      }
+    });
+    return () => {
+      off?.();
+    };
+  }, [notify]);
+
+  return null;
+}

--- a/src/components/AgentBridge/AgentBridgeToasts.tsx
+++ b/src/components/AgentBridge/AgentBridgeToasts.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from "react-i18next";
+
+import { useAgentBridgeStore } from "@/store/agentBridgeStore";
+
+export function AgentBridgeToasts() {
+  const { t } = useTranslation();
+  const toasts = useAgentBridgeStore((s) => s.toasts);
+  const dismiss = useAgentBridgeStore((s) => s.dismiss);
+  if (!toasts.length) return null;
+  return (
+    <div className="agent-bridge-toasts" aria-live="polite">
+      {toasts.map((toast) => (
+        <div key={toast.id} className="agent-bridge-toast" role="status">
+          <span>{toast.text}</span>
+          <button
+            type="button"
+            className="agent-bridge-toast-close"
+            aria-label={t("common.close")}
+            onClick={() => dismiss(toast.id)}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/CLI/DetailColumn.tsx
+++ b/src/components/CLI/DetailColumn.tsx
@@ -1,0 +1,99 @@
+import { useEffect, type MouseEvent } from "react";
+
+import { useTranslation } from "react-i18next";
+
+import { useConversationStore } from "@/store/conversationStore";
+import { useDetailLayoutStore, selectDetailWidth } from "@/store/detailLayoutStore";
+import { useDraftPreviewStore } from "@/store/draftPreviewStore";
+import { DraftCanvas } from "../Draft/DraftCanvas";
+import { WorkspacePanel } from "./WorkspacePanel";
+
+export function DetailColumn({ runningCount }: { runningCount: number }) {
+  const { t } = useTranslation();
+  const activeId = useConversationStore((s) => s.activeId);
+  const entry = useDraftPreviewStore((s) =>
+    activeId ? s.byConv[activeId] : undefined
+  );
+  const activeTab = useDetailLayoutStore((s) => s.activeTab);
+  const setActiveTab = useDetailLayoutStore((s) => s.setActiveTab);
+
+  useEffect(() => {
+    if (!activeId) return;
+    useDetailLayoutStore.getState().setActiveTab("overview");
+    const conv = useConversationStore
+      .getState()
+      .conversations.find((c) => c.id === activeId);
+    void useDraftPreviewStore.getState().ensureFor(activeId, conv?.cwd);
+  }, [activeId]);
+
+  const previewAvailable = Boolean(entry?.entryRel);
+
+  const onResizeStart = (e: MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = selectDetailWidth(useDetailLayoutStore.getState());
+    const onMove = (ev: globalThis.MouseEvent) => {
+      useDetailLayoutStore.getState().setWidth(startWidth - (ev.clientX - startX));
+    };
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  };
+
+  return (
+    <aside
+      className="details-panel workspace-panel detail-column"
+      aria-label={t("workspace.panelAria")}
+    >
+      <div
+        className="detail-resizer"
+        role="separator"
+        aria-orientation="vertical"
+        onMouseDown={onResizeStart}
+      />
+      <div className="detail-tab-body">
+        {activeTab === "overview" ? (
+          <>
+            <button
+              type="button"
+              className={`detail-entry${previewAvailable ? " available" : ""}`}
+              onClick={() => setActiveTab("preview")}
+              title={t("draft.tabPreview")}
+            >
+              <svg
+                className="detail-entry-icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3" y="4" width="18" height="13" rx="2" />
+                <path d="M9 21h6M12 17v4" />
+              </svg>
+              <span>{t("draft.tabPreview")}</span>
+              {previewAvailable && (
+                <span
+                  className="detail-entry-badge"
+                  aria-label={t("draft.previewBadge")}
+                />
+              )}
+            </button>
+            <WorkspacePanel runningCount={runningCount} />
+          </>
+        ) : (
+          <DraftCanvas onClose={() => setActiveTab("overview")} />
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/CLI/WorkspacePanel.tsx
+++ b/src/components/CLI/WorkspacePanel.tsx
@@ -179,7 +179,7 @@ export function WorkspacePanel({
   ]);
 
   return (
-    <aside className="details-panel workspace-panel" aria-label={t("workspace.panelAria")}>
+    <div className="workspace-cards" aria-label={t("workspace.panelAria")}>
       <WorkflowRunPanel />
 
       {isTeamRun ? null : (
@@ -355,7 +355,7 @@ export function WorkspacePanel({
           </ol>
         </section>
       )}
-    </aside>
+    </div>
   );
 }
 

--- a/src/components/Draft/DraftCanvas.tsx
+++ b/src/components/Draft/DraftCanvas.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo } from "react";
+
+import { useTranslation } from "react-i18next";
+
+import type { CliStreamItem } from "@/services/cli/parsers";
+import type { ConversationMessage } from "@/services/cli/types";
+import { useConversationStore } from "@/store/conversationStore";
+import { useDraftPreviewStore } from "@/store/draftPreviewStore";
+import { DraftToolbar } from "./DraftToolbar";
+
+const EMPTY_MESSAGES: ConversationMessage[] = [];
+
+function extractLastFileEditPath(
+  items: CliStreamItem[] | undefined,
+  messages: ConversationMessage[]
+): string | undefined {
+  if (items && items.length) {
+    for (let i = items.length - 1; i >= 0; i -= 1) {
+      const it = items[i];
+      if (it.kind === "file-edit" && it.path) return it.path;
+    }
+  }
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.role !== "assistant") continue;
+    try {
+      const parsed = JSON.parse(message.content) as unknown;
+      if (!Array.isArray(parsed)) continue;
+      const parsedItems = parsed as CliStreamItem[];
+      for (let j = parsedItems.length - 1; j >= 0; j -= 1) {
+        const it = parsedItems[j];
+        if (it.kind === "file-edit" && it.path) return it.path;
+      }
+    } catch {
+      // ignore legacy plain content
+    }
+  }
+  return undefined;
+}
+
+export function DraftCanvas({ onClose }: { onClose?: () => void }) {
+  const { t } = useTranslation();
+  const activeId = useConversationStore((s) => s.activeId);
+  const cwd = useConversationStore((s) => {
+    const conv = s.conversations.find((c) => c.id === s.activeId);
+    return conv?.cwd;
+  });
+  const liveItems = useConversationStore((s) =>
+    s.activeId ? s.live[s.activeId]?.items : undefined
+  );
+  const messages = useConversationStore((s) =>
+    s.activeId ? s.messages[s.activeId] ?? EMPTY_MESSAGES : EMPTY_MESSAGES
+  );
+  const entry = useDraftPreviewStore((s) =>
+    activeId ? s.byConv[activeId] : undefined
+  );
+
+  useEffect(() => {
+    if (!activeId) return;
+    void useDraftPreviewStore.getState().ensureFor(activeId, cwd);
+  }, [activeId, cwd]);
+
+  const lastEditPath = useMemo(
+    () => extractLastFileEditPath(liveItems, messages),
+    [liveItems, messages]
+  );
+
+  useEffect(() => {
+    if (!activeId || !lastEditPath) return;
+    useDraftPreviewStore.getState().scheduleReload(activeId);
+  }, [activeId, lastEditPath]);
+
+  const hasEntry = Boolean(entry?.url);
+
+  return (
+    <div className="draft-canvas">
+      <DraftToolbar
+        entryRel={entry?.manualEntry ?? entry?.entryRel ?? ""}
+        onClose={onClose}
+      />
+      <div className="draft-frame-wrap">
+        {hasEntry ? (
+          <iframe
+            src={entry!.url}
+            className="draft-frame"
+            title={t("draft.title")}
+            sandbox="allow-scripts allow-forms allow-popups allow-modals"
+          />
+        ) : (
+          <div className="draft-empty">
+            <p>{cwd ? t("draft.emptyNoEntry") : t("draft.emptyNoWorkspace")}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Draft/DraftToolbar.tsx
+++ b/src/components/Draft/DraftToolbar.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState, type KeyboardEvent } from "react";
+
+import { useTranslation } from "react-i18next";
+
+import { useConversationStore } from "@/store/conversationStore";
+import { useDraftPreviewStore } from "@/store/draftPreviewStore";
+
+export function DraftToolbar({
+  entryRel,
+  onClose
+}: {
+  entryRel: string;
+  onClose?: () => void;
+}) {
+  const { t } = useTranslation();
+  const activeId = useConversationStore((s) => s.activeId);
+  const [value, setValue] = useState(entryRel);
+
+  useEffect(() => {
+    setValue(entryRel);
+  }, [entryRel]);
+
+  const commit = () => {
+    const trimmed = value.trim();
+    if (activeId && trimmed) {
+      useDraftPreviewStore.getState().setManualEntry(activeId, trimmed);
+    }
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+    }
+  };
+
+  return (
+    <div className="draft-toolbar">
+      <input
+        className="draft-address"
+        type="text"
+        value={value}
+        spellCheck={false}
+        autoComplete="off"
+        placeholder={t("draft.entryPlaceholder")}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={onKeyDown}
+      />
+      <button
+        type="button"
+        className="draft-action"
+        title={t("draft.refresh")}
+        aria-label={t("draft.refresh")}
+        onClick={() => activeId && useDraftPreviewStore.getState().reload(activeId)}
+      >
+        ⟳
+      </button>
+      {onClose && (
+        <button
+          type="button"
+          className="draft-action draft-close"
+          title={t("common.close")}
+          aria-label={t("common.close")}
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -447,5 +447,15 @@
       "downloaded": "Version {{version}} is ready to install.",
       "error": "Update check failed."
     }
+  },
+  "draft": {
+    "title": "Preview",
+    "tabOverview": "Overview",
+    "tabPreview": "Preview",
+    "previewBadge": "Preview available",
+    "refresh": "Refresh",
+    "entryPlaceholder": "Entry path (e.g. index.html)",
+    "emptyNoWorkspace": "No workspace selected. Pick a working directory to preview the agent's output.",
+    "emptyNoEntry": "No previewable web entry found. Ask the agent to create an index.html, or build the project first."
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -446,5 +446,15 @@
       "downloaded": "{{version}} 已准备就绪，可立即安装。",
       "error": "检查更新失败。"
     }
+  },
+  "draft": {
+    "title": "预览",
+    "tabOverview": "概览",
+    "tabPreview": "预览",
+    "previewBadge": "预览可用",
+    "refresh": "刷新",
+    "entryPlaceholder": "入口路径(如 index.html)",
+    "emptyNoWorkspace": "未选择工作区目录。选择一个工作目录即可预览 agent 的产出。",
+    "emptyNoEntry": "未找到可预览的 web 入口。让 agent 创建 index.html,或先构建项目。"
   }
 }

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -151,6 +151,12 @@ export const cliClient = {
   selectAttachments(): Promise<AttachmentCandidate[]> {
     return api().selectAttachments();
   },
+  resolveDraftEntry(cwd: string): Promise<string | null> {
+    return api().resolveDraftEntry(cwd);
+  },
+  ensureAgentGuides(cwd: string): Promise<string[]> {
+    return api().ensureAgentGuides(cwd);
+  },
 
   getSetting(key: string): Promise<string | null> {
     const api = window.freebuddy;

--- a/src/store/agentBridgeStore.ts
+++ b/src/store/agentBridgeStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+export interface BridgeToast {
+  id: string;
+  text: string;
+}
+
+interface AgentBridgeState {
+  toasts: BridgeToast[];
+  notify(text: string): void;
+  dismiss(id: string): void;
+}
+
+export const useAgentBridgeStore = create<AgentBridgeState>((set) => ({
+  toasts: [],
+
+  notify(text) {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    set((s) => ({ toasts: [...s.toasts, { id, text }] }));
+    window.setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, 4000);
+  },
+
+  dismiss(id) {
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+  }
+}));

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -203,6 +203,14 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     ensureWorkflowMessageSubscription(id, async (cid, messageIds) => {
       await get().loadMessages(cid, messageIds);
     });
+    if (id) {
+      const conv = get().conversations.find((c) => c.id === id);
+      if (conv?.cwd) {
+        void cliClient.ensureAgentGuides(conv.cwd).catch(() => {
+          // best-effort: guide files are optional
+        });
+      }
+    }
   },
 
   async loadMessages(id, messageIds) {
@@ -267,6 +275,11 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     ensureWorkflowMessageSubscription(conv.id, async (cid, messageIds) => {
       await get().loadMessages(cid, messageIds);
     });
+    if (cwd) {
+      void cliClient.ensureAgentGuides(cwd).catch(() => {
+        // best-effort: guide files are optional
+      });
+    }
     return conv;
   },
 

--- a/src/store/detailLayoutStore.ts
+++ b/src/store/detailLayoutStore.ts
@@ -1,0 +1,83 @@
+import { create } from "zustand";
+
+import { cliClient } from "@/services/cli/client";
+
+const OVERVIEW_KEY = "detailOverviewWidth";
+const PREVIEW_KEY = "detailPreviewWidth";
+
+export const DEFAULT_OVERVIEW_WIDTH = 360;
+export const DEFAULT_PREVIEW_WIDTH = 680;
+export const DETAIL_MIN_WIDTH = 320;
+export const DETAIL_MAX_WIDTH = 960;
+
+export type DetailTab = "overview" | "preview";
+
+function clampWidth(value: number): number {
+  return Math.min(
+    DETAIL_MAX_WIDTH,
+    Math.max(DETAIL_MIN_WIDTH, Math.round(value))
+  );
+}
+
+interface DetailLayoutState {
+  overviewWidth: number;
+  previewWidth: number;
+  activeTab: DetailTab;
+  loaded: boolean;
+  load(): Promise<void>;
+  setActiveTab(tab: DetailTab): void;
+  setWidth(width: number): void;
+}
+
+export const useDetailLayoutStore = create<DetailLayoutState>((set, get) => ({
+  overviewWidth: DEFAULT_OVERVIEW_WIDTH,
+  previewWidth: DEFAULT_PREVIEW_WIDTH,
+  activeTab: "overview",
+  loaded: false,
+
+  async load() {
+    if (get().loaded) return;
+    let overviewWidth = DEFAULT_OVERVIEW_WIDTH;
+    let previewWidth = DEFAULT_PREVIEW_WIDTH;
+    try {
+      const o = await cliClient.getSetting(OVERVIEW_KEY);
+      if (o) {
+        const n = Number(o);
+        if (Number.isFinite(n)) overviewWidth = clampWidth(n);
+      }
+      const p = await cliClient.getSetting(PREVIEW_KEY);
+      if (p) {
+        const n = Number(p);
+        if (Number.isFinite(n)) previewWidth = clampWidth(n);
+      }
+    } catch {
+      // ignore — fall back to defaults
+    }
+    set({ overviewWidth, previewWidth, loaded: true });
+  },
+
+  setActiveTab(tab) {
+    set({ activeTab: tab });
+  },
+
+  setWidth(width) {
+    const clamped = clampWidth(width);
+    if (get().activeTab === "overview") {
+      set({ overviewWidth: clamped });
+      void cliClient.setSetting(OVERVIEW_KEY, String(clamped)).catch(() => {
+        // ignore persistence failures
+      });
+    } else {
+      set({ previewWidth: clamped });
+      void cliClient.setSetting(PREVIEW_KEY, String(clamped)).catch(() => {
+        // ignore persistence failures
+      });
+    }
+  }
+}));
+
+export function selectDetailWidth(state: DetailLayoutState): number {
+  return state.activeTab === "overview"
+    ? state.overviewWidth
+    : state.previewWidth;
+}

--- a/src/store/draftPreviewStore.ts
+++ b/src/store/draftPreviewStore.ts
@@ -1,0 +1,138 @@
+import { create } from "zustand";
+
+import { cliClient } from "@/services/cli/client";
+
+export interface DraftPreviewEntry {
+  cwd: string;
+  /** Auto-detected entry relative path (e.g. "index.html"). null if none. */
+  entryRel: string | null;
+  /** User-overridden entry relative path; takes precedence over entryRel. */
+  manualEntry?: string;
+  /** Entry resolution finished (entry may still be null). */
+  ready: boolean;
+  /** Bumped to force the iframe to reload (url embeds it). */
+  reloadNonce: number;
+  /** Fully composed freebuddy-draft:// url, empty when no entry. */
+  url: string;
+}
+
+interface DraftPreviewState {
+  byConv: Record<string, DraftPreviewEntry>;
+  timers: Record<string, ReturnType<typeof setTimeout>>;
+  ensureFor(convId: string, cwd: string | undefined): Promise<void>;
+  setManualEntry(convId: string, rel: string): void;
+  reload(convId: string): void;
+  scheduleReload(convId: string, delay?: number): void;
+}
+
+function composeUrl(
+  cwd: string,
+  entryRel: string | null | undefined,
+  nonce: number
+): string {
+  if (!cwd || !entryRel) return "";
+  const rel = entryRel.split("/").map(encodeURIComponent).join("/");
+  return `freebuddy-draft://render/${rel}?root=${encodeURIComponent(cwd)}&v=${nonce}`;
+}
+
+function entryOf(entry: DraftPreviewEntry | undefined): string | null | undefined {
+  if (!entry) return null;
+  return entry.manualEntry ?? entry.entryRel;
+}
+
+export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
+  byConv: {},
+  timers: {},
+
+  async ensureFor(convId, cwd) {
+    if (!cwd) {
+      set((s) => ({
+        byConv: {
+          ...s.byConv,
+          [convId]: { cwd: "", entryRel: null, ready: true, reloadNonce: 0, url: "" }
+        }
+      }));
+      return;
+    }
+    const prev = get().byConv[convId];
+    if (prev && prev.cwd === cwd && prev.ready) return;
+    let entryRel: string | null = null;
+    try {
+      if (cliClient.isAvailable()) {
+        entryRel = await cliClient.resolveDraftEntry(cwd);
+      }
+    } catch {
+      entryRel = null;
+    }
+    set((s) => {
+      const existing = s.byConv[convId];
+      const manualEntry = existing?.manualEntry;
+      return {
+        byConv: {
+          ...s.byConv,
+          [convId]: {
+            cwd,
+            entryRel,
+            manualEntry,
+            ready: true,
+            reloadNonce: existing?.reloadNonce ?? 0,
+            url: composeUrl(cwd, manualEntry ?? entryRel, existing?.reloadNonce ?? 0)
+          }
+        }
+      };
+    });
+  },
+
+  setManualEntry(convId, rel) {
+    set((s) => {
+      const entry = s.byConv[convId];
+      const cwd = entry?.cwd ?? "";
+      const nonce = (entry?.reloadNonce ?? 0) + 1;
+      return {
+        byConv: {
+          ...s.byConv,
+          [convId]: {
+            cwd,
+            entryRel: entry?.entryRel ?? null,
+            manualEntry: rel,
+            ready: true,
+            reloadNonce: nonce,
+            url: composeUrl(cwd, rel, nonce)
+          }
+        }
+      };
+    });
+  },
+
+  reload(convId) {
+    set((s) => {
+      const entry = s.byConv[convId];
+      if (!entry || !entry.url) return s;
+      const nonce = entry.reloadNonce + 1;
+      return {
+        byConv: {
+          ...s.byConv,
+          [convId]: {
+            ...entry,
+            reloadNonce: nonce,
+            url: composeUrl(entry.cwd, entryOf(entry), nonce)
+          }
+        }
+      };
+    });
+  },
+
+  scheduleReload(convId, delay = 300) {
+    const timers = get().timers;
+    if (timers[convId]) clearTimeout(timers[convId]);
+    const t = setTimeout(() => {
+      set((s) => {
+        const next = { ...s.timers };
+        delete next[convId];
+        return { timers: next };
+      });
+      get().reload(convId);
+    }, delay);
+    set((s) => ({ timers: { ...s.timers, [convId]: t } }));
+  }
+}));

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -103,12 +103,17 @@ declare global {
 
     selectDirectory(): Promise<string | null>;
     selectAttachments(): Promise<AttachmentCandidate[]>;
+    resolveDraftEntry(cwd: string): Promise<string | null>;
+    ensureAgentGuides(cwd: string): Promise<string[]>;
 
     onEvent(sessionId: string, cb: (event: CliEvent) => void): () => void;
   }
 
   interface FreebuddyWindow {
     onChromeVisible(cb: (visible: boolean) => void): () => void;
+    onBridge(
+      cb: (event: { action: string; params: Record<string, string> }) => void
+    ): () => void;
   }
 
   interface FreebuddySettings {

--- a/styles.css
+++ b/styles.css
@@ -113,7 +113,7 @@ button {
   position: fixed;
   inset: 0;
   display: grid;
-  grid-template-columns: 272px minmax(420px, 1fr) 320px;
+  grid-template-columns: 272px minmax(420px, 1fr) var(--fb-detail-width, 440px);
   width: auto;
   height: auto;
   min-height: 0;
@@ -127,7 +127,7 @@ button {
 }
 
 .app-shell.sidebar-collapsed {
-  grid-template-columns: minmax(420px, 1fr) 320px;
+  grid-template-columns: minmax(420px, 1fr) var(--fb-detail-width, 440px);
 }
 
 .app-shell.sidebar-collapsed.new-task-mode {
@@ -140,7 +140,7 @@ button {
 
 .sidebar-collapsed .chat-composer {
   left: 0;
-  width: min(820px, calc(100vw - 320px - 44px));
+  width: min(820px, calc(100vw - var(--fb-detail-width, 440px) - 44px));
 }
 
 .sidebar-collapsed .titlebar {
@@ -2694,10 +2694,10 @@ button {
   position: fixed;
   grid-row: 2;
   left: 272px;
-  right: 320px;
+  right: var(--fb-detail-width, 440px);
   bottom: 18px;
   z-index: 20;
-  width: min(820px, calc(100vw - 272px - 320px - 44px));
+  width: min(820px, calc(100vw - 272px - var(--fb-detail-width, 440px) - 44px));
   margin: 0 auto;
   padding: 0;
   border: 1px solid var(--fb-border-strong);
@@ -3397,6 +3397,269 @@ button.ghost:disabled {
   overflow: hidden;
   background: var(--fb-home-bg-primary);
   border-left: 1px solid var(--fb-border);
+}
+
+.workspace-cards {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.detail-resizer {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: calc(var(--fb-detail-width, 440px) - 4px);
+  width: 8px;
+  z-index: 30;
+  cursor: col-resize;
+  background: transparent;
+  transition: background 0.15s ease;
+}
+
+.detail-resizer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--fb-border);
+  opacity: 0.7;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.detail-resizer:hover,
+.detail-resizer:active {
+  background: transparent;
+}
+
+.detail-resizer:hover::after,
+.detail-resizer:active::after {
+  background: var(--fb-brand);
+  opacity: 1;
+}
+
+.detail-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  width: 100%;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fb-text-tertiary);
+  background: var(--fb-panel-bg);
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-md, 8px);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.detail-entry:hover,
+.detail-entry.available {
+  color: var(--fb-brand);
+  border-color: var(--fb-brand);
+}
+
+.detail-entry-icon {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+}
+
+.detail-entry-badge {
+  margin-left: auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--fb-brand);
+}
+
+.draft-close {
+  font-size: 13px;
+}
+
+.detail-tabs {
+  display: flex;
+  gap: 4px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--fb-border);
+}
+
+.detail-tab {
+  position: relative;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fb-text-tertiary);
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.detail-tab:hover {
+  color: var(--fb-text-primary);
+}
+
+.detail-tab.active {
+  color: var(--fb-brand);
+  border-bottom-color: var(--fb-brand);
+}
+
+.detail-tab-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--fb-brand);
+}
+
+.detail-tab-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.draft-canvas {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  gap: 10px;
+}
+
+.draft-toolbar {
+  display: flex;
+  gap: 8px;
+}
+
+.draft-address {
+  flex: 1;
+  min-width: 0;
+  height: 30px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-family: var(--fb-font-mono, monospace);
+  color: var(--fb-text-primary);
+  background: var(--fb-panel-bg);
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-md, 8px);
+  outline: none;
+}
+
+.draft-address:focus {
+  border-color: var(--fb-brand);
+}
+
+.draft-action {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  font-size: 15px;
+  color: var(--fb-text-tertiary);
+  background: var(--fb-panel-bg);
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-md, 8px);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.draft-action:hover {
+  color: var(--fb-brand);
+  border-color: var(--fb-brand);
+}
+
+.draft-frame-wrap {
+  flex: 1;
+  min-height: 0;
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-lg);
+  overflow: hidden;
+  background: #0b0f19;
+}
+
+.draft-frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+  background: #ffffff;
+}
+
+.draft-empty {
+  height: 100%;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  color: var(--fb-text-tertiary);
+  font-size: 13px;
+  line-height: 1.6;
+  text-align: center;
+}
+
+.agent-bridge-toasts {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(360px, calc(100vw - 32px));
+  pointer-events: none;
+}
+
+.agent-bridge-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fb-text-primary);
+  background: var(--fb-panel-bg);
+  border: 1px solid var(--fb-border-strong);
+  border-left: 3px solid var(--fb-brand);
+  border-radius: var(--fb-rounded-md, 8px);
+  box-shadow: var(--fb-shadow);
+  pointer-events: auto;
+}
+
+.agent-bridge-toast span {
+  flex: 1;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-bridge-toast-close {
+  flex: 0 0 auto;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--fb-text-tertiary);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.agent-bridge-toast-close:hover {
+  color: var(--fb-text-primary);
 }
 
 .side-card {

--- a/tests/agent-bridge.test.mjs
+++ b/tests/agent-bridge.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+async function loadBridge() {
+  const source = fs.readFileSync(
+    new URL("../electron/agentBridge.ts", import.meta.url),
+    "utf8"
+  );
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(`data:text/javascript;base64,${Buffer.from(output).toString("base64")}`);
+}
+
+test("parseBridgeRequest routes /freebuddy/<action>", async () => {
+  const { parseBridgeRequest } = await loadBridge();
+  assert.deepEqual(parseBridgeRequest("/freebuddy/preview"), {
+    action: "preview",
+    params: {}
+  });
+  const nav = parseBridgeRequest("/freebuddy/navigate?to=about.html");
+  assert.equal(nav?.action, "navigate");
+  assert.equal(nav?.params.to, "about.html");
+});
+
+test("parseBridgeRequest supports legacy /preview", async () => {
+  const { parseBridgeRequest } = await loadBridge();
+  assert.deepEqual(parseBridgeRequest("/preview"), {
+    action: "preview",
+    params: {}
+  });
+});
+
+test("parseBridgeRequest returns null for non-bridge paths", async () => {
+  const { parseBridgeRequest } = await loadBridge();
+  assert.equal(parseBridgeRequest("/foo"), null);
+  assert.equal(parseBridgeRequest("/"), null);
+});
+
+test("isKnownBridgeAction flags catalog entries only", async () => {
+  const { isKnownBridgeAction } = await loadBridge();
+  assert.equal(isKnownBridgeAction("preview"), true);
+  assert.equal(isKnownBridgeAction("navigate"), true);
+  assert.equal(isKnownBridgeAction("notify"), true);
+  assert.equal(isKnownBridgeAction("nope"), false);
+});
+
+test("buildBridgeSection lists actions with the live port", async () => {
+  const { buildBridgeSection } = await loadBridge();
+  const md = buildBridgeSection(12345);
+  assert.ok(md.includes("/freebuddy/preview"));
+  assert.ok(md.includes("/freebuddy/navigate"));
+  assert.ok(md.includes("/freebuddy/notify"));
+  assert.ok(md.includes("127.0.0.1:12345"));
+});

--- a/tests/chat-layout.test.mjs
+++ b/tests/chat-layout.test.mjs
@@ -38,7 +38,7 @@ test("workspace keeps the composer inside the visible column", () => {
   assert.match(stylesSource, /\.chat-section\s*\{[^}]*position:\s*relative;[^}]*min-height:\s*0;/m);
   assert.match(stylesSource, /\.chat-view\s*\{[^}]*position:\s*absolute;[^}]*inset:\s*0;[^}]*grid-template-rows:\s*minmax\(0,\s*1fr\)\s*auto;/m);
   assert.match(stylesSource, /\.chat-composer\s*\{[^}]*position:\s*fixed;[^}]*bottom:\s*18px;/m);
-  assert.match(stylesSource, /\.chat-composer\s*\{[^}]*left:\s*272px;[^}]*right:\s*320px;/m);
+  assert.match(stylesSource, /\.chat-composer\s*\{[^}]*left:\s*272px;[^}]*right:\s*var\(--fb-detail-width,\s*440px\);/m);
 });
 
 test("sending a message restores auto-follow to the latest output", () => {
@@ -64,7 +64,7 @@ test("sidebar collapse toggle hides the sidebar column", () => {
   assert.match(stylesSource, /\.sidebar-toggle\.floating\s*\{[\s\S]*?position:\s*absolute;/m);
   assert.match(
     stylesSource,
-    /\.app-shell\.sidebar-collapsed\s*\{[\s\S]*?grid-template-columns:\s*minmax\(420px,\s*1fr\)\s*320px;/
+    /\.app-shell\.sidebar-collapsed\s*\{[\s\S]*?grid-template-columns:\s*minmax\(420px,\s*1fr\)\s*var\(--fb-detail-width,\s*440px\);/
   );
   assert.match(stylesSource, /\.sidebar-collapsed \.sidebar\s*\{[\s\S]*?display:\s*none;/m);
   assert.match(

--- a/tests/draft-protocol.test.mjs
+++ b/tests/draft-protocol.test.mjs
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+async function loadDraftModule() {
+  const source = fs.readFileSync(
+    new URL("../electron/draftProtocol.ts", import.meta.url),
+    "utf8"
+  );
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(`data:text/javascript;base64,${Buffer.from(output).toString("base64")}`);
+}
+
+function buildDraftUrl(root, rel) {
+  const pathPart = rel ? `/${rel}` : "/";
+  return `freebuddy-draft://render${pathPart}?root=${encodeURIComponent(root)}`;
+}
+
+test("parseDraftUrl resolves root and relative path", async () => {
+  const { parseDraftUrl } = await loadDraftModule();
+  const { root, rel } = parseDraftUrl(
+    buildDraftUrl(path.resolve("/tmp/demo"), "dist/index.html")
+  );
+  assert.equal(root, path.resolve("/tmp/demo"));
+  assert.equal(rel, "dist/index.html");
+});
+
+test("handleDraftRequest serves index.html with text/html mime", async () => {
+  const { handleDraftRequest } = await loadDraftModule();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.writeFileSync(path.join(dir, "index.html"), "<h1>hello</h1>");
+
+  const response = await handleDraftRequest(
+    new Request(buildDraftUrl(dir, "index.html"))
+  );
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("Content-Type") ?? "", /^text\/html/);
+  const body = await response.text();
+  assert.equal(body, "<h1>hello</h1>");
+});
+
+test("handleDraftRequest auto-appends index.html for directory request", async () => {
+  const { handleDraftRequest } = await loadDraftModule();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.writeFileSync(path.join(dir, "index.html"), "<p>dir</p>");
+
+  const response = await handleDraftRequest(new Request(buildDraftUrl(dir, "")));
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "<p>dir</p>");
+});
+
+test("handleDraftRequest returns 404 for missing file", async () => {
+  const { handleDraftRequest } = await loadDraftModule();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+
+  const response = await handleDraftRequest(
+    new Request(buildDraftUrl(dir, "nope.html"))
+  );
+  assert.equal(response.status, 404);
+});
+
+test("isWithinRoot confines access to the root subtree", async () => {
+  const { isWithinRoot } = await loadDraftModule();
+  const root = path.resolve(os.tmpdir(), "draft-root");
+  assert.equal(isWithinRoot(path.join(root, "index.html"), root), true);
+  assert.equal(isWithinRoot(path.join(root, "sub", "a.css"), root), true);
+  assert.equal(isWithinRoot(root, root), true);
+  assert.equal(
+    isWithinRoot(path.join(path.dirname(root), "outside.html"), root),
+    false
+  );
+});
+
+test("handleDraftRequest neutralizes encoded dot-segment traversal", async () => {
+  const { handleDraftRequest } = await loadDraftModule();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  const outside = path.join(path.dirname(dir), "draft-outside-secret.txt");
+  fs.writeFileSync(outside, "secret");
+
+  try {
+    // The WHATWG URL parser collapses ".." (even when %2e%2e-encoded), so the
+    // request is resolved inside root where no such file exists. The outside
+    // file must never be served.
+    const url = `freebuddy-draft://render/%2e%2e/${path.basename(outside)}?root=${encodeURIComponent(dir)}`;
+    const response = await handleDraftRequest(new Request(url));
+    assert.notEqual(response.status, 200);
+    const body = await response.text();
+    assert.equal(body.includes("secret"), false);
+  } finally {
+    fs.unlinkSync(outside);
+  }
+});
+
+test("resolveDraftEntry finds index.html and returns null when absent", async () => {
+  const { resolveDraftEntry } = await loadDraftModule();
+
+  const withEntry = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.writeFileSync(path.join(withEntry, "index.html"), "<p>x</p>");
+  assert.equal(await resolveDraftEntry(withEntry), "index.html");
+
+  const distOnly = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.mkdirSync(path.join(distOnly, "dist"));
+  fs.writeFileSync(path.join(distOnly, "dist", "index.html"), "<p>x</p>");
+  assert.equal(await resolveDraftEntry(distOnly), "dist/index.html");
+
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  assert.equal(await resolveDraftEntry(empty), null);
+
+  assert.equal(await resolveDraftEntry(""), null);
+});


### PR DESCRIPTION
Draft preview in the third column: freebuddy-draft protocol serves the workspace read-only, a sandboxed iframe renders cwd output, auto-refresh on file-edit, overview/preview split with resizable widths that adapt to window size.

Agent Bridge: inject context via AGENTS.md/CLAUDE.md/.cursorrules; local HTTP bridge at /freebuddy/<action> (preview, navigate, notify) lets agents call back; fixed port 17878; docs and tests included.

Switching conversations resets the panel to overview.