### PR TITLE
feat: upgrade draft previews and Cursor sessions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,12 @@ jobs:
             builder_args: --mac --arm64
             assets: |
               FreeBuddy_macOS-Apple-Silicon.dmg|*.dmg
+              FreeBuddy_macOS-Apple-Silicon.zip|*.zip
           - platform: macos-latest
             builder_args: --mac --x64
             assets: |
               FreeBuddy_macOS-Intel.dmg|*.dmg
+              FreeBuddy_macOS-Intel.zip|*.zip
           - platform: windows-latest
             builder_args: --win --x64
             assets: |
@@ -122,6 +124,8 @@ jobs:
           sed -i.bak \
             -e 's#FreeBuddy-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}-mac-arm64\.dmg#FreeBuddy_macOS-Apple-Silicon.dmg#g' \
             -e 's#FreeBuddy-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}-mac-x64\.dmg#FreeBuddy_macOS-Intel.dmg#g' \
+            -e 's#FreeBuddy-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}-mac-arm64\.zip#FreeBuddy_macOS-Apple-Silicon.zip#g' \
+            -e 's#FreeBuddy-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}-mac-x64\.zip#FreeBuddy_macOS-Intel.zip#g' \
             "$yml"
           # Tag the yml with the arch so the two matrix jobs don't clobber
           # each other. A follow-up job merges them into latest-mac.yml.
@@ -134,15 +138,27 @@ jobs:
           gh release upload "$tag" "latest-mac-${arch_tag}.yml" \
             --repo "$repo" --clobber
           # Also upload the blockmap so delta updates work.
-          blockmap=$(find release -name "*.dmg.blockmap" -type f | head -1)
-          if [ -n "$blockmap" ]; then
+          dmg_blockmap=$(find release -name "*.dmg.blockmap" -type f | head -1)
+          if [ -n "$dmg_blockmap" ]; then
             if [ "$arch_tag" = "arm64" ]; then
-              cp "$blockmap" "FreeBuddy_macOS-Apple-Silicon.dmg.blockmap"
+              cp "$dmg_blockmap" "FreeBuddy_macOS-Apple-Silicon.dmg.blockmap"
               gh release upload "$tag" "FreeBuddy_macOS-Apple-Silicon.dmg.blockmap" \
                 --repo "$repo" --clobber
             else
-              cp "$blockmap" "FreeBuddy_macOS-Intel.dmg.blockmap"
+              cp "$dmg_blockmap" "FreeBuddy_macOS-Intel.dmg.blockmap"
               gh release upload "$tag" "FreeBuddy_macOS-Intel.dmg.blockmap" \
+                --repo "$repo" --clobber
+            fi
+          fi
+          zip_blockmap=$(find release -name "*.zip.blockmap" -type f | head -1)
+          if [ -n "$zip_blockmap" ]; then
+            if [ "$arch_tag" = "arm64" ]; then
+              cp "$zip_blockmap" "FreeBuddy_macOS-Apple-Silicon.zip.blockmap"
+              gh release upload "$tag" "FreeBuddy_macOS-Apple-Silicon.zip.blockmap" \
+                --repo "$repo" --clobber
+            else
+              cp "$zip_blockmap" "FreeBuddy_macOS-Intel.zip.blockmap"
+              gh release upload "$tag" "FreeBuddy_macOS-Intel.zip.blockmap" \
                 --repo "$repo" --clobber
             fi
           fi

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,7 @@ mac:
   identity: null
   target:
     - target: dmg
+    - target: zip
 
 win:
   icon: assets/app-icon.ico

--- a/electron/agentBridge.ts
+++ b/electron/agentBridge.ts
@@ -28,15 +28,46 @@ export const BRIDGE_ACTIONS: BridgeAction[] = [
   },
   {
     name: "navigate",
-    summary: "Point the preview at a workspace-relative path.",
+    summary: "Point the preview at a workspace-relative path or local dev-server URL.",
     description:
-      "Re-target the preview iframe to a different entry file (e.g. another page).",
+      "Re-target the preview iframe to another entry file, route, or localhost URL. Use this after starting npm run dev.",
     params: [
       {
         name: "to",
-        description: "Workspace-relative path, e.g. about.html",
+        description: "Workspace-relative path, route, or http://127.0.0.1:<port>/ URL",
         required: true
       }
+    ]
+  },
+  {
+    name: "entry",
+    summary: "Select the preview entry without changing tabs.",
+    description:
+      "Set the Draft preview target to a workspace-relative file or localhost dev-server URL.",
+    params: [
+      {
+        name: "to",
+        description: "Workspace-relative path or http://127.0.0.1:<port>/ URL",
+        required: true
+      }
+    ]
+  },
+  {
+    name: "status",
+    summary: "Report preview/build status to FreeBuddy.",
+    description:
+      "Show the user what is happening with a build, dev server, or preview setup.",
+    params: [
+      { name: "text", description: "Status message", required: true }
+    ]
+  },
+  {
+    name: "error",
+    summary: "Report a preview/build error to FreeBuddy.",
+    description:
+      "Tell the user why the preview cannot currently render and keep the details in the chat.",
+    params: [
+      { name: "text", description: "Error message", required: true }
     ]
   },
   {
@@ -92,7 +123,24 @@ export function buildBridgeSection(port: number): string {
     "## FreeBuddy bridge",
     "",
     "You can talk back to FreeBuddy over a local HTTP bridge while it is running.",
-    "Run any of these from the project root:",
+    "Always use the bridge to open Draft after you create or update something previewable; do not wait for the user to open it manually.",
+    "Draft supports localhost web apps, static HTML, Markdown files, and image files.",
+    "When previewing npm/Vite/Next/React/Vue apps, prefer starting the dev server and navigating Draft to its localhost URL instead of opening index.html directly.",
+    "",
+    "Dev-server preview flow:",
+    "```sh",
+    "npm run dev -- --host 127.0.0.1",
+    `curl -s "http://127.0.0.1:${port}/freebuddy/navigate?to=http%3A%2F%2F127.0.0.1%3A5173%2F"`,
+    `curl -s "http://127.0.0.1:${port}/freebuddy/status?text=Preview%20is%20running%20at%20http%3A%2F%2F127.0.0.1%3A5173%2F"`,
+    "```",
+    "",
+    "Markdown/image preview examples:",
+    "```sh",
+    `curl -s "http://127.0.0.1:${port}/freebuddy/navigate?to=README.md"`,
+    `curl -s "http://127.0.0.1:${port}/freebuddy/navigate?to=assets%2Fmockup.png"`,
+    "```",
+    "",
+    "Available actions:",
     ""
   ];
   for (const action of BRIDGE_ACTIONS) {

--- a/electron/agentGuides.ts
+++ b/electron/agentGuides.ts
@@ -18,12 +18,15 @@ as a coding agent and streams your work to the user in real time.
 - File edits and creates you make are tracked and shown live to the user.
 - The user can preview web output (HTML/CSS/JS) in a side panel.
 
-## Producing previewable web output
-When the task involves building or changing a web page:
-- Write a self-contained \`index.html\` at the project root (or under \`dist/\`).
-- Use **relative paths** for CSS/JS/assets so they load inside the preview.
-- Plain HTML/CSS/JS renders directly. Projects that need a dev server or a
-  build step will NOT preview until built to static files.
+## Producing previewable output
+When the task involves building or changing anything visual or document-like:
+- After creating or updating previewable output, proactively call the FreeBuddy bridge to open Draft. Do not ask the user to open files manually.
+- If the project has a dev script (Vite/Next/React/Vue/etc.), start it with a localhost host, e.g. \`npm run dev -- --host 127.0.0.1\`, then point Draft at the dev-server URL with the FreeBuddy bridge.
+- Do not point Draft at \`index.html\` for bundled apps that require \`npm run dev\`; that often misses CSS/assets/routes.
+- For plain static pages, write a self-contained \`index.html\` at the project root (or under \`dist/\`) and use relative paths for CSS/JS/assets.
+- For documentation output, write or update a Markdown file such as \`README.md\`, then immediately call \`/freebuddy/navigate?to=README.md\`.
+- For generated visual assets, write an image such as \`assets/mockup.png\`, then immediately call \`/freebuddy/navigate?to=assets%2Fmockup.png\`.
+- Report build/dev-server/status or errors through the bridge so the user can see what happened.
 
 ${bridge}
 

--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -198,6 +198,23 @@ export function buildSessionResumeRequest(
   };
 }
 
+export function buildSessionLoadRequest(
+  id: AcpRequestId,
+  sessionId: string,
+  cwd?: string
+): AcpMessage {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "session/load",
+    params: {
+      sessionId,
+      cwd: cwd || process.cwd(),
+      mcpServers: []
+    }
+  };
+}
+
 export interface AcpPromptAttachment {
   path: string;
   kind: "image" | "document" | "code";

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -12,6 +12,7 @@ import {
   buildSessionCancelNotification,
   buildSessionCloseRequest,
   buildSessionListRequest,
+  buildSessionLoadRequest,
   buildSessionNewRequest,
   buildSessionPromptRequest,
   buildSessionResumeRequest,
@@ -527,7 +528,13 @@ export async function runAcpAgent({
       if (items.length) emit({ type: "items", items });
     };
 
-    if (toolSessionId && agentCaps?.sessionCapabilities?.resume) {
+    if (toolSessionId && agentCaps?.loadSession) {
+      const loaded = await request(
+        buildSessionLoadRequest(nextId(), toolSessionId, args.cwd)
+      );
+      activeAcpSessionId = toolSessionId;
+      emitSetupItems(loaded);
+    } else if (toolSessionId && agentCaps?.sessionCapabilities?.resume) {
       const resumed = await request(
         buildSessionResumeRequest(nextId(), toolSessionId, args.cwd)
       );

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -43,7 +43,7 @@ import {
   type UpdateMessageInput
 } from "./conversations.js";
 import { getSetting, setSetting, getLanguage } from "./settings.js";
-import { readDraftMarkdown, resolveDraftEntry } from "../draftProtocol.js";
+import { parseDraftUrl, readDraftMarkdown, resolveDraftEntry } from "../draftProtocol.js";
 import { ensureAgentGuides } from "../agentGuides.js";
 import { tMain } from "./i18n.js";
 import { setApplicationMenuForLanguage } from "../menu.js";
@@ -259,11 +259,7 @@ export function registerCliIpc() {
       return true;
     }
     if (!url.startsWith("freebuddy-draft://")) return false;
-    const parsed = new URL(url);
-    const rootRaw = parsed.searchParams.get("root");
-    if (!rootRaw) return false;
-    const root = path.resolve(decodeURIComponent(rootRaw));
-    const rel = decodeURIComponent(parsed.pathname.replace(/^\//, "")) || "index.html";
+    const { root, rel } = parseDraftUrl(url);
     const filePath = path.resolve(root, rel);
     if (!filePath.startsWith(root + path.sep) && filePath !== root) return false;
     await shell.openExternal(pathToFileURL(filePath).toString());

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -1,6 +1,7 @@
-import { ipcMain, BrowserWindow, dialog, type IpcMainInvokeEvent } from "electron";
+import { ipcMain, BrowserWindow, dialog, shell, type IpcMainInvokeEvent } from "electron";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { cliAdapterDefinitions } from "./adapters.js";
 import { cliCheck, cliInstall, cliInstallStream, listRuntimes } from "./check.js";
@@ -42,7 +43,7 @@ import {
   type UpdateMessageInput
 } from "./conversations.js";
 import { getSetting, setSetting, getLanguage } from "./settings.js";
-import { resolveDraftEntry } from "../draftProtocol.js";
+import { readDraftMarkdown, resolveDraftEntry } from "../draftProtocol.js";
 import { ensureAgentGuides } from "../agentGuides.js";
 import { tMain } from "./i18n.js";
 import { setApplicationMenuForLanguage } from "../menu.js";
@@ -244,6 +245,30 @@ export function registerCliIpc() {
   ipcMain.handle("cli:resolveDraftEntry", (_e, cwd: string) =>
     resolveDraftEntry(cwd ?? "")
   );
+
+  ipcMain.handle(
+    "cli:readDraftMarkdown",
+    (_e, args: { cwd?: string; rel?: string }) =>
+      readDraftMarkdown(args?.cwd ?? "", args?.rel ?? "")
+  );
+
+  ipcMain.handle("cli:openDraftExternal", async (_e, url: string) => {
+    if (!url) return false;
+    if (/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:\/|$)/i.test(url)) {
+      await shell.openExternal(url);
+      return true;
+    }
+    if (!url.startsWith("freebuddy-draft://")) return false;
+    const parsed = new URL(url);
+    const rootRaw = parsed.searchParams.get("root");
+    if (!rootRaw) return false;
+    const root = path.resolve(decodeURIComponent(rootRaw));
+    const rel = decodeURIComponent(parsed.pathname.replace(/^\//, "")) || "index.html";
+    const filePath = path.resolve(root, rel);
+    if (!filePath.startsWith(root + path.sep) && filePath !== root) return false;
+    await shell.openExternal(pathToFileURL(filePath).toString());
+    return true;
+  });
 
   ipcMain.handle("cli:ensureAgentGuides", (_e, cwd: string) =>
     ensureAgentGuides(cwd ?? "")

--- a/electron/draftProtocol.ts
+++ b/electron/draftProtocol.ts
@@ -39,8 +39,28 @@ const ENTRY_CANDIDATES = [
   "index.html",
   "public/index.html",
   "dist/index.html",
-  "build/index.html"
+  "build/index.html",
+  "out/index.html",
+  "storybook-static/index.html",
+  "docs/index.html",
+  "site/index.html",
+  "app/index.html",
+  "src/index.html",
+  "www/index.html"
 ];
+
+const FRAMEWORK_ENTRY_CANDIDATES: Record<string, string[]> = {
+  vite: ["index.html", "dist/index.html"],
+  next: ["out/index.html"],
+  nuxt: ["dist/index.html", ".output/public/index.html"],
+  astro: ["dist/index.html"],
+  svelte: ["build/index.html", "dist/index.html"],
+  angular: ["dist/index.html"],
+  vue: ["index.html", "dist/index.html"],
+  react: ["index.html", "build/index.html", "dist/index.html"],
+  preact: ["index.html", "dist/index.html"],
+  solid: ["index.html", "dist/index.html"]
+};
 
 function mimeForPath(filePath: string): string {
   const ext = path.extname(filePath).slice(1).toLowerCase();
@@ -108,18 +128,90 @@ export async function handleDraftRequest(
   }
 }
 
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function readPackageCandidates(cwd: string): Promise<string[]> {
+  try {
+    const raw = await fs.readFile(path.join(cwd, "package.json"), "utf8");
+    const pkg = JSON.parse(raw) as {
+      scripts?: Record<string, string>;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const deps = {
+      ...(pkg.dependencies ?? {}),
+      ...(pkg.devDependencies ?? {})
+    };
+    const scripts = Object.values(pkg.scripts ?? {}).join(" ").toLowerCase();
+    const names = new Set<string>();
+    for (const name of Object.keys(FRAMEWORK_ENTRY_CANDIDATES)) {
+      if (deps[name] || scripts.includes(name)) names.add(name);
+    }
+    if (deps["@vitejs/plugin-react"] || deps["@vitejs/plugin-vue"]) names.add("vite");
+    if (deps["@sveltejs/kit"]) names.add("svelte");
+    return [...names].flatMap((name) => FRAMEWORK_ENTRY_CANDIDATES[name] ?? []);
+  } catch {
+    return [];
+  }
+}
+
+async function discoverHtmlCandidates(cwd: string): Promise<string[]> {
+  const dirs = [".", "public", "dist", "build", "out"];
+  const candidates: string[] = [];
+  for (const dir of dirs) {
+    try {
+      const entries = await fs.readdir(path.join(cwd, dir), { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.toLowerCase().endsWith(".html")) {
+          candidates.push(dir === "." ? entry.name : `${dir}/${entry.name}`);
+        }
+      }
+    } catch {
+      // try next directory
+    }
+  }
+  return candidates;
+}
+
+export async function readDraftMarkdown(
+  cwd: string,
+  rel: string
+): Promise<string | null> {
+  if (!cwd || !path.isAbsolute(cwd) || !rel) return null;
+  const root = path.resolve(cwd);
+  const filePath = path.resolve(root, rel);
+  if (!isWithinRoot(filePath, root)) return null;
+  if (path.extname(filePath).toLowerCase() !== ".md") return null;
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) return null;
+    return fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
 export async function resolveDraftEntry(
   cwd: string
 ): Promise<string | null> {
   if (!cwd || !path.isAbsolute(cwd)) return null;
-  for (const candidate of ENTRY_CANDIDATES) {
-    try {
-      const full = path.join(cwd, candidate);
-      const stat = await fs.stat(full);
-      if (stat.isFile()) return candidate;
-    } catch {
-      // try next candidate
-    }
+  const root = path.resolve(cwd);
+  const candidates = [
+    ...ENTRY_CANDIDATES,
+    ...(await readPackageCandidates(root)),
+    ...(await discoverHtmlCandidates(root))
+  ];
+  for (const candidate of [...new Set(candidates)]) {
+    const full = path.resolve(root, candidate);
+    if (!isWithinRoot(full, root)) continue;
+    if (await isFile(full)) return candidate;
   }
   return null;
 }

--- a/electron/draftProtocol.ts
+++ b/electron/draftProtocol.ts
@@ -77,16 +77,30 @@ export interface DraftRequestParams {
   rel: string;
 }
 
+function parsePathRootUrl(url: URL): DraftRequestParams | null {
+  const raw = url.pathname.replace(/^\//, "");
+  const parts = raw.split("/");
+  if (parts.length < 2 || !parts[0]) return null;
+  const root = path.resolve(decodeURIComponent(parts[0]));
+  if (!path.isAbsolute(root)) return null;
+  const rel = parts.slice(1).map(decodeURIComponent).join("/") || "index.html";
+  return { root, rel };
+}
+
 export function parseDraftUrl(requestUrl: string): DraftRequestParams {
   const url = new URL(requestUrl);
   const rootRaw = url.searchParams.get("root");
-  if (!rootRaw) throw new Error("Missing root");
-  const root = path.resolve(decodeURIComponent(rootRaw));
-  if (!path.isAbsolute(root)) throw new Error("root must be absolute");
+  if (rootRaw) {
+    const root = path.resolve(decodeURIComponent(rootRaw));
+    if (!path.isAbsolute(root)) throw new Error("root must be absolute");
+    const relRaw = decodeURIComponent(url.pathname.replace(/^\//, ""));
+    const rel = relRaw === "" ? "index.html" : relRaw;
+    return { root, rel };
+  }
 
-  const relRaw = decodeURIComponent(url.pathname.replace(/^\//, ""));
-  const rel = relRaw === "" ? "index.html" : relRaw;
-  return { root, rel };
+  const pathRoot = parsePathRootUrl(url);
+  if (pathRoot) return pathRoot;
+  throw new Error("Missing root");
 }
 
 export async function handleDraftRequest(
@@ -180,6 +194,8 @@ async function discoverHtmlCandidates(cwd: string): Promise<string[]> {
   return candidates;
 }
 
+const DOCUMENT_EXTENSIONS = new Set(["md", "txt", "log", "json", "yaml", "yml", "csv"]);
+
 export async function readDraftMarkdown(
   cwd: string,
   rel: string
@@ -188,7 +204,8 @@ export async function readDraftMarkdown(
   const root = path.resolve(cwd);
   const filePath = path.resolve(root, rel);
   if (!isWithinRoot(filePath, root)) return null;
-  if (path.extname(filePath).toLowerCase() !== ".md") return null;
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  if (!DOCUMENT_EXTENSIONS.has(ext)) return null;
   try {
     const stat = await fs.stat(filePath);
     if (!stat.isFile()) return null;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -67,6 +67,10 @@ const cli = {
 
   resolveDraftEntry: (cwd: string) =>
     ipcRenderer.invoke("cli:resolveDraftEntry", cwd),
+  readDraftMarkdown: (cwd: string, rel: string) =>
+    ipcRenderer.invoke("cli:readDraftMarkdown", { cwd, rel }),
+  openDraftExternal: (url: string) =>
+    ipcRenderer.invoke("cli:openDraftExternal", url),
 
   ensureAgentGuides: (cwd: string) =>
     ipcRenderer.invoke("cli:ensureAgentGuides", cwd),

--- a/src/components/AgentBridge/AgentBridgeListener.tsx
+++ b/src/components/AgentBridge/AgentBridgeListener.tsx
@@ -1,7 +1,4 @@
-import { nanoid } from "nanoid";
 import { useEffect } from "react";
-
-import { cliClient } from "@/services/cli/client";
 
 import { useAgentBridgeStore } from "@/store/agentBridgeStore";
 import { useConversationStore } from "@/store/conversationStore";
@@ -16,37 +13,6 @@ export function AgentBridgeListener() {
   const notify = useAgentBridgeStore((s) => s.notify);
 
   useEffect(() => {
-    const appendBridgeMessage = (text: string, status: "done" | "failed" = "done") => {
-      const convId = useConversationStore.getState().activeId;
-      if (!convId) return;
-      const id = nanoid();
-      const now = new Date().toISOString();
-      const message = {
-        id,
-        conversationId: convId,
-        role: "system" as const,
-        status,
-        content: text,
-        createdAt: now,
-        updatedAt: now
-      };
-      useConversationStore.setState((s) => ({
-        messages: {
-          ...s.messages,
-          [convId]: [...(s.messages[convId] ?? []), message]
-        }
-      }));
-      if (cliClient.isAvailable()) {
-        void cliClient.appendMessage({
-          id,
-          conversationId: convId,
-          role: "system",
-          status,
-          content: text
-        });
-      }
-    };
-
     const setTarget = (to: string | undefined, openPreview: boolean) => {
       const convId = useConversationStore.getState().activeId;
       if (to && convId) {
@@ -71,18 +37,12 @@ export function AgentBridgeListener() {
       }
       if (action === "status") {
         const text = params?.text;
-        if (text) {
-          notify(text);
-          appendBridgeMessage(`Preview status: ${text}`);
-        }
+        if (text) notify(text);
         return;
       }
       if (action === "error") {
         const text = params?.text;
-        if (text) {
-          notify(text);
-          appendBridgeMessage(`Preview error: ${text}`, "failed");
-        }
+        if (text) notify(text);
         return;
       }
       if (action === "notify") {

--- a/src/components/AgentBridge/AgentBridgeListener.tsx
+++ b/src/components/AgentBridge/AgentBridgeListener.tsx
@@ -1,4 +1,7 @@
+import { nanoid } from "nanoid";
 import { useEffect } from "react";
+
+import { cliClient } from "@/services/cli/client";
 
 import { useAgentBridgeStore } from "@/store/agentBridgeStore";
 import { useConversationStore } from "@/store/conversationStore";
@@ -13,6 +16,45 @@ export function AgentBridgeListener() {
   const notify = useAgentBridgeStore((s) => s.notify);
 
   useEffect(() => {
+    const appendBridgeMessage = (text: string, status: "done" | "failed" = "done") => {
+      const convId = useConversationStore.getState().activeId;
+      if (!convId) return;
+      const id = nanoid();
+      const now = new Date().toISOString();
+      const message = {
+        id,
+        conversationId: convId,
+        role: "system" as const,
+        status,
+        content: text,
+        createdAt: now,
+        updatedAt: now
+      };
+      useConversationStore.setState((s) => ({
+        messages: {
+          ...s.messages,
+          [convId]: [...(s.messages[convId] ?? []), message]
+        }
+      }));
+      if (cliClient.isAvailable()) {
+        void cliClient.appendMessage({
+          id,
+          conversationId: convId,
+          role: "system",
+          status,
+          content: text
+        });
+      }
+    };
+
+    const setTarget = (to: string | undefined, openPreview: boolean) => {
+      const convId = useConversationStore.getState().activeId;
+      if (to && convId) {
+        useDraftPreviewStore.getState().setPreviewTarget(convId, to);
+        if (openPreview) useDetailLayoutStore.getState().setActiveTab("preview");
+      }
+    };
+
     const off = window.freebuddy?.window?.onBridge?.((event) => {
       const { action, params } = event;
       if (action === "preview") {
@@ -20,11 +62,26 @@ export function AgentBridgeListener() {
         return;
       }
       if (action === "navigate") {
-        const to = params?.to;
-        const convId = useConversationStore.getState().activeId;
-        if (to && convId) {
-          useDraftPreviewStore.getState().setManualEntry(convId, to);
-          useDetailLayoutStore.getState().setActiveTab("preview");
+        setTarget(params?.to, true);
+        return;
+      }
+      if (action === "entry") {
+        setTarget(params?.to, false);
+        return;
+      }
+      if (action === "status") {
+        const text = params?.text;
+        if (text) {
+          notify(text);
+          appendBridgeMessage(`Preview status: ${text}`);
+        }
+        return;
+      }
+      if (action === "error") {
+        const text = params?.text;
+        if (text) {
+          notify(text);
+          appendBridgeMessage(`Preview error: ${text}`, "failed");
         }
         return;
       }

--- a/src/components/CLI/DetailColumn.tsx
+++ b/src/components/CLI/DetailColumn.tsx
@@ -26,7 +26,7 @@ export function DetailColumn({ runningCount }: { runningCount: number }) {
     void useDraftPreviewStore.getState().ensureFor(activeId, conv?.cwd);
   }, [activeId]);
 
-  const previewAvailable = Boolean(entry?.entryRel);
+  const previewAvailable = Boolean(entry?.url);
 
   const onResizeStart = (e: MouseEvent) => {
     e.preventDefault();

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -456,31 +456,100 @@ export const MessageBubble = memo(function MessageBubble({
   const timeStr = useMemo(() => {
     try {
       const d = new Date(message.createdAt);
-      return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+      return d.toLocaleString([], {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false
+      });
     } catch {
       return "";
     }
   }, [message.createdAt]);
   const [copyMenu, setCopyMenu] = useState<{ x: number; y: number } | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [vote, setVote] = useState<"up" | "down" | null>(null);
   const copyText = messageText(message, items).trim();
+  const getSelectionText = () => {
+    const sel = window.getSelection();
+    return sel && sel.toString().trim().length > 0 ? sel.toString().trim() : "";
+  };
   const handleContextMenu = (event: MouseEvent) => {
     if (!copyText) return;
     event.preventDefault();
     setCopyMenu({ x: event.clientX, y: event.clientY });
   };
-  const handleCopy = () => {
-    if (copyText) void navigator.clipboard?.writeText(copyText);
+  const doCopy = (text: string) => {
+    if (text) void navigator.clipboard?.writeText(text);
     setCopyMenu(null);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
   };
-  const copyMenuNode = copyMenu ? (
-    <div
-      className="message-context-menu"
-      style={{ left: copyMenu.x, top: copyMenu.y }}
-      onMouseLeave={() => setCopyMenu(null)}
-    >
-      <button type="button" onClick={handleCopy}>
-        {t("message.copy")}
+  const copyMenuNode = copyMenu ? (() => {
+    const sel = getSelectionText();
+    return (
+      <div
+        className="message-context-menu"
+        style={{ left: copyMenu.x, top: copyMenu.y }}
+        onMouseLeave={() => setCopyMenu(null)}
+      >
+        {sel && (
+          <button type="button" onClick={() => doCopy(sel)}>
+            {t("message.copySelection")}
+          </button>
+        )}
+        <button type="button" onClick={() => doCopy(copyText)}>
+          {t("message.copy")}
+        </button>
+      </div>
+    );
+  })() : null;
+  const actionBarNode = copyText ? (
+    <div className="msg-actions">
+      <button
+        type="button"
+        className={`msg-action-btn${copied ? " copied" : ""}`}
+        onClick={() => doCopy(copyText)}
+        title={t("message.copy")}
+        aria-label={t("message.copy")}
+      >
+        {copied ? (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+            <rect x="9" y="9" width="11" height="11" rx="2" />
+            <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+          </svg>
+        )}
       </button>
+      <button
+        type="button"
+        className={`msg-action-btn${vote === "up" ? " active up" : ""}`}
+        onClick={() => setVote((v) => (v === "up" ? null : "up"))}
+        title={t("message.upvote")}
+        aria-label={t("message.upvote")}
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+          <path d="M7 10v12" />
+          <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L14 1a3.13 3.13 0 0 1 1 5.88Z" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className={`msg-action-btn${vote === "down" ? " active down" : ""}`}
+        onClick={() => setVote((v) => (v === "down" ? null : "down"))}
+        title={t("message.downvote")}
+        aria-label={t("message.downvote")}
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+          <path d="M17 14V2" />
+          <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L10 23a3.13 3.13 0 0 1-1-5.88Z" />
+        </svg>
+      </button>
+      {timeStr && <span className="msg-action-time">{timeStr}</span>}
     </div>
   ) : null;
 
@@ -496,7 +565,6 @@ export const MessageBubble = memo(function MessageBubble({
         <div className="msg-content-wrapper" onContextMenu={handleContextMenu}>
           <div className="msg-header">
             <span className="msg-author">{t("message.you")}</span>
-            <span className="msg-time">{timeStr}</span>
           </div>
           {showBubble && (
             <div className="msg-bubble">
@@ -548,7 +616,6 @@ export const MessageBubble = memo(function MessageBubble({
       <div className="msg-content-wrapper" onContextMenu={handleContextMenu}>
         <div className="msg-header">
           <span className="msg-author">{agentLabel}</span>
-          <span className="msg-time">{timeStr}</span>
           {(roleLabel || statusText) && (
             <span className={`status-pill ${message.status}`}>
               {roleLabel && (
@@ -583,6 +650,7 @@ export const MessageBubble = memo(function MessageBubble({
             <span>{t("message.thinking")}</span>
           </div>
         )}
+        {actionBarNode}
         {copyMenuNode}
       </div>
     </div>

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -232,43 +232,14 @@ function visibleBlocks(items: CliStreamItem[]): VisibleBlock[] {
   return blocks;
 }
 
-function itemText(item: CliStreamItem): string {
-  switch (item.kind) {
-    case "text":
-    case "thinking":
-    case "raw":
-      return item.content;
-    case "error":
-      return [item.message, item.details].filter(Boolean).join("\n");
-    case "command":
-      return item.command;
-    case "command-output":
-    case "tool-result":
-      return item.content;
-    case "tool-call":
-      return [
-        item.tool,
-        item.input === undefined
-          ? ""
-          : typeof item.input === "string"
-            ? item.input
-            : JSON.stringify(item.input, null, 2),
-        item.output ?? ""
-      ].filter(Boolean).join("\n");
-    case "file-edit":
-      return [item.path, item.oldText, item.newText].filter(Boolean).join("\n");
-    case "content-block":
-      return [item.title, item.name, item.text, item.uri]
-        .filter(Boolean)
-        .join("\n");
-    default:
-      return "";
-  }
+function copyableItemText(item: CliStreamItem): string {
+  if (item.kind === "text" || item.kind === "raw") return item.content;
+  return "";
 }
 
 function messageText(message: ConversationMessage, items: CliStreamItem[]): string {
   if (message.role === "user" || message.role === "system") return message.content;
-  return items.map(itemText).filter(Boolean).join("\n\n");
+  return items.map(copyableItemText).filter(Boolean).join("\n\n");
 }
 
 function attachmentSummary(attachment: ChatAttachment): string {
@@ -471,6 +442,7 @@ export const MessageBubble = memo(function MessageBubble({
   const [copied, setCopied] = useState(false);
   const [vote, setVote] = useState<"up" | "down" | null>(null);
   const copyText = messageText(message, items).trim();
+  const showActionBar = message.role === "assistant" && message.status === "done" && Boolean(copyText);
   const getSelectionText = () => {
     const sel = window.getSelection();
     return sel && sel.toString().trim().length > 0 ? sel.toString().trim() : "";
@@ -505,7 +477,7 @@ export const MessageBubble = memo(function MessageBubble({
       </div>
     );
   })() : null;
-  const actionBarNode = copyText ? (
+  const actionBarNode = showActionBar ? (
     <div className="msg-actions">
       <button
         type="button"
@@ -515,11 +487,11 @@ export const MessageBubble = memo(function MessageBubble({
         aria-label={t("message.copy")}
       >
         {copied ? (
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
             <path d="M20 6 9 17l-5-5" />
           </svg>
         ) : (
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
             <rect x="9" y="9" width="11" height="11" rx="2" />
             <path d="M5 15V5a2 2 0 0 1 2-2h10" />
           </svg>
@@ -532,9 +504,9 @@ export const MessageBubble = memo(function MessageBubble({
         title={t("message.upvote")}
         aria-label={t("message.upvote")}
       >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
-          <path d="M7 10v12" />
-          <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L14 1a3.13 3.13 0 0 1 1 5.88Z" />
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+          <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.3a2 2 0 0 0 2-1.7l1.4-9a2 2 0 0 0-2-2.3H14Z" />
+          <path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
         </svg>
       </button>
       <button
@@ -544,9 +516,9 @@ export const MessageBubble = memo(function MessageBubble({
         title={t("message.downvote")}
         aria-label={t("message.downvote")}
       >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
-          <path d="M17 14V2" />
-          <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L10 23a3.13 3.13 0 0 1-1-5.88Z" />
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="msg-action-icon">
+          <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.7a2 2 0 0 0-2 1.7l-1.4 9A2 2 0 0 0 4.3 15H10Z" />
+          <path d="M17 2h3a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-3" />
         </svg>
       </button>
       {timeStr && <span className="msg-action-time">{timeStr}</span>}

--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -185,7 +185,7 @@ function tableCells(line: string) {
     .map((cell) => cell.trim());
 }
 
-function MarkdownText({ content }: { content: string }) {
+export function MarkdownText({ content }: { content: string }) {
   const blocks: ReactNode[] = [];
   const lines = content.replace(/\r\n/g, "\n").split("\n");
   let i = 0;
@@ -930,14 +930,11 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
         </div>
       );
     case "done":
+      if (!item.exitCode || item.exitCode === 0) return null;
       return (
-        <div className={`stream-meta done${item.exitCode && item.exitCode !== 0 ? " failed" : ""}`}>
-          <span className="stream-label">
-            {item.exitCode && item.exitCode !== 0 ? t("stream.exitLabel") : t("stream.doneOk")}
-          </span>
-          {item.exitCode != null && (
-            <span> {t("stream.exitCode", { code: item.exitCode })}</span>
-          )}
+        <div className="stream-meta done failed">
+          <span className="stream-label">{t("stream.exitLabel")}</span>
+          <span> {t("stream.exitCode", { code: item.exitCode })}</span>
         </div>
       );
     case "raw": {

--- a/src/components/Draft/DraftCanvas.tsx
+++ b/src/components/Draft/DraftCanvas.tsx
@@ -1,14 +1,57 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 
 import type { CliStreamItem } from "@/services/cli/parsers";
 import type { ConversationMessage } from "@/services/cli/types";
+import { cliClient } from "@/services/cli/client";
 import { useConversationStore } from "@/store/conversationStore";
 import { useDraftPreviewStore } from "@/store/draftPreviewStore";
-import { DraftToolbar } from "./DraftToolbar";
+import { DraftToolbar, type DraftViewport } from "./DraftToolbar";
+import { MarkdownText } from "../CLI/StreamItem";
 
 const EMPTY_MESSAGES: ConversationMessage[] = [];
+const FRAME_WIDTH: Record<DraftViewport, number | null> = {
+  responsive: null,
+  desktop: 1440,
+  tablet: 768,
+  mobile: 390
+};
+
+const IMAGE_TARGET_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+  "gif",
+  "svg",
+  "avif",
+  "bmp"
+]);
+
+function targetExtension(target: string | undefined, url: string | undefined): string {
+  const value = target || url || "";
+  try {
+    const parsed = new URL(value);
+    return parsed.pathname.split(".").pop()?.toLowerCase() ?? "";
+  } catch {
+    return value.split("?")[0].split(".").pop()?.toLowerCase() ?? "";
+  }
+}
+
+function isMarkdownTarget(target: string | undefined, url: string | undefined): boolean {
+  return targetExtension(target, url) === "md";
+}
+
+function isImageTarget(target: string | undefined, url: string | undefined): boolean {
+  return IMAGE_TARGET_EXTENSIONS.has(targetExtension(target, url));
+}
+
+function markdownRel(target: string | undefined): string | null {
+  if (!target || /^https?:\/\//i.test(target)) return null;
+  const rel = target.split("?")[0].trim();
+  return rel.toLowerCase().endsWith(".md") ? rel : null;
+}
 
 function extractLastFileEditPath(
   items: CliStreamItem[] | undefined,
@@ -40,6 +83,17 @@ function extractLastFileEditPath(
 
 export function DraftCanvas({ onClose }: { onClose?: () => void }) {
   const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [viewport, setViewport] = useState<DraftViewport>("responsive");
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [manualInput, setManualInput] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+  const panStart = useRef({ x: 0, y: 0 });
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
   const activeId = useConversationStore((s) => s.activeId);
   const cwd = useConversationStore((s) => {
     const conv = s.conversations.find((c) => c.id === s.activeId);
@@ -54,6 +108,10 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
   const entry = useDraftPreviewStore((s) =>
     activeId ? s.byConv[activeId] : undefined
   );
+  const hasEntry = Boolean(entry?.url);
+  const isMarkdown = isMarkdownTarget(entry?.manualEntry, entry?.url);
+  const isImage = isImageTarget(entry?.manualEntry, entry?.url);
+  const frameWidth = FRAME_WIDTH[viewport];
 
   useEffect(() => {
     if (!activeId) return;
@@ -67,28 +125,182 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
 
   useEffect(() => {
     if (!activeId || !lastEditPath) return;
-    useDraftPreviewStore.getState().scheduleReload(activeId);
+    const ext = lastEditPath.split(".").pop()?.toLowerCase();
+    const delay = ext === "css" || ext === "html" || ext === "htm" ? 120 : 450;
+    useDraftPreviewStore.getState().scheduleReload(activeId, delay);
   }, [activeId, lastEditPath]);
 
-  const hasEntry = Boolean(entry?.url);
+  useEffect(() => {
+    if (!entry?.url) return;
+    setIsLoading(true);
+    setError(null);
+    setMarkdown(null);
+  }, [entry?.url]);
+
+  useEffect(() => {
+    const rel = markdownRel(entry?.manualEntry);
+    if (!entry?.url || !isMarkdown || !cwd || !rel) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    void cliClient
+      .readDraftMarkdown(cwd, rel)
+      .then((text) => {
+        if (cancelled) return;
+        if (text == null) throw new Error("Markdown not found");
+        setMarkdown(text);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setMarkdown(null);
+        setIsLoading(false);
+        setError(t("draft.loadError"));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd, entry?.manualEntry, entry?.url, isMarkdown, t]);
+
+  const focusFrame = () => {
+    frameRef.current?.focus();
+    frameRef.current?.contentWindow?.focus();
+  };
+
+  const commitManual = () => {
+    const trimmed = manualInput.trim();
+    if (!activeId || !trimmed) return;
+    useDraftPreviewStore.getState().setPreviewTarget(activeId, trimmed);
+  };
+
+  const onDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isImage || zoom <= 1) return;
+      e.preventDefault();
+      setIsDragging(true);
+      dragStart.current = { x: e.clientX, y: e.clientY };
+      panStart.current = { ...pan };
+    },
+    [isImage, zoom, pan]
+  );
+
+  const resetPan = useCallback(() => setPan({ x: 0, y: 0 }), []);
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const onMove = (e: MouseEvent) => {
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+      setPan({ x: panStart.current.x + dx, y: panStart.current.y + dy });
+    };
+    const onUp = () => setIsDragging(false);
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [isDragging]);
+
+  useEffect(() => {
+    setPan({ x: 0, y: 0 });
+  }, [zoom]);
 
   return (
     <div className="draft-canvas">
       <DraftToolbar
-        entryRel={entry?.manualEntry ?? entry?.entryRel ?? ""}
+        url={entry?.url}
+        viewport={viewport}
+        zoom={zoom}
+        onViewportChange={setViewport}
+        onZoomChange={setZoom}
         onClose={onClose}
       />
-      <div className="draft-frame-wrap">
+      <div
+        className={`draft-frame-wrap${isMarkdown ? " markdown" : ""}${isImage ? " image" : ""}`}
+        onMouseDown={hasEntry && !isMarkdown && !isImage ? focusFrame : undefined}
+      >
         {hasEntry ? (
-          <iframe
-            src={entry!.url}
-            className="draft-frame"
-            title={t("draft.title")}
-            sandbox="allow-scripts allow-forms allow-popups allow-modals"
-          />
+          <>
+            {isLoading && <div className="draft-status">{t("draft.loading")}</div>}
+            {error && <div className="draft-status draft-error">{error}</div>}
+            {isMarkdown ? (
+              <div
+                className="draft-markdown-wrap"
+                style={{ transform: `scale(${zoom})`, transformOrigin: "top center" }}
+              >
+                {markdown != null && <MarkdownText content={markdown} />}
+              </div>
+            ) : isImage ? (
+              <div
+                className="draft-image-wrap"
+                style={zoom > 1 ? { cursor: isDragging ? "grabbing" : "grab" } : undefined}
+                onMouseDown={onDragStart}
+                onDoubleClick={resetPan}
+              >
+                <img
+                  src={entry!.url}
+                  alt={entry?.manualEntry ?? t("draft.title")}
+                  className="draft-image"
+                  style={{
+                    zoom,
+                    transform: `translate(${pan.x}px, ${pan.y}px)`
+                  }}
+                  draggable={false}
+                  onLoad={() => setIsLoading(false)}
+                  onError={() => {
+                    setIsLoading(false);
+                    setError(t("draft.loadError"));
+                  }}
+                />
+              </div>
+            ) : (
+              <iframe
+                ref={frameRef}
+                key={entry!.url}
+                src={entry!.url}
+                className="draft-frame"
+                style={{
+                  ...(frameWidth ? { width: frameWidth } : undefined),
+                  transform: `scale(${zoom})`,
+                  transformOrigin: "top center"
+                }}
+                title={t("draft.title")}
+                allow="autoplay; fullscreen; gamepad; pointer-lock; clipboard-read; clipboard-write"
+                sandbox="allow-scripts allow-forms allow-popups allow-modals allow-pointer-lock allow-same-origin"
+                onLoad={() => {
+                  setIsLoading(false);
+                  focusFrame();
+                }}
+                onError={() => {
+                  setIsLoading(false);
+                  setError(t("draft.loadError"));
+                }}
+              />
+            )}
+          </>
         ) : (
           <div className="draft-empty">
             <p>{cwd ? t("draft.emptyNoEntry") : t("draft.emptyNoWorkspace")}</p>
+            {cwd && (
+              <input
+                className="draft-manual-fallback"
+                type="text"
+                value={manualInput}
+                spellCheck={false}
+                autoComplete="off"
+                placeholder={t("draft.manualFallbackPlaceholder")}
+                onChange={(e) => setManualInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && activeId && manualInput.trim()) {
+                    e.preventDefault();
+                    useDraftPreviewStore
+                      .getState()
+                      .setPreviewTarget(activeId, manualInput.trim());
+                  }
+                }}
+              />
+            )}
           </div>
         )}
       </div>

--- a/src/components/Draft/DraftCanvas.tsx
+++ b/src/components/Draft/DraftCanvas.tsx
@@ -29,6 +29,8 @@ const IMAGE_TARGET_EXTENSIONS = new Set([
   "bmp"
 ]);
 
+const DOCUMENT_TARGET_EXTENSIONS = new Set(["txt", "log", "json", "yaml", "yml", "csv"]);
+
 function targetExtension(target: string | undefined, url: string | undefined): string {
   const value = target || url || "";
   try {
@@ -47,10 +49,32 @@ function isImageTarget(target: string | undefined, url: string | undefined): boo
   return IMAGE_TARGET_EXTENSIONS.has(targetExtension(target, url));
 }
 
-function markdownRel(target: string | undefined): string | null {
+function isDocumentTarget(target: string | undefined, url: string | undefined): boolean {
+  return DOCUMENT_TARGET_EXTENSIONS.has(targetExtension(target, url));
+}
+
+function isPdfTarget(target: string | undefined, url: string | undefined): boolean {
+  return targetExtension(target, url) === "pdf";
+}
+
+function documentRel(target: string | undefined): string | null {
   if (!target || /^https?:\/\//i.test(target)) return null;
   const rel = target.split("?")[0].trim();
-  return rel.toLowerCase().endsWith(".md") ? rel : null;
+  const ext = rel.split(".").pop()?.toLowerCase() ?? "";
+  return ext === "md" || DOCUMENT_TARGET_EXTENSIONS.has(ext) ? rel : null;
+}
+
+function formatDocumentContent(ext: string, content: string): string {
+  if (ext !== "json") return content;
+  try {
+    return JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    return content;
+  }
+}
+
+function DocumentText({ content, extension }: { content: string; extension: string }) {
+  return <pre className={`draft-document-text ${extension}`}>{formatDocumentContent(extension, content)}</pre>;
 }
 
 function extractLastFileEditPath(
@@ -93,6 +117,7 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
   const dragStart = useRef({ x: 0, y: 0 });
   const panStart = useRef({ x: 0, y: 0 });
   const [markdown, setMarkdown] = useState<string | null>(null);
+  const [documentText, setDocumentText] = useState<string | null>(null);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const activeId = useConversationStore((s) => s.activeId);
   const cwd = useConversationStore((s) => {
@@ -111,6 +136,10 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
   const hasEntry = Boolean(entry?.url);
   const isMarkdown = isMarkdownTarget(entry?.manualEntry, entry?.url);
   const isImage = isImageTarget(entry?.manualEntry, entry?.url);
+  const isDocument = isDocumentTarget(entry?.manualEntry, entry?.url);
+  const isPdf = isPdfTarget(entry?.manualEntry, entry?.url);
+  const pdfUrl = isPdf && entry?.url ? `${entry.url}#view=FitH&navpanes=0` : "";
+  const documentExtension = targetExtension(entry?.manualEntry, entry?.url);
   const frameWidth = FRAME_WIDTH[viewport];
 
   useEffect(() => {
@@ -135,11 +164,12 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
     setIsLoading(true);
     setError(null);
     setMarkdown(null);
+    setDocumentText(null);
   }, [entry?.url]);
 
   useEffect(() => {
-    const rel = markdownRel(entry?.manualEntry);
-    if (!entry?.url || !isMarkdown || !cwd || !rel) return;
+    const rel = documentRel(entry?.manualEntry);
+    if (!entry?.url || (!isMarkdown && !isDocument) || !cwd || !rel) return;
     let cancelled = false;
     setIsLoading(true);
     setError(null);
@@ -147,20 +177,27 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
       .readDraftMarkdown(cwd, rel)
       .then((text) => {
         if (cancelled) return;
-        if (text == null) throw new Error("Markdown not found");
-        setMarkdown(text);
+        if (text == null) throw new Error("Document not found");
+        if (isMarkdown) {
+          setMarkdown(text);
+          setDocumentText(null);
+        } else {
+          setDocumentText(text);
+          setMarkdown(null);
+        }
         setIsLoading(false);
       })
       .catch(() => {
         if (cancelled) return;
         setMarkdown(null);
+        setDocumentText(null);
         setIsLoading(false);
         setError(t("draft.loadError"));
       });
     return () => {
       cancelled = true;
     };
-  }, [cwd, entry?.manualEntry, entry?.url, isMarkdown, t]);
+  }, [cwd, entry?.manualEntry, entry?.url, isDocument, isMarkdown, t]);
 
   const focusFrame = () => {
     frameRef.current?.focus();
@@ -217,8 +254,8 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
         onClose={onClose}
       />
       <div
-        className={`draft-frame-wrap${isMarkdown ? " markdown" : ""}${isImage ? " image" : ""}`}
-        onMouseDown={hasEntry && !isMarkdown && !isImage ? focusFrame : undefined}
+        className={`draft-frame-wrap${isMarkdown || isDocument ? " markdown" : ""}${isImage ? " image" : ""}${isPdf ? " pdf" : ""}`}
+        onMouseDown={hasEntry && !isMarkdown && !isDocument && !isImage && !isPdf ? focusFrame : undefined}
       >
         {hasEntry ? (
           <>
@@ -230,6 +267,15 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
                 style={{ transform: `scale(${zoom})`, transformOrigin: "top center" }}
               >
                 {markdown != null && <MarkdownText content={markdown} />}
+              </div>
+            ) : isDocument ? (
+              <div
+                className="draft-document-wrap"
+                style={{ transform: `scale(${zoom})`, transformOrigin: "top center" }}
+              >
+                {documentText != null && (
+                  <DocumentText content={documentText} extension={documentExtension} />
+                )}
               </div>
             ) : isImage ? (
               <div
@@ -254,6 +300,18 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
                   }}
                 />
               </div>
+            ) : isPdf ? (
+              <embed
+                key={pdfUrl}
+                src={pdfUrl}
+                className="draft-pdf"
+                type="application/pdf"
+                onLoad={() => setIsLoading(false)}
+                onError={() => {
+                  setIsLoading(false);
+                  setError(t("draft.loadError"));
+                }}
+              />
             ) : (
               <iframe
                 ref={frameRef}

--- a/src/components/Draft/DraftToolbar.tsx
+++ b/src/components/Draft/DraftToolbar.tsx
@@ -66,7 +66,7 @@ export function DraftToolbar({
           </option>
         ))}
       </select>
-      <div className="draft-zoom-control" aria-label={t("draft.zoom")}> 
+      <div className="draft-zoom-control" aria-label={t("draft.zoom")}>
         <button
           type="button"
           className="draft-action"

--- a/src/components/Draft/DraftToolbar.tsx
+++ b/src/components/Draft/DraftToolbar.tsx
@@ -1,51 +1,104 @@
-import { useEffect, useState, type KeyboardEvent } from "react";
+import { useMemo } from "react";
 
 import { useTranslation } from "react-i18next";
 
+import { cliClient } from "@/services/cli/client";
 import { useConversationStore } from "@/store/conversationStore";
 import { useDraftPreviewStore } from "@/store/draftPreviewStore";
 
+type DraftViewport = "responsive" | "desktop" | "tablet" | "mobile";
+
+const VIEWPORTS: Array<{ key: DraftViewport; label: string }> = [
+  { key: "responsive", label: "自适应" },
+  { key: "desktop", label: "1440" },
+  { key: "tablet", label: "768" },
+  { key: "mobile", label: "390" }
+];
+
+const ICON_PROPS = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.8,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  "aria-hidden": true
+};
+
 export function DraftToolbar({
-  entryRel,
+  url,
+  viewport,
+  zoom,
+  onViewportChange,
+  onZoomChange,
   onClose
 }: {
-  entryRel: string;
+  url?: string;
+  viewport: DraftViewport;
+  zoom: number;
+  onViewportChange: (viewport: DraftViewport) => void;
+  onZoomChange: (zoom: number) => void;
   onClose?: () => void;
 }) {
   const { t } = useTranslation();
   const activeId = useConversationStore((s) => s.activeId);
-  const [value, setValue] = useState(entryRel);
+  const canOpenExternal = Boolean(url && cliClient.isAvailable());
 
-  useEffect(() => {
-    setValue(entryRel);
-  }, [entryRel]);
-
-  const commit = () => {
-    const trimmed = value.trim();
-    if (activeId && trimmed) {
-      useDraftPreviewStore.getState().setManualEntry(activeId, trimmed);
-    }
+  const openExternal = () => {
+    if (!url || !canOpenExternal) return;
+    void cliClient.openDraftExternal(url);
   };
 
-  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      commit();
-    }
-  };
+  const viewportOptions = useMemo(() => VIEWPORTS, []);
+  const setZoom = (next: number) => onZoomChange(Math.min(2, Math.max(0.5, next)));
 
   return (
     <div className="draft-toolbar">
-      <input
-        className="draft-address"
-        type="text"
-        value={value}
-        spellCheck={false}
-        autoComplete="off"
-        placeholder={t("draft.entryPlaceholder")}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={onKeyDown}
-      />
+      <select
+        className="draft-viewport-select"
+        value={viewport}
+        aria-label={t("draft.viewport")}
+        onChange={(e) => onViewportChange(e.target.value as DraftViewport)}
+      >
+        {viewportOptions.map((option) => (
+          <option key={option.key} value={option.key}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <div className="draft-zoom-control" aria-label={t("draft.zoom")}> 
+        <button
+          type="button"
+          className="draft-action"
+          title={t("draft.zoomOut")}
+          aria-label={t("draft.zoomOut")}
+          onClick={() => setZoom(zoom - 0.1)}
+        >
+          <svg {...ICON_PROPS} className="draft-action-icon">
+            <path d="M5 12h14" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="draft-zoom-value"
+          title={t("draft.resetZoom")}
+          aria-label={t("draft.resetZoom")}
+          onClick={() => setZoom(1)}
+        >
+          {Math.round(zoom * 100)}%
+        </button>
+        <button
+          type="button"
+          className="draft-action"
+          title={t("draft.zoomIn")}
+          aria-label={t("draft.zoomIn")}
+          onClick={() => setZoom(zoom + 0.1)}
+        >
+          <svg {...ICON_PROPS} className="draft-action-icon">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+        </button>
+      </div>
       <button
         type="button"
         className="draft-action"
@@ -53,7 +106,24 @@ export function DraftToolbar({
         aria-label={t("draft.refresh")}
         onClick={() => activeId && useDraftPreviewStore.getState().reload(activeId)}
       >
-        ⟳
+        <svg {...ICON_PROPS} className="draft-action-icon">
+          <path d="M21 12a9 9 0 1 1-3-6.7L21 8" />
+          <path d="M21 3v5h-5" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className="draft-action"
+        title={t("draft.openExternal")}
+        aria-label={t("draft.openExternal")}
+        disabled={!canOpenExternal}
+        onClick={openExternal}
+      >
+        <svg {...ICON_PROPS} className="draft-action-icon">
+          <path d="M15 3h6v6" />
+          <path d="M10 14 21 3" />
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+        </svg>
       </button>
       {onClose && (
         <button
@@ -63,9 +133,13 @@ export function DraftToolbar({
           aria-label={t("common.close")}
           onClick={onClose}
         >
-          ✕
+          <svg {...ICON_PROPS} className="draft-action-icon">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
         </button>
       )}
     </div>
   );
 }
+
+export type { DraftViewport };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -491,9 +491,13 @@
     "resetEntry": "Reset to auto entry",
     "openExternal": "Open in browser",
     "viewport": "Preview size",
+    "zoom": "Zoom",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "resetZoom": "Reset zoom",
     "loading": "Loading preview…",
     "loadError": "Preview failed to load. Check the entry path or build output.",
-    "manualFallbackPlaceholder": "or enter a URL / README.md / image.png…",
+    "manualFallbackPlaceholder": "or enter a URL / README.md / data.json / image.png / file.pdf…",
     "emptyNoWorkspace": "No workspace selected. Pick a working directory to preview the agent's output.",
     "emptyNoEntry": "No preview yet. Ask the agent to start a dev server, create a page, write a Markdown doc, or generate an image, then it will open here automatically."
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -153,7 +153,13 @@
     "you": "You",
     "thinking": "Thinking",
     "system": "System",
-    "copy": "Copy"
+    "copy": "Copy",
+    "copySelection": "Copy selection",
+    "upvote": "Good response",
+    "downvote": "Bad response",
+    "upvote": "Upvote",
+    "downvote": "Downvote",
+    "copyAll": "Copy all"
   },
   "stream": {
     "read": "Read {{target}}",
@@ -482,8 +488,13 @@
     "tabPreview": "Preview",
     "previewBadge": "Preview available",
     "refresh": "Refresh",
-    "entryPlaceholder": "Entry path (e.g. index.html)",
+    "resetEntry": "Reset to auto entry",
+    "openExternal": "Open in browser",
+    "viewport": "Preview size",
+    "loading": "Loading preview…",
+    "loadError": "Preview failed to load. Check the entry path or build output.",
+    "manualFallbackPlaceholder": "or enter a URL / README.md / image.png…",
     "emptyNoWorkspace": "No workspace selected. Pick a working directory to preview the agent's output.",
-    "emptyNoEntry": "No previewable web entry found. Ask the agent to create an index.html, or build the project first."
+    "emptyNoEntry": "No preview yet. Ask the agent to start a dev server, create a page, write a Markdown doc, or generate an image, then it will open here automatically."
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -494,7 +494,7 @@
     "resetZoom": "重置缩放",
     "loading": "正在加载预览…",
     "loadError": "预览加载失败。请检查入口路径或构建产物。",
-    "manualFallbackPlaceholder": "或手动输入地址 / README.md / image.png…",
+    "manualFallbackPlaceholder": "或手动输入地址 / README.md / data.json / image.png / file.pdf…",
     "emptyNoWorkspace": "未选择工作区目录。选择一个工作目录即可预览 agent 的产出。",
     "emptyNoEntry": "尚未指向预览入口。让 agent 启动 dev server、创建页面、Markdown 文档或图片后，通过 bridge 自动指向这里。"
   }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -153,7 +153,11 @@
     "you": "你",
     "thinking": "思考中",
     "system": "系统",
-    "copy": "复制"
+    "copy": "复制",
+    "copySelection": "复制选中",
+    "upvote": "赞",
+    "downvote": "倒赞",
+    "copyAll": "复制全部"
   },
   "stream": {
     "read": "读取 {{target}}",
@@ -481,8 +485,17 @@
     "tabPreview": "预览",
     "previewBadge": "预览可用",
     "refresh": "刷新",
-    "entryPlaceholder": "入口路径(如 index.html)",
+    "resetEntry": "恢复自动入口",
+    "openExternal": "在浏览器打开",
+    "viewport": "预览尺寸",
+    "zoom": "缩放",
+    "zoomIn": "放大",
+    "zoomOut": "缩小",
+    "resetZoom": "重置缩放",
+    "loading": "正在加载预览…",
+    "loadError": "预览加载失败。请检查入口路径或构建产物。",
+    "manualFallbackPlaceholder": "或手动输入地址 / README.md / image.png…",
     "emptyNoWorkspace": "未选择工作区目录。选择一个工作目录即可预览 agent 的产出。",
-    "emptyNoEntry": "未找到可预览的 web 入口。让 agent 创建 index.html,或先构建项目。"
+    "emptyNoEntry": "尚未指向预览入口。让 agent 启动 dev server、创建页面、Markdown 文档或图片后，通过 bridge 自动指向这里。"
   }
 }

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -154,6 +154,12 @@ export const cliClient = {
   resolveDraftEntry(cwd: string): Promise<string | null> {
     return api().resolveDraftEntry(cwd);
   },
+  readDraftMarkdown(cwd: string, rel: string): Promise<string | null> {
+    return api().readDraftMarkdown(cwd, rel);
+  },
+  openDraftExternal(url: string): Promise<boolean> {
+    return api().openDraftExternal(url);
+  },
   ensureAgentGuides(cwd: string): Promise<string[]> {
     return api().ensureAgentGuides(cwd);
   },

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -442,7 +442,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     ];
     const toolSessionScope = workflowRun
       ? `workflow:${workflowRun.id}:${member.id}`
-      : conv.cwd ?? `conversation:${conv.id}`;
+      : `conversation:${conv.id}`;
 
     let resumedFromSessionId: string | undefined;
     if (!wantFresh) {

--- a/src/store/draftPreviewStore.ts
+++ b/src/store/draftPreviewStore.ts
@@ -36,7 +36,7 @@ function composeUrl(
   }
   if (!cwd) return "";
   const rel = target.split("/").map(encodeURIComponent).join("/");
-  return `freebuddy-draft://render/${rel}?root=${encodeURIComponent(cwd)}&v=${nonce}`;
+  return `freebuddy-draft://render/${encodeURIComponent(cwd)}/${rel}?v=${nonce}`;
 }
 
 function entryOf(entry: DraftPreviewEntry | undefined): string | null | undefined {

--- a/src/store/draftPreviewStore.ts
+++ b/src/store/draftPreviewStore.ts
@@ -1,18 +1,14 @@
 import { create } from "zustand";
 
-import { cliClient } from "@/services/cli/client";
-
 export interface DraftPreviewEntry {
   cwd: string;
-  /** Auto-detected entry relative path (e.g. "index.html"). null if none. */
-  entryRel: string | null;
-  /** User-overridden entry relative path; takes precedence over entryRel. */
+  /** User/agent-set preview target: relative path or localhost URL. */
   manualEntry?: string;
-  /** Entry resolution finished (entry may still be null). */
+  /** Entry resolution finished. */
   ready: boolean;
   /** Bumped to force the iframe to reload (url embeds it). */
   reloadNonce: number;
-  /** Fully composed freebuddy-draft:// url, empty when no entry. */
+  /** Fully composed preview url, empty when no target. */
   url: string;
 }
 
@@ -21,23 +17,31 @@ interface DraftPreviewState {
   timers: Record<string, ReturnType<typeof setTimeout>>;
   ensureFor(convId: string, cwd: string | undefined): Promise<void>;
   setManualEntry(convId: string, rel: string): void;
+  setPreviewTarget(convId: string, target: string): void;
+  clearManualEntry(convId: string): void;
   reload(convId: string): void;
   scheduleReload(convId: string, delay?: number): void;
 }
 
 function composeUrl(
   cwd: string,
-  entryRel: string | null | undefined,
+  target: string | null | undefined,
   nonce: number
 ): string {
-  if (!cwd || !entryRel) return "";
-  const rel = entryRel.split("/").map(encodeURIComponent).join("/");
+  if (!target) return "";
+  if (/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:\/|$)/i.test(target)) {
+    const url = new URL(target);
+    url.searchParams.set("freebuddyDraft", String(nonce));
+    return url.toString();
+  }
+  if (!cwd) return "";
+  const rel = target.split("/").map(encodeURIComponent).join("/");
   return `freebuddy-draft://render/${rel}?root=${encodeURIComponent(cwd)}&v=${nonce}`;
 }
 
 function entryOf(entry: DraftPreviewEntry | undefined): string | null | undefined {
   if (!entry) return null;
-  return entry.manualEntry ?? entry.entryRel;
+  return entry.manualEntry;
 }
 
 export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
@@ -45,38 +49,21 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
   timers: {},
 
   async ensureFor(convId, cwd) {
-    if (!cwd) {
-      set((s) => ({
-        byConv: {
-          ...s.byConv,
-          [convId]: { cwd: "", entryRel: null, ready: true, reloadNonce: 0, url: "" }
-        }
-      }));
-      return;
-    }
     const prev = get().byConv[convId];
-    if (prev && prev.cwd === cwd && prev.ready) return;
-    let entryRel: string | null = null;
-    try {
-      if (cliClient.isAvailable()) {
-        entryRel = await cliClient.resolveDraftEntry(cwd);
-      }
-    } catch {
-      entryRel = null;
-    }
+    if (prev && prev.cwd === (cwd ?? "") && prev.ready) return;
     set((s) => {
       const existing = s.byConv[convId];
-      const manualEntry = existing?.manualEntry;
+      const manualEntry = existing?.cwd === (cwd ?? "") ? existing?.manualEntry : undefined;
+      const nonce = existing?.cwd === (cwd ?? "") ? existing?.reloadNonce ?? 0 : 0;
       return {
         byConv: {
           ...s.byConv,
           [convId]: {
-            cwd,
-            entryRel,
+            cwd: cwd ?? "",
             manualEntry,
             ready: true,
-            reloadNonce: existing?.reloadNonce ?? 0,
-            url: composeUrl(cwd, manualEntry ?? entryRel, existing?.reloadNonce ?? 0)
+            reloadNonce: nonce,
+            url: composeUrl(cwd ?? "", manualEntry, nonce)
           }
         }
       };
@@ -84,6 +71,10 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
   },
 
   setManualEntry(convId, rel) {
+    get().setPreviewTarget(convId, rel);
+  },
+
+  setPreviewTarget(convId, target) {
     set((s) => {
       const entry = s.byConv[convId];
       const cwd = entry?.cwd ?? "";
@@ -93,11 +84,29 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
           ...s.byConv,
           [convId]: {
             cwd,
-            entryRel: entry?.entryRel ?? null,
-            manualEntry: rel,
+            manualEntry: target,
             ready: true,
             reloadNonce: nonce,
-            url: composeUrl(cwd, rel, nonce)
+            url: composeUrl(cwd, target, nonce)
+          }
+        }
+      };
+    });
+  },
+
+  clearManualEntry(convId) {
+    set((s) => {
+      const entry = s.byConv[convId];
+      if (!entry?.manualEntry) return s;
+      const nonce = entry.reloadNonce + 1;
+      return {
+        byConv: {
+          ...s.byConv,
+          [convId]: {
+            ...entry,
+            manualEntry: undefined,
+            reloadNonce: nonce,
+            url: composeUrl(entry.cwd, undefined, nonce)
           }
         }
       };

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -104,6 +104,8 @@ declare global {
     selectDirectory(): Promise<string | null>;
     selectAttachments(): Promise<AttachmentCandidate[]>;
     resolveDraftEntry(cwd: string): Promise<string | null>;
+    readDraftMarkdown(cwd: string, rel: string): Promise<string | null>;
+    openDraftExternal(url: string): Promise<boolean>;
     ensureAgentGuides(cwd: string): Promise<string[]>;
 
     onEvent(sessionId: string, cb: (event: CliEvent) => void): () => void;

--- a/styles.css
+++ b/styles.css
@@ -2419,22 +2419,16 @@ button {
   align-items: center;
   justify-content: flex-start;
   gap: 4px;
-  padding: 2px 0 0;
+  padding: 4px 0 0;
   margin-left: -3px;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.msg-content-wrapper:hover .msg-actions {
-  opacity: 1;
 }
 
 .msg-action-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -2461,8 +2455,9 @@ button {
 }
 
 .msg-action-icon {
-  width: 14px;
-  height: 14px;
+  width: 15px;
+  height: 15px;
+  display: block;
 }
 
 .msg-action-time {
@@ -3752,6 +3747,11 @@ button.ghost:disabled {
   background-size: 20px 20px;
 }
 
+.draft-frame-wrap.pdf {
+  overflow: hidden;
+  background: #2f2f2f;
+}
+
 .draft-frame {
   width: 100%;
   min-height: 100%;
@@ -3761,7 +3761,17 @@ button.ghost:disabled {
   background: #ffffff;
 }
 
-.draft-markdown-wrap {
+.draft-pdf {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  border: 0;
+  display: block;
+  background: #ffffff;
+}
+
+.draft-markdown-wrap,
+.draft-document-wrap {
   width: 100%;
   min-height: 100%;
   padding: 24px;
@@ -3772,6 +3782,23 @@ button.ghost:disabled {
 .draft-markdown-wrap .markdown-body {
   max-width: 860px;
   margin: 0 auto;
+}
+
+.draft-document-text {
+  width: min(100%, 980px);
+  min-height: calc(100% - 48px);
+  margin: 0 auto;
+  padding: 18px;
+  overflow: auto;
+  color: var(--fb-text-primary);
+  background: var(--fb-surface-bg, #0f172a);
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-md, 8px);
+  font-family: var(--fb-font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  font-size: 12px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .draft-image-wrap {

--- a/styles.css
+++ b/styles.css
@@ -2414,6 +2414,64 @@ button {
   text-align: left;
 }
 
+.msg-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 4px;
+  padding: 2px 0 0;
+  margin-left: -3px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.msg-content-wrapper:hover .msg-actions {
+  opacity: 1;
+}
+
+.msg-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--fb-text-tertiary);
+  cursor: pointer;
+  transition: color 0.15s ease;
+  flex: 0 0 auto;
+}
+
+.msg-action-btn:hover {
+  color: var(--fb-text-primary);
+}
+
+.msg-action-btn.copied {
+  color: var(--fb-brand);
+}
+
+.msg-action-btn.active.up {
+  color: var(--fb-brand);
+}
+
+.msg-action-btn.active.down {
+  color: var(--fb-danger, #ef4444);
+}
+
+.msg-action-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.msg-action-time {
+  margin-left: 4px;
+  font-size: 11px;
+  color: var(--fb-text-tertiary);
+  white-space: nowrap;
+}
+
 .msg-user .msg-bubble {
   border-color: transparent;
   background: var(--fb-brand-gradient);
@@ -3575,6 +3633,7 @@ button.ghost:disabled {
 .draft-toolbar {
   display: flex;
   gap: 8px;
+  align-items: center;
 }
 
 .draft-address {
@@ -3595,13 +3654,52 @@ button.ghost:disabled {
   border-color: var(--fb-brand);
 }
 
+.draft-viewport-select {
+  flex: 0 0 auto;
+  height: 30px;
+  padding: 0 8px;
+  font-size: 12px;
+  color: var(--fb-text-primary);
+  background: var(--fb-panel-bg);
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-md, 8px);
+  outline: none;
+}
+
+.draft-viewport-select:focus {
+  border-color: var(--fb-brand);
+}
+
+.draft-zoom-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.draft-zoom-value {
+  flex: 0 0 auto;
+  height: 30px;
+  min-width: 46px;
+  padding: 0 8px;
+  font-size: 12px;
+  color: var(--fb-text-secondary);
+  background: var(--fb-panel-bg);
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-md, 8px);
+  cursor: pointer;
+}
+
+.draft-zoom-value:hover {
+  color: var(--fb-brand);
+  border-color: var(--fb-brand);
+}
+
 .draft-action {
   flex: 0 0 auto;
   width: 30px;
   height: 30px;
   display: grid;
   place-items: center;
-  font-size: 15px;
   color: var(--fb-text-tertiary);
   background: var(--fb-panel-bg);
   border: 1px solid var(--fb-border-strong);
@@ -3610,26 +3708,90 @@ button.ghost:disabled {
   transition: color 0.15s ease, border-color 0.15s ease;
 }
 
-.draft-action:hover {
+.draft-action-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.draft-action:hover:not(:disabled) {
   color: var(--fb-brand);
   border-color: var(--fb-brand);
 }
 
+.draft-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 .draft-frame-wrap {
+  position: relative;
   flex: 1;
   min-height: 0;
+  display: flex;
+  justify-content: center;
   border: 1px solid var(--fb-border-strong);
   border-radius: var(--fb-rounded-lg);
-  overflow: hidden;
+  overflow: auto;
   background: #0b0f19;
+}
+
+.draft-frame-wrap.markdown {
+  display: block;
+  background: var(--fb-panel-bg);
+}
+
+.draft-frame-wrap.image {
+  align-items: center;
+  background-color: #111827;
+  background-image:
+    linear-gradient(45deg, rgba(255, 255, 255, 0.06) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(255, 255, 255, 0.06) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(255, 255, 255, 0.06) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(255, 255, 255, 0.06) 75%);
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0;
+  background-size: 20px 20px;
 }
 
 .draft-frame {
   width: 100%;
+  min-height: 100%;
   height: 100%;
   border: 0;
   display: block;
   background: #ffffff;
+}
+
+.draft-markdown-wrap {
+  width: 100%;
+  min-height: 100%;
+  padding: 24px;
+  color: var(--fb-text-primary);
+  background: var(--fb-panel-bg);
+}
+
+.draft-markdown-wrap .markdown-body {
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.draft-image-wrap {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  overflow: hidden;
+}
+
+.draft-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+  background: transparent;
+  box-shadow: var(--fb-shadow);
+  user-select: none;
 }
 
 .draft-empty {
@@ -3641,6 +3803,25 @@ button.ghost:disabled {
   font-size: 13px;
   line-height: 1.6;
   text-align: center;
+}
+
+.draft-status {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  z-index: 2;
+  transform: translateX(-50%);
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--fb-text-primary);
+  background: var(--fb-panel-bg);
+  border: 1px solid var(--fb-border-strong);
+  border-radius: var(--fb-rounded-md, 8px);
+  box-shadow: var(--fb-shadow-sm);
+}
+
+.draft-error {
+  border-color: var(--fb-danger, #ef4444);
 }
 
 .agent-bridge-toasts {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -8,6 +8,7 @@ import {
   acpUpdateToItems,
   buildInitializeRequest,
   buildPromptContentBlocks,
+  buildSessionLoadRequest,
   buildSessionPromptRequest,
   contentBlockToItems,
   parseAcpLine,
@@ -229,6 +230,19 @@ test("buildSessionPromptRequest sends a text content block", () => {
     params: {
       sessionId: "sess-1",
       prompt: [{ type: "text", text: "hello" }]
+    }
+  });
+});
+
+test("buildSessionLoadRequest loads Cursor-style ACP sessions", () => {
+  assert.deepEqual(buildSessionLoadRequest(9, "sess-1", "/tmp/project"), {
+    jsonrpc: "2.0",
+    id: 9,
+    method: "session/load",
+    params: {
+      sessionId: "sess-1",
+      cwd: "/tmp/project",
+      mcpServers: []
     }
   });
 });

--- a/tests/agent-bridge.test.mjs
+++ b/tests/agent-bridge.test.mjs
@@ -26,6 +26,10 @@ test("parseBridgeRequest routes /freebuddy/<action>", async () => {
   const nav = parseBridgeRequest("/freebuddy/navigate?to=about.html");
   assert.equal(nav?.action, "navigate");
   assert.equal(nav?.params.to, "about.html");
+  const server = parseBridgeRequest(
+    "/freebuddy/navigate?to=http%3A%2F%2F127.0.0.1%3A5173%2F"
+  );
+  assert.equal(server?.params.to, "http://127.0.0.1:5173/");
 });
 
 test("parseBridgeRequest supports legacy /preview", async () => {
@@ -46,6 +50,9 @@ test("isKnownBridgeAction flags catalog entries only", async () => {
   const { isKnownBridgeAction } = await loadBridge();
   assert.equal(isKnownBridgeAction("preview"), true);
   assert.equal(isKnownBridgeAction("navigate"), true);
+  assert.equal(isKnownBridgeAction("entry"), true);
+  assert.equal(isKnownBridgeAction("status"), true);
+  assert.equal(isKnownBridgeAction("error"), true);
   assert.equal(isKnownBridgeAction("notify"), true);
   assert.equal(isKnownBridgeAction("nope"), false);
 });
@@ -55,6 +62,12 @@ test("buildBridgeSection lists actions with the live port", async () => {
   const md = buildBridgeSection(12345);
   assert.ok(md.includes("/freebuddy/preview"));
   assert.ok(md.includes("/freebuddy/navigate"));
+  assert.ok(md.includes("/freebuddy/entry"));
+  assert.ok(md.includes("/freebuddy/status"));
+  assert.ok(md.includes("/freebuddy/error"));
   assert.ok(md.includes("/freebuddy/notify"));
   assert.ok(md.includes("127.0.0.1:12345"));
+  assert.ok(md.includes("npm run dev"));
+  assert.ok(md.includes("README.md"));
+  assert.ok(md.includes("assets%2Fmockup.png"));
 });

--- a/tests/draft-protocol.test.mjs
+++ b/tests/draft-protocol.test.mjs
@@ -111,8 +111,43 @@ test("resolveDraftEntry finds index.html and returns null when absent", async ()
   fs.writeFileSync(path.join(distOnly, "dist", "index.html"), "<p>x</p>");
   assert.equal(await resolveDraftEntry(distOnly), "dist/index.html");
 
+  const outOnly = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.mkdirSync(path.join(outOnly, "out"));
+  fs.writeFileSync(path.join(outOnly, "out", "index.html"), "<p>x</p>");
+  assert.equal(await resolveDraftEntry(outOnly), "out/index.html");
+
   const empty = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
   assert.equal(await resolveDraftEntry(empty), null);
 
   assert.equal(await resolveDraftEntry(""), null);
+});
+
+test("resolveDraftEntry discovers package framework and html candidates", async () => {
+  const { resolveDraftEntry } = await loadDraftModule();
+
+  const nextApp = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.writeFileSync(
+    path.join(nextApp, "package.json"),
+    JSON.stringify({ dependencies: { next: "latest" } })
+  );
+  fs.mkdirSync(path.join(nextApp, "out"));
+  fs.writeFileSync(path.join(nextApp, "out", "index.html"), "<p>next</p>");
+  assert.equal(await resolveDraftEntry(nextApp), "out/index.html");
+
+  const htmlOnly = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.mkdirSync(path.join(htmlOnly, "public"));
+  fs.writeFileSync(path.join(htmlOnly, "public", "demo.html"), "<p>demo</p>");
+  assert.equal(await resolveDraftEntry(htmlOnly), "public/demo.html");
+});
+
+test("readDraftMarkdown reads workspace markdown and blocks invalid paths", async () => {
+  const { readDraftMarkdown } = await loadDraftModule();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.writeFileSync(path.join(dir, "README.md"), "# Hello");
+  fs.writeFileSync(path.join(dir, "index.html"), "<p>x</p>");
+
+  assert.equal(await readDraftMarkdown(dir, "README.md"), "# Hello");
+  assert.equal(await readDraftMarkdown(dir, "index.html"), null);
+  assert.equal(await readDraftMarkdown(dir, "../README.md"), null);
+  assert.equal(await readDraftMarkdown("", "README.md"), null);
 });

--- a/tests/draft-protocol.test.mjs
+++ b/tests/draft-protocol.test.mjs
@@ -24,6 +24,22 @@ function buildDraftUrl(root, rel) {
   return `freebuddy-draft://render${pathPart}?root=${encodeURIComponent(root)}`;
 }
 
+function buildEmbeddedRootDraftUrl(root, rel) {
+  const encodedRoot = encodeURIComponent(root);
+  const encodedRel = rel.split("/").map(encodeURIComponent).join("/");
+  return `freebuddy-draft://render/${encodedRoot}/${encodedRel}`;
+}
+
+test("parseDraftUrl resolves root embedded in path", async () => {
+  const { parseDraftUrl } = await loadDraftModule();
+  const rootPath = path.resolve("/tmp/demo app");
+  const { root, rel } = parseDraftUrl(
+    buildEmbeddedRootDraftUrl(rootPath, "docs/sample.pdf")
+  );
+  assert.equal(root, rootPath);
+  assert.equal(rel, "docs/sample.pdf");
+});
+
 test("parseDraftUrl resolves root and relative path", async () => {
   const { parseDraftUrl } = await loadDraftModule();
   const { root, rel } = parseDraftUrl(
@@ -45,6 +61,18 @@ test("handleDraftRequest serves index.html with text/html mime", async () => {
   assert.match(response.headers.get("Content-Type") ?? "", /^text\/html/);
   const body = await response.text();
   assert.equal(body, "<h1>hello</h1>");
+});
+
+test("handleDraftRequest serves pdf with application/pdf mime", async () => {
+  const { handleDraftRequest } = await loadDraftModule();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
+  fs.writeFileSync(path.join(dir, "sample.pdf"), Buffer.from("%PDF-1.4"));
+
+  const response = await handleDraftRequest(
+    new Request(buildEmbeddedRootDraftUrl(dir, "sample.pdf"))
+  );
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Content-Type"), "application/pdf");
 });
 
 test("handleDraftRequest auto-appends index.html for directory request", async () => {
@@ -140,13 +168,17 @@ test("resolveDraftEntry discovers package framework and html candidates", async 
   assert.equal(await resolveDraftEntry(htmlOnly), "public/demo.html");
 });
 
-test("readDraftMarkdown reads workspace markdown and blocks invalid paths", async () => {
+test("readDraftMarkdown reads workspace text documents and blocks invalid paths", async () => {
   const { readDraftMarkdown } = await loadDraftModule();
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "draft-"));
   fs.writeFileSync(path.join(dir, "README.md"), "# Hello");
+  fs.writeFileSync(path.join(dir, "data.json"), "{\"ok\":true}");
+  fs.writeFileSync(path.join(dir, "notes.txt"), "hello");
   fs.writeFileSync(path.join(dir, "index.html"), "<p>x</p>");
 
   assert.equal(await readDraftMarkdown(dir, "README.md"), "# Hello");
+  assert.equal(await readDraftMarkdown(dir, "data.json"), "{\"ok\":true}");
+  assert.equal(await readDraftMarkdown(dir, "notes.txt"), "hello");
   assert.equal(await readDraftMarkdown(dir, "index.html"), null);
   assert.equal(await readDraftMarkdown(dir, "../README.md"), null);
   assert.equal(await readDraftMarkdown("", "README.md"), null);

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -23,7 +23,7 @@ test("package exposes electron-builder release scripts", () => {
 test("electron-builder config packages FreeBuddy for desktop platforms", () => {
   assert.match(builderConfig, /^appId:\s+dev\.freebuddy\.app/m);
   assert.match(builderConfig, /^productName:\s+FreeBuddy/m);
-  assert.match(builderConfig, /mac:[\s\S]*target:[\s\S]*- target:\s+dmg/m);
+  assert.match(builderConfig, /mac:[\s\S]*target:[\s\S]*- target:\s+dmg[\s\S]*- target:\s+zip/m);
   assert.match(builderConfig, /win:[\s\S]*target:[\s\S]*- target:\s+nsis/m);
   assert.match(builderConfig, /linux:[\s\S]*target:[\s\S]*- target:\s+AppImage[\s\S]*- target:\s+deb/m);
   assert.match(builderConfig, /linux:[\s\S]*maintainer:\s+FreeBuddy <noreply@freebuddy\.dev>/m);
@@ -34,13 +34,20 @@ test("release workflow uploads friendly-named assets and Windows update metadata
   assert.match(workflow, /name:\s+Release/);
   assert.match(workflow, /tags:\s+\['v\*'\]/);
   assert.match(workflow, /FreeBuddy_macOS-Apple-Silicon\.dmg/);
+  assert.match(workflow, /FreeBuddy_macOS-Apple-Silicon\.zip/);
+  assert.match(workflow, /FreeBuddy_macOS-Apple-Silicon\.zip\.blockmap/);
   assert.match(workflow, /FreeBuddy_macOS-Intel\.dmg/);
+  assert.match(workflow, /FreeBuddy_macOS-Intel\.zip/);
+  assert.match(workflow, /FreeBuddy_macOS-Intel\.zip\.blockmap/);
   assert.match(workflow, /FreeBuddy_Windows_x64\.exe/);
   assert.match(workflow, /npm ci/);
   assert.match(workflow, /npm test/);
   // Build only; assets are renamed and uploaded manually to keep friendly names.
   assert.match(workflow, /npx electron-builder \$\{\{ matrix\.builder_args \}\} --publish never/);
   assert.match(workflow, /gh release upload/);
+  assert.match(workflow, /Upload macOS update metadata/);
+  assert.match(workflow, /FreeBuddy-[^']+mac-arm64\\\.zip#FreeBuddy_macOS-Apple-Silicon\.zip/);
+  assert.match(workflow, /FreeBuddy-[^']+mac-x64\\\.zip#FreeBuddy_macOS-Intel\.zip/);
   // Auto-update metadata: latest.yml rewritten to the friendly Windows name.
   assert.match(workflow, /Upload Windows update metadata/);
   assert.match(workflow, /FreeBuddy_Windows_x64\.exe\.blockmap/);

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -136,13 +136,32 @@ test("Settings modal opens with CLI agents before General", () => {
   assert.match(src, /const TABS[\s\S]*key: "cli"[\s\S]*key: "workflowTeams"[\s\S]*key: "general"/);
 });
 
-test("MessageBubble supports right-click copy", () => {
+test("MessageBubble supports right-click and inline copy button", () => {
   const src = read("../src/components/CLI/MessageBubble.tsx");
   const css = read("../styles.css");
   assert.match(src, /onContextMenu=\{handleContextMenu\}/);
-  assert.match(src, /navigator\.clipboard\?\.writeText\(copyText\)/);
-  assert.match(src, /message\.copy/);
+  assert.match(src, /navigator\.clipboard\?\.writeText/);
+  assert.match(src, /message\.copySelection/);
+  assert.match(src, /getSelectionText/);
+  assert.match(src, /msg-actions/);
+  assert.match(src, /msg-action-btn/);
+  assert.match(src, /message\.upvote/);
+  assert.match(src, /message\.downvote/);
   assert.match(css, /\.message-context-menu/);
+  assert.match(css, /\.msg-actions/);
+});
+
+test("DraftCanvas renders markdown and image targets without iframe", () => {
+  const src = read("../src/components/Draft/DraftCanvas.tsx");
+  const css = read("../styles.css");
+  assert.match(src, /isMarkdownTarget/);
+  assert.match(src, /MarkdownText/);
+  assert.match(src, /readDraftMarkdown/);
+  assert.match(src, /isImageTarget/);
+  assert.match(src, /draft-image-wrap/);
+  assert.match(src, /draft-markdown-wrap/);
+  assert.match(css, /\.draft-image-wrap/);
+  assert.match(css, /\.draft-markdown-wrap/);
 });
 
 test("conversationStore routes workflow follow-ups to the workflow summary agent", () => {

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -143,25 +143,48 @@ test("MessageBubble supports right-click and inline copy button", () => {
   assert.match(src, /navigator\.clipboard\?\.writeText/);
   assert.match(src, /message\.copySelection/);
   assert.match(src, /getSelectionText/);
+  assert.match(src, /copyableItemText/);
+  assert.match(src, /item\.kind === "text" \|\| item\.kind === "raw"/);
+  assert.doesNotMatch(src, /case "tool-call"[\s\S]*return/);
+  assert.match(src, /showActionBar = message\.role === "assistant" && message\.status === "done"/);
   assert.match(src, /msg-actions/);
   assert.match(src, /msg-action-btn/);
   assert.match(src, /message\.upvote/);
   assert.match(src, /message\.downvote/);
   assert.match(css, /\.message-context-menu/);
   assert.match(css, /\.msg-actions/);
+  assert.doesNotMatch(css, /msg-content-wrapper:hover \.msg-actions/);
 });
 
-test("DraftCanvas renders markdown and image targets without iframe", () => {
+test("AgentBridgeListener keeps status/error events out of chat history", () => {
+  const src = read("../src/components/AgentBridge/AgentBridgeListener.tsx");
+  assert.match(src, /if \(action === "status"\)/);
+  assert.match(src, /if \(action === "error"\)/);
+  assert.doesNotMatch(src, /appendBridgeMessage/);
+  assert.doesNotMatch(src, /role: "system"/);
+  assert.doesNotMatch(src, /appendMessage/);
+});
+
+test("DraftCanvas renders markdown, document, pdf, and image targets without iframe", () => {
   const src = read("../src/components/Draft/DraftCanvas.tsx");
   const css = read("../styles.css");
   assert.match(src, /isMarkdownTarget/);
   assert.match(src, /MarkdownText/);
   assert.match(src, /readDraftMarkdown/);
+  assert.match(src, /isDocumentTarget/);
+  assert.match(src, /DocumentText/);
+  assert.match(src, /draft-document-wrap/);
+  assert.match(src, /isPdfTarget/);
+  assert.match(src, /#view=FitH&navpanes=0/);
+  assert.match(src, /draft-pdf/);
+  assert.match(src, /type="application\/pdf"/);
   assert.match(src, /isImageTarget/);
   assert.match(src, /draft-image-wrap/);
   assert.match(src, /draft-markdown-wrap/);
   assert.match(css, /\.draft-image-wrap/);
   assert.match(css, /\.draft-markdown-wrap/);
+  assert.match(css, /\.draft-document-text/);
+  assert.match(css, /\.draft-pdf/);
 });
 
 test("conversationStore routes workflow follow-ups to the workflow summary agent", () => {
@@ -174,6 +197,8 @@ test("conversationStore routes workflow follow-ups to the workflow summary agent
   assert.match(src, /workflowRunForConversation/);
   assert.match(src, /memberForWorkflowFollowup\(workflowRun, get\(\)\.members\)/);
   assert.match(src, /workflow:\$\{workflowRun\.id\}:\$\{member\.id\}/);
+  assert.match(src, /conversation:\$\{conv\.id\}/);
+  assert.doesNotMatch(src, /: conv\.cwd \?\? `conversation:\$\{conv\.id\}`/);
   assert.match(chat, /workflowFollowupAgentId\(activeRun\)/);
   assert.match(chat, /workflowFollowupAgent \?\? conv\.agentId/);
   assert.match(chat, /resolveWorkflowFollowupMember/);


### PR DESCRIPTION
## Summary
- upgrade draft previews with viewport/zoom controls, image pan, Markdown/document/image/PDF rendering, and external open
- improve PDF protocol handling, fit-width defaults, and document preview support
- fix Cursor ACP session continuation via session/load and conversation-scoped session persistence
- clean up bridge/system messages and assistant action bar copy/vote behavior

## Tests
- npm run typecheck
- npm run build:electron && node --test tests/acp.test.mjs tests/workflow-ui.test.mjs
- node --test tests/draft-protocol.test.mjs tests/workflow-ui.test.mjs