### PR TITLE
feat: 补全会话标题 titleSource 首发与 done 结算

### DIFF
--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -41,7 +41,7 @@ function sessionTitleFromItems(items: CliStreamItem[]): string | undefined {
   return undefined;
 }
 
-function applyConversationTitle(
+export function applyConversationTitle(
   conversations: ConversationState["conversations"],
   conversationId: string,
   title: string,
@@ -323,6 +323,22 @@ async function finalizeRun(
     status: finalStatus,
     content: JSON.stringify(live.items)
   });
+
+  if (reason === "done" && !live.preserveConversationTitle) {
+    const title = sessionTitleFromItems(live.items);
+    if (title) {
+      set((s) => {
+        const conversations = applyConversationTitle(
+          s.conversations,
+          conversationId,
+          title,
+          s.messages[conversationId] ?? []
+        );
+        if (conversations === s.conversations) return s;
+        return { conversations };
+      });
+    }
+  }
 
   const ctx = runCtxMap.get(live.taskSessionId);
   ctx?.unsubscribe();

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -30,9 +30,11 @@ import {
 
 import { useCliExecutorStore } from "./cliExecutorStore";
 import {
+  buildConversationTitle,
   collectStreamMessageIds,
   defaultTitleFor,
   feedArticleTitleFromMessages,
+  inferConversationTitleSource,
   mergeConversationMessages,
   shouldApplyAgentSessionTitle,
   upsertConversationMessage
@@ -598,6 +600,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
 
     const conv = get().conversations.find((c) => c.id === conversationId);
     if (!conv) return;
+    const priorUserCount = (get().messages[conversationId] ?? []).filter(
+      (message) => message.role === "user"
+    ).length;
     const workflowRun = await workflowRunForConversation(conversationId);
     const member =
       memberForWorkflowFollowup(workflowRun, get().members) ??
@@ -678,6 +683,26 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       agentName: member.name,
       adapter: member.cli.adapter
     });
+
+    if (
+      !preserveConversationTitle &&
+      priorUserCount === 0 &&
+      inferConversationTitleSource(conv) === "default"
+    ) {
+      const nextTitle = buildConversationTitle({
+        prompt: trimmed,
+        attachmentName: attachments[0]?.name,
+        fallback: conv.title
+      });
+      await cliClient.renameConversation(conversationId, nextTitle, "prompt");
+      set((s) => ({
+        conversations: s.conversations.map((c) =>
+          c.id === conversationId
+            ? { ...c, title: nextTitle, titleSource: "prompt" as const }
+            : c
+        )
+      }));
+    }
 
     const taskSessionId = nanoid();
     const wantFresh = get().pendingFreshContext[conversationId] === true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

补全「会话标题优先采用 Agent 总结」设计中的两处落点，与 `docs/superpowers/specs/2026-07-09-conversation-title-agent-summary-design.zh-CN.md` 对齐。

## 变更

1. **首发设临时标题**：在 `sendMessage` 中，当会话仍为 `default` 标题且为第一条用户消息时，用 `buildConversationTitle` 写入截取标题，并将 `titleSource` 标为 `prompt`。
2. **done 再结算 Agent 标题**：在 `finalizeRun` 中于首轮结束时再次尝试应用 ACP `session.title`，避免标题仅在流式收尾才到达而被遗漏。
3. **导出 `applyConversationTitle`**：供流式与 done 结算复用同一套 `titleSource` 状态机逻辑。

## 验证

- `npm test` — 380 项全部通过
- `npx tsc --noEmit` — 通过

## 相关文档

- `docs/superpowers/specs/2026-07-09-conversation-title-agent-summary-design.zh-CN.md`
- `docs/superpowers/plans/2026-07-09-conversation-title-agent-summary.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6673a03-d625-4b94-b4c1-c835a6f69d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6673a03-d625-4b94-b4c1-c835a6f69d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

