### PR TITLE
fix(ci): scope CSC signing secrets to macOS only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,11 @@ jobs:
       - name: Build Electron app
         env:
           # macOS code signing (REQUIRED for Squirrel.Mac auto-update to work).
-          # Works with a free "Apple Development" certificate (.p12) created
-          # via Xcode with an Apple ID; export it and base64-encode here.
-          # First-time install still needs `xattr -cr` (Gatekeeper), but
-          # in-app updates then validate because the signing identity is stable.
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # Scoped to macOS only: the Apple Development cert cannot sign
+          # Windows exes, and feeding the multi-cert .p12 to Windows
+          # signtool fails with "Multiple certificates were found".
+          CSC_LINK: ${{ matrix.platform == 'macos-latest' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
         run: |
           npm run build
           npx electron-builder ${{ matrix.builder_args }} --publish never


### PR DESCRIPTION
## Problem

The v0.2.4 Windows release job failed at code signing:

```
signtool.exe sign /f ...1.p12 /d FreeBuddy ... FreeBuddy.exe
SignTool Error: Multiple certificates were found that meet all the given criteria
```

## Root cause

`CSC_LINK` / `CSC_KEY_PASSWORD` were attached to the **shared** Build Electron app step (runs for every matrix job). The Windows job therefore received the macOS `.p12` (which bundles leaf + WWDR G3 + Apple Root CA) and signtool couldn't pick one. The Apple Development cert also cannot meaningfully Authenticode-sign a Windows exe.

This also blocked the downstream `publish-release` job (the matrix has `fail-fast: false`, but `needs: build` still waits on all jobs), so v0.2.4 never actually got published.

## Fix

Gate the secrets on `matrix.platform == 'macos-latest'`:

```yaml
CSC_LINK: ${{ matrix.platform == 'macos-latest' && secrets.CSC_LINK || '' }}
```

Windows now gets an empty `CSC_LINK` and builds unsigned (the previous behavior). macOS keeps signing with the Apple Development cert.

Windows Authenticode signing is a separate, future concern (needs its own cert + secret).