### PR TITLE
fix(mac): enable code signing for Squirrel.Mac auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,14 @@ jobs:
         run: npm test
 
       - name: Build Electron app
+        env:
+          # macOS code signing (REQUIRED for Squirrel.Mac auto-update to work).
+          # Works with a free "Apple Development" certificate (.p12) created
+          # via Xcode with an Apple ID; export it and base64-encode here.
+          # First-time install still needs `xattr -cr` (Gatekeeper), but
+          # in-app updates then validate because the signing identity is stable.
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
           npm run build
           npx electron-builder ${{ matrix.builder_args }} --publish never

--- a/desktop/macos/entitlements.mac.inherit.plist
+++ b/desktop/macos/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/desktop/macos/entitlements.mac.plist
+++ b/desktop/macos/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,7 +27,9 @@ publish:
 mac:
   icon: desktop/macos/AppIcon.icns
   category: public.app-category.productivity
-  identity: null
+  hardenedRuntime: true
+  entitlements: desktop/macos/entitlements.mac.plist
+  entitlementsInherit: desktop/macos/entitlements.mac.inherit.plist
   target:
     - target: dmg
     - target: zip


### PR DESCRIPTION
## Problem

macOS auto-update fails after download:

```
Code signature at URL .../FreeBuddy.app/ did not pass validation:
代码不含资源，但签名指示这些资源必须存在
```

## Root cause

The macOS build was **never signed**. `electron-builder.yml` set `mac.identity: null`, which makes electron-builder skip signing entirely. The app shipped with only the **linker's ad-hoc signature** on the raw Electron binary:

```
Identifier=Electron            # wrong
flags=(adhoc, linker-signed)   # linker sig, not a real codesign
Sealed Resources=none          # no resource seal → triggers the error
```

Reproduced the exact error against the installed app:
```
$ codesign --verify /Applications/FreeBuddy.app
code has no resources but signature indicates they must be present
```

Squirrel.Mac validates the **downloaded** update against the **running** app's designated requirement (DR). With no proper signature there's nothing stable to match, so validation fails.

## Fix

Remove `identity: null` so electron-builder signs the bundle, and pass `CSC_LINK` / `CSC_KEY_PASSWORD` in CI. Added `hardenedRuntime` + entitlements (mirrors the proven buddy-macos setup; `disable-library-validation` keeps `better-sqlite3` working).

### $99 is NOT required

Verified by inspecting a deployed signed app (buddy-macos): it uses a **free "Apple Development" certificate**, not a paid "Developer ID Application". An Apple Development cert yields a stable cert-based DR, which is all Squirrel needs for cross-version updates to validate.

| Signing | Cost | Auto-update works | First install needs `xattr -cr` |
|---|---|---|---|
| unsigned / ad-hoc (current) | free | ❌ | yes |
| **Apple Development** (this PR) | **free** | ✅ | yes |
| Developer ID + notarize | $99 | ✅ | no |

## Action items (one-time, before next release)

1. Create an "Apple Development" certificate via Xcode (free Apple ID)
2. Export `.p12` → `base64 -i cert.p12 | pbcopy` → GitHub Secret `CSC_LINK`; password → `CSC_KEY_PASSWORD`
3. Merge + cut a new release → in-app updates validate from that version on

## Caveat

Already-shipped v0.2.1–v0.2.3 users must **manually reinstall once** — their DR is locked to a per-build ad-hoc cdhash no future build can match.

## Verification

- `npm run typecheck` ✅
- YAML + plist lint ✅
- Local `--dir` build confirmed electron-builder no longer errors and (with a cert) signs; without a cert it skips (unchanged dev behavior)