### PR TITLE
feat: 码鞭彩蛋 — 执行中点头像抽打特效

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist-electron/
 release/
 node_modules/
 .DS_Store
+.superpowers/

--- a/docs/superpowers/plans/2026-07-09-code-whip-easter-egg.md
+++ b/docs/superpowers/plans/2026-07-09-code-whip-easter-egg.md
@@ -1,0 +1,329 @@
+# Code Whip Easter Egg Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users click a running/starting assistant avatar in the main chat to play a ~0.8s comedy “码鞭” hit effect, with no impact on agent execution.
+
+**Architecture:** Local React state in `MessageBubble` (`whipping` + `whipNonce`) toggles a `whip-hit` CSS class and short-lived effect nodes on the avatar wrapper. Pure frontend; no store/IPC/DB/audio.
+
+**Tech Stack:** React, CSS keyframes in `styles.css`, Node test runner (source-assert tests).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-code-whip-easter-egg-design.zh-CN.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `src/components/CLI/MessageBubble.tsx` | Click gate, local whip state, effect DOM |
+| `styles.css` | Whip keyframes, pointer/hover, reduced-motion |
+| `src/locales/en.json` + `zh-CN.json` | Optional `aria-label` for whipable avatar |
+| `tests/code-whip.test.mjs` | Source/contract assertions for trigger + CSS |
+
+---
+
+### Task 1: Failing contract tests
+
+**Files:**
+- Create: `tests/code-whip.test.mjs`
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
+
+test("MessageBubble gates code whip to running/starting assistant avatars", () => {
+  const src = read("../src/components/CLI/MessageBubble.tsx");
+  assert.match(src, /whipNonce/);
+  assert.match(src, /whipping/);
+  assert.match(src, /whip-hit/);
+  assert.match(src, /status === "running" \|\| message\.status === "starting"/);
+  assert.match(src, /onClick=\{.*whip|handleWhip|onWhip/s);
+});
+
+test("styles define whip-hit comedy effect and reduced-motion fallback", () => {
+  const css = read("../styles.css");
+  assert.match(css, /\.whip-hit/);
+  assert.match(css, /@keyframes whip/);
+  assert.match(css, /prefers-reduced-motion/);
+  assert.match(css, /啪|whip-pop|whip-crack/);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `node --test tests/code-whip.test.mjs`
+
+- [ ] **Step 3: Commit tests**
+
+```bash
+git add tests/code-whip.test.mjs
+git commit -m "test: add code whip contract tests"
+```
+
+---
+
+### Task 2: MessageBubble whip trigger
+
+**Files:**
+- Modify: `src/components/CLI/MessageBubble.tsx`
+- Modify: `src/locales/en.json`, `src/locales/zh-CN.json` (aria-label)
+
+- [ ] **Step 1: Add i18n keys**
+
+In both locale files under `message`:
+
+```json
+"whipAvatar": "Code whip"
+```
+
+zh-CN:
+
+```json
+"whipAvatar": "码鞭"
+```
+
+- [ ] **Step 2: Wire avatar click + effect nodes in assistant branch**
+
+Near the assistant `AgentAvatar` render (~line 912):
+
+1. Import `useCallback`, `useEffect`, `useRef` if needed (already has `useState`).
+2. Inside the memo component (before returns that need it, or only in assistant path via hooks at top level):
+
+```tsx
+const [whipping, setWhipping] = useState(false);
+const [whipNonce, setWhipNonce] = useState(0);
+const whipTimerRef = useRef<number | null>(null);
+
+const canWhip =
+  message.role === "assistant" &&
+  (message.status === "running" || message.status === "starting");
+
+const handleWhip = useCallback(() => {
+  if (!canWhip || whipping) return;
+  setWhipping(true);
+  setWhipNonce((n) => n + 1);
+  if (whipTimerRef.current != null) window.clearTimeout(whipTimerRef.current);
+  whipTimerRef.current = window.setTimeout(() => {
+    setWhipping(false);
+    whipTimerRef.current = null;
+  }, 800);
+}, [canWhip, whipping]);
+
+useEffect(() => {
+  return () => {
+    if (whipTimerRef.current != null) window.clearTimeout(whipTimerRef.current);
+  };
+}, []);
+```
+
+3. Wrap avatar:
+
+```tsx
+<button
+  type="button"
+  className={`msg-avatar-whip-target${whipping ? " whip-hit" : ""}${canWhip ? " whipable" : ""}`}
+  onClick={canWhip ? handleWhip : undefined}
+  disabled={!canWhip}
+  aria-label={canWhip ? t("message.whipAvatar") : undefined}
+  tabIndex={canWhip ? 0 : -1}
+>
+  <AgentAvatar
+    key={whipNonce}
+    adapter={message.adapter ?? adapter}
+    agentId={message.agentId}
+    iconKey={agentIconKey}
+    className="msg-avatar agent-avatar"
+    fallback={<span>✦</span>}
+  />
+  {whipping && (
+    <>
+      <span className="whip-arc" aria-hidden="true" />
+      <span className="whip-crack" aria-hidden="true">
+        啪
+      </span>
+      <span className="whip-spark whip-spark-1" aria-hidden="true" />
+      <span className="whip-spark whip-spark-2" aria-hidden="true" />
+      <span className="whip-spark whip-spark-3" aria-hidden="true" />
+    </>
+  )}
+</button>
+```
+
+Notes:
+- Hooks must stay at top level of the component (not inside role branches).
+- Prefer `<button>` for a11y; style it to look like the bare avatar (reset border/background/padding).
+- When `!canWhip`, keep layout identical but non-interactive (`disabled` / no pointer).
+
+- [ ] **Step 3: Run contract test — expect MessageBubble assertions PASS (CSS still FAIL)**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/CLI/MessageBubble.tsx src/locales/en.json src/locales/zh-CN.json
+git commit -m "feat: trigger code whip on running assistant avatar click"
+```
+
+---
+
+### Task 3: CSS comedy effect
+
+**Files:**
+- Modify: `styles.css` (near `.msg-avatar` / `.msg-assistant .msg-avatar`)
+
+- [ ] **Step 1: Add styles**
+
+```css
+.msg-avatar-whip-target {
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: default;
+}
+
+.msg-avatar-whip-target.whipable {
+  cursor: pointer;
+}
+
+.msg-avatar-whip-target.whipable:hover .msg-avatar {
+  transform: scale(1.12);
+}
+
+.msg-avatar-whip-target:disabled {
+  cursor: default;
+}
+
+.msg-avatar-whip-target .msg-avatar {
+  /* avatar fills the button; keep existing look */
+}
+
+.whip-hit .msg-avatar {
+  animation: whip-shake 0.45s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
+.whip-arc {
+  position: absolute;
+  inset: -10px -14px auto auto;
+  width: 28px;
+  height: 28px;
+  border: 2px solid transparent;
+  border-top-color: #f59e0b;
+  border-right-color: #f59e0b;
+  border-radius: 50%;
+  transform-origin: 20% 80%;
+  animation: whip-arc-swing 0.15s ease-out both;
+  pointer-events: none;
+}
+
+.whip-crack {
+  position: absolute;
+  left: 100%;
+  top: -6px;
+  margin-left: 4px;
+  font-size: 14px;
+  font-weight: 800;
+  color: #ef4444;
+  text-shadow: 0 1px 0 #fff, 1px 1px 0 rgba(0, 0, 0, 0.15);
+  animation: whip-crack-pop 0.45s ease-out both;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.whip-spark {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fbbf24;
+  pointer-events: none;
+  animation: whip-spark-fly 0.5s ease-out both;
+}
+
+.whip-spark-1 { top: 2px; right: -2px; animation-delay: 0.15s; }
+.whip-spark-2 { top: 12px; right: -8px; animation-delay: 0.18s; background: #f97316; }
+.whip-spark-3 { top: -2px; right: 8px; animation-delay: 0.2s; background: #fde68a; }
+
+@keyframes whip-arc-swing {
+  from { transform: rotate(-40deg) scale(0.6); opacity: 0; }
+  to { transform: rotate(25deg) scale(1); opacity: 1; }
+}
+
+@keyframes whip-shake {
+  0%, 100% { transform: translate(0, 0) rotate(0); }
+  15% { transform: translate(-3px, 1px) rotate(-8deg); }
+  30% { transform: translate(4px, -1px) rotate(7deg); }
+  45% { transform: translate(-3px, 1px) rotate(-6deg); }
+  60% { transform: translate(2px, 0) rotate(4deg); }
+  75% { transform: translate(-1px, 0) rotate(-2deg); }
+}
+
+@keyframes whip-crack-pop {
+  0% { transform: scale(0.4); opacity: 0; }
+  30% { transform: scale(1.35); opacity: 1; }
+  100% { transform: scale(1) translateY(-6px); opacity: 0; }
+}
+
+@keyframes whip-spark-fly {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(10px, -12px) scale(0); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .whip-arc,
+  .whip-crack,
+  .whip-spark {
+    display: none !important;
+  }
+  .whip-hit .msg-avatar {
+    animation: whip-shake-reduced 0.2s ease-out both;
+  }
+}
+
+@keyframes whip-shake-reduced {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(2px, 0); }
+}
+```
+
+Adjust so existing `.msg:hover .msg-avatar` does not fight `whipable` hover; scoping under `.msg-avatar-whip-target` is enough.
+
+- [ ] **Step 2: Run `node --test tests/code-whip.test.mjs` — expect PASS**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add styles.css
+git commit -m "feat: add code whip CSS comedy effect"
+```
+
+---
+
+### Task 4: Verification
+
+- [ ] **Step 1:** `npm test`
+- [ ] **Step 2:** `npx tsc --noEmit`
+- [ ] **Step 3:** Push branch; open/update PR
+
+---
+
+## Spec coverage
+
+| Requirement | Task |
+|-------------|------|
+| Click running/starting avatar | 2 |
+| Comedy 0.8s effect | 3 |
+| Ignore clicks while playing | 2 (`whipping` gate) |
+| No store/IPC/audio | (non-goal) |
+| reduced-motion | 3 |
+| Idle/history no-op | 2 (`canWhip`) |

--- a/docs/superpowers/specs/2026-07-09-code-whip-easter-egg-design.zh-CN.md
+++ b/docs/superpowers/specs/2026-07-09-code-whip-easter-egg-design.zh-CN.md
@@ -1,0 +1,157 @@
+# 码鞭（Code Whip）彩蛋设计
+
+## 目标
+
+在会话主页面为正在执行的 Agent 增加一个隐蔽彩蛋：用户点击该助手消息头像时，播放夸张喜剧风的「码鞭」抽打特效。
+
+用户心智：
+
+> Agent 还在跑的时候，点一下它的头像，会甩出一鞭、头像晃一下，还冒个「啪」。好玩，但不影响它干活。
+
+## 非目标
+
+- 不影响 Agent 执行、停止、权限、ACP 协议或任何后端逻辑。
+- 不写入消息、不落库、不做埋点统计。
+- 本版不做音效（可后续加）。
+- 不做连击计数、催促语义、聊天吐槽气泡。
+- 不同步侧栏 `WorkspacePanel` 头像。
+- 不在 composer 工具栏增加显式「道具」按钮。
+
+## 已确认决策
+
+| 决策 | 选择 |
+|------|------|
+| 性质 | 纯彩蛋特效，不影响执行 |
+| 入口 | 仅点击会话主列表中正在执行的助手消息头像 |
+| 特效风格 | 夸张喜剧（甩鞭弧线 + 大晃 +「啪」字样，约 0.8s） |
+| 音效 | 本版不做，后续可选 |
+| 可用时机 | 仅 `running` / `starting` |
+| 实现路径 | CSS 特效挂在 `MessageBubble` 本地状态 |
+
+## 背景
+
+现有会话主页结构：
+
+- `ChatView` 渲染消息列表与底部 composer
+- 助手消息在 `MessageBubble` 中通过 `AgentAvatar` 显示头像（`.msg-avatar.agent-avatar`）
+- 执行中助手消息 `status` 为 `running` 或 `starting`，内容随 `conversationHandlers` 流式更新
+- 已有 CSS 动画先例（`msgSlideIn`、`dots-pulse`、头像 hover `scale(1.05)`），无现成彩蛋/音效基础设施
+
+## 交互
+
+### 触发
+
+1. 仅当助手消息 `status ∈ {running, starting}` 时，其头像可点击。
+2. 单击触发一次抽打特效。
+3. 执行中头像使用 `cursor: pointer`，hover 比默认略明显，暗示可点但不做显式文案引导。
+
+### 冷却
+
+- 特效时长约 **0.8s**。
+- 播放中再次点击**忽略**，避免动画叠加。
+- 播放结束后可立即再次触发。
+
+### 空闲 / 其他目标
+
+以下情况点击无特效、无 toast、无控制台噪音：
+
+- 非执行中的助手消息头像
+- 历史消息头像
+- 用户头像
+- 侧栏头像
+- Replay 切片中非 live 状态的消息
+
+## 视觉
+
+挂在被点击头像的定位容器上，不遮挡消息正文阅读。
+
+### 时间线（约 0.8s）
+
+| 阶段 | 时间 | 表现 |
+|------|------|------|
+| 甩鞭 | 0–0.15s | 短鞭影从右上甩向头像（弧线 + 细尾迹） |
+| 命中 | 0.15–0.45s | 头像大幅左右晃动 + 轻微旋转；「啪」字样漫画感弹出后淡出 |
+| 收尾 | 0.45–0.8s | 头像回正；2–3 个星点/火花散开后消失 |
+
+### 实现要点
+
+- 用临时 class（如 `whip-hit`）+ `whipNonce` 重触发同一套 CSS keyframes。
+- 鞭影、「啪」、星点：伪元素或头像旁绝对定位的短生命周期节点；动画结束移除或靠 class 摘除。
+- 「啪」为本版固定视觉字样（非 i18n 文案依赖）；若需要可访问名称，可为可点击头像增加 `aria-label`（如「码鞭」）。
+
+### 无障碍
+
+尊重 `prefers-reduced-motion: reduce`：
+
+- 去掉甩鞭弧线与「啪」大字
+- 改为短促微抖或轻微闪一下（明显短于 0.8s）
+
+## 架构
+
+### 状态
+
+全部放在 `MessageBubble`（或头像包装层）的**组件本地 state**：
+
+- `whipping: boolean` — 是否正在播放
+- `whipNonce: number` — 每次成功触发递增，用于强制重启 CSS 动画
+
+不引入 Zustand store、不改 `conversationStore` / IPC / DB。
+
+### 数据流
+
+```
+用户点击执行中助手头像
+  → MessageBubble 判断 status ∈ {running, starting} 且 !whipping
+  → whipping=true, whipNonce++
+  → 头像容器加上 whip-hit（及 nonce 相关 key）
+  → CSS 播放约 0.8s
+  → animationend / timeout → whipping=false
+```
+
+### 代码落点
+
+| 文件 | 变更 |
+|------|------|
+| `src/components/CLI/MessageBubble.tsx` | 执行中头像 onClick；本地 whip 状态；特效节点 |
+| `styles.css` | `whip-hit`、鞭影、「啪」、星点 keyframes；reduced-motion |
+| `src/components/CLI/AgentAvatar.tsx` | 仅当现有 props 不足以透传 `onClick` / `className` 时做最小扩展 |
+| `src/locales/*.json` | 可选：可点击头像的 `aria-label` 文案 |
+
+### 明确不改
+
+- `conversationStore` / `conversationHandlers`
+- Electron IPC / SQLite
+- composer `.composer-tools`
+- `WorkspacePanel` 侧栏头像
+
+## 边界情况
+
+| 场景 | 行为 |
+|------|------|
+| 执行中连点 | 第一次播放；播放中忽略 |
+| 特效播放中 Agent 结束（status → done） | 当前动画可播完；结束后头像不再可点 |
+| 消息列表重渲染 / 流式更新 | 本地 state 保留在该 bubble 实例上；不因 content 更新取消动画 |
+| 滚动离开视口 | 动画可在后台播完；不要求追焦 |
+| Replay 模式 | 非 live running/starting 不可抽 |
+| reduced-motion | 减弱特效 |
+
+## 验收标准
+
+1. Agent 执行中点击该条助手头像 → 约 0.8s 夸张喜剧特效（甩鞭 + 晃动 +「啪」）。
+2. 空闲或历史头像点击 → 无可见反馈。
+3. 连点不叠加多套动画。
+4. 抽打不改变 Agent 运行状态，不产生消息或 DB 写入。
+5. `prefers-reduced-motion` 下特效明显减弱且仍可完成一次反馈。
+
+## 测试计划
+
+1. 组件/样式级：执行中头像可点；非执行中不可触发（可用 DOM/class 断言或轻量行为测试）。
+2. 手动：跑一轮真实 Agent，点头像看特效与停止按钮仍可用。
+3. 手动：系统开启减少动态效果时确认减弱路径。
+
+## 后续可选（不在本版）
+
+- 短「啪」音效（用户手势触发，可关）
+- 侧栏头像同步晃动
+- 连击彩蛋文案
+- composer 显式道具入口

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -29,6 +29,7 @@ import {
   validateAttachmentCandidate
 } from "@/utils/chatAttachments";
 import { MessageBubble } from "./MessageBubble";
+import { CodeWhipOverlay } from "./CodeWhipOverlay";
 import { useReplayStore } from "@/store/replayStore";
 import { parseSlashDraft, SlashCommandMenu } from "./SlashCommandMenu";
 import {
@@ -964,6 +965,7 @@ export function ChatView() {
 
   return (
     <div className="chat-view">
+      <CodeWhipOverlay />
       <div className={`chat-scroll${replaying ? " replay-active" : ""}`} ref={scrollRef} onScroll={handleScroll}>
         {messages.length === 0 && (
           <div className="chat-empty chat-empty-hero">

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -6,7 +6,13 @@ import {
   WHIP_EFFECT_MS,
   WHIP_HIT_AT_MS
 } from "@/store/whipEffectStore";
-import { computeArmSwing, computeWhipFrame } from "@/utils/whipMotion";
+import {
+  computeStageFade,
+  createWhipSimulation,
+  swingProgress,
+  WHIP_ATTACH_POINT,
+  type CrackParticle
+} from "@/utils/whipMotion";
 
 export function CodeWhipOverlay() {
   const { t } = useTranslation();
@@ -15,40 +21,59 @@ export function CodeWhipOverlay() {
   const target = useWhipEffectStore((s) => s.target);
 
   const stageRef = useRef<HTMLDivElement | null>(null);
+  const handleRef = useRef<SVGGElement | null>(null);
   const ropeRef = useRef<SVGPathElement | null>(null);
   const baseRef = useRef<SVGPathElement | null>(null);
   const crackerRef = useRef<SVGGElement | null>(null);
+  const particlesRef = useRef<SVGGElement | null>(null);
 
   useEffect(() => {
     if (!active) return;
-    const applyFrame = (elapsed: number, opacityOverride?: number) => {
-      const swing = computeArmSwing(elapsed, WHIP_HIT_AT_MS, WHIP_EFFECT_MS);
-      const frame = computeWhipFrame(elapsed, WHIP_HIT_AT_MS);
+
+    const sim = createWhipSimulation();
+    const paint = (
+      elapsed: number,
+      frame: ReturnType<typeof sim.advanceTo>,
+      opacityOverride?: number
+    ) => {
+      const fade = computeStageFade(elapsed, WHIP_EFFECT_MS);
       if (stageRef.current) {
-        stageRef.current.style.transform = `rotate(${swing.deg}deg) scale(${swing.scale})`;
-        stageRef.current.style.opacity = String(opacityOverride ?? swing.opacity);
+        stageRef.current.style.opacity = String(
+          opacityOverride ?? fade.opacity
+        );
       }
+      const dx = frame.handleX - WHIP_ATTACH_POINT.x;
+      const dy = frame.handleY - WHIP_ATTACH_POINT.y;
+      handleRef.current?.setAttribute("transform", `translate(${dx} ${dy})`);
       ropeRef.current?.setAttribute("d", frame.ropeD);
       baseRef.current?.setAttribute("d", frame.baseD);
       crackerRef.current?.setAttribute(
         "transform",
         `translate(${frame.tipX} ${frame.tipY}) rotate(${(frame.tipAngle * 180) / Math.PI})`
       );
+      paintParticles(particlesRef.current, frame.particles);
     };
+
     const reduceMotion =
       typeof window !== "undefined" &&
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
     if (reduceMotion) {
-      // Hold a single "mid-crack" pose instead of animating through the
-      // full wind-up/snap/ring-down sequence.
-      applyFrame(WHIP_HIT_AT_MS + 60, 1);
+      // Hold a single mid-crack pose instead of animating the full swing.
+      const frame = sim.advanceTo(WHIP_HIT_AT_MS + 60, WHIP_HIT_AT_MS, WHIP_EFFECT_MS);
+      paint(WHIP_HIT_AT_MS + 60, frame, 1);
       return;
     }
+
     let raf = 0;
     const start = performance.now();
     const tick = () => {
       const elapsed = Math.min(performance.now() - start, WHIP_EFFECT_MS);
-      applyFrame(elapsed);
+      // One physics step per display frame, driven by swing progress so the
+      // tip-speed peak lands near WHIP_HIT_AT_MS (same as the canvas demo).
+      const progress = swingProgress(elapsed, WHIP_HIT_AT_MS, WHIP_EFFECT_MS);
+      const frame = sim.step(progress);
+      frame.opacity = computeStageFade(elapsed, WHIP_EFFECT_MS).opacity;
+      paint(elapsed, frame);
       if (elapsed < WHIP_EFFECT_MS) {
         raf = requestAnimationFrame(tick);
       }
@@ -90,8 +115,12 @@ export function CodeWhipOverlay() {
             </linearGradient>
           </defs>
 
-          {/* Short straight handle on the right */}
-          <g className="code-whip-handle">
+          {/*
+            Decorative handle translates with the Verlet root each frame
+            (see createWhipSimulation / handlePos). The soft lash is a
+            distance-constrained rope driven by that same root motion.
+          */}
+          <g className="code-whip-handle" ref={handleRef}>
             <circle cx="508" cy="198" r="10" fill="#2a2a2a" />
             <circle cx="508" cy="198" r="6.5" fill="#3d3d3d" />
             <circle cx="496" cy="191" r="7" fill="#d4a017" />
@@ -117,12 +146,6 @@ export function CodeWhipOverlay() {
             <circle cx="436" cy="155" r="5.5" fill="#3d3d3d" />
           </g>
 
-          {/*
-            Rope driven by requestAnimationFrame (see computeWhipFrame): a
-            continuous traveling wave, not discrete CSS keyframes, so the
-            lash flows like a real cracking whip rather than a jointed arm.
-            The thicker base path fakes a taper toward the thin tip.
-          */}
           <g className="code-whip-tip">
             <path
               ref={baseRef}
@@ -141,8 +164,6 @@ export function CodeWhipOverlay() {
               strokeLinecap="round"
             />
             <g ref={crackerRef} className="code-whip-cracker">
-              {/* Local +x continues along the rope's current direction
-                  (rotate() maps it there), so these extend past the tip. */}
               <path
                 d="M0 0 L22 -8"
                 fill="none"
@@ -159,6 +180,7 @@ export function CodeWhipOverlay() {
               />
               <circle cx="18" cy="4" r="3" fill="#1a1008" />
             </g>
+            <g ref={particlesRef} className="code-whip-particles" />
           </g>
         </svg>
       </div>
@@ -172,4 +194,38 @@ export function CodeWhipOverlay() {
       </div>
     </div>
   );
+}
+
+function paintParticles(
+  group: SVGGElement | null,
+  particles: CrackParticle[]
+) {
+  if (!group) return;
+  while (group.firstChild) group.removeChild(group.firstChild);
+  const ns = "http://www.w3.org/2000/svg";
+  for (const p of particles) {
+    if (p.ring) {
+      const ring = document.createElementNS(ns, "circle");
+      ring.setAttribute("cx", String(p.x));
+      ring.setAttribute("cy", String(p.y));
+      ring.setAttribute("r", String(p.r ?? 4));
+      ring.setAttribute("fill", "none");
+      ring.setAttribute(
+        "stroke",
+        `rgba(255, 220, 150, ${Math.max(0, p.life * 0.7)})`
+      );
+      ring.setAttribute("stroke-width", String(Math.max(0.5, 3 * p.life)));
+      group.appendChild(ring);
+    } else {
+      const dot = document.createElementNS(ns, "circle");
+      dot.setAttribute("cx", String(p.x));
+      dot.setAttribute("cy", String(p.y));
+      dot.setAttribute("r", String(Math.max(0.2, p.size * p.life)));
+      dot.setAttribute(
+        "fill",
+        `hsla(${p.hue}, 100%, 65%, ${Math.max(0, p.life)})`
+      );
+      group.appendChild(dot);
+    }
+  }
 }

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -41,50 +41,50 @@ export function CodeWhipOverlay() {
               <stop offset="100%" stopColor="#1a1008" />
             </linearGradient>
           </defs>
-          {/* Straight wooden handle on the right */}
+          {/* Short straight wooden handle on the right */}
           <path
-            d="M586 268 L508 224"
+            d="M586 268 L548 246"
             fill="none"
             stroke="url(#whip-handle-grad)"
-            strokeWidth="24"
+            strokeWidth="22"
             strokeLinecap="round"
           />
           <path
-            d="M576 260 L528 234"
+            d="M580 262 L558 250"
             fill="none"
             stroke="#6b3f1d"
-            strokeWidth="3.5"
+            strokeWidth="3"
             strokeLinecap="round"
             opacity="0.5"
           />
-          <circle cx="590" cy="270" r="9" fill="#3f2410" />
-          {/* Long cord arcs left toward the tip */}
+          <circle cx="590" cy="270" r="8" fill="#3f2410" />
+          {/* Longer cord arcs left toward the tip */}
           <path
             className="code-whip-cord"
-            d="M508 224 C430 170, 350 118, 270 98 C190 76, 120 92, 70 130 C40 152, 18 178, 4 206 C-6 226, -16 246, -28 268"
+            d="M548 246 C460 188, 370 120, 280 96 C190 70, 110 88, 52 132 C18 158, -8 190, -28 224 C-42 248, -58 274, -78 300"
             fill="none"
             stroke="url(#whip-cord-grad)"
-            strokeWidth="12"
+            strokeWidth="11"
             strokeLinecap="round"
           />
           <path
             className="code-whip-cord-thin"
-            d="M270 98 C190 76, 120 92, 70 130 C40 152, 18 178, 4 206 C-6 226, -16 246, -28 268"
+            d="M280 96 C190 70, 110 88, 52 132 C18 158, -8 190, -28 224 C-42 248, -58 274, -78 300"
             fill="none"
             stroke="#1a1008"
-            strokeWidth="5.5"
+            strokeWidth="5"
             strokeLinecap="round"
           />
-          {/* Longer tip / popper on the left */}
+          {/* Extra-long tip / popper on the left */}
           <path
             className="code-whip-tip"
-            d="M-28 268 L-78 302"
+            d="M-78 300 L-148 348"
             fill="none"
             stroke="#111"
-            strokeWidth="2.8"
+            strokeWidth="2.6"
             strokeLinecap="round"
           />
-          <circle className="code-whip-tip-dot" cx="-80" cy="304" r="4.5" fill="#111" />
+          <circle className="code-whip-tip-dot" cx="-150" cy="350" r="4.5" fill="#111" />
         </svg>
       </div>
       <div className="code-whip-hit-fx" style={hitStyle}>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -25,9 +25,9 @@ export function CodeWhipOverlay() {
       <div className="code-whip-stage" style={aimStyle}>
         <svg
           className="code-whip-svg"
-          viewBox="0 0 720 360"
-          width="720"
-          height="360"
+          viewBox="0 0 560 300"
+          width="560"
+          height="300"
         >
           <defs>
             <linearGradient id="whip-grip-grad" x1="0" y1="0" x2="1" y2="1">
@@ -43,39 +43,39 @@ export function CodeWhipOverlay() {
 
           {/* Short straight handle on the right */}
           <g className="code-whip-handle">
-            <circle cx="678" cy="248" r="11" fill="#2a2a2a" />
-            <circle cx="678" cy="248" r="7" fill="#3d3d3d" />
-            <circle cx="664" cy="240" r="7.5" fill="#d4a017" />
-            <circle cx="664" cy="240" r="4.5" fill="#f0c94a" />
+            <circle cx="508" cy="198" r="10" fill="#2a2a2a" />
+            <circle cx="508" cy="198" r="6.5" fill="#3d3d3d" />
+            <circle cx="496" cy="191" r="7" fill="#d4a017" />
+            <circle cx="496" cy="191" r="4" fill="#f0c94a" />
             <path
-              d="M658 236 L612 210"
+              d="M490 187 L454 166"
               fill="none"
               stroke="url(#whip-grip-grad)"
-              strokeWidth="16"
+              strokeWidth="15"
               strokeLinecap="butt"
             />
             <path
-              d="M650 232 L644 228 M642 227 L636 223 M634 222 L628 218 M626 217 L620 213"
+              d="M484 184 L478 180 M476 179 L470 175 M468 174 L462 170"
               fill="none"
               stroke="#3a1014"
-              strokeWidth="1.6"
+              strokeWidth="1.5"
               strokeLinecap="round"
               opacity="0.55"
             />
-            <circle cx="606" cy="206" r="7.5" fill="#d4a017" />
-            <circle cx="606" cy="206" r="4.5" fill="#f0c94a" />
-            <circle cx="592" cy="198" r="10" fill="#2a2a2a" />
-            <circle cx="592" cy="198" r="6" fill="#3d3d3d" />
+            <circle cx="448" cy="162" r="7" fill="#d4a017" />
+            <circle cx="448" cy="162" r="4" fill="#f0c94a" />
+            <circle cx="436" cy="155" r="9" fill="#2a2a2a" />
+            <circle cx="436" cy="155" r="5.5" fill="#3d3d3d" />
           </g>
 
-          {/* Long thin tip with snake-wave path morph — always visible */}
+          {/* Shorter tip — stays inside viewBox during wind-up */}
           <g className="code-whip-tip">
             <path
               className="code-whip-cord"
-              d="M586 194 C500 150, 420 112, 340 98 C260 84, 180 96, 110 130 C50 160, 0 204, -40 250 C-70 284, -104 318, -140 348"
+              d="M430 152 C370 120, 310 98, 250 96 C190 94, 140 112, 100 140 C70 162, 48 188, 32 214"
               fill="none"
               stroke="url(#whip-tip-grad)"
-              strokeWidth="3.6"
+              strokeWidth="3.4"
               strokeLinecap="round"
             >
               <animate
@@ -86,32 +86,32 @@ export function CodeWhipOverlay() {
                 keyTimes="0;0.2;0.35;0.48;0.58;0.75;1"
                 keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.2 0 0.1 1;0.4 0 0.2 1;0.4 0 0.2 1"
                 values="
-M586 194 C530 170, 470 156, 410 158 C350 160, 290 178, 230 206 C170 234, 110 270, 50 308 C20 328, -10 344, -40 356;
-M586 194 C505 145, 435 108, 365 96 C295 84, 225 100, 155 138 C95 170, 35 216, -15 262 C-45 290, -80 320, -118 346;
-M586 194 C495 158, 420 128, 345 114 C270 100, 195 116, 125 154 C65 186, 10 230, -35 274 C-65 300, -98 328, -132 350;
-M586 194 C508 142, 432 102, 352 88 C272 74, 192 90, 120 130 C58 164, 2 214, -42 262 C-72 292, -108 326, -146 354;
-M586 194 C500 150, 420 112, 340 98 C260 84, 180 96, 110 130 C50 160, 0 204, -40 250 C-70 284, -104 318, -140 348;
-M586 194 C512 156, 432 122, 352 110 C272 98, 192 114, 122 152 C62 184, 12 228, -28 270 C-56 298, -88 328, -124 350;
-M586 194 C518 162, 442 132, 366 122 C290 112, 214 130, 144 168 C90 198, 40 238, 0 276 C-24 300, -52 326, -80 346
+M430 152 C380 138, 330 132, 280 136 C230 140, 185 156, 145 178 C115 196, 90 218, 70 240;
+M430 152 C372 118, 314 96, 256 94 C198 92, 148 112, 108 142 C80 164, 56 192, 38 218;
+M430 152 C368 128, 308 108, 248 104 C188 100, 138 120, 98 150 C70 172, 48 198, 30 222;
+M430 152 C374 116, 316 94, 254 90 C192 86, 140 108, 98 140 C68 164, 44 194, 26 220;
+M430 152 C370 120, 310 98, 250 96 C190 94, 140 112, 100 140 C70 162, 48 188, 32 214;
+M430 152 C374 124, 316 104, 256 100 C196 96, 146 116, 106 146 C78 168, 56 194, 38 218;
+M430 152 C378 130, 324 112, 268 110 C212 108, 164 126, 124 152 C98 170, 78 192, 62 214
 "
               />
             </path>
             <g className="code-whip-cracker">
               <path
-                d="M-118 330 L-162 352"
+                d="M40 208 L18 228"
                 fill="none"
                 stroke="#3f2410"
-                strokeWidth="1.8"
+                strokeWidth="1.7"
                 strokeLinecap="round"
               />
               <path
-                d="M-118 334 L-158 362"
+                d="M40 212 L14 234"
                 fill="none"
                 stroke="#2a1a0c"
-                strokeWidth="1.6"
+                strokeWidth="1.5"
                 strokeLinecap="round"
               />
-              <circle cx="-150" cy="354" r="3.2" fill="#1a1008" />
+              <circle cx="20" cy="226" r="3" fill="#1a1008" />
             </g>
           </g>
         </svg>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -37,7 +37,7 @@ export function CodeWhipOverlay() {
             </linearGradient>
           </defs>
 
-          {/* Short straight handle on the right: pommel → gold → grip → gold → ferrule */}
+          {/* Short straight handle on the right */}
           <g className="code-whip-handle">
             <circle cx="678" cy="248" r="11" fill="#2a2a2a" />
             <circle cx="678" cy="248" r="7" fill="#3d3d3d" />
@@ -64,35 +64,65 @@ export function CodeWhipOverlay() {
             <circle cx="592" cy="198" r="6" fill="#3d3d3d" />
           </g>
 
-          {/* Long thin tip only — no thick lash body */}
-          <g className="code-whip-tip">
-            <path
-              className="code-whip-cord"
-              d="M586 194
-                 C480 140, 360 96, 250 88
-                 C160 82, 80 110, 20 160
-                 C-20 194, -60 240, -100 290
-                 C-118 312, -136 332, -156 350"
-              fill="none"
-              stroke="#2a1a0c"
-              strokeWidth="2.8"
-              strokeLinecap="round"
-            />
-            <path
-              d="M-130 328 L-168 342"
-              fill="none"
-              stroke="#3f2410"
-              strokeWidth="1.4"
-              strokeLinecap="round"
-            />
-            <path
-              d="M-130 332 L-164 358"
-              fill="none"
-              stroke="#2a1a0c"
-              strokeWidth="1.4"
-              strokeLinecap="round"
-            />
-            <circle className="code-whip-tip-dot" cx="-158" cy="352" r="3" fill="#1a1008" />
+          {/* Segmented tip: wave travels handle → tip */}
+          <g className="code-whip-tip code-whip-seg code-whip-seg-1">
+            <g className="code-whip-seg code-whip-seg-2">
+              <g className="code-whip-seg code-whip-seg-3">
+                <g className="code-whip-seg code-whip-seg-4">
+                  <path
+                    className="code-whip-cord"
+                    d="M586 194
+                       C500 150, 420 112, 340 98
+                       C260 84, 180 96, 110 130
+                       C50 160, 0 204, -40 250
+                       C-70 284, -104 318, -140 348"
+                    fill="none"
+                    stroke="#2a1a0c"
+                    strokeWidth="2.8"
+                    strokeLinecap="round"
+                  >
+                    <animate
+                      attributeName="d"
+                      dur="2.3s"
+                      fill="freeze"
+                      keyTimes="0;0.18;0.32;0.45;0.55;0.72;1"
+                      values="
+M586 194 C520 168, 460 150, 400 148 C340 146, 280 160, 220 186 C160 212, 100 250, 40 292 C10 314, -20 334, -50 350;
+M586 194 C500 140, 430 100, 360 92 C290 84, 220 100, 150 136 C90 168, 30 214, -20 260 C-50 288, -84 318, -120 344;
+M586 194 C490 160, 410 130, 330 118 C250 106, 170 120, 100 156 C40 188, -10 232, -50 276 C-78 302, -110 328, -142 350;
+M586 194 C505 145, 425 105, 345 90 C265 76, 185 90, 115 128 C55 160, 0 208, -45 256 C-75 288, -110 322, -148 352;
+M586 194 C500 150, 420 112, 340 98 C260 84, 180 96, 110 130 C50 160, 0 204, -40 250 C-70 284, -104 318, -140 348;
+M586 194 C510 155, 430 120, 350 108 C270 96, 190 110, 120 148 C60 180, 10 224, -30 268 C-58 296, -90 326, -128 350;
+M586 194 C515 160, 440 130, 365 120 C290 110, 215 128, 145 164 C90 194, 40 234, 0 272 C-24 296, -52 322, -80 344
+"
+                    />
+                  </path>
+                  <g className="code-whip-cracker">
+                    <path
+                      d="M-118 330 L-158 348"
+                      fill="none"
+                      stroke="#3f2410"
+                      strokeWidth="1.4"
+                      strokeLinecap="round"
+                    />
+                    <path
+                      d="M-118 334 L-154 360"
+                      fill="none"
+                      stroke="#2a1a0c"
+                      strokeWidth="1.4"
+                      strokeLinecap="round"
+                    />
+                    <circle
+                      className="code-whip-tip-dot"
+                      cx="-148"
+                      cy="352"
+                      r="3"
+                      fill="#1a1008"
+                    />
+                  </g>
+                </g>
+              </g>
+            </g>
           </g>
         </svg>
       </div>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -25,9 +25,9 @@ export function CodeWhipOverlay() {
       <div className="code-whip-stage" style={aimStyle}>
         <svg
           className="code-whip-svg"
-          viewBox="0 0 520 320"
-          width="520"
-          height="320"
+          viewBox="0 0 640 360"
+          width="640"
+          height="360"
         >
           <defs>
             <linearGradient id="whip-handle-grad" x1="1" y1="0" x2="0" y2="1">
@@ -37,54 +37,54 @@ export function CodeWhipOverlay() {
             </linearGradient>
             <linearGradient id="whip-cord-grad" x1="1" y1="0" x2="0" y2="0">
               <stop offset="0%" stopColor="#4a2c14" />
-              <stop offset="70%" stopColor="#2b1a0d" />
+              <stop offset="55%" stopColor="#2b1a0d" />
               <stop offset="100%" stopColor="#1a1008" />
             </linearGradient>
           </defs>
           {/* Straight wooden handle on the right */}
           <path
-            d="M472 236 L402 198"
+            d="M586 268 L508 224"
             fill="none"
             stroke="url(#whip-handle-grad)"
-            strokeWidth="22"
+            strokeWidth="24"
             strokeLinecap="round"
           />
           <path
-            d="M464 230 L418 206"
+            d="M576 260 L528 234"
             fill="none"
             stroke="#6b3f1d"
             strokeWidth="3.5"
             strokeLinecap="round"
             opacity="0.5"
           />
-          <circle cx="476" cy="238" r="8" fill="#3f2410" />
-          {/* Cord arcs left toward the tip */}
+          <circle cx="590" cy="270" r="9" fill="#3f2410" />
+          {/* Long cord arcs left toward the tip */}
           <path
             className="code-whip-cord"
-            d="M402 198 C348 160, 292 118, 236 102 C176 84, 118 96, 72 132 C48 148, 30 166, 18 186"
+            d="M508 224 C430 170, 350 118, 270 98 C190 76, 120 92, 70 130 C40 152, 18 178, 4 206 C-6 226, -16 246, -28 268"
             fill="none"
             stroke="url(#whip-cord-grad)"
-            strokeWidth="11"
+            strokeWidth="12"
             strokeLinecap="round"
           />
           <path
             className="code-whip-cord-thin"
-            d="M236 102 C176 84, 118 96, 72 132 C48 148, 30 166, 18 186"
+            d="M270 98 C190 76, 120 92, 70 130 C40 152, 18 178, 4 206 C-6 226, -16 246, -28 268"
             fill="none"
             stroke="#1a1008"
-            strokeWidth="5"
+            strokeWidth="5.5"
             strokeLinecap="round"
           />
-          {/* Tip / popper on the left */}
+          {/* Longer tip / popper on the left */}
           <path
             className="code-whip-tip"
-            d="M18 186 L-8 204"
+            d="M-28 268 L-78 302"
             fill="none"
             stroke="#111"
-            strokeWidth="2.5"
+            strokeWidth="2.8"
             strokeLinecap="round"
           />
-          <circle className="code-whip-tip-dot" cx="-10" cy="206" r="4" fill="#111" />
+          <circle className="code-whip-tip-dot" cx="-80" cy="304" r="4.5" fill="#111" />
         </svg>
       </div>
       <div className="code-whip-hit-fx" style={hitStyle}>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useWhipEffectStore } from "@/store/whipEffectStore";
@@ -6,42 +7,91 @@ export function CodeWhipOverlay() {
   const { t } = useTranslation();
   const active = useWhipEffectStore((s) => s.active);
   const nonce = useWhipEffectStore((s) => s.nonce);
-  if (!active) return null;
+  const target = useWhipEffectStore((s) => s.target);
+  if (!active || !target) return null;
+
+  const hitStyle: CSSProperties = {
+    left: `${target.x}px`,
+    top: `${target.y}px`
+  };
+  const aimStyle = {
+    "--whip-hit-x": `${target.x}px`,
+    "--whip-hit-y": `${target.y}px`
+  } as CSSProperties;
 
   return (
     <div className="code-whip-overlay" key={nonce} aria-hidden="true">
-      <div className="code-whip-flash" />
-      <div className="code-whip-stage">
+      <div className="code-whip-flash" style={aimStyle} />
+      <div className="code-whip-stage" style={aimStyle}>
         <svg
           className="code-whip-svg"
-          viewBox="0 0 640 360"
-          width="640"
-          height="360"
+          viewBox="0 0 520 320"
+          width="520"
+          height="320"
         >
+          <defs>
+            <linearGradient id="whip-handle-grad" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stopColor="#c48a4a" />
+              <stop offset="55%" stopColor="#8b5a2b" />
+              <stop offset="100%" stopColor="#5c3317" />
+            </linearGradient>
+            <linearGradient id="whip-cord-grad" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor="#4a2c14" />
+              <stop offset="70%" stopColor="#2b1a0d" />
+              <stop offset="100%" stopColor="#1a1008" />
+            </linearGradient>
+          </defs>
           <path
-            className="code-whip-handle"
-            d="M72 268 L168 214"
+            d="M46 248 C52 236, 70 228, 92 220 L118 208"
             fill="none"
-            stroke="#8B5A2B"
-            strokeWidth="18"
+            stroke="url(#whip-handle-grad)"
+            strokeWidth="22"
             strokeLinecap="round"
           />
+          <path
+            d="M54 246 C60 238, 74 232, 90 224"
+            fill="none"
+            stroke="#6b3f1d"
+            strokeWidth="4"
+            strokeLinecap="round"
+            opacity="0.55"
+          />
+          <circle cx="48" cy="250" r="8" fill="#3f2410" />
           <path
             className="code-whip-cord"
-            d="M168 214 C268 132, 390 78, 560 96"
+            d="M118 208 C168 168, 214 112, 268 92 C330 68, 392 78, 458 118 C478 130, 492 148, 502 168"
             fill="none"
-            stroke="#5C3317"
-            strokeWidth="10"
+            stroke="url(#whip-cord-grad)"
+            strokeWidth="11"
             strokeLinecap="round"
           />
-          <circle className="code-whip-tip" cx="560" cy="96" r="12" fill="#3f2a14" />
+          <path
+            className="code-whip-cord-thin"
+            d="M268 92 C330 68, 392 78, 458 118 C478 130, 492 148, 502 168"
+            fill="none"
+            stroke="#1a1008"
+            strokeWidth="5"
+            strokeLinecap="round"
+          />
+          <path
+            className="code-whip-tip"
+            d="M502 168 L528 186"
+            fill="none"
+            stroke="#111"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+          />
+          <circle className="code-whip-tip-dot" cx="530" cy="188" r="4" fill="#111" />
         </svg>
       </div>
-      <div className="code-whip-crack">{t("message.whipCrack")}</div>
-      <div className="code-whip-spark code-whip-spark-1" />
-      <div className="code-whip-spark code-whip-spark-2" />
-      <div className="code-whip-spark code-whip-spark-3" />
-      <div className="code-whip-spark code-whip-spark-4" />
+      <div className="code-whip-hit-fx" style={hitStyle}>
+        <div className="code-whip-impact" />
+        <div className="code-whip-crack">{t("message.whipCrack")}</div>
+        <div className="code-whip-spark code-whip-spark-1" />
+        <div className="code-whip-spark code-whip-spark-2" />
+        <div className="code-whip-spark code-whip-spark-3" />
+        <div className="code-whip-spark code-whip-spark-4" />
+      </div>
     </div>
   );
 }

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from "react-i18next";
+
+import { useWhipEffectStore } from "@/store/whipEffectStore";
+
+export function CodeWhipOverlay() {
+  const { t } = useTranslation();
+  const active = useWhipEffectStore((s) => s.active);
+  const nonce = useWhipEffectStore((s) => s.nonce);
+  if (!active) return null;
+
+  return (
+    <div className="code-whip-overlay" key={nonce} aria-hidden="true">
+      <div className="code-whip-flash" />
+      <div className="code-whip-stage">
+        <svg
+          className="code-whip-svg"
+          viewBox="0 0 640 360"
+          width="640"
+          height="360"
+        >
+          <path
+            className="code-whip-handle"
+            d="M72 268 L168 214"
+            fill="none"
+            stroke="#8B5A2B"
+            strokeWidth="18"
+            strokeLinecap="round"
+          />
+          <path
+            className="code-whip-cord"
+            d="M168 214 C268 132, 390 78, 560 96"
+            fill="none"
+            stroke="#5C3317"
+            strokeWidth="10"
+            strokeLinecap="round"
+          />
+          <circle className="code-whip-tip" cx="560" cy="96" r="12" fill="#3f2a14" />
+        </svg>
+      </div>
+      <div className="code-whip-crack">{t("message.whipCrack")}</div>
+      <div className="code-whip-spark code-whip-spark-1" />
+      <div className="code-whip-spark code-whip-spark-2" />
+      <div className="code-whip-spark code-whip-spark-3" />
+      <div className="code-whip-spark code-whip-spark-4" />
+    </div>
+  );
+}

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -35,22 +35,14 @@ export function CodeWhipOverlay() {
               <stop offset="45%" stopColor="#6b1f24" />
               <stop offset="100%" stopColor="#4a1418" />
             </linearGradient>
-            <linearGradient id="whip-lash-grad" x1="1" y1="0" x2="0" y2="0">
-              <stop offset="0%" stopColor="#8b5a2b" />
-              <stop offset="55%" stopColor="#6b4220" />
-              <stop offset="100%" stopColor="#4a2c14" />
-            </linearGradient>
           </defs>
 
           {/* Short straight handle on the right: pommel → gold → grip → gold → ferrule */}
           <g className="code-whip-handle">
-            {/* pommel (right end) */}
             <circle cx="678" cy="248" r="11" fill="#2a2a2a" />
             <circle cx="678" cy="248" r="7" fill="#3d3d3d" />
-            {/* gold ring */}
             <circle cx="664" cy="240" r="7.5" fill="#d4a017" />
             <circle cx="664" cy="240" r="4.5" fill="#f0c94a" />
-            {/* maroon wrapped grip (short & straight) */}
             <path
               d="M658 236 L612 210"
               fill="none"
@@ -58,7 +50,6 @@ export function CodeWhipOverlay() {
               strokeWidth="16"
               strokeLinecap="butt"
             />
-            {/* wrap ridges */}
             <path
               d="M650 232 L644 228 M642 227 L636 223 M634 222 L628 218 M626 217 L620 213"
               fill="none"
@@ -67,62 +58,41 @@ export function CodeWhipOverlay() {
               strokeLinecap="round"
               opacity="0.55"
             />
-            {/* gold ring */}
             <circle cx="606" cy="206" r="7.5" fill="#d4a017" />
             <circle cx="606" cy="206" r="4.5" fill="#f0c94a" />
-            {/* ferrule / throat (left end of handle) */}
             <circle cx="592" cy="198" r="10" fill="#2a2a2a" />
             <circle cx="592" cy="198" r="6" fill="#3d3d3d" />
           </g>
 
-          {/* Long brown lash extending left in an S-curve */}
-          <path
-            className="code-whip-cord"
-            d="M586 194
-               C520 150, 460 108, 390 92
-               C310 72, 240 88, 180 120
-               C120 152, 70 188, 30 230
-               C8 254, -12 280, -36 308"
-            fill="none"
-            stroke="url(#whip-lash-grad)"
-            strokeWidth="10"
-            strokeLinecap="round"
-          />
-          <path
-            className="code-whip-cord-thin"
-            d="M390 92
-               C310 72, 240 88, 180 120
-               C120 152, 70 188, 30 230
-               C8 254, -12 280, -36 308"
-            fill="none"
-            stroke="#3f2410"
-            strokeWidth="5"
-            strokeLinecap="round"
-          />
-          {/* Frayed cracker / popper */}
+          {/* Long thin tip only — no thick lash body */}
           <g className="code-whip-tip">
             <path
-              d="M-36 308 L-92 344"
+              className="code-whip-cord"
+              d="M586 194
+                 C480 140, 360 96, 250 88
+                 C160 82, 80 110, 20 160
+                 C-20 194, -60 240, -100 290
+                 C-118 312, -136 332, -156 350"
               fill="none"
               stroke="#2a1a0c"
-              strokeWidth="2.4"
+              strokeWidth="2.8"
               strokeLinecap="round"
             />
             <path
-              d="M-70 328 L-98 336"
+              d="M-130 328 L-168 342"
               fill="none"
               stroke="#3f2410"
               strokeWidth="1.4"
               strokeLinecap="round"
             />
             <path
-              d="M-70 330 L-96 350"
+              d="M-130 332 L-164 358"
               fill="none"
               stroke="#2a1a0c"
               strokeWidth="1.4"
               strokeLinecap="round"
             />
-            <circle className="code-whip-tip-dot" cx="-94" cy="346" r="3" fill="#1a1008" />
+            <circle className="code-whip-tip-dot" cx="-158" cy="352" r="3" fill="#1a1008" />
           </g>
         </svg>
       </div>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -19,6 +19,7 @@ export function CodeWhipOverlay() {
   const active = useWhipEffectStore((s) => s.active);
   const nonce = useWhipEffectStore((s) => s.nonce);
   const target = useWhipEffectStore((s) => s.target);
+  const power = useWhipEffectStore((s) => s.power);
 
   const stageRef = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<SVGGElement | null>(null);
@@ -30,7 +31,7 @@ export function CodeWhipOverlay() {
   useEffect(() => {
     if (!active) return;
 
-    const sim = createWhipSimulation();
+    const sim = createWhipSimulation(WHIP_ATTACH_POINT, { power });
     const paint = (
       elapsed: number,
       frame: ReturnType<typeof sim.advanceTo>,
@@ -80,7 +81,23 @@ export function CodeWhipOverlay() {
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [active, nonce]);
+  }, [active, nonce, power]);
+
+  const stars = useMemo(() => {
+    const count = Math.round(14 + power * 8);
+    const colors = ["#fde047", "#fef08a", "#fbbf24", "#fff7cd", "#facc15", "#ffffff"];
+    return Array.from({ length: count }, () => {
+      const angle = Math.random() * Math.PI * 2;
+      const dist = 38 + Math.random() * 64;
+      return {
+        bx: Math.cos(angle) * dist,
+        by: Math.sin(angle) * dist - 12,
+        delay: 1.0 + Math.random() * 0.14,
+        size: 12 + Math.random() * 14,
+        color: colors[Math.floor(Math.random() * colors.length)]
+      };
+    });
+  }, [nonce, power]);
 
   if (!active || !target) return null;
 
@@ -94,8 +111,9 @@ export function CodeWhipOverlay() {
   } as CSSProperties;
 
   return (
-    <div className="code-whip-overlay" key={nonce} aria-hidden="true">
+    <div className="code-whip-overlay" key={nonce} aria-hidden="true" style={{ "--whip-power": power } as CSSProperties}>
       <div className="code-whip-flash" style={aimStyle} />
+      <div className="code-whip-shake">
       <div
         className="code-whip-stage"
         ref={stageRef}
@@ -109,9 +127,8 @@ export function CodeWhipOverlay() {
         >
           <defs>
             <linearGradient id="whip-grip-grad" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stopColor="#8a2f2f" />
-              <stop offset="45%" stopColor="#6b1f24" />
-              <stop offset="100%" stopColor="#4a1418" />
+              <stop offset="0%" stopColor="#8b5a2b" />
+              <stop offset="100%" stopColor="#5c3a1a" />
             </linearGradient>
           </defs>
 
@@ -121,29 +138,13 @@ export function CodeWhipOverlay() {
             distance-constrained rope driven by that same root motion.
           */}
           <g className="code-whip-handle" ref={handleRef}>
-            <circle cx="508" cy="198" r="10" fill="#2a2a2a" />
-            <circle cx="508" cy="198" r="6.5" fill="#3d3d3d" />
-            <circle cx="496" cy="191" r="7" fill="#d4a017" />
-            <circle cx="496" cy="191" r="4" fill="#f0c94a" />
             <path
-              d="M490 187 L454 166"
+              d="M436 156 L506 198"
               fill="none"
               stroke="url(#whip-grip-grad)"
-              strokeWidth="15"
-              strokeLinecap="butt"
-            />
-            <path
-              d="M484 184 L478 180 M476 179 L470 175 M468 174 L462 170"
-              fill="none"
-              stroke="#3a1014"
-              strokeWidth="1.5"
+              strokeWidth="13"
               strokeLinecap="round"
-              opacity="0.55"
             />
-            <circle cx="448" cy="162" r="7" fill="#d4a017" />
-            <circle cx="448" cy="162" r="4" fill="#f0c94a" />
-            <circle cx="436" cy="155" r="9" fill="#2a2a2a" />
-            <circle cx="436" cy="155" r="5.5" fill="#3d3d3d" />
           </g>
 
           <g className="code-whip-tip">
@@ -185,12 +186,22 @@ export function CodeWhipOverlay() {
         </svg>
       </div>
       <div className="code-whip-hit-fx" style={hitStyle}>
-        <div className="code-whip-impact" />
         <div className="code-whip-crack">{t("message.whipCrack")}</div>
-        <div className="code-whip-spark code-whip-spark-1" />
-        <div className="code-whip-spark code-whip-spark-2" />
-        <div className="code-whip-spark code-whip-spark-3" />
-        <div className="code-whip-spark code-whip-spark-4" />
+        {stars.map((s, i) => (
+          <span
+            key={i}
+            className="code-whip-star"
+            style={{
+              "--bx": `${s.bx}px`,
+              "--by": `${s.by}px`,
+              width: `${s.size}px`,
+              height: `${s.size}px`,
+              background: s.color,
+              animationDelay: `${s.delay}s`
+            } as CSSProperties}
+          />
+        ))}
+      </div>
       </div>
     </div>
   );

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -1,13 +1,56 @@
-import type { CSSProperties } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useWhipEffectStore } from "@/store/whipEffectStore";
+import {
+  useWhipEffectStore,
+  WHIP_EFFECT_MS,
+  WHIP_HIT_AT_MS
+} from "@/store/whipEffectStore";
+import { computeWhipFrame } from "@/utils/whipMotion";
 
 export function CodeWhipOverlay() {
   const { t } = useTranslation();
   const active = useWhipEffectStore((s) => s.active);
   const nonce = useWhipEffectStore((s) => s.nonce);
   const target = useWhipEffectStore((s) => s.target);
+
+  const ropeRef = useRef<SVGPathElement | null>(null);
+  const baseRef = useRef<SVGPathElement | null>(null);
+  const crackerRef = useRef<SVGGElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const applyFrame = (elapsed: number) => {
+      const frame = computeWhipFrame(elapsed, WHIP_HIT_AT_MS);
+      ropeRef.current?.setAttribute("d", frame.ropeD);
+      baseRef.current?.setAttribute("d", frame.baseD);
+      crackerRef.current?.setAttribute(
+        "transform",
+        `translate(${frame.tipX} ${frame.tipY}) rotate(${(frame.tipAngle * 180) / Math.PI})`
+      );
+    };
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) {
+      // Hold a single "mid-crack" pose instead of animating through the
+      // full wind-up/snap/ring-down sequence.
+      applyFrame(WHIP_HIT_AT_MS + 60);
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = () => {
+      const elapsed = Math.min(performance.now() - start, WHIP_EFFECT_MS);
+      applyFrame(elapsed);
+      if (elapsed < WHIP_EFFECT_MS) {
+        raf = requestAnimationFrame(tick);
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [active, nonce]);
+
   if (!active || !target) return null;
 
   const hitStyle: CSSProperties = {
@@ -65,76 +108,46 @@ export function CodeWhipOverlay() {
           </g>
 
           {/*
-            Jointed lash: a kinematic chain of nested groups, each pivoting
-            at the previous segment's end. A traveling wave (increasing
-            amplitude + delayed phase per joint) simulates a real bullwhip
-            crack instead of a single warped path.
+            Rope driven by requestAnimationFrame (see computeWhipFrame): a
+            continuous traveling wave, not discrete CSS keyframes, so the
+            lash flows like a real cracking whip rather than a jointed arm.
+            The thicker base path fakes a taper toward the thin tip.
           */}
           <g className="code-whip-tip">
             <path
-              className="code-whip-seg code-whip-seg-1"
-              d="M430 152 L372 150"
+              ref={baseRef}
+              className="code-whip-base"
               fill="none"
-              stroke="#6b4220"
-              strokeWidth="3.6"
+              stroke="#5c3819"
+              strokeWidth="4.2"
               strokeLinecap="round"
             />
-            <g className="code-whip-joint code-whip-joint-1">
+            <path
+              ref={ropeRef}
+              className="code-whip-rope"
+              fill="none"
+              stroke="#2a1a0c"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+            />
+            <g ref={crackerRef} className="code-whip-cracker">
+              {/* Local +x continues along the rope's current direction
+                  (rotate() maps it there), so these extend past the tip. */}
               <path
-                className="code-whip-seg code-whip-seg-2"
-                d="M372 150 L312 158"
+                d="M0 0 L22 -8"
                 fill="none"
-                stroke="#5c3819"
-                strokeWidth="3.2"
+                stroke="#2a1a0c"
+                strokeWidth="1.6"
                 strokeLinecap="round"
               />
-              <g className="code-whip-joint code-whip-joint-2">
-                <path
-                  className="code-whip-seg code-whip-seg-3"
-                  d="M312 158 L246 178"
-                  fill="none"
-                  stroke="#4d3015"
-                  strokeWidth="2.8"
-                  strokeLinecap="round"
-                />
-                <g className="code-whip-joint code-whip-joint-3">
-                  <path
-                    className="code-whip-seg code-whip-seg-4"
-                    d="M246 178 L176 204"
-                    fill="none"
-                    stroke="#3f2712"
-                    strokeWidth="2.4"
-                    strokeLinecap="round"
-                  />
-                  <g className="code-whip-joint code-whip-joint-4">
-                    <path
-                      className="code-whip-seg code-whip-seg-5"
-                      d="M176 204 L108 226"
-                      fill="none"
-                      stroke="#2a1a0c"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                    />
-                    <g className="code-whip-cracker">
-                      <path
-                        d="M108 226 L86 234"
-                        fill="none"
-                        stroke="#2a1a0c"
-                        strokeWidth="1.6"
-                        strokeLinecap="round"
-                      />
-                      <path
-                        d="M108 230 L82 240"
-                        fill="none"
-                        stroke="#1a1008"
-                        strokeWidth="1.4"
-                        strokeLinecap="round"
-                      />
-                      <circle cx="88" cy="236" r="3" fill="#1a1008" />
-                    </g>
-                  </g>
-                </g>
-              </g>
+              <path
+                d="M0 2 L26 14"
+                fill="none"
+                stroke="#1a1008"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+              />
+              <circle cx="18" cy="4" r="3" fill="#1a1008" />
             </g>
           </g>
         </svg>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -6,7 +6,7 @@ import {
   WHIP_EFFECT_MS,
   WHIP_HIT_AT_MS
 } from "@/store/whipEffectStore";
-import { computeWhipFrame } from "@/utils/whipMotion";
+import { computeArmSwing, computeWhipFrame } from "@/utils/whipMotion";
 
 export function CodeWhipOverlay() {
   const { t } = useTranslation();
@@ -14,14 +14,20 @@ export function CodeWhipOverlay() {
   const nonce = useWhipEffectStore((s) => s.nonce);
   const target = useWhipEffectStore((s) => s.target);
 
+  const stageRef = useRef<HTMLDivElement | null>(null);
   const ropeRef = useRef<SVGPathElement | null>(null);
   const baseRef = useRef<SVGPathElement | null>(null);
   const crackerRef = useRef<SVGGElement | null>(null);
 
   useEffect(() => {
     if (!active) return;
-    const applyFrame = (elapsed: number) => {
+    const applyFrame = (elapsed: number, opacityOverride?: number) => {
+      const swing = computeArmSwing(elapsed, WHIP_HIT_AT_MS, WHIP_EFFECT_MS);
       const frame = computeWhipFrame(elapsed, WHIP_HIT_AT_MS);
+      if (stageRef.current) {
+        stageRef.current.style.transform = `rotate(${swing.deg}deg) scale(${swing.scale})`;
+        stageRef.current.style.opacity = String(opacityOverride ?? swing.opacity);
+      }
       ropeRef.current?.setAttribute("d", frame.ropeD);
       baseRef.current?.setAttribute("d", frame.baseD);
       crackerRef.current?.setAttribute(
@@ -35,7 +41,7 @@ export function CodeWhipOverlay() {
     if (reduceMotion) {
       // Hold a single "mid-crack" pose instead of animating through the
       // full wind-up/snap/ring-down sequence.
-      applyFrame(WHIP_HIT_AT_MS + 60);
+      applyFrame(WHIP_HIT_AT_MS + 60, 1);
       return;
     }
     let raf = 0;
@@ -65,7 +71,11 @@ export function CodeWhipOverlay() {
   return (
     <div className="code-whip-overlay" key={nonce} aria-hidden="true">
       <div className="code-whip-flash" style={aimStyle} />
-      <div className="code-whip-stage" style={aimStyle}>
+      <div
+        className="code-whip-stage"
+        ref={stageRef}
+        style={{ ...aimStyle, opacity: 0 }}
+      >
         <svg
           className="code-whip-svg"
           viewBox="0 0 560 300"

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -25,66 +25,105 @@ export function CodeWhipOverlay() {
       <div className="code-whip-stage" style={aimStyle}>
         <svg
           className="code-whip-svg"
-          viewBox="0 0 640 360"
-          width="640"
+          viewBox="0 0 720 360"
+          width="720"
           height="360"
         >
           <defs>
-            <linearGradient id="whip-handle-grad" x1="1" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#c48a4a" />
-              <stop offset="55%" stopColor="#8b5a2b" />
-              <stop offset="100%" stopColor="#5c3317" />
+            <linearGradient id="whip-grip-grad" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stopColor="#8a2f2f" />
+              <stop offset="45%" stopColor="#6b1f24" />
+              <stop offset="100%" stopColor="#4a1418" />
             </linearGradient>
-            <linearGradient id="whip-cord-grad" x1="1" y1="0" x2="0" y2="0">
-              <stop offset="0%" stopColor="#4a2c14" />
-              <stop offset="55%" stopColor="#2b1a0d" />
-              <stop offset="100%" stopColor="#1a1008" />
+            <linearGradient id="whip-lash-grad" x1="1" y1="0" x2="0" y2="0">
+              <stop offset="0%" stopColor="#8b5a2b" />
+              <stop offset="55%" stopColor="#6b4220" />
+              <stop offset="100%" stopColor="#4a2c14" />
             </linearGradient>
           </defs>
-          {/* Short straight wooden handle on the right */}
-          <path
-            d="M586 268 L548 246"
-            fill="none"
-            stroke="url(#whip-handle-grad)"
-            strokeWidth="22"
-            strokeLinecap="round"
-          />
-          <path
-            d="M580 262 L558 250"
-            fill="none"
-            stroke="#6b3f1d"
-            strokeWidth="3"
-            strokeLinecap="round"
-            opacity="0.5"
-          />
-          <circle cx="590" cy="270" r="8" fill="#3f2410" />
-          {/* Longer cord arcs left toward the tip */}
+
+          {/* Short straight handle on the right: pommel → gold → grip → gold → ferrule */}
+          <g className="code-whip-handle">
+            {/* pommel (right end) */}
+            <circle cx="678" cy="248" r="11" fill="#2a2a2a" />
+            <circle cx="678" cy="248" r="7" fill="#3d3d3d" />
+            {/* gold ring */}
+            <circle cx="664" cy="240" r="7.5" fill="#d4a017" />
+            <circle cx="664" cy="240" r="4.5" fill="#f0c94a" />
+            {/* maroon wrapped grip (short & straight) */}
+            <path
+              d="M658 236 L612 210"
+              fill="none"
+              stroke="url(#whip-grip-grad)"
+              strokeWidth="16"
+              strokeLinecap="butt"
+            />
+            {/* wrap ridges */}
+            <path
+              d="M650 232 L644 228 M642 227 L636 223 M634 222 L628 218 M626 217 L620 213"
+              fill="none"
+              stroke="#3a1014"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              opacity="0.55"
+            />
+            {/* gold ring */}
+            <circle cx="606" cy="206" r="7.5" fill="#d4a017" />
+            <circle cx="606" cy="206" r="4.5" fill="#f0c94a" />
+            {/* ferrule / throat (left end of handle) */}
+            <circle cx="592" cy="198" r="10" fill="#2a2a2a" />
+            <circle cx="592" cy="198" r="6" fill="#3d3d3d" />
+          </g>
+
+          {/* Long brown lash extending left in an S-curve */}
           <path
             className="code-whip-cord"
-            d="M548 246 C460 188, 370 120, 280 96 C190 70, 110 88, 52 132 C18 158, -8 190, -28 224 C-42 248, -58 274, -78 300"
+            d="M586 194
+               C520 150, 460 108, 390 92
+               C310 72, 240 88, 180 120
+               C120 152, 70 188, 30 230
+               C8 254, -12 280, -36 308"
             fill="none"
-            stroke="url(#whip-cord-grad)"
-            strokeWidth="11"
+            stroke="url(#whip-lash-grad)"
+            strokeWidth="10"
             strokeLinecap="round"
           />
           <path
             className="code-whip-cord-thin"
-            d="M280 96 C190 70, 110 88, 52 132 C18 158, -8 190, -28 224 C-42 248, -58 274, -78 300"
+            d="M390 92
+               C310 72, 240 88, 180 120
+               C120 152, 70 188, 30 230
+               C8 254, -12 280, -36 308"
             fill="none"
-            stroke="#1a1008"
+            stroke="#3f2410"
             strokeWidth="5"
             strokeLinecap="round"
           />
-          {/* Extra-long tip / popper on the left */}
-          <path
-            className="code-whip-tip"
-            d="M-78 300 L-148 348"
-            fill="none"
-            stroke="#111"
-            strokeWidth="2.6"
-            strokeLinecap="round"
-          />
-          <circle className="code-whip-tip-dot" cx="-150" cy="350" r="4.5" fill="#111" />
+          {/* Frayed cracker / popper */}
+          <g className="code-whip-tip">
+            <path
+              d="M-36 308 L-92 344"
+              fill="none"
+              stroke="#2a1a0c"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+            />
+            <path
+              d="M-70 328 L-98 336"
+              fill="none"
+              stroke="#3f2410"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+            />
+            <path
+              d="M-70 330 L-96 350"
+              fill="none"
+              stroke="#2a1a0c"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+            />
+            <circle className="code-whip-tip-dot" cx="-94" cy="346" r="3" fill="#1a1008" />
+          </g>
         </svg>
       </div>
       <div className="code-whip-hit-fx" style={hitStyle}>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -35,10 +35,6 @@ export function CodeWhipOverlay() {
               <stop offset="45%" stopColor="#6b1f24" />
               <stop offset="100%" stopColor="#4a1418" />
             </linearGradient>
-            <linearGradient id="whip-tip-grad" x1="1" y1="0" x2="0" y2="0">
-              <stop offset="0%" stopColor="#6b4220" />
-              <stop offset="100%" stopColor="#2a1a0c" />
-            </linearGradient>
           </defs>
 
           {/* Short straight handle on the right */}
@@ -68,50 +64,77 @@ export function CodeWhipOverlay() {
             <circle cx="436" cy="155" r="5.5" fill="#3d3d3d" />
           </g>
 
-          {/* Shorter tip — stays inside viewBox during wind-up */}
+          {/*
+            Jointed lash: a kinematic chain of nested groups, each pivoting
+            at the previous segment's end. A traveling wave (increasing
+            amplitude + delayed phase per joint) simulates a real bullwhip
+            crack instead of a single warped path.
+          */}
           <g className="code-whip-tip">
             <path
-              className="code-whip-cord"
-              d="M430 152 C370 120, 310 98, 250 96 C190 94, 140 112, 100 140 C70 162, 48 188, 32 214"
+              className="code-whip-seg code-whip-seg-1"
+              d="M430 152 L372 150"
               fill="none"
-              stroke="url(#whip-tip-grad)"
-              strokeWidth="3.4"
+              stroke="#6b4220"
+              strokeWidth="3.6"
               strokeLinecap="round"
-            >
-              <animate
-                attributeName="d"
-                dur="2.3s"
-                fill="freeze"
-                calcMode="spline"
-                keyTimes="0;0.2;0.35;0.48;0.58;0.75;1"
-                keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.2 0 0.1 1;0.4 0 0.2 1;0.4 0 0.2 1"
-                values="
-M430 152 C380 138, 330 132, 280 136 C230 140, 185 156, 145 178 C115 196, 90 218, 70 240;
-M430 152 C372 118, 314 96, 256 94 C198 92, 148 112, 108 142 C80 164, 56 192, 38 218;
-M430 152 C368 128, 308 108, 248 104 C188 100, 138 120, 98 150 C70 172, 48 198, 30 222;
-M430 152 C374 116, 316 94, 254 90 C192 86, 140 108, 98 140 C68 164, 44 194, 26 220;
-M430 152 C370 120, 310 98, 250 96 C190 94, 140 112, 100 140 C70 162, 48 188, 32 214;
-M430 152 C374 124, 316 104, 256 100 C196 96, 146 116, 106 146 C78 168, 56 194, 38 218;
-M430 152 C378 130, 324 112, 268 110 C212 108, 164 126, 124 152 C98 170, 78 192, 62 214
-"
-              />
-            </path>
-            <g className="code-whip-cracker">
+            />
+            <g className="code-whip-joint code-whip-joint-1">
               <path
-                d="M40 208 L18 228"
+                className="code-whip-seg code-whip-seg-2"
+                d="M372 150 L312 158"
                 fill="none"
-                stroke="#3f2410"
-                strokeWidth="1.7"
+                stroke="#5c3819"
+                strokeWidth="3.2"
                 strokeLinecap="round"
               />
-              <path
-                d="M40 212 L14 234"
-                fill="none"
-                stroke="#2a1a0c"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              />
-              <circle cx="20" cy="226" r="3" fill="#1a1008" />
+              <g className="code-whip-joint code-whip-joint-2">
+                <path
+                  className="code-whip-seg code-whip-seg-3"
+                  d="M312 158 L246 178"
+                  fill="none"
+                  stroke="#4d3015"
+                  strokeWidth="2.8"
+                  strokeLinecap="round"
+                />
+                <g className="code-whip-joint code-whip-joint-3">
+                  <path
+                    className="code-whip-seg code-whip-seg-4"
+                    d="M246 178 L176 204"
+                    fill="none"
+                    stroke="#3f2712"
+                    strokeWidth="2.4"
+                    strokeLinecap="round"
+                  />
+                  <g className="code-whip-joint code-whip-joint-4">
+                    <path
+                      className="code-whip-seg code-whip-seg-5"
+                      d="M176 204 L108 226"
+                      fill="none"
+                      stroke="#2a1a0c"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
+                    <g className="code-whip-cracker">
+                      <path
+                        d="M108 226 L86 234"
+                        fill="none"
+                        stroke="#2a1a0c"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                      />
+                      <path
+                        d="M108 230 L82 240"
+                        fill="none"
+                        stroke="#1a1008"
+                        strokeWidth="1.4"
+                        strokeLinecap="round"
+                      />
+                      <circle cx="88" cy="236" r="3" fill="#1a1008" />
+                    </g>
+                  </g>
+                </g>
+              </g>
             </g>
           </g>
         </svg>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -35,6 +35,10 @@ export function CodeWhipOverlay() {
               <stop offset="45%" stopColor="#6b1f24" />
               <stop offset="100%" stopColor="#4a1418" />
             </linearGradient>
+            <linearGradient id="whip-tip-grad" x1="1" y1="0" x2="0" y2="0">
+              <stop offset="0%" stopColor="#6b4220" />
+              <stop offset="100%" stopColor="#2a1a0c" />
+            </linearGradient>
           </defs>
 
           {/* Short straight handle on the right */}
@@ -64,64 +68,50 @@ export function CodeWhipOverlay() {
             <circle cx="592" cy="198" r="6" fill="#3d3d3d" />
           </g>
 
-          {/* Segmented tip: wave travels handle → tip */}
-          <g className="code-whip-tip code-whip-seg code-whip-seg-1">
-            <g className="code-whip-seg code-whip-seg-2">
-              <g className="code-whip-seg code-whip-seg-3">
-                <g className="code-whip-seg code-whip-seg-4">
-                  <path
-                    className="code-whip-cord"
-                    d="M586 194
-                       C500 150, 420 112, 340 98
-                       C260 84, 180 96, 110 130
-                       C50 160, 0 204, -40 250
-                       C-70 284, -104 318, -140 348"
-                    fill="none"
-                    stroke="#2a1a0c"
-                    strokeWidth="2.8"
-                    strokeLinecap="round"
-                  >
-                    <animate
-                      attributeName="d"
-                      dur="2.3s"
-                      fill="freeze"
-                      keyTimes="0;0.18;0.32;0.45;0.55;0.72;1"
-                      values="
-M586 194 C520 168, 460 150, 400 148 C340 146, 280 160, 220 186 C160 212, 100 250, 40 292 C10 314, -20 334, -50 350;
-M586 194 C500 140, 430 100, 360 92 C290 84, 220 100, 150 136 C90 168, 30 214, -20 260 C-50 288, -84 318, -120 344;
-M586 194 C490 160, 410 130, 330 118 C250 106, 170 120, 100 156 C40 188, -10 232, -50 276 C-78 302, -110 328, -142 350;
-M586 194 C505 145, 425 105, 345 90 C265 76, 185 90, 115 128 C55 160, 0 208, -45 256 C-75 288, -110 322, -148 352;
+          {/* Long thin tip with snake-wave path morph — always visible */}
+          <g className="code-whip-tip">
+            <path
+              className="code-whip-cord"
+              d="M586 194 C500 150, 420 112, 340 98 C260 84, 180 96, 110 130 C50 160, 0 204, -40 250 C-70 284, -104 318, -140 348"
+              fill="none"
+              stroke="url(#whip-tip-grad)"
+              strokeWidth="3.6"
+              strokeLinecap="round"
+            >
+              <animate
+                attributeName="d"
+                dur="2.3s"
+                fill="freeze"
+                calcMode="spline"
+                keyTimes="0;0.2;0.35;0.48;0.58;0.75;1"
+                keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.2 0 0.1 1;0.4 0 0.2 1;0.4 0 0.2 1"
+                values="
+M586 194 C530 170, 470 156, 410 158 C350 160, 290 178, 230 206 C170 234, 110 270, 50 308 C20 328, -10 344, -40 356;
+M586 194 C505 145, 435 108, 365 96 C295 84, 225 100, 155 138 C95 170, 35 216, -15 262 C-45 290, -80 320, -118 346;
+M586 194 C495 158, 420 128, 345 114 C270 100, 195 116, 125 154 C65 186, 10 230, -35 274 C-65 300, -98 328, -132 350;
+M586 194 C508 142, 432 102, 352 88 C272 74, 192 90, 120 130 C58 164, 2 214, -42 262 C-72 292, -108 326, -146 354;
 M586 194 C500 150, 420 112, 340 98 C260 84, 180 96, 110 130 C50 160, 0 204, -40 250 C-70 284, -104 318, -140 348;
-M586 194 C510 155, 430 120, 350 108 C270 96, 190 110, 120 148 C60 180, 10 224, -30 268 C-58 296, -90 326, -128 350;
-M586 194 C515 160, 440 130, 365 120 C290 110, 215 128, 145 164 C90 194, 40 234, 0 272 C-24 296, -52 322, -80 344
+M586 194 C512 156, 432 122, 352 110 C272 98, 192 114, 122 152 C62 184, 12 228, -28 270 C-56 298, -88 328, -124 350;
+M586 194 C518 162, 442 132, 366 122 C290 112, 214 130, 144 168 C90 198, 40 238, 0 276 C-24 300, -52 326, -80 346
 "
-                    />
-                  </path>
-                  <g className="code-whip-cracker">
-                    <path
-                      d="M-118 330 L-158 348"
-                      fill="none"
-                      stroke="#3f2410"
-                      strokeWidth="1.4"
-                      strokeLinecap="round"
-                    />
-                    <path
-                      d="M-118 334 L-154 360"
-                      fill="none"
-                      stroke="#2a1a0c"
-                      strokeWidth="1.4"
-                      strokeLinecap="round"
-                    />
-                    <circle
-                      className="code-whip-tip-dot"
-                      cx="-148"
-                      cy="352"
-                      r="3"
-                      fill="#1a1008"
-                    />
-                  </g>
-                </g>
-              </g>
+              />
+            </path>
+            <g className="code-whip-cracker">
+              <path
+                d="M-118 330 L-162 352"
+                fill="none"
+                stroke="#3f2410"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+              />
+              <path
+                d="M-118 334 L-158 362"
+                fill="none"
+                stroke="#2a1a0c"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+              />
+              <circle cx="-150" cy="354" r="3.2" fill="#1a1008" />
             </g>
           </g>
         </svg>

--- a/src/components/CLI/CodeWhipOverlay.tsx
+++ b/src/components/CLI/CodeWhipOverlay.tsx
@@ -30,36 +30,38 @@ export function CodeWhipOverlay() {
           height="320"
         >
           <defs>
-            <linearGradient id="whip-handle-grad" x1="0" y1="0" x2="1" y2="1">
+            <linearGradient id="whip-handle-grad" x1="1" y1="0" x2="0" y2="1">
               <stop offset="0%" stopColor="#c48a4a" />
               <stop offset="55%" stopColor="#8b5a2b" />
               <stop offset="100%" stopColor="#5c3317" />
             </linearGradient>
-            <linearGradient id="whip-cord-grad" x1="0" y1="0" x2="1" y2="0">
+            <linearGradient id="whip-cord-grad" x1="1" y1="0" x2="0" y2="0">
               <stop offset="0%" stopColor="#4a2c14" />
               <stop offset="70%" stopColor="#2b1a0d" />
               <stop offset="100%" stopColor="#1a1008" />
             </linearGradient>
           </defs>
+          {/* Straight wooden handle on the right */}
           <path
-            d="M46 248 C52 236, 70 228, 92 220 L118 208"
+            d="M472 236 L402 198"
             fill="none"
             stroke="url(#whip-handle-grad)"
             strokeWidth="22"
             strokeLinecap="round"
           />
           <path
-            d="M54 246 C60 238, 74 232, 90 224"
+            d="M464 230 L418 206"
             fill="none"
             stroke="#6b3f1d"
-            strokeWidth="4"
+            strokeWidth="3.5"
             strokeLinecap="round"
-            opacity="0.55"
+            opacity="0.5"
           />
-          <circle cx="48" cy="250" r="8" fill="#3f2410" />
+          <circle cx="476" cy="238" r="8" fill="#3f2410" />
+          {/* Cord arcs left toward the tip */}
           <path
             className="code-whip-cord"
-            d="M118 208 C168 168, 214 112, 268 92 C330 68, 392 78, 458 118 C478 130, 492 148, 502 168"
+            d="M402 198 C348 160, 292 118, 236 102 C176 84, 118 96, 72 132 C48 148, 30 166, 18 186"
             fill="none"
             stroke="url(#whip-cord-grad)"
             strokeWidth="11"
@@ -67,21 +69,22 @@ export function CodeWhipOverlay() {
           />
           <path
             className="code-whip-cord-thin"
-            d="M268 92 C330 68, 392 78, 458 118 C478 130, 492 148, 502 168"
+            d="M236 102 C176 84, 118 96, 72 132 C48 148, 30 166, 18 186"
             fill="none"
             stroke="#1a1008"
             strokeWidth="5"
             strokeLinecap="round"
           />
+          {/* Tip / popper on the left */}
           <path
             className="code-whip-tip"
-            d="M502 168 L528 186"
+            d="M18 186 L-8 204"
             fill="none"
             stroke="#111"
             strokeWidth="2.5"
             strokeLinecap="round"
           />
-          <circle className="code-whip-tip-dot" cx="530" cy="188" r="4" fill="#111" />
+          <circle className="code-whip-tip-dot" cx="-10" cy="206" r="4" fill="#111" />
         </svg>
       </div>
       <div className="code-whip-hit-fx" style={hitStyle}>

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -12,7 +12,7 @@ import {
   Wrench,
   type LucideIcon
 } from "lucide-react";
-import { memo, useCallback, useMemo, useRef, useState, type MouseEvent } from "react";
+import { memo, useCallback, useMemo, useRef, useState, type CSSProperties, type MouseEvent, type PointerEvent as ReactPointerEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -27,7 +27,7 @@ import { AgentAvatar } from "./AgentAvatar";
 import { useImageLightbox } from "./ImageLightbox";
 import { StreamItem, StreamToolInvocation } from "./StreamItem";
 import { isVisibleItem, visibleBlocks } from "./messageBlocks";
-import { useWhipEffectStore } from "@/store/whipEffectStore";
+import { useWhipEffectStore, type WhipTargetPoint } from "@/store/whipEffectStore";
 
 type MessageBlock = ReturnType<typeof visibleBlocks>[number];
 type MessageSection =
@@ -788,28 +788,96 @@ export const MessageBubble = memo(function MessageBubble({
   const whipActive = useWhipEffectStore(
     (s) => s.active && s.targetMessageId === message.id
   );
+  const whipPower = useWhipEffectStore((s) =>
+    s.active && s.targetMessageId === message.id ? s.power : 1
+  );
   const canWhip = message.role === "assistant";
-  const handleWhip = useCallback(() => {
-    if (!canWhip) return;
+  const [charging, setCharging] = useState(false);
+  const chargeStartRef = useRef<number | null>(null);
+  const comboRef = useRef<{ count: number; lastFire: number }>({ count: 0, lastFire: 0 });
+
+  const computeWhipTarget = useCallback((): WhipTargetPoint => {
     const avatarEl = avatarRef.current;
     const chatView = avatarEl?.closest(".chat-view");
-    if (!avatarEl || !chatView) {
-      useWhipEffectStore.getState().trigger({
+    if (!avatarEl || !chatView) return { x: 120, y: 120 };
+    const ar = avatarEl.getBoundingClientRect();
+    const cr = chatView.getBoundingClientRect();
+    return {
+      x: ar.left - cr.left + ar.width / 2,
+      y: ar.top - cr.top + ar.height / 2
+    };
+  }, []);
+
+  const powerFromChargeMs = useCallback((ms: number): number => {
+    if (ms <= 120) return 0.9;
+    if (ms >= 1300) return 1.9;
+    return 0.9 + (ms - 120) / 1180;
+  }, []);
+
+  const fireWhip = useCallback(
+    (chargePower: number) => {
+      const state = useWhipEffectStore.getState();
+      if (state.active) return;
+      const now = performance.now();
+      const combo = comboRef.current;
+      const inWindow = now - combo.lastFire < 2500;
+      combo.count = inWindow ? combo.count + 1 : 0;
+      combo.lastFire = now;
+      const power = Math.min(1.9, chargePower + combo.count * 0.2);
+      state.trigger({
         messageId: message.id,
-        target: { x: 120, y: 120 }
+        target: computeWhipTarget(),
+        power
       });
-      return;
-    }
-    const avatarRect = avatarEl.getBoundingClientRect();
-    const chatRect = chatView.getBoundingClientRect();
-    useWhipEffectStore.getState().trigger({
-      messageId: message.id,
-      target: {
-        x: avatarRect.left - chatRect.left + avatarRect.width / 2,
-        y: avatarRect.top - chatRect.top + avatarRect.height / 2
+    },
+    [computeWhipTarget, message.id]
+  );
+
+  const handleWhipStart = useCallback(
+    (e: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!canWhip) return;
+      e.preventDefault();
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        /* ignore */
       }
-    });
-  }, [canWhip, message.id]);
+      chargeStartRef.current = performance.now();
+      setCharging(true);
+    },
+    [canWhip]
+  );
+
+  const handleWhipRelease = useCallback(
+    (e: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!canWhip || chargeStartRef.current == null) return;
+      const dur = performance.now() - chargeStartRef.current;
+      chargeStartRef.current = null;
+      setCharging(false);
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        /* ignore */
+      }
+      fireWhip(powerFromChargeMs(dur));
+    },
+    [canWhip, fireWhip, powerFromChargeMs]
+  );
+
+  const handleWhipCancel = useCallback(() => {
+    chargeStartRef.current = null;
+    setCharging(false);
+  }, []);
+
+  const handleWhipKeyActivate = useCallback(
+    (e: MouseEvent) => {
+      // Pointer-driven clicks (detail > 0) are handled by pointerup; this
+      // branch only fires for keyboard activation (Enter / Space).
+      if (e.detail > 0 || !canWhip) return;
+      fireWhip(1);
+    },
+    [canWhip, fireWhip]
+  );
   const copyText = messageText(message, items).trim();
   const showActionBar = message.role === "assistant" && message.status === "done" && Boolean(copyText);
   const getSelectionText = () => {
@@ -941,11 +1009,15 @@ export const MessageBubble = memo(function MessageBubble({
       <button
         type="button"
         ref={avatarRef}
-        className={`msg-avatar-whip-target${canWhip ? " whipable" : ""}${whipActive ? " whip-hit" : ""}`}
-        onClick={canWhip ? handleWhip : undefined}
+        className={`msg-avatar-whip-target${canWhip ? " whipable" : ""}${whipActive ? " whip-hit" : ""}${charging ? " charging" : ""}`}
+        onClick={canWhip ? handleWhipKeyActivate : undefined}
+        onPointerDown={canWhip ? handleWhipStart : undefined}
+        onPointerUp={canWhip ? handleWhipRelease : undefined}
+        onPointerCancel={canWhip ? handleWhipCancel : undefined}
         disabled={!canWhip}
         aria-label={canWhip ? t("message.whipAvatar") : undefined}
         tabIndex={canWhip ? 0 : -1}
+        style={{ "--whip-power": whipPower } as CSSProperties}
       >
         <AgentAvatar
           adapter={message.adapter ?? adapter}

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -952,7 +952,7 @@ export const MessageBubble = memo(function MessageBubble({
           <>
             <span className="whip-arc" aria-hidden="true" />
             <span className="whip-crack" aria-hidden="true">
-              啪
+              {t("message.whipCrack")}
             </span>
             <span className="whip-spark whip-spark-1" aria-hidden="true" />
             <span className="whip-spark whip-spark-2" aria-hidden="true" />

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -950,10 +950,42 @@ export const MessageBubble = memo(function MessageBubble({
         />
         {whipping && (
           <>
-            <span className="whip-arc" aria-hidden="true" />
+            <span className="whip-lash" aria-hidden="true">
+              <svg
+                className="whip-lash-svg"
+                viewBox="0 0 120 80"
+                width="120"
+                height="80"
+              >
+                <path
+                  className="whip-lash-handle"
+                  d="M8 62 L28 48"
+                  fill="none"
+                  stroke="#8B5A2B"
+                  strokeWidth="5"
+                  strokeLinecap="round"
+                />
+                <path
+                  className="whip-lash-cord"
+                  d="M28 48 C48 28, 78 12, 108 18"
+                  fill="none"
+                  stroke="#5C3317"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                />
+                <circle
+                  className="whip-lash-tip"
+                  cx="108"
+                  cy="18"
+                  r="3.5"
+                  fill="#3f2a14"
+                />
+              </svg>
+            </span>
             <span className="whip-crack" aria-hidden="true">
               {t("message.whipCrack")}
             </span>
+            <span className="whip-impact" aria-hidden="true" />
             <span className="whip-spark whip-spark-1" aria-hidden="true" />
             <span className="whip-spark whip-spark-2" aria-hidden="true" />
             <span className="whip-spark whip-spark-3" aria-hidden="true" />

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -12,7 +12,7 @@ import {
   Wrench,
   type LucideIcon
 } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import { memo, useCallback, useMemo, useState, type MouseEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -27,6 +27,7 @@ import { AgentAvatar } from "./AgentAvatar";
 import { useImageLightbox } from "./ImageLightbox";
 import { StreamItem, StreamToolInvocation } from "./StreamItem";
 import { isVisibleItem, visibleBlocks } from "./messageBlocks";
+import { useWhipEffectStore } from "@/store/whipEffectStore";
 
 type MessageBlock = ReturnType<typeof visibleBlocks>[number];
 type MessageSection =
@@ -783,27 +784,11 @@ export const MessageBubble = memo(function MessageBubble({
   const [copyMenu, setCopyMenu] = useState<{ x: number; y: number } | null>(null);
   const [copied, setCopied] = useState(false);
   const [vote, setVote] = useState<"up" | "down" | null>(null);
-  const [whipping, setWhipping] = useState(false);
-  const [whipNonce, setWhipNonce] = useState(0);
-  const whipTimerRef = useRef<number | null>(null);
-  const canWhip =
-    message.role === "assistant" &&
-    (message.status === "running" || message.status === "starting");
+  const canWhip = message.role === "assistant";
   const handleWhip = useCallback(() => {
-    if (!canWhip || whipping) return;
-    setWhipping(true);
-    setWhipNonce((n) => n + 1);
-    if (whipTimerRef.current != null) window.clearTimeout(whipTimerRef.current);
-    whipTimerRef.current = window.setTimeout(() => {
-      setWhipping(false);
-      whipTimerRef.current = null;
-    }, 800);
-  }, [canWhip, whipping]);
-  useEffect(() => {
-    return () => {
-      if (whipTimerRef.current != null) window.clearTimeout(whipTimerRef.current);
-    };
-  }, []);
+    if (!canWhip) return;
+    useWhipEffectStore.getState().trigger();
+  }, [canWhip]);
   const copyText = messageText(message, items).trim();
   const showActionBar = message.role === "assistant" && message.status === "done" && Boolean(copyText);
   const getSelectionText = () => {
@@ -934,63 +919,19 @@ export const MessageBubble = memo(function MessageBubble({
     <div className="msg msg-assistant">
       <button
         type="button"
-        className={`msg-avatar-whip-target${whipping ? " whip-hit" : ""}${canWhip ? " whipable" : ""}`}
+        className={`msg-avatar-whip-target${canWhip ? " whipable" : ""}`}
         onClick={canWhip ? handleWhip : undefined}
         disabled={!canWhip}
         aria-label={canWhip ? t("message.whipAvatar") : undefined}
         tabIndex={canWhip ? 0 : -1}
       >
         <AgentAvatar
-          key={whipNonce}
           adapter={message.adapter ?? adapter}
           agentId={message.agentId}
           iconKey={agentIconKey}
           className="msg-avatar agent-avatar"
           fallback={<span>✦</span>}
         />
-        {whipping && (
-          <>
-            <span className="whip-lash" aria-hidden="true">
-              <svg
-                className="whip-lash-svg"
-                viewBox="0 0 120 80"
-                width="120"
-                height="80"
-              >
-                <path
-                  className="whip-lash-handle"
-                  d="M8 62 L28 48"
-                  fill="none"
-                  stroke="#8B5A2B"
-                  strokeWidth="5"
-                  strokeLinecap="round"
-                />
-                <path
-                  className="whip-lash-cord"
-                  d="M28 48 C48 28, 78 12, 108 18"
-                  fill="none"
-                  stroke="#5C3317"
-                  strokeWidth="3"
-                  strokeLinecap="round"
-                />
-                <circle
-                  className="whip-lash-tip"
-                  cx="108"
-                  cy="18"
-                  r="3.5"
-                  fill="#3f2a14"
-                />
-              </svg>
-            </span>
-            <span className="whip-crack" aria-hidden="true">
-              {t("message.whipCrack")}
-            </span>
-            <span className="whip-impact" aria-hidden="true" />
-            <span className="whip-spark whip-spark-1" aria-hidden="true" />
-            <span className="whip-spark whip-spark-2" aria-hidden="true" />
-            <span className="whip-spark whip-spark-3" aria-hidden="true" />
-          </>
-        )}
       </button>
       <div className="msg-content-wrapper" onContextMenu={handleContextMenu}>
         <div className="msg-header">

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -12,7 +12,7 @@ import {
   Wrench,
   type LucideIcon
 } from "lucide-react";
-import { memo, useCallback, useMemo, useState, type MouseEvent } from "react";
+import { memo, useCallback, useMemo, useRef, useState, type MouseEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -784,11 +784,32 @@ export const MessageBubble = memo(function MessageBubble({
   const [copyMenu, setCopyMenu] = useState<{ x: number; y: number } | null>(null);
   const [copied, setCopied] = useState(false);
   const [vote, setVote] = useState<"up" | "down" | null>(null);
+  const avatarRef = useRef<HTMLButtonElement | null>(null);
+  const whipActive = useWhipEffectStore(
+    (s) => s.active && s.targetMessageId === message.id
+  );
   const canWhip = message.role === "assistant";
   const handleWhip = useCallback(() => {
     if (!canWhip) return;
-    useWhipEffectStore.getState().trigger();
-  }, [canWhip]);
+    const avatarEl = avatarRef.current;
+    const chatView = avatarEl?.closest(".chat-view");
+    if (!avatarEl || !chatView) {
+      useWhipEffectStore.getState().trigger({
+        messageId: message.id,
+        target: { x: 120, y: 120 }
+      });
+      return;
+    }
+    const avatarRect = avatarEl.getBoundingClientRect();
+    const chatRect = chatView.getBoundingClientRect();
+    useWhipEffectStore.getState().trigger({
+      messageId: message.id,
+      target: {
+        x: avatarRect.left - chatRect.left + avatarRect.width / 2,
+        y: avatarRect.top - chatRect.top + avatarRect.height / 2
+      }
+    });
+  }, [canWhip, message.id]);
   const copyText = messageText(message, items).trim();
   const showActionBar = message.role === "assistant" && message.status === "done" && Boolean(copyText);
   const getSelectionText = () => {
@@ -919,7 +940,8 @@ export const MessageBubble = memo(function MessageBubble({
     <div className="msg msg-assistant">
       <button
         type="button"
-        className={`msg-avatar-whip-target${canWhip ? " whipable" : ""}`}
+        ref={avatarRef}
+        className={`msg-avatar-whip-target${canWhip ? " whipable" : ""}${whipActive ? " whip-hit" : ""}`}
         onClick={canWhip ? handleWhip : undefined}
         disabled={!canWhip}
         aria-label={canWhip ? t("message.whipAvatar") : undefined}

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -12,7 +12,7 @@ import {
   Wrench,
   type LucideIcon
 } from "lucide-react";
-import { memo, useMemo, useState, type MouseEvent } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -783,6 +783,27 @@ export const MessageBubble = memo(function MessageBubble({
   const [copyMenu, setCopyMenu] = useState<{ x: number; y: number } | null>(null);
   const [copied, setCopied] = useState(false);
   const [vote, setVote] = useState<"up" | "down" | null>(null);
+  const [whipping, setWhipping] = useState(false);
+  const [whipNonce, setWhipNonce] = useState(0);
+  const whipTimerRef = useRef<number | null>(null);
+  const canWhip =
+    message.role === "assistant" &&
+    (message.status === "running" || message.status === "starting");
+  const handleWhip = useCallback(() => {
+    if (!canWhip || whipping) return;
+    setWhipping(true);
+    setWhipNonce((n) => n + 1);
+    if (whipTimerRef.current != null) window.clearTimeout(whipTimerRef.current);
+    whipTimerRef.current = window.setTimeout(() => {
+      setWhipping(false);
+      whipTimerRef.current = null;
+    }, 800);
+  }, [canWhip, whipping]);
+  useEffect(() => {
+    return () => {
+      if (whipTimerRef.current != null) window.clearTimeout(whipTimerRef.current);
+    };
+  }, []);
   const copyText = messageText(message, items).trim();
   const showActionBar = message.role === "assistant" && message.status === "done" && Boolean(copyText);
   const getSelectionText = () => {
@@ -911,13 +932,34 @@ export const MessageBubble = memo(function MessageBubble({
 
   return (
     <div className="msg msg-assistant">
-      <AgentAvatar
-        adapter={message.adapter ?? adapter}
-        agentId={message.agentId}
-        iconKey={agentIconKey}
-        className="msg-avatar agent-avatar"
-        fallback={<span>✦</span>}
-      />
+      <button
+        type="button"
+        className={`msg-avatar-whip-target${whipping ? " whip-hit" : ""}${canWhip ? " whipable" : ""}`}
+        onClick={canWhip ? handleWhip : undefined}
+        disabled={!canWhip}
+        aria-label={canWhip ? t("message.whipAvatar") : undefined}
+        tabIndex={canWhip ? 0 : -1}
+      >
+        <AgentAvatar
+          key={whipNonce}
+          adapter={message.adapter ?? adapter}
+          agentId={message.agentId}
+          iconKey={agentIconKey}
+          className="msg-avatar agent-avatar"
+          fallback={<span>✦</span>}
+        />
+        {whipping && (
+          <>
+            <span className="whip-arc" aria-hidden="true" />
+            <span className="whip-crack" aria-hidden="true">
+              啪
+            </span>
+            <span className="whip-spark whip-spark-1" aria-hidden="true" />
+            <span className="whip-spark whip-spark-2" aria-hidden="true" />
+            <span className="whip-spark whip-spark-3" aria-hidden="true" />
+          </>
+        )}
+      </button>
       <div className="msg-content-wrapper" onContextMenu={handleContextMenu}>
         <div className="msg-header">
           <span className="msg-author">{agentLabel}</span>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -199,6 +199,7 @@
     "you": "You",
     "thinking": "Thinking",
     "whipAvatar": "Code whip",
+    "whipCrack": "Whap",
     "system": "System",
     "copy": "Copy",
     "copySelection": "Copy selection",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -198,6 +198,7 @@
   "message": {
     "you": "You",
     "thinking": "Thinking",
+    "whipAvatar": "Code whip",
     "system": "System",
     "copy": "Copy",
     "copySelection": "Copy selection",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -198,6 +198,7 @@
   "message": {
     "you": "你",
     "thinking": "思考中",
+    "whipAvatar": "码鞭",
     "system": "系统",
     "copy": "复制",
     "copySelection": "复制选中",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -199,6 +199,7 @@
     "you": "你",
     "thinking": "思考中",
     "whipAvatar": "码鞭",
+    "whipCrack": "啪",
     "system": "系统",
     "copy": "复制",
     "copySelection": "复制选中",

--- a/src/store/whipEffectStore.ts
+++ b/src/store/whipEffectStore.ts
@@ -1,11 +1,24 @@
 import { create } from "zustand";
 
-export const WHIP_EFFECT_MS = 1200;
+export const WHIP_EFFECT_MS = 1300;
+export const WHIP_HIT_AT_MS = 380;
+
+export interface WhipTargetPoint {
+  /** Center X of the avatar, relative to the chat-view overlay. */
+  x: number;
+  /** Center Y of the avatar, relative to the chat-view overlay. */
+  y: number;
+}
 
 interface WhipEffectState {
   nonce: number;
   active: boolean;
-  trigger: () => void;
+  targetMessageId?: string;
+  target?: WhipTargetPoint;
+  trigger: (input: {
+    messageId: string;
+    target: WhipTargetPoint;
+  }) => void;
   clear: () => void;
 }
 
@@ -14,14 +27,25 @@ let clearTimer: number | null = null;
 export const useWhipEffectStore = create<WhipEffectState>((set, get) => ({
   nonce: 0,
   active: false,
-  trigger: () => {
+  targetMessageId: undefined,
+  target: undefined,
+  trigger: ({ messageId, target }) => {
     if (get().active) return;
     const nonce = get().nonce + 1;
-    set({ active: true, nonce });
+    set({
+      active: true,
+      nonce,
+      targetMessageId: messageId,
+      target
+    });
     if (clearTimer != null) window.clearTimeout(clearTimer);
     clearTimer = window.setTimeout(() => {
       clearTimer = null;
-      set({ active: false });
+      set({
+        active: false,
+        targetMessageId: undefined,
+        target: undefined
+      });
     }, WHIP_EFFECT_MS);
   },
   clear: () => {
@@ -29,6 +53,10 @@ export const useWhipEffectStore = create<WhipEffectState>((set, get) => ({
       window.clearTimeout(clearTimer);
       clearTimer = null;
     }
-    set({ active: false });
+    set({
+      active: false,
+      targetMessageId: undefined,
+      target: undefined
+    });
   }
 }));

--- a/src/store/whipEffectStore.ts
+++ b/src/store/whipEffectStore.ts
@@ -13,11 +13,14 @@ export interface WhipTargetPoint {
 interface WhipEffectState {
   nonce: number;
   active: boolean;
+  /** Whip power for the current shot (drives lash force + feedback). ~0.6–1.6. */
+  power: number;
   targetMessageId?: string;
   target?: WhipTargetPoint;
   trigger: (input: {
     messageId: string;
     target: WhipTargetPoint;
+    power: number;
   }) => void;
   clear: () => void;
 }
@@ -27,14 +30,16 @@ let clearTimer: number | null = null;
 export const useWhipEffectStore = create<WhipEffectState>((set, get) => ({
   nonce: 0,
   active: false,
+  power: 1,
   targetMessageId: undefined,
   target: undefined,
-  trigger: ({ messageId, target }) => {
+  trigger: ({ messageId, target, power }) => {
     if (get().active) return;
     const nonce = get().nonce + 1;
     set({
       active: true,
       nonce,
+      power,
       targetMessageId: messageId,
       target
     });
@@ -43,6 +48,7 @@ export const useWhipEffectStore = create<WhipEffectState>((set, get) => ({
       clearTimer = null;
       set({
         active: false,
+        power: 1,
         targetMessageId: undefined,
         target: undefined
       });
@@ -55,6 +61,7 @@ export const useWhipEffectStore = create<WhipEffectState>((set, get) => ({
     }
     set({
       active: false,
+      power: 1,
       targetMessageId: undefined,
       target: undefined
     });

--- a/src/store/whipEffectStore.ts
+++ b/src/store/whipEffectStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
-export const WHIP_EFFECT_MS = 1300;
-export const WHIP_HIT_AT_MS = 380;
+export const WHIP_EFFECT_MS = 2300;
+export const WHIP_HIT_AT_MS = 1050;
 
 export interface WhipTargetPoint {
   /** Center X of the avatar, relative to the chat-view overlay. */

--- a/src/store/whipEffectStore.ts
+++ b/src/store/whipEffectStore.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+export const WHIP_EFFECT_MS = 1200;
+
+interface WhipEffectState {
+  nonce: number;
+  active: boolean;
+  trigger: () => void;
+  clear: () => void;
+}
+
+let clearTimer: number | null = null;
+
+export const useWhipEffectStore = create<WhipEffectState>((set, get) => ({
+  nonce: 0,
+  active: false,
+  trigger: () => {
+    if (get().active) return;
+    const nonce = get().nonce + 1;
+    set({ active: true, nonce });
+    if (clearTimer != null) window.clearTimeout(clearTimer);
+    clearTimer = window.setTimeout(() => {
+      clearTimer = null;
+      set({ active: false });
+    }, WHIP_EFFECT_MS);
+  },
+  clear: () => {
+    if (clearTimer != null) {
+      window.clearTimeout(clearTimer);
+      clearTimer = null;
+    }
+    set({ active: false });
+  }
+}));

--- a/src/utils/whipMotion.ts
+++ b/src/utils/whipMotion.ts
@@ -1,104 +1,133 @@
 /**
- * Continuous rope-chain model of a bullwhip crack.
+ * Verlet-rope bullwhip, adapted from a classic canvas demo:
+ *   - many mass points linked by distance constraints
+ *   - the handle (root) is driven along a wind-up → snap → recover path
+ *   - gravity + damping let the soft rope lag and crack like a real lash
+ *   - tip speed above a threshold spawns a crack burst
  *
- * Instead of a handful of discrete CSS keyframes (which reads as a
- * mechanical, multi-segment robot arm), the rope is sampled at many points
- * and each point's rotation relative to the previous one is a smooth
- * function of time: a traveling wave that reaches point `u` after
- * `u * crackAtMs`, snaps forward once it arrives, and rings down. Rotations
- * compound down the chain (like a real rope), and the sampled points are
- * rendered through a Catmull-Rom spline so the curve stays fluid — no
- * visible joints.
- *
- * This module has no runtime dependencies on the rest of the app (the
- * caller passes `crackAtMs`, which should match
- * `whipEffectStore.WHIP_HIT_AT_MS`) so the wave math can be unit tested in
- * isolation.
+ * Pure math / simulation — no React. The overlay owns the RAF loop and
+ * feeds `elapsedMs` in; unit tests step the same sim without a DOM.
  */
 
-interface Point {
+export interface Point {
   x: number;
   y: number;
 }
 
+interface VerletPoint {
+  x: number;
+  y: number;
+  px: number;
+  py: number;
+}
+
+export interface CrackParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  size: number;
+  hue: number;
+  ring?: boolean;
+  r?: number;
+}
+
+/** Rest attach of the lash on the decorative handle (viewBox 560×300). */
 export const WHIP_ATTACH_POINT: Point = { x: 430, y: 152 };
-
-/** Rest-shape control points for a relaxed S-curve from handle to tip. */
-const REST_CONTROL: [Point, Point, Point] = [
-  { x: 358, y: 96 },
-  { x: 186, y: 108 },
-  { x: 96, y: 230 }
-];
-
-const JOINT_COUNT = 9; // sample points including the fixed attach point
-
-function restBezierPoint(t: number): Point {
-  const [p1, p2, p3] = REST_CONTROL;
-  const mt = 1 - t;
-  const a = mt * mt * mt;
-  const b = 3 * mt * mt * t;
-  const c = 3 * mt * t * t;
-  const d = t * t * t;
-  return {
-    x: a * WHIP_ATTACH_POINT.x + b * p1.x + c * p2.x + d * p3.x,
-    y: a * WHIP_ATTACH_POINT.y + b * p1.y + c * p2.y + d * p3.y
-  };
-}
-
-interface RestJoint {
-  /** Normalized position along the rope, 0 = handle, 1 = tip. */
-  u: number;
-  /** Rest turn relative to the previous segment's direction (radians). */
-  relativeAngle: number;
-  length: number;
-}
-
-function buildRestJoints(): RestJoint[] {
-  const points: Point[] = [];
-  for (let i = 0; i < JOINT_COUNT; i += 1) {
-    const t = i / (JOINT_COUNT - 1);
-    points.push(i === 0 ? WHIP_ATTACH_POINT : restBezierPoint(t));
-  }
-  const joints: RestJoint[] = [];
-  let prevAngle = 0;
-  for (let i = 1; i < points.length; i += 1) {
-    const dx = points[i].x - points[i - 1].x;
-    const dy = points[i].y - points[i - 1].y;
-    const angle = Math.atan2(dy, dx);
-    joints.push({
-      u: i / (JOINT_COUNT - 1),
-      relativeAngle: i === 1 ? angle : angle - prevAngle,
-      length: Math.hypot(dx, dy)
-    });
-    prevAngle = angle;
-  }
-  return joints;
-}
-
-const REST_JOINTS = buildRestJoints();
 
 /** Default time-to-crack, matching whipEffectStore.WHIP_HIT_AT_MS. */
 export const DEFAULT_CRACK_AT_MS = 1050;
-/** Peak swing amplitude at the tip (u=1), in radians. */
-const AMP_MAX = 0.46;
-/** Oscillation period once the wave reaches a point. */
-const PERIOD_MS = 260;
-/** Ring-down time constant after the wave passes a point. */
-const DECAY_TAU_MS = 230;
+export const DEFAULT_TOTAL_MS = 2300;
 
-/**
- * Local bend at normalized position `u`, `localT` ms after the traveling
- * wave reached it. Starts pulled back (anticipation), snaps forward through
- * zero at the half period (the crack), then rings down and settles.
- */
-function bendDelta(u: number, localT: number): number {
-  if (localT < 0) return 0;
-  const amp = AMP_MAX * Math.pow(u, 1.6);
-  const decay = Math.exp(-localT / DECAY_TAU_MS);
-  return amp * decay * -Math.cos((2 * Math.PI * localT) / PERIOD_MS);
+const SEGMENTS = 32;
+const SEG_LEN = 11;
+const GRAVITY = 0.42;
+const DAMPING = 0.995;
+const CONSTRAINT_ITERS = 28;
+const TIP_SPEED_CRACK = 32;
+const CRACK_COOLDOWN_FRAMES = 28;
+const FRAME_MS = 1000 / 60;
+
+/** Wind-up occupies the first ~42% of the time-to-crack (same as before). */
+const WINDUP_FRACTION = 0.42;
+
+function clamp01(x: number): number {
+  return Math.min(1, Math.max(0, x));
 }
 
-/** Catmull-Rom → cubic Bezier smoothing through a point sequence. */
+function easeOutQuad(x: number): number {
+  return 1 - (1 - x) * (1 - x);
+}
+
+function easeInQuad(x: number): number {
+  return x * x;
+}
+
+function easeOutCubic(x: number): number {
+  const c = 1 - x;
+  return 1 - c * c * c;
+}
+
+/**
+ * Map wall-clock elapsed time onto the demo's 0→1 swing progress so the
+ * tip-speed peak lands near `crackAtMs` (snap phase 0.35→0.6).
+ */
+export function swingProgress(
+  elapsedMs: number,
+  crackAtMs: number = DEFAULT_CRACK_AT_MS,
+  totalMs: number = DEFAULT_TOTAL_MS
+): number {
+  const windupEnd = crackAtMs * WINDUP_FRACTION;
+  if (elapsedMs <= 0) return 0;
+  if (elapsedMs <= windupEnd) {
+    return 0.35 * easeOutQuad(clamp01(elapsedMs / windupEnd));
+  }
+  if (elapsedMs <= crackAtMs) {
+    const k = clamp01((elapsedMs - windupEnd) / Math.max(crackAtMs - windupEnd, 1));
+    return 0.35 + 0.25 * easeInQuad(k);
+  }
+  const k = clamp01((elapsedMs - crackAtMs) / Math.max(totalMs - crackAtMs, 1));
+  return 0.6 + 0.4 * easeOutCubic(k);
+}
+
+/**
+ * Handle trajectory in viewBox space. Mirrored from the canvas demo so the
+ * grip sits on the right and the lash cracks toward the left (avatar).
+ *
+ *   0→0.35  wind-up: pull back right + up
+ *   0.35→0.6 snap: accelerate left + down
+ *   0.6→1   recover toward rest
+ */
+export function handlePos(progress: number, base: Point = WHIP_ATTACH_POINT): Point {
+  const p = clamp01(progress);
+  if (p < 0.35) {
+    const k = p / 0.35;
+    const e = easeOutQuad(k);
+    return { x: base.x + e * 88, y: base.y - e * 108 };
+  }
+  if (p < 0.6) {
+    const k = (p - 0.35) / 0.25;
+    const e = easeInQuad(k);
+    return { x: base.x + 88 - e * 210, y: base.y - 108 + e * 155 };
+  }
+  const k = (p - 0.6) / 0.4;
+  const e = easeOutCubic(k);
+  return { x: base.x - 122 + e * 122, y: base.y + 47 - e * 47 };
+}
+
+function createHangChain(base: Point): VerletPoint[] {
+  const points: VerletPoint[] = [];
+  for (let i = 0; i < SEGMENTS; i += 1) {
+    const t = i / Math.max(SEGMENTS - 1, 1);
+    // Rest hang: left and slightly down toward the avatar contact zone.
+    const x = base.x - t * (SEG_LEN * (SEGMENTS - 1)) * 0.92;
+    const y = base.y + t * (SEG_LEN * (SEGMENTS - 1)) * 0.28;
+    points.push({ x, y, px: x, py: y });
+  }
+  return points;
+}
+
 function smoothPath(points: Point[]): string {
   if (points.length === 0) return "";
   if (points.length === 1) return `M${points[0].x} ${points[0].y}`;
@@ -118,115 +147,237 @@ function smoothPath(points: Point[]): string {
 }
 
 export interface WhipFrame {
-  /** Smooth path `d` for the full rope, from the handle attach point. */
   ropeD: string;
-  /** Smooth path `d` for just the base half — layered thicker for taper. */
   baseD: string;
   tipX: number;
   tipY: number;
-  /** Direction (radians) the last segment points, for the cracker flourish. */
   tipAngle: number;
-}
-
-function clamp01(x: number): number {
-  return Math.min(1, Math.max(0, x));
-}
-
-function easeOutCubic(x: number): number {
-  const c = 1 - x;
-  return 1 - c * c * c;
-}
-
-function easeInCubic(x: number): number {
-  return x * x * x;
-}
-
-const WINDUP_ANGLE_DEG = 24;
-const SNAP_ANGLE_DEG = -9;
-const SETTLE_ANGLE_DEG = -2;
-const SNAP_SCALE = 1.05;
-/** Wind-up occupies the first ~42% of the time-to-crack. */
-const WINDUP_FRACTION = 0.42;
-
-export interface ArmSwing {
-  /** Rotation in degrees (apply directly as `rotate(${deg}deg)`). */
-  deg: number;
-  scale: number;
+  tipSpeed: number;
+  handleX: number;
+  handleY: number;
+  /** Stage opacity (fade in / out). */
   opacity: number;
+  /** True on the frame the tip first exceeds the crack threshold. */
+  cracked: boolean;
+  particles: CrackParticle[];
+}
+
+export interface WhipSimulation {
+  /** Advance one ~60fps physics frame at the given swing progress. */
+  step(progress: number): WhipFrame;
+  /**
+   * Catch the sim up to `elapsedMs` with fixed 60fps substeps (for tests /
+   * reduced-motion pose sampling).
+   */
+  advanceTo(
+    elapsedMs: number,
+    crackAtMs?: number,
+    totalMs?: number
+  ): WhipFrame;
+  reset(): void;
+}
+
+function fadeOpacity(elapsedMs: number, totalMs: number): number {
+  const fadeInMs = 140;
+  const fadeOutMs = 260;
+  if (elapsedMs < fadeInMs) return clamp01(elapsedMs / fadeInMs);
+  return clamp01((totalMs - elapsedMs) / fadeOutMs);
+}
+
+export function createWhipSimulation(
+  base: Point = WHIP_ATTACH_POINT
+): WhipSimulation {
+  let points = createHangChain(base);
+  let particles: CrackParticle[] = [];
+  let crackCooldown = 0;
+  let lastElapsed = -FRAME_MS;
+  let crackedThisStep = false;
+
+  function spawnCrack(x: number, y: number, vx: number, vy: number) {
+    for (let i = 0; i < 22; i += 1) {
+      const a = Math.random() * Math.PI * 2;
+      const s = 2 + Math.random() * 8;
+      particles.push({
+        x,
+        y,
+        vx: Math.cos(a) * s + vx * 0.22,
+        vy: Math.sin(a) * s + vy * 0.22,
+        life: 1,
+        size: 1 + Math.random() * 2.8,
+        hue: 28 + Math.random() * 28
+      });
+    }
+    particles.push({
+      x,
+      y,
+      vx: 0,
+      vy: 0,
+      life: 1,
+      size: 0,
+      hue: 40,
+      ring: true,
+      r: 4
+    });
+  }
+
+  function snapshot(tipSpeed: number): WhipFrame {
+    const pts: Point[] = points.map((p) => ({ x: p.x, y: p.y }));
+    const tip = pts[pts.length - 1];
+    const prev = pts[pts.length - 2] ?? tip;
+    const tipAngle = Math.atan2(tip.y - prev.y, tip.x - prev.x);
+    const handle = pts[0];
+    const baseCount = Math.min(pts.length, Math.ceil(pts.length * 0.45));
+    return {
+      ropeD: smoothPath(pts),
+      baseD: smoothPath(pts.slice(0, baseCount)),
+      tipX: tip.x,
+      tipY: tip.y,
+      tipAngle,
+      tipSpeed,
+      handleX: handle.x,
+      handleY: handle.y,
+      opacity: 1,
+      cracked: crackedThisStep,
+      particles: particles.map((p) => ({ ...p }))
+    };
+  }
+
+  function physicsStep(progress: number): WhipFrame {
+    crackedThisStep = false;
+    const h = handlePos(progress, base);
+
+    for (let i = 1; i < SEGMENTS; i += 1) {
+      const p = points[i];
+      const vx = (p.x - p.px) * DAMPING;
+      const vy = (p.y - p.py) * DAMPING;
+      p.px = p.x;
+      p.py = p.y;
+      p.x += vx;
+      p.y += vy + GRAVITY;
+    }
+
+    points[0].x = h.x;
+    points[0].y = h.y;
+    points[0].px = h.x;
+    points[0].py = h.y;
+
+    for (let iter = 0; iter < CONSTRAINT_ITERS; iter += 1) {
+      for (let i = 0; i < SEGMENTS - 1; i += 1) {
+        const a = points[i];
+        const b = points[i + 1];
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        const dist = Math.hypot(dx, dy) || 0.001;
+        const diff = (dist - SEG_LEN) / dist;
+        if (i === 0) {
+          b.x -= dx * diff;
+          b.y -= dy * diff;
+        } else {
+          a.x += dx * diff * 0.5;
+          a.y += dy * diff * 0.5;
+          b.x -= dx * diff * 0.5;
+          b.y -= dy * diff * 0.5;
+        }
+      }
+    }
+
+    const tip = points[SEGMENTS - 1];
+    const tvx = tip.x - tip.px;
+    const tvy = tip.y - tip.py;
+    const tipSpeed = Math.hypot(tvx, tvy);
+
+    if (crackCooldown > 0) crackCooldown -= 1;
+    if (tipSpeed > TIP_SPEED_CRACK && crackCooldown === 0) {
+      spawnCrack(tip.x, tip.y, tvx, tvy);
+      crackCooldown = CRACK_COOLDOWN_FRAMES;
+      crackedThisStep = true;
+    }
+
+    for (let i = particles.length - 1; i >= 0; i -= 1) {
+      const p = particles[i];
+      if (p.ring) {
+        p.r = (p.r ?? 4) + 7;
+        p.life -= 0.07;
+      } else {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.vy += 0.14;
+        p.vx *= 0.96;
+        p.vy *= 0.96;
+        p.life -= 0.035;
+      }
+      if (p.life <= 0) particles.splice(i, 1);
+    }
+
+    return snapshot(tipSpeed);
+  }
+
+  return {
+    step(progress: number) {
+      return physicsStep(progress);
+    },
+    advanceTo(elapsedMs, crackAtMs = DEFAULT_CRACK_AT_MS, totalMs = DEFAULT_TOTAL_MS) {
+      const target = Math.max(0, elapsedMs);
+      // First call (or after reset): step from 0 up to target.
+      let t = Math.max(0, lastElapsed);
+      if (t < 0) t = 0;
+      let frame = snapshot(0);
+      if (target <= t && lastElapsed >= 0) {
+        frame = physicsStep(swingProgress(target, crackAtMs, totalMs));
+        frame.opacity = fadeOpacity(target, totalMs);
+        lastElapsed = target;
+        return frame;
+      }
+      while (t < target) {
+        t = Math.min(t + FRAME_MS, target);
+        frame = physicsStep(swingProgress(t, crackAtMs, totalMs));
+      }
+      frame.opacity = fadeOpacity(target, totalMs);
+      lastElapsed = target;
+      return frame;
+    },
+    reset() {
+      points = createHangChain(base);
+      particles = [];
+      crackCooldown = 0;
+      lastElapsed = -FRAME_MS;
+      crackedThisStep = false;
+    }
+  };
 }
 
 /**
- * The arm's own swing (wind-up → forward snap → settle), computed with the
- * same "continuous function of time" philosophy as the rope wave so both
- * move as one connected gesture instead of two independently-timed
- * animations (a CSS keyframe swing layered over a JS-driven rope tends to
- * read as two things happening at once, not one whip crack).
- *
- * The forward-snap phase uses an ease-IN curve (slow → fast), so angular
- * velocity peaks right as `crackAtMs` is reached — that peak velocity,
- * not the peak angle, is what should read as "the crack".
+ * Convenience for reduced-motion / one-shot sampling: run a fresh sim up to
+ * `elapsedMs` and return that frame (with fade opacity applied).
  */
-export function computeArmSwing(
-  elapsedMs: number,
-  crackAtMs: number = DEFAULT_CRACK_AT_MS,
-  totalMs = 2300
-): ArmSwing {
-  const windupEnd = crackAtMs * WINDUP_FRACTION;
-  let deg: number;
-  let scale: number;
-
-  if (elapsedMs <= windupEnd) {
-    const p = easeOutCubic(clamp01(elapsedMs / windupEnd));
-    deg = p * WINDUP_ANGLE_DEG;
-    scale = 1 + p * 0.02;
-  } else if (elapsedMs <= crackAtMs) {
-    const p = easeInCubic(
-      clamp01((elapsedMs - windupEnd) / (crackAtMs - windupEnd))
-    );
-    deg = WINDUP_ANGLE_DEG + p * (SNAP_ANGLE_DEG - WINDUP_ANGLE_DEG);
-    scale = 1.02 + p * (SNAP_SCALE - 1.02);
-  } else {
-    const t = elapsedMs - crackAtMs;
-    const settleSpan = Math.max(totalMs - crackAtMs, 1);
-    const p = easeOutCubic(clamp01(t / settleSpan));
-    const wiggle = 3 * Math.exp(-t / 350) * Math.cos((2 * Math.PI * t) / 450);
-    deg = SNAP_ANGLE_DEG + p * (SETTLE_ANGLE_DEG - SNAP_ANGLE_DEG) + wiggle;
-    scale = SNAP_SCALE + p * (1 - SNAP_SCALE);
-  }
-
-  const fadeInMs = 140;
-  const fadeOutMs = 260;
-  const opacity =
-    elapsedMs < fadeInMs
-      ? clamp01(elapsedMs / fadeInMs)
-      : clamp01((totalMs - elapsedMs) / fadeOutMs);
-
-  return { deg, scale, opacity: Math.min(1, opacity) };
-}
-
 export function computeWhipFrame(
   elapsedMs: number,
-  crackAtMs: number = DEFAULT_CRACK_AT_MS
+  crackAtMs: number = DEFAULT_CRACK_AT_MS,
+  totalMs: number = DEFAULT_TOTAL_MS
 ): WhipFrame {
-  const points: Point[] = [WHIP_ATTACH_POINT];
-  let cumAngle = 0;
-  for (const joint of REST_JOINTS) {
-    const delay = joint.u * crackAtMs;
-    const localT = elapsedMs - delay;
-    cumAngle += joint.relativeAngle + bendDelta(joint.u, localT);
-    const prev = points[points.length - 1];
-    points.push({
-      x: prev.x + joint.length * Math.cos(cumAngle),
-      y: prev.y + joint.length * Math.sin(cumAngle)
-    });
-  }
-  const tip = points[points.length - 1];
-  const baseCount = Math.min(points.length, 6);
+  const sim = createWhipSimulation();
+  return sim.advanceTo(elapsedMs, crackAtMs, totalMs);
+}
+
+/**
+ * Stage no longer rotates independently — the Verlet handle path *is* the
+ * swing. Kept as a thin fade helper so the overlay can still set opacity
+ * without a second animation timeline.
+ */
+export function computeStageFade(
+  elapsedMs: number,
+  totalMs: number = DEFAULT_TOTAL_MS
+): { opacity: number; deg: number; scale: number } {
   return {
-    ropeD: smoothPath(points),
-    baseD: smoothPath(points.slice(0, baseCount)),
-    tipX: tip.x,
-    tipY: tip.y,
-    tipAngle: cumAngle
+    opacity: fadeOpacity(elapsedMs, totalMs),
+    deg: 0,
+    scale: 1
   };
 }
+
+/** @deprecated Use computeStageFade — arm rotation is now handle-driven. */
+export const computeArmSwing = (
+  elapsedMs: number,
+  _crackAtMs?: number,
+  totalMs: number = DEFAULT_TOTAL_MS
+) => computeStageFade(elapsedMs, totalMs);

--- a/src/utils/whipMotion.ts
+++ b/src/utils/whipMotion.ts
@@ -113,7 +113,7 @@ export function swingProgress(
  *
  * Screen y grows downward. From rest (grip to the right of the pivot),
  * counterclockwise lifts the grip up/back, then continues over the top
- * and down toward the avatar on the left — a full "抡圆了" arc.
+ * and down toward the avatar on the left — a full circular throw.
  *
  *   0→0.35  wind-up: lean back up
  *   0.35→0.6 snap: accelerate ~250° over the top

--- a/src/utils/whipMotion.ts
+++ b/src/utils/whipMotion.ts
@@ -43,7 +43,7 @@ export const DEFAULT_TOTAL_MS = 2300;
 const SEGMENTS = 32;
 const SEG_LEN = 11;
 const GRAVITY = 0.32;
-const DAMPING = 0.988;
+const DAMPING = 0.993;
 const CONSTRAINT_ITERS = 24;
 const TIP_SPEED_CRACK = 28;
 const CRACK_COOLDOWN_FRAMES = 28;
@@ -52,21 +52,46 @@ const FRAME_MS = 1000 / 60;
 /** Wind-up occupies the first ~42% of the time-to-crack (same as before). */
 const WINDUP_FRACTION = 0.42;
 
-/** Shoulder-ish pivot: left of and slightly below the rest attach. */
-const PIVOT_DX = -118;
-const PIVOT_DY = 28;
 /**
- * Wind-up lean (radians, counterclockwise from rest): lifts the grip up
- * and back so the throw has room to come over the top.
+ * Keyframe grip path (offsets from the rest attach, in viewBox units).
+ *
+ * A real bullwhip crack is a linear "pull back → lash forward → abrupt
+ * halt": the hand stops dead while the soft rope keeps flying, and the tip
+ * overshoots past the sound barrier. That is the opposite of a circular
+ * windmill, so the grip follows waypoints in space instead of a pivot angle.
  */
-const WINDUP_DELTA = 1.25;
+interface GripWaypoint {
+  dx: number;
+  dy: number;
+}
+/** Rest at the decorative handle. */
+const GRIP_REST: GripWaypoint = { dx: 0, dy: 0 };
+/** Raise the grip high overhead to load the downward lash. */
+const GRIP_WINDUP: GripWaypoint = { dx: 35, dy: -155 };
+/** Drive the lash straight down toward the avatar. */
+const GRIP_SNAP: GripWaypoint = { dx: -145, dy: 135 };
+/** Abrupt halt at the contact zone with a tiny pull-back up — the stop that lets the tip crack. */
+const GRIP_RECOIL: GripWaypoint = { dx: -115, dy: 100 };
+
+function lerpWaypoint(a: GripWaypoint, b: GripWaypoint, k: number): GripWaypoint {
+  return { dx: a.dx + (b.dx - a.dx) * k, dy: a.dy + (b.dy - a.dy) * k };
+}
+
 /**
- * Forward throw past the wind-up peak (radians, still counterclockwise).
- * Combined with wind-up this is ~250° over the top — a full circular crack.
+ * Scale a waypoint away from an anchor by `power` (1 = unchanged). Heavier
+ * whip power lengthens/strengthens the lash; the wind-up anchor stays put so
+ * the wind-up pose is identical regardless of power.
  */
-const SNAP_DELTA = 3.15;
-/** Radius stretch at peak snap so the throw reads bigger / harder. */
-const SNAP_RADIUS_BOOST = 1.45;
+function scaleFromAnchor(
+  anchor: GripWaypoint,
+  target: GripWaypoint,
+  power: number
+): GripWaypoint {
+  return {
+    dx: anchor.dx + (target.dx - anchor.dx) * power,
+    dy: anchor.dy + (target.dy - anchor.dy) * power
+  };
+}
 
 function clamp01(x: number): number {
   return Math.min(1, Math.max(0, x));
@@ -109,53 +134,37 @@ export function swingProgress(
 }
 
 /**
- * Handle trajectory: one big circular throw around a shoulder-ish pivot.
+ * Handle trajectory: a "raise overhead → drive straight down → halt" along
+ * waypoints, not a circular throw around a pivot.
  *
- * Screen y grows downward. From rest (grip to the right of the pivot),
- * counterclockwise lifts the grip up/back, then continues over the top
- * and down toward the avatar on the left — a full circular throw.
- *
- *   0→0.35  wind-up: lean back up
- *   0.35→0.6 snap: accelerate ~250° over the top
- *   0.6→1   recover toward rest
+ *   0→0.32  wind-up: ease the grip up overhead to load the lash
+ *   0.32→0.58 lash: ease-IN quartic so velocity explodes straight down toward the target
+ *   0.58→0.63 halt: snap to a near-stop + tiny reverse — this stop cracks the tip
+ *   0.63→1   recover: ease straight back to rest (no unwinding lap)
  */
-export function handlePos(progress: number, base: Point = WHIP_ATTACH_POINT): Point {
+export function handlePos(
+  progress: number,
+  base: Point = WHIP_ATTACH_POINT,
+  power: number = 1
+): Point {
   const p = clamp01(progress);
-  const cx = base.x + PIVOT_DX;
-  const cy = base.y + PIVOT_DY;
-  const restDx = base.x - cx;
-  const restDy = base.y - cy;
-  const restAngle = Math.atan2(restDy, restDx);
-  const restR = Math.hypot(restDx, restDy);
-
-  let angle: number;
-  let radius = restR;
-
-  if (p < 0.35) {
-    const k = easeOutQuad(p / 0.35);
-    // Counterclockwise = up and back from rest.
-    angle = restAngle - k * WINDUP_DELTA;
-    radius = restR * (1 + k * 0.14);
-  } else if (p < 0.6) {
-    const k = easeInQuart((p - 0.35) / 0.25);
-    // Keep going the long way: wind-up peak → over the top → forward crack.
-    const from = restAngle - WINDUP_DELTA;
-    const to = restAngle - WINDUP_DELTA - SNAP_DELTA;
-    angle = from + k * (to - from);
-    radius = restR * (1.14 + k * (SNAP_RADIUS_BOOST - 1.14));
+  const snap = scaleFromAnchor(GRIP_WINDUP, GRIP_SNAP, power);
+  const recoil = scaleFromAnchor(GRIP_WINDUP, GRIP_RECOIL, power);
+  let wp: GripWaypoint;
+  if (p < 0.32) {
+    const k = easeOutQuad(p / 0.32);
+    wp = lerpWaypoint(GRIP_REST, GRIP_WINDUP, k);
+  } else if (p < 0.58) {
+    const k = easeInQuart((p - 0.32) / (0.58 - 0.32));
+    wp = lerpWaypoint(GRIP_WINDUP, snap, k);
+  } else if (p < 0.63) {
+    const k = easeOutQuad((p - 0.58) / (0.63 - 0.58));
+    wp = lerpWaypoint(snap, recoil, k);
   } else {
-    const k = easeOutCubic((p - 0.6) / 0.4);
-    const from = restAngle - WINDUP_DELTA - SNAP_DELTA;
-    // Shortest recover back toward rest (unwrap toward restAngle - 2π).
-    const to = restAngle - Math.PI * 2;
-    angle = from + k * (to - from);
-    radius = restR * (SNAP_RADIUS_BOOST + k * (1 - SNAP_RADIUS_BOOST));
+    const k = easeOutCubic((p - 0.63) / (1 - 0.63));
+    wp = lerpWaypoint(recoil, GRIP_REST, k);
   }
-
-  return {
-    x: cx + Math.cos(angle) * radius,
-    y: cy + Math.sin(angle) * radius
-  };
+  return { x: base.x + wp.dx, y: base.y + wp.dy };
 }
 
 function createHangChain(base: Point): VerletPoint[] {
@@ -227,16 +236,25 @@ function fadeOpacity(elapsedMs: number, totalMs: number): number {
 }
 
 export function createWhipSimulation(
-  base: Point = WHIP_ATTACH_POINT
+  base: Point = WHIP_ATTACH_POINT,
+  options?: { power?: number }
 ): WhipSimulation {
+  const power = options?.power ?? 1;
   let points = createHangChain(base);
   let particles: CrackParticle[] = [];
   let crackCooldown = 0;
   let lastElapsed = -FRAME_MS;
   let crackedThisStep = false;
 
-  function spawnCrack(x: number, y: number, vx: number, vy: number) {
-    for (let i = 0; i < 22; i += 1) {
+  function spawnCrack(
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    crackPower: number
+  ) {
+    const count = Math.max(6, Math.round(22 * crackPower));
+    for (let i = 0; i < count; i += 1) {
       const a = Math.random() * Math.PI * 2;
       const s = 2 + Math.random() * 8;
       particles.push({
@@ -286,7 +304,7 @@ export function createWhipSimulation(
 
   function physicsStep(progress: number): WhipFrame {
     crackedThisStep = false;
-    const h = handlePos(progress, base);
+    const h = handlePos(progress, base, power);
 
     for (let i = 1; i < SEGMENTS; i += 1) {
       const p = points[i];
@@ -330,7 +348,7 @@ export function createWhipSimulation(
 
     if (crackCooldown > 0) crackCooldown -= 1;
     if (tipSpeed > TIP_SPEED_CRACK && crackCooldown === 0) {
-      spawnCrack(tip.x, tip.y, tvx, tvy);
+      spawnCrack(tip.x, tip.y, tvx, tvy, power);
       crackCooldown = CRACK_COOLDOWN_FRAMES;
       crackedThisStep = true;
     }

--- a/src/utils/whipMotion.ts
+++ b/src/utils/whipMotion.ts
@@ -1,0 +1,156 @@
+/**
+ * Continuous rope-chain model of a bullwhip crack.
+ *
+ * Instead of a handful of discrete CSS keyframes (which reads as a
+ * mechanical, multi-segment robot arm), the rope is sampled at many points
+ * and each point's rotation relative to the previous one is a smooth
+ * function of time: a traveling wave that reaches point `u` after
+ * `u * crackAtMs`, snaps forward once it arrives, and rings down. Rotations
+ * compound down the chain (like a real rope), and the sampled points are
+ * rendered through a Catmull-Rom spline so the curve stays fluid — no
+ * visible joints.
+ *
+ * This module has no runtime dependencies on the rest of the app (the
+ * caller passes `crackAtMs`, which should match
+ * `whipEffectStore.WHIP_HIT_AT_MS`) so the wave math can be unit tested in
+ * isolation.
+ */
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+export const WHIP_ATTACH_POINT: Point = { x: 430, y: 152 };
+
+/** Rest-shape control points for a relaxed S-curve from handle to tip. */
+const REST_CONTROL: [Point, Point, Point] = [
+  { x: 358, y: 96 },
+  { x: 186, y: 108 },
+  { x: 96, y: 230 }
+];
+
+const JOINT_COUNT = 9; // sample points including the fixed attach point
+
+function restBezierPoint(t: number): Point {
+  const [p1, p2, p3] = REST_CONTROL;
+  const mt = 1 - t;
+  const a = mt * mt * mt;
+  const b = 3 * mt * mt * t;
+  const c = 3 * mt * t * t;
+  const d = t * t * t;
+  return {
+    x: a * WHIP_ATTACH_POINT.x + b * p1.x + c * p2.x + d * p3.x,
+    y: a * WHIP_ATTACH_POINT.y + b * p1.y + c * p2.y + d * p3.y
+  };
+}
+
+interface RestJoint {
+  /** Normalized position along the rope, 0 = handle, 1 = tip. */
+  u: number;
+  /** Rest turn relative to the previous segment's direction (radians). */
+  relativeAngle: number;
+  length: number;
+}
+
+function buildRestJoints(): RestJoint[] {
+  const points: Point[] = [];
+  for (let i = 0; i < JOINT_COUNT; i += 1) {
+    const t = i / (JOINT_COUNT - 1);
+    points.push(i === 0 ? WHIP_ATTACH_POINT : restBezierPoint(t));
+  }
+  const joints: RestJoint[] = [];
+  let prevAngle = 0;
+  for (let i = 1; i < points.length; i += 1) {
+    const dx = points[i].x - points[i - 1].x;
+    const dy = points[i].y - points[i - 1].y;
+    const angle = Math.atan2(dy, dx);
+    joints.push({
+      u: i / (JOINT_COUNT - 1),
+      relativeAngle: i === 1 ? angle : angle - prevAngle,
+      length: Math.hypot(dx, dy)
+    });
+    prevAngle = angle;
+  }
+  return joints;
+}
+
+const REST_JOINTS = buildRestJoints();
+
+/** Default time-to-crack, matching whipEffectStore.WHIP_HIT_AT_MS. */
+export const DEFAULT_CRACK_AT_MS = 1050;
+/** Peak swing amplitude at the tip (u=1), in radians. */
+const AMP_MAX = 0.46;
+/** Oscillation period once the wave reaches a point. */
+const PERIOD_MS = 260;
+/** Ring-down time constant after the wave passes a point. */
+const DECAY_TAU_MS = 230;
+
+/**
+ * Local bend at normalized position `u`, `localT` ms after the traveling
+ * wave reached it. Starts pulled back (anticipation), snaps forward through
+ * zero at the half period (the crack), then rings down and settles.
+ */
+function bendDelta(u: number, localT: number): number {
+  if (localT < 0) return 0;
+  const amp = AMP_MAX * Math.pow(u, 1.6);
+  const decay = Math.exp(-localT / DECAY_TAU_MS);
+  return amp * decay * -Math.cos((2 * Math.PI * localT) / PERIOD_MS);
+}
+
+/** Catmull-Rom → cubic Bezier smoothing through a point sequence. */
+function smoothPath(points: Point[]): string {
+  if (points.length === 0) return "";
+  if (points.length === 1) return `M${points[0].x} ${points[0].y}`;
+  let d = `M${points[0].x} ${points[0].y}`;
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const p0 = points[i - 1] ?? points[i];
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const p3 = points[i + 2] ?? p2;
+    const c1x = p1.x + (p2.x - p0.x) / 6;
+    const c1y = p1.y + (p2.y - p0.y) / 6;
+    const c2x = p2.x - (p3.x - p1.x) / 6;
+    const c2y = p2.y - (p3.y - p1.y) / 6;
+    d += ` C${c1x} ${c1y}, ${c2x} ${c2y}, ${p2.x} ${p2.y}`;
+  }
+  return d;
+}
+
+export interface WhipFrame {
+  /** Smooth path `d` for the full rope, from the handle attach point. */
+  ropeD: string;
+  /** Smooth path `d` for just the base half — layered thicker for taper. */
+  baseD: string;
+  tipX: number;
+  tipY: number;
+  /** Direction (radians) the last segment points, for the cracker flourish. */
+  tipAngle: number;
+}
+
+export function computeWhipFrame(
+  elapsedMs: number,
+  crackAtMs: number = DEFAULT_CRACK_AT_MS
+): WhipFrame {
+  const points: Point[] = [WHIP_ATTACH_POINT];
+  let cumAngle = 0;
+  for (const joint of REST_JOINTS) {
+    const delay = joint.u * crackAtMs;
+    const localT = elapsedMs - delay;
+    cumAngle += joint.relativeAngle + bendDelta(joint.u, localT);
+    const prev = points[points.length - 1];
+    points.push({
+      x: prev.x + joint.length * Math.cos(cumAngle),
+      y: prev.y + joint.length * Math.sin(cumAngle)
+    });
+  }
+  const tip = points[points.length - 1];
+  const baseCount = Math.min(points.length, 6);
+  return {
+    ropeD: smoothPath(points),
+    baseD: smoothPath(points.slice(0, baseCount)),
+    tipX: tip.x,
+    tipY: tip.y,
+    tipAngle: cumAngle
+  };
+}

--- a/src/utils/whipMotion.ts
+++ b/src/utils/whipMotion.ts
@@ -42,15 +42,31 @@ export const DEFAULT_TOTAL_MS = 2300;
 
 const SEGMENTS = 32;
 const SEG_LEN = 11;
-const GRAVITY = 0.42;
-const DAMPING = 0.995;
-const CONSTRAINT_ITERS = 28;
-const TIP_SPEED_CRACK = 32;
+const GRAVITY = 0.32;
+const DAMPING = 0.988;
+const CONSTRAINT_ITERS = 24;
+const TIP_SPEED_CRACK = 28;
 const CRACK_COOLDOWN_FRAMES = 28;
 const FRAME_MS = 1000 / 60;
 
 /** Wind-up occupies the first ~42% of the time-to-crack (same as before). */
 const WINDUP_FRACTION = 0.42;
+
+/** Shoulder-ish pivot: left of and slightly below the rest attach. */
+const PIVOT_DX = -118;
+const PIVOT_DY = 28;
+/**
+ * Wind-up lean (radians, counterclockwise from rest): lifts the grip up
+ * and back so the throw has room to come over the top.
+ */
+const WINDUP_DELTA = 1.25;
+/**
+ * Forward throw past the wind-up peak (radians, still counterclockwise).
+ * Combined with wind-up this is ~250° over the top — a full circular crack.
+ */
+const SNAP_DELTA = 3.15;
+/** Radius stretch at peak snap so the throw reads bigger / harder. */
+const SNAP_RADIUS_BOOST = 1.45;
 
 function clamp01(x: number): number {
   return Math.min(1, Math.max(0, x));
@@ -60,8 +76,8 @@ function easeOutQuad(x: number): number {
   return 1 - (1 - x) * (1 - x);
 }
 
-function easeInQuad(x: number): number {
-  return x * x;
+function easeInQuart(x: number): number {
+  return x * x * x * x;
 }
 
 function easeOutCubic(x: number): number {
@@ -84,36 +100,62 @@ export function swingProgress(
     return 0.35 * easeOutQuad(clamp01(elapsedMs / windupEnd));
   }
   if (elapsedMs <= crackAtMs) {
+    // Ease-IN quartic: slow → very fast so angular velocity peaks at crack.
     const k = clamp01((elapsedMs - windupEnd) / Math.max(crackAtMs - windupEnd, 1));
-    return 0.35 + 0.25 * easeInQuad(k);
+    return 0.35 + 0.25 * easeInQuart(k);
   }
   const k = clamp01((elapsedMs - crackAtMs) / Math.max(totalMs - crackAtMs, 1));
   return 0.6 + 0.4 * easeOutCubic(k);
 }
 
 /**
- * Handle trajectory in viewBox space. Mirrored from the canvas demo so the
- * grip sits on the right and the lash cracks toward the left (avatar).
+ * Handle trajectory: one big circular throw around a shoulder-ish pivot.
  *
- *   0→0.35  wind-up: pull back right + up
- *   0.35→0.6 snap: accelerate left + down
+ * Screen y grows downward. From rest (grip to the right of the pivot),
+ * counterclockwise lifts the grip up/back, then continues over the top
+ * and down toward the avatar on the left — a full "抡圆了" arc.
+ *
+ *   0→0.35  wind-up: lean back up
+ *   0.35→0.6 snap: accelerate ~250° over the top
  *   0.6→1   recover toward rest
  */
 export function handlePos(progress: number, base: Point = WHIP_ATTACH_POINT): Point {
   const p = clamp01(progress);
+  const cx = base.x + PIVOT_DX;
+  const cy = base.y + PIVOT_DY;
+  const restDx = base.x - cx;
+  const restDy = base.y - cy;
+  const restAngle = Math.atan2(restDy, restDx);
+  const restR = Math.hypot(restDx, restDy);
+
+  let angle: number;
+  let radius = restR;
+
   if (p < 0.35) {
-    const k = p / 0.35;
-    const e = easeOutQuad(k);
-    return { x: base.x + e * 88, y: base.y - e * 108 };
+    const k = easeOutQuad(p / 0.35);
+    // Counterclockwise = up and back from rest.
+    angle = restAngle - k * WINDUP_DELTA;
+    radius = restR * (1 + k * 0.14);
+  } else if (p < 0.6) {
+    const k = easeInQuart((p - 0.35) / 0.25);
+    // Keep going the long way: wind-up peak → over the top → forward crack.
+    const from = restAngle - WINDUP_DELTA;
+    const to = restAngle - WINDUP_DELTA - SNAP_DELTA;
+    angle = from + k * (to - from);
+    radius = restR * (1.14 + k * (SNAP_RADIUS_BOOST - 1.14));
+  } else {
+    const k = easeOutCubic((p - 0.6) / 0.4);
+    const from = restAngle - WINDUP_DELTA - SNAP_DELTA;
+    // Shortest recover back toward rest (unwrap toward restAngle - 2π).
+    const to = restAngle - Math.PI * 2;
+    angle = from + k * (to - from);
+    radius = restR * (SNAP_RADIUS_BOOST + k * (1 - SNAP_RADIUS_BOOST));
   }
-  if (p < 0.6) {
-    const k = (p - 0.35) / 0.25;
-    const e = easeInQuad(k);
-    return { x: base.x + 88 - e * 210, y: base.y - 108 + e * 155 };
-  }
-  const k = (p - 0.6) / 0.4;
-  const e = easeOutCubic(k);
-  return { x: base.x - 122 + e * 122, y: base.y + 47 - e * 47 };
+
+  return {
+    x: cx + Math.cos(angle) * radius,
+    y: cy + Math.sin(angle) * radius
+  };
 }
 
 function createHangChain(base: Point): VerletPoint[] {

--- a/src/utils/whipMotion.ts
+++ b/src/utils/whipMotion.ts
@@ -128,6 +128,82 @@ export interface WhipFrame {
   tipAngle: number;
 }
 
+function clamp01(x: number): number {
+  return Math.min(1, Math.max(0, x));
+}
+
+function easeOutCubic(x: number): number {
+  const c = 1 - x;
+  return 1 - c * c * c;
+}
+
+function easeInCubic(x: number): number {
+  return x * x * x;
+}
+
+const WINDUP_ANGLE_DEG = 24;
+const SNAP_ANGLE_DEG = -9;
+const SETTLE_ANGLE_DEG = -2;
+const SNAP_SCALE = 1.05;
+/** Wind-up occupies the first ~42% of the time-to-crack. */
+const WINDUP_FRACTION = 0.42;
+
+export interface ArmSwing {
+  /** Rotation in degrees (apply directly as `rotate(${deg}deg)`). */
+  deg: number;
+  scale: number;
+  opacity: number;
+}
+
+/**
+ * The arm's own swing (wind-up → forward snap → settle), computed with the
+ * same "continuous function of time" philosophy as the rope wave so both
+ * move as one connected gesture instead of two independently-timed
+ * animations (a CSS keyframe swing layered over a JS-driven rope tends to
+ * read as two things happening at once, not one whip crack).
+ *
+ * The forward-snap phase uses an ease-IN curve (slow → fast), so angular
+ * velocity peaks right as `crackAtMs` is reached — that peak velocity,
+ * not the peak angle, is what should read as "the crack".
+ */
+export function computeArmSwing(
+  elapsedMs: number,
+  crackAtMs: number = DEFAULT_CRACK_AT_MS,
+  totalMs = 2300
+): ArmSwing {
+  const windupEnd = crackAtMs * WINDUP_FRACTION;
+  let deg: number;
+  let scale: number;
+
+  if (elapsedMs <= windupEnd) {
+    const p = easeOutCubic(clamp01(elapsedMs / windupEnd));
+    deg = p * WINDUP_ANGLE_DEG;
+    scale = 1 + p * 0.02;
+  } else if (elapsedMs <= crackAtMs) {
+    const p = easeInCubic(
+      clamp01((elapsedMs - windupEnd) / (crackAtMs - windupEnd))
+    );
+    deg = WINDUP_ANGLE_DEG + p * (SNAP_ANGLE_DEG - WINDUP_ANGLE_DEG);
+    scale = 1.02 + p * (SNAP_SCALE - 1.02);
+  } else {
+    const t = elapsedMs - crackAtMs;
+    const settleSpan = Math.max(totalMs - crackAtMs, 1);
+    const p = easeOutCubic(clamp01(t / settleSpan));
+    const wiggle = 3 * Math.exp(-t / 350) * Math.cos((2 * Math.PI * t) / 450);
+    deg = SNAP_ANGLE_DEG + p * (SETTLE_ANGLE_DEG - SNAP_ANGLE_DEG) + wiggle;
+    scale = SNAP_SCALE + p * (1 - SNAP_SCALE);
+  }
+
+  const fadeInMs = 140;
+  const fadeOutMs = 260;
+  const opacity =
+    elapsedMs < fadeInMs
+      ? clamp01(elapsedMs / fadeInMs)
+      : clamp01((totalMs - elapsedMs) / fadeOutMs);
+
+  return { deg, scale, opacity: Math.min(1, opacity) };
+}
+
 export function computeWhipFrame(
   elapsedMs: number,
   crackAtMs: number = DEFAULT_CRACK_AT_MS

--- a/styles.css
+++ b/styles.css
@@ -3445,10 +3445,10 @@ button {
   top: var(--whip-hit-y, 40%);
   width: var(--whip-w);
   height: var(--whip-h);
-  /* Tip sits near the right/bottom of the SVG; pin that tip onto the avatar. */
-  margin-left: calc(var(--whip-w) * -0.98);
-  margin-top: calc(var(--whip-h) * -0.62);
-  transform-origin: 10% 82%;
+  /* Tip sits near the left of the SVG; pin that tip onto the avatar. */
+  margin-left: calc(var(--whip-w) * 0.02);
+  margin-top: calc(var(--whip-h) * -0.645);
+  transform-origin: 91% 74%;
   animation: code-whip-swing 1.3s cubic-bezier(0.16, 0.84, 0.18, 1) both;
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
@@ -3563,23 +3563,23 @@ button {
 
 @keyframes code-whip-swing {
   0% {
-    transform: rotate(-92deg) scale(0.88);
+    transform: rotate(92deg) scale(0.88);
     opacity: 0;
   }
   10% {
     opacity: 1;
   }
   26% {
-    transform: rotate(-58deg) scale(1);
+    transform: rotate(58deg) scale(1);
   }
   38% {
-    transform: rotate(8deg) scale(1.06);
+    transform: rotate(-8deg) scale(1.06);
   }
   52% {
-    transform: rotate(-2deg) scale(1);
+    transform: rotate(2deg) scale(1);
   }
   100% {
-    transform: rotate(4deg) scale(0.97);
+    transform: rotate(-4deg) scale(0.97);
     opacity: 0;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -3438,17 +3438,18 @@ button {
 }
 
 .code-whip-stage {
-  --whip-w: min(98vw, 780px);
-  --whip-h: calc(var(--whip-w) * 0.5);
+  --whip-w: min(78vw, 520px);
+  --whip-h: calc(var(--whip-w) * 0.535);
   position: absolute;
   left: var(--whip-hit-x, 50%);
   top: var(--whip-hit-y, 40%);
   width: var(--whip-w);
   height: var(--whip-h);
-  /* Tip sits far left of the SVG; pin that tip onto the avatar. */
-  margin-left: calc(var(--whip-w) * 0.2);
-  margin-top: calc(var(--whip-h) * -0.96);
-  transform-origin: 94% 70%;
+  /* Tip (~4% from left, ~75% down) pins onto the avatar. */
+  margin-left: calc(var(--whip-w) * -0.04);
+  margin-top: calc(var(--whip-h) * -0.75);
+  /* Pivot near the handle so wind-up stays in the chat viewport. */
+  transform-origin: 88% 62%;
   animation: code-whip-swing 2.3s cubic-bezier(0.22, 0.7, 0.18, 1) both;
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
@@ -3467,12 +3468,12 @@ button {
 
 .code-whip-tip {
   opacity: 1;
-  transform-origin: 586px 194px;
+  transform-origin: 430px 152px;
   animation: code-whip-tip-wave 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
 }
 
 .code-whip-cracker {
-  transform-origin: -118px 332px;
+  transform-origin: 40px 212px;
   animation: code-whip-cracker-flick 2.3s ease-out both;
 }
 
@@ -3571,36 +3572,36 @@ button {
   }
 }
 
-/* Wind-up (抡鞭) then crack onto the avatar tip pin. */
+/* Wind-up stays compact so the tip never leaves the chat viewport. */
 @keyframes code-whip-swing {
   0% {
-    transform: rotate(118deg) scale(0.9);
+    transform: rotate(42deg) scale(0.94);
     opacity: 0;
   }
   6% {
     opacity: 1;
   }
   18% {
-    transform: rotate(98deg) scale(1);
+    transform: rotate(34deg) scale(1);
   }
   32% {
-    transform: rotate(128deg) scale(1.02);
+    transform: rotate(48deg) scale(1.02);
   }
   42% {
-    transform: rotate(108deg) scale(1.04);
+    transform: rotate(38deg) scale(1.03);
   }
   48% {
-    transform: rotate(-10deg) scale(1.08);
+    transform: rotate(-8deg) scale(1.05);
   }
   56% {
-    transform: rotate(4deg) scale(1);
+    transform: rotate(3deg) scale(1);
   }
   72% {
-    transform: rotate(-2deg) scale(0.99);
+    transform: rotate(-1deg) scale(0.99);
     opacity: 1;
   }
   100% {
-    transform: rotate(-6deg) scale(0.96);
+    transform: rotate(-3deg) scale(0.97);
     opacity: 0;
   }
 }
@@ -3620,16 +3621,16 @@ button {
     transform: rotate(0deg);
   }
   22% {
-    transform: rotate(6deg);
-  }
-  34% {
-    transform: rotate(-5deg);
-  }
-  46% {
     transform: rotate(4deg);
   }
+  34% {
+    transform: rotate(-3deg);
+  }
+  46% {
+    transform: rotate(3deg);
+  }
   52% {
-    transform: rotate(-7deg);
+    transform: rotate(-5deg);
   }
   64% {
     transform: rotate(2deg);

--- a/styles.css
+++ b/styles.css
@@ -3463,13 +3463,50 @@ button {
 .code-whip-cord-thin {
   stroke-dasharray: 1000;
   stroke-dashoffset: 1000;
-  animation: code-whip-unfurl 0.55s ease-out both;
+  animation: code-whip-unfurl 0.7s ease-out both;
 }
 
-.code-whip-tip,
+.code-whip-tip {
+  opacity: 0;
+  animation: code-whip-tip 0.55s ease-out both;
+  transform-box: fill-box;
+  transform-origin: right center;
+}
+
 .code-whip-tip-dot {
   opacity: 0;
   animation: code-whip-tip 0.55s ease-out both;
+}
+
+.code-whip-seg {
+  transform-box: fill-box;
+  transform-origin: right center;
+}
+
+.code-whip-seg-1 {
+  animation: code-whip-snake-1 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
+  transform-origin: 586px 194px;
+}
+
+.code-whip-seg-2 {
+  animation: code-whip-snake-2 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
+  transform-origin: 420px 120px;
+}
+
+.code-whip-seg-3 {
+  animation: code-whip-snake-3 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
+  transform-origin: 220px 150px;
+}
+
+.code-whip-seg-4 {
+  animation: code-whip-snake-4 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
+  transform-origin: 40px 230px;
+}
+
+.code-whip-cracker {
+  animation: code-whip-cracker-flick 2.3s ease-out both;
+  transform-origin: -118px 332px;
+  transform-box: fill-box;
 }
 
 .code-whip-hit-fx {
@@ -3619,6 +3656,131 @@ button {
   }
 }
 
+/* Snake wave: each segment lags the previous, handle → tip */
+@keyframes code-whip-snake-1 {
+  0%,
+  8% {
+    transform: rotate(0deg);
+  }
+  18% {
+    transform: rotate(7deg);
+  }
+  28% {
+    transform: rotate(-5deg);
+  }
+  38% {
+    transform: rotate(4deg);
+  }
+  48% {
+    transform: rotate(-8deg);
+  }
+  58% {
+    transform: rotate(2deg);
+  }
+  72%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes code-whip-snake-2 {
+  0%,
+  12% {
+    transform: rotate(0deg);
+  }
+  22% {
+    transform: rotate(-9deg);
+  }
+  32% {
+    transform: rotate(7deg);
+  }
+  42% {
+    transform: rotate(-5deg);
+  }
+  50% {
+    transform: rotate(10deg);
+  }
+  60% {
+    transform: rotate(-3deg);
+  }
+  76%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes code-whip-snake-3 {
+  0%,
+  16% {
+    transform: rotate(0deg);
+  }
+  26% {
+    transform: rotate(11deg);
+  }
+  36% {
+    transform: rotate(-9deg);
+  }
+  46% {
+    transform: rotate(6deg);
+  }
+  52% {
+    transform: rotate(-12deg);
+  }
+  64% {
+    transform: rotate(4deg);
+  }
+  80%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes code-whip-snake-4 {
+  0%,
+  20% {
+    transform: rotate(0deg);
+  }
+  30% {
+    transform: rotate(-13deg);
+  }
+  40% {
+    transform: rotate(12deg);
+  }
+  48% {
+    transform: rotate(-8deg);
+  }
+  54% {
+    transform: rotate(14deg);
+  }
+  68% {
+    transform: rotate(-4deg);
+  }
+  84%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes code-whip-cracker-flick {
+  0%,
+  42% {
+    transform: rotate(0deg);
+  }
+  48% {
+    transform: rotate(18deg);
+  }
+  54% {
+    transform: rotate(-22deg);
+  }
+  62% {
+    transform: rotate(8deg);
+  }
+  72%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
 @keyframes code-whip-avatar-hit {
   0%,
   100% {
@@ -3683,13 +3845,20 @@ button {
   .code-whip-crack,
   .code-whip-spark,
   .code-whip-flash,
-  .code-whip-impact {
+  .code-whip-impact,
+  .code-whip-seg,
+  .code-whip-cracker {
     animation-duration: 0.25s !important;
   }
 
   .code-whip-stage {
     transform: none !important;
     opacity: 0.85;
+  }
+
+  .code-whip-seg,
+  .code-whip-cracker {
+    animation: none !important;
   }
 
   .msg-avatar-whip-target.whip-hit .msg-avatar {

--- a/styles.css
+++ b/styles.css
@@ -3393,12 +3393,17 @@ button {
   border: 0;
   background: transparent;
   cursor: default;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .msg-avatar-whip-target .msg-avatar {
   width: 100%;
   height: 100%;
   box-shadow: none;
+  transition: transform 0.18s ease-out;
 }
 
 .msg-avatar-whip-target.whipable {
@@ -3415,6 +3420,11 @@ button {
 
 .msg-avatar-whip-target.whip-hit .msg-avatar {
   animation: code-whip-avatar-hit 0.85s cubic-bezier(0.36, 0.07, 0.19, 0.97) 1.05s both;
+}
+
+.msg-avatar-whip-target.charging .msg-avatar {
+  transition: transform 1.3s cubic-bezier(0.3, 0, 0.7, 1);
+  transform: scale(0.78) rotate(-4deg);
 }
 
 .code-whip-overlay {
@@ -3435,6 +3445,31 @@ button {
     transparent 68%
   );
   animation: code-whip-flash 2.3s ease-out both;
+}
+
+.code-whip-shake {
+  position: absolute;
+  inset: 0;
+  animation: code-whip-shake 0.45s ease-out 1.02s both;
+}
+
+@keyframes code-whip-shake {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  15% {
+    transform: translate(calc(-9px * var(--whip-power, 1)), calc(5px * var(--whip-power, 1)));
+  }
+  30% {
+    transform: translate(calc(8px * var(--whip-power, 1)), calc(-4px * var(--whip-power, 1)));
+  }
+  45% {
+    transform: translate(calc(-5px * var(--whip-power, 1)), calc(3px * var(--whip-power, 1)));
+  }
+  60% {
+    transform: translate(calc(3px * var(--whip-power, 1)), 0);
+  }
 }
 
 .code-whip-stage {
@@ -3487,24 +3522,24 @@ button {
   z-index: 5;
 }
 
-.code-whip-impact {
+.code-whip-star {
   position: absolute;
   left: 50%;
   top: 50%;
-  width: 54px;
-  height: 54px;
-  margin: -27px 0 0 -27px;
-  border-radius: 50%;
-  border: 3px solid rgba(239, 68, 68, 0.9);
+  width: 14px;
+  height: 14px;
+  background: #fde047;
+  filter: drop-shadow(0 0 6px rgba(253, 224, 71, 0.95));
+  clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
   opacity: 0;
-  animation: code-whip-impact-ring 0.5s ease-out 1.05s both;
+  animation: code-whip-star-burst 0.7s ease-out both;
 }
 
 .code-whip-crack {
   position: absolute;
   left: 18px;
   top: -34px;
-  font-size: clamp(34px, 5.5vw, 64px);
+  font-size: calc(clamp(34px, 5.5vw, 64px) * var(--whip-power, 1));
   font-weight: 900;
   letter-spacing: 0.04em;
   color: #ef4444;
@@ -3515,59 +3550,18 @@ button {
   white-space: nowrap;
 }
 
-.code-whip-spark {
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: #fbbf24;
-  animation: code-whip-spark-fly 0.75s ease-out 1.08s both;
-}
-
-.code-whip-spark-1 {
-  left: 6px;
-  top: -8px;
-}
-
-.code-whip-spark-2 {
-  left: 14px;
-  top: 4px;
-  width: 9px;
-  height: 9px;
-  background: #f97316;
-  animation-delay: 1.12s;
-}
-
-.code-whip-spark-3 {
-  left: -10px;
-  top: -12px;
-  width: 10px;
-  height: 10px;
-  background: #fde68a;
-  animation-delay: 1.14s;
-}
-
-.code-whip-spark-4 {
-  left: 18px;
-  top: -18px;
-  width: 7px;
-  height: 7px;
-  background: #fb7185;
-  animation-delay: 1.16s;
-}
-
 @keyframes code-whip-flash {
   0% {
     opacity: 0;
   }
   8% {
-    opacity: 0.35;
+    opacity: calc(0.35 * var(--whip-power, 1));
   }
   35% {
-    opacity: 0.2;
+    opacity: calc(0.2 * var(--whip-power, 1));
   }
   46% {
-    opacity: 1;
+    opacity: var(--whip-power, 1);
   }
   100% {
     opacity: 0;
@@ -3580,19 +3574,19 @@ button {
     transform: translate(0, 0) rotate(0) scale(1);
   }
   14% {
-    transform: translate(-7px, 3px) rotate(-16deg) scale(0.9);
+    transform: translate(calc(-7px * var(--whip-power, 1)), calc(3px * var(--whip-power, 1))) rotate(calc(-16deg * var(--whip-power, 1))) scale(0.9);
   }
   30% {
-    transform: translate(8px, -3px) rotate(14deg) scale(1.12);
+    transform: translate(calc(8px * var(--whip-power, 1)), calc(-3px * var(--whip-power, 1))) rotate(calc(14deg * var(--whip-power, 1))) scale(1.12);
   }
   46% {
-    transform: translate(-5px, 2px) rotate(-10deg) scale(0.96);
+    transform: translate(calc(-5px * var(--whip-power, 1)), calc(2px * var(--whip-power, 1))) rotate(calc(-10deg * var(--whip-power, 1))) scale(0.96);
   }
   62% {
-    transform: translate(4px, -1px) rotate(7deg);
+    transform: translate(calc(4px * var(--whip-power, 1)), calc(-1px * var(--whip-power, 1))) rotate(calc(7deg * var(--whip-power, 1)));
   }
   78% {
-    transform: translate(-2px, 0) rotate(-3deg);
+    transform: translate(calc(-2px * var(--whip-power, 1)), 0) rotate(calc(-3deg * var(--whip-power, 1)));
   }
 }
 
@@ -3611,39 +3605,39 @@ button {
   }
 }
 
-@keyframes code-whip-impact-ring {
+@keyframes code-whip-star-burst {
   0% {
-    transform: scale(0.45);
-    opacity: 0.95;
-  }
-  100% {
-    transform: scale(1.7);
+    transform: translate(-50%, -50%) scale(0) rotate(0deg);
     opacity: 0;
   }
-}
-
-@keyframes code-whip-spark-fly {
-  0% {
-    transform: translate(0, 0) scale(1);
+  25% {
+    transform: translate(-50%, -50%) scale(1.4) rotate(90deg);
     opacity: 1;
   }
   100% {
-    transform: translate(36px, -42px) scale(0);
+    transform: translate(calc(-50% + var(--bx, 0px)), calc(-50% + var(--by, 0px))) scale(0.2) rotate(420deg);
     opacity: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .code-whip-crack,
-  .code-whip-spark,
   .code-whip-flash,
-  .code-whip-impact {
+  .code-whip-star {
     animation-duration: 0.25s !important;
   }
 
   .code-whip-stage {
     transform: none !important;
     opacity: 0.85 !important;
+  }
+
+  .code-whip-shake {
+    animation: none !important;
+  }
+
+  .msg-avatar-whip-target.charging .msg-avatar {
+    transform: none !important;
   }
 
   .msg-avatar-whip-target.whip-hit .msg-avatar {

--- a/styles.css
+++ b/styles.css
@@ -3445,10 +3445,10 @@ button {
   top: var(--whip-hit-y, 40%);
   width: var(--whip-w);
   height: var(--whip-h);
-  /* Tip sits near the far left of the SVG; pin that tip onto the avatar. */
-  margin-left: calc(var(--whip-w) * 0.12);
-  margin-top: calc(var(--whip-h) * -0.82);
-  transform-origin: 92% 76%;
+  /* Tip sits further left of the SVG; pin that tip onto the avatar. */
+  margin-left: calc(var(--whip-w) * 0.22);
+  margin-top: calc(var(--whip-h) * -0.94);
+  transform-origin: 93% 76%;
   animation: code-whip-swing 2.3s cubic-bezier(0.22, 0.7, 0.18, 1) both;
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
@@ -3461,8 +3461,8 @@ button {
 
 .code-whip-cord,
 .code-whip-cord-thin {
-  stroke-dasharray: 900;
-  stroke-dashoffset: 900;
+  stroke-dasharray: 1100;
+  stroke-dashoffset: 1100;
   animation: code-whip-unfurl 0.55s ease-out both;
 }
 
@@ -3603,7 +3603,7 @@ button {
 
 @keyframes code-whip-unfurl {
   from {
-    stroke-dashoffset: 900;
+    stroke-dashoffset: 1100;
   }
   to {
     stroke-dashoffset: 0;

--- a/styles.css
+++ b/styles.css
@@ -3464,32 +3464,20 @@ button {
   opacity: 1;
 }
 
-/* Kinematic chain: each joint pivots at its own start point (in the SVG's
-   local coordinate space) and rotates independently, so rotation composes
-   naturally down the chain — a real traveling whip wave, not a path morph. */
-.code-whip-joint-1 {
-  transform-origin: 372px 150px;
-  animation: code-whip-joint-1 2.3s ease-in-out both;
-}
-
-.code-whip-joint-2 {
-  transform-origin: 312px 158px;
-  animation: code-whip-joint-2 2.3s ease-in-out both;
-}
-
-.code-whip-joint-3 {
-  transform-origin: 246px 178px;
-  animation: code-whip-joint-3 2.3s ease-in-out both;
-}
-
-.code-whip-joint-4 {
-  transform-origin: 176px 204px;
-  animation: code-whip-joint-4 2.3s ease-in-out both;
+/*
+ * The rope itself is driven frame-by-frame from JS (see whipMotion.ts /
+ * CodeWhipOverlay) using a continuous traveling-wave formula rather than
+ * discrete CSS keyframes, so it flows like a real rope/snake instead of a
+ * jointed arm. `.code-whip-base` / `.code-whip-rope` just need their base
+ * stroke styling here; their `d` attribute is set imperatively.
+ */
+.code-whip-base,
+.code-whip-rope {
+  vector-effect: non-scaling-stroke;
 }
 
 .code-whip-cracker {
-  transform-origin: 108px 226px;
-  animation: code-whip-cracker-flick 2.3s ease-out both;
+  pointer-events: none;
 }
 
 .code-whip-hit-fx {
@@ -3587,198 +3575,39 @@ button {
   }
 }
 
-/* Wind-up stays compact so the tip never leaves the chat viewport. */
+/*
+ * Coarse arm swing only — the rope itself (driven by whipMotion.ts) now
+ * carries most of the visible "life", so this just needs a gentle wind-up
+ * and a moderate forward snap timed to land near WHIP_HIT_AT_MS (~46%).
+ * Kept compact so the tip never leaves the chat viewport.
+ */
 @keyframes code-whip-swing {
   0% {
-    transform: rotate(42deg) scale(0.94);
+    transform: rotate(26deg) scale(0.96);
     opacity: 0;
   }
   6% {
     opacity: 1;
   }
-  18% {
-    transform: rotate(34deg) scale(1);
+  20% {
+    transform: rotate(20deg) scale(1);
   }
-  32% {
-    transform: rotate(48deg) scale(1.02);
+  34% {
+    transform: rotate(28deg) scale(1.01);
   }
-  42% {
-    transform: rotate(38deg) scale(1.03);
-  }
-  48% {
-    transform: rotate(-8deg) scale(1.05);
+  46% {
+    transform: rotate(-6deg) scale(1.03);
   }
   56% {
-    transform: rotate(3deg) scale(1);
+    transform: rotate(2deg) scale(1);
   }
   72% {
     transform: rotate(-1deg) scale(0.99);
     opacity: 1;
   }
   100% {
-    transform: rotate(-3deg) scale(0.97);
+    transform: rotate(-2deg) scale(0.97);
     opacity: 0;
-  }
-}
-
-@keyframes code-whip-unfurl {
-  from {
-    stroke-dashoffset: 1000;
-  }
-  to {
-    stroke-dashoffset: 0;
-  }
-}
-
-/*
- * Traveling whip wave: joint-1 (near handle) leads with a small, early
- * ripple; each later joint has a larger swing that peaks progressively
- * later, so the motion visibly cascades from handle to tip and lands the
- * sharp "crack" at joint-4 / the cracker right around WHIP_HIT_AT_MS
- * (~46% of the 2.3s effect).
- */
-@keyframes code-whip-joint-1 {
-  0%,
-  10% {
-    transform: rotate(0deg);
-  }
-  22% {
-    transform: rotate(4deg);
-  }
-  30% {
-    transform: rotate(-5deg);
-  }
-  38% {
-    transform: rotate(6deg);
-  }
-  44% {
-    transform: rotate(-6deg);
-  }
-  52% {
-    transform: rotate(3deg);
-  }
-  62% {
-    transform: rotate(-2deg);
-  }
-  76%,
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
-@keyframes code-whip-joint-2 {
-  0%,
-  14% {
-    transform: rotate(0deg);
-  }
-  26% {
-    transform: rotate(-6deg);
-  }
-  34% {
-    transform: rotate(8deg);
-  }
-  41% {
-    transform: rotate(-9deg);
-  }
-  46% {
-    transform: rotate(9deg);
-  }
-  54% {
-    transform: rotate(-5deg);
-  }
-  64% {
-    transform: rotate(2deg);
-  }
-  80%,
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
-@keyframes code-whip-joint-3 {
-  0%,
-  18% {
-    transform: rotate(0deg);
-  }
-  30% {
-    transform: rotate(9deg);
-  }
-  38% {
-    transform: rotate(-12deg);
-  }
-  44% {
-    transform: rotate(13deg);
-  }
-  48% {
-    transform: rotate(-15deg);
-  }
-  56% {
-    transform: rotate(7deg);
-  }
-  68% {
-    transform: rotate(-3deg);
-  }
-  84%,
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
-@keyframes code-whip-joint-4 {
-  0%,
-  22% {
-    transform: rotate(0deg);
-  }
-  33% {
-    transform: rotate(-11deg);
-  }
-  40% {
-    transform: rotate(15deg);
-  }
-  44% {
-    transform: rotate(-20deg);
-  }
-  46% {
-    transform: rotate(26deg);
-  }
-  52% {
-    transform: rotate(-16deg);
-  }
-  60% {
-    transform: rotate(8deg);
-  }
-  70% {
-    transform: rotate(-4deg);
-  }
-  86%,
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
-@keyframes code-whip-cracker-flick {
-  0%,
-  30% {
-    transform: rotate(0deg);
-  }
-  38% {
-    transform: rotate(-14deg);
-  }
-  44% {
-    transform: rotate(20deg);
-  }
-  46% {
-    transform: rotate(-30deg);
-  }
-  50% {
-    transform: rotate(14deg);
-  }
-  58% {
-    transform: rotate(-6deg);
-  }
-  70%,
-  100% {
-    transform: rotate(0deg);
   }
 }
 
@@ -3853,14 +3682,6 @@ button {
   .code-whip-stage {
     transform: none !important;
     opacity: 0.85;
-  }
-
-  .code-whip-joint-1,
-  .code-whip-joint-2,
-  .code-whip-joint-3,
-  .code-whip-joint-4,
-  .code-whip-cracker {
-    animation: none !important;
   }
 
   .msg-avatar-whip-target.whip-hit .msg-avatar {

--- a/styles.css
+++ b/styles.css
@@ -3413,131 +3413,157 @@ button {
   cursor: default;
 }
 
-.whip-hit .msg-avatar {
-  animation: whip-shake 0.55s cubic-bezier(0.36, 0.07, 0.19, 0.97) 0.22s both;
-}
-
-.whip-lash {
+.code-whip-overlay {
   position: absolute;
-  left: -18px;
-  top: -58px;
-  width: 120px;
-  height: 80px;
-  transform-origin: 12px 62px;
-  animation: whip-swing 0.75s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  inset: 0;
+  z-index: 40;
   pointer-events: none;
-  z-index: 3;
-  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.25));
+  overflow: hidden;
+  display: grid;
+  place-items: center;
 }
 
-.whip-lash-svg {
-  display: block;
+.code-whip-flash {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 55% 42%,
+    rgba(255, 214, 102, 0.28),
+    rgba(239, 68, 68, 0.08) 42%,
+    transparent 70%
+  );
+  animation: code-whip-flash 1.2s ease-out both;
+}
+
+.code-whip-stage {
+  position: relative;
+  width: min(92vw, 720px);
+  height: min(52vh, 420px);
+  display: grid;
+  place-items: center;
+  transform-origin: 18% 78%;
+  animation: code-whip-swing 1.2s cubic-bezier(0.18, 0.82, 0.2, 1) both;
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.28));
+}
+
+.code-whip-svg {
+  width: 100%;
+  height: auto;
   overflow: visible;
 }
 
-.whip-lash-cord {
-  stroke-dasharray: 140;
-  stroke-dashoffset: 140;
-  animation: whip-cord-unfurl 0.28s ease-out both;
+.code-whip-cord {
+  stroke-dasharray: 520;
+  stroke-dashoffset: 520;
+  animation: code-whip-unfurl 0.35s ease-out both;
 }
 
-.whip-lash-tip {
+.code-whip-tip {
   opacity: 0;
-  animation: whip-tip-appear 0.28s ease-out both;
+  animation: code-whip-tip 0.35s ease-out both;
 }
 
-.whip-crack {
+.code-whip-crack {
   position: absolute;
-  left: 50%;
-  top: -18px;
-  margin-left: 10px;
-  font-size: 22px;
+  left: 58%;
+  top: 34%;
+  font-size: clamp(48px, 8vw, 96px);
   font-weight: 900;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   color: #ef4444;
   text-shadow:
-    0 1px 0 #fff,
-    2px 2px 0 rgba(0, 0, 0, 0.18);
-  animation: whip-crack-pop 0.5s ease-out 0.22s both;
-  pointer-events: none;
+    0 2px 0 #fff,
+    4px 4px 0 rgba(0, 0, 0, 0.2);
+  animation: code-whip-crack-pop 0.7s ease-out 0.28s both;
   white-space: nowrap;
-  z-index: 4;
 }
 
-.whip-impact {
+.code-whip-spark {
   position: absolute;
-  inset: -6px;
-  border-radius: 50%;
-  border: 3px solid rgba(239, 68, 68, 0.85);
-  opacity: 0;
-  animation: whip-impact-ring 0.4s ease-out 0.22s both;
-  pointer-events: none;
-  z-index: 2;
-}
-
-.whip-spark {
-  position: absolute;
-  width: 6px;
-  height: 6px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: #fbbf24;
-  pointer-events: none;
-  animation: whip-spark-fly 0.55s ease-out 0.22s both;
-  z-index: 4;
+  animation: code-whip-spark-fly 0.7s ease-out 0.3s both;
 }
 
-.whip-spark-1 {
-  top: 0;
-  right: -4px;
+.code-whip-spark-1 {
+  left: 62%;
+  top: 40%;
 }
 
-.whip-spark-2 {
-  top: 14px;
-  right: -10px;
+.code-whip-spark-2 {
+  left: 68%;
+  top: 46%;
+  width: 10px;
+  height: 10px;
   background: #f97316;
-  animation-delay: 0.26s;
+  animation-delay: 0.34s;
 }
 
-.whip-spark-3 {
-  top: -6px;
-  right: 10px;
+.code-whip-spark-3 {
+  left: 56%;
+  top: 36%;
+  width: 12px;
+  height: 12px;
   background: #fde68a;
-  animation-delay: 0.28s;
+  animation-delay: 0.36s;
 }
 
-@keyframes whip-swing {
+.code-whip-spark-4 {
+  left: 72%;
+  top: 38%;
+  width: 8px;
+  height: 8px;
+  background: #fb7185;
+  animation-delay: 0.38s;
+}
+
+@keyframes code-whip-flash {
   0% {
-    transform: rotate(-78deg) scale(0.92);
     opacity: 0;
   }
-  12% {
+  18% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes code-whip-swing {
+  0% {
+    transform: translate(-18%, -8%) rotate(-86deg) scale(0.86);
+    opacity: 0;
+  }
+  10% {
     opacity: 1;
   }
   28% {
-    transform: rotate(-52deg) scale(1);
+    transform: translate(-8%, -2%) rotate(-48deg) scale(1);
   }
   42% {
-    transform: rotate(18deg) scale(1.05);
+    transform: translate(4%, 2%) rotate(22deg) scale(1.08);
   }
   58% {
-    transform: rotate(8deg) scale(1);
+    transform: translate(2%, 0) rotate(8deg) scale(1);
   }
   100% {
-    transform: rotate(4deg) scale(0.98);
+    transform: translate(6%, -4%) rotate(2deg) scale(0.96);
     opacity: 0;
   }
 }
 
-@keyframes whip-cord-unfurl {
+@keyframes code-whip-unfurl {
   from {
-    stroke-dashoffset: 140;
+    stroke-dashoffset: 520;
   }
   to {
     stroke-dashoffset: 0;
   }
 }
 
-@keyframes whip-tip-appear {
+@keyframes code-whip-tip {
   from {
     opacity: 0;
   }
@@ -3546,85 +3572,47 @@ button {
   }
 }
 
-@keyframes whip-shake {
-  0%,
-  100% {
-    transform: translate(0, 0) rotate(0) scale(1);
-  }
-  12% {
-    transform: translate(-5px, 2px) rotate(-14deg) scale(0.94);
-  }
-  28% {
-    transform: translate(6px, -2px) rotate(12deg) scale(1.06);
-  }
-  44% {
-    transform: translate(-4px, 2px) rotate(-9deg) scale(0.98);
-  }
-  60% {
-    transform: translate(3px, -1px) rotate(6deg);
-  }
-  76% {
-    transform: translate(-2px, 0) rotate(-3deg);
-  }
-}
-
-@keyframes whip-crack-pop {
+@keyframes code-whip-crack-pop {
   0% {
-    transform: scale(0.2) rotate(-8deg);
+    transform: scale(0.2) rotate(-10deg);
     opacity: 0;
   }
-  28% {
-    transform: scale(1.55) rotate(4deg);
+  30% {
+    transform: scale(1.35) rotate(4deg);
     opacity: 1;
   }
   100% {
-    transform: scale(1) translateY(-10px) rotate(0);
+    transform: scale(1) translateY(-24px);
     opacity: 0;
   }
 }
 
-@keyframes whip-impact-ring {
-  0% {
-    transform: scale(0.55);
-    opacity: 0.9;
-  }
-  100% {
-    transform: scale(1.55);
-    opacity: 0;
-  }
-}
-
-@keyframes whip-spark-fly {
+@keyframes code-whip-spark-fly {
   0% {
     transform: translate(0, 0) scale(1);
     opacity: 1;
   }
   100% {
-    transform: translate(14px, -16px) scale(0);
+    transform: translate(48px, -56px) scale(0);
     opacity: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .whip-lash,
-  .whip-crack,
-  .whip-impact,
-  .whip-spark {
-    display: none !important;
+  .code-whip-stage,
+  .code-whip-crack,
+  .code-whip-spark,
+  .code-whip-flash {
+    animation-duration: 0.25s !important;
   }
 
-  .whip-hit .msg-avatar {
-    animation: whip-shake-reduced 0.2s ease-out both;
+  .code-whip-stage {
+    transform: none !important;
+    opacity: 0.85;
   }
-}
 
-@keyframes whip-shake-reduced {
-  0%,
-  100% {
-    transform: translate(0, 0);
-  }
-  50% {
-    transform: translate(2px, 0);
+  .code-whip-crack {
+    font-size: 36px;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3413,37 +3413,44 @@ button {
   cursor: default;
 }
 
+.msg-avatar-whip-target.whip-hit .msg-avatar {
+  animation: code-whip-avatar-hit 0.7s cubic-bezier(0.36, 0.07, 0.19, 0.97) 0.34s both;
+}
+
 .code-whip-overlay {
   position: absolute;
   inset: 0;
   z-index: 40;
   pointer-events: none;
   overflow: hidden;
-  display: grid;
-  place-items: center;
 }
 
 .code-whip-flash {
   position: absolute;
   inset: 0;
   background: radial-gradient(
-    circle at 55% 42%,
-    rgba(255, 214, 102, 0.28),
-    rgba(239, 68, 68, 0.08) 42%,
-    transparent 70%
+    circle at var(--whip-hit-x, 50%) var(--whip-hit-y, 40%),
+    rgba(255, 214, 102, 0.34),
+    rgba(239, 68, 68, 0.1) 34%,
+    transparent 68%
   );
-  animation: code-whip-flash 1.2s ease-out both;
+  animation: code-whip-flash 1.3s ease-out both;
 }
 
 .code-whip-stage {
-  position: relative;
-  width: min(92vw, 720px);
-  height: min(52vh, 420px);
-  display: grid;
-  place-items: center;
-  transform-origin: 18% 78%;
-  animation: code-whip-swing 1.2s cubic-bezier(0.18, 0.82, 0.2, 1) both;
-  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.28));
+  --whip-w: min(88vw, 560px);
+  --whip-h: calc(var(--whip-w) * 0.615);
+  position: absolute;
+  left: var(--whip-hit-x, 50%);
+  top: var(--whip-hit-y, 40%);
+  width: var(--whip-w);
+  height: var(--whip-h);
+  /* Tip sits near the right/bottom of the SVG; pin that tip onto the avatar. */
+  margin-left: calc(var(--whip-w) * -0.98);
+  margin-top: calc(var(--whip-h) * -0.62);
+  transform-origin: 10% 82%;
+  animation: code-whip-swing 1.3s cubic-bezier(0.16, 0.84, 0.18, 1) both;
+  filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
 
 .code-whip-svg {
@@ -3452,71 +3459,94 @@ button {
   overflow: visible;
 }
 
-.code-whip-cord {
-  stroke-dasharray: 520;
-  stroke-dashoffset: 520;
-  animation: code-whip-unfurl 0.35s ease-out both;
+.code-whip-cord,
+.code-whip-cord-thin {
+  stroke-dasharray: 620;
+  stroke-dashoffset: 620;
+  animation: code-whip-unfurl 0.42s ease-out both;
 }
 
-.code-whip-tip {
+.code-whip-tip,
+.code-whip-tip-dot {
   opacity: 0;
-  animation: code-whip-tip 0.35s ease-out both;
+  animation: code-whip-tip 0.42s ease-out both;
+}
+
+.code-whip-hit-fx {
+  position: absolute;
+  width: 0;
+  height: 0;
+  transform: translate(-50%, -50%);
+  z-index: 5;
+}
+
+.code-whip-impact {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 54px;
+  height: 54px;
+  margin: -27px 0 0 -27px;
+  border-radius: 50%;
+  border: 3px solid rgba(239, 68, 68, 0.9);
+  opacity: 0;
+  animation: code-whip-impact-ring 0.45s ease-out 0.34s both;
 }
 
 .code-whip-crack {
   position: absolute;
-  left: 58%;
-  top: 34%;
-  font-size: clamp(48px, 8vw, 96px);
+  left: 18px;
+  top: -34px;
+  font-size: clamp(34px, 5.5vw, 64px);
   font-weight: 900;
   letter-spacing: 0.04em;
   color: #ef4444;
   text-shadow:
     0 2px 0 #fff,
-    4px 4px 0 rgba(0, 0, 0, 0.2);
-  animation: code-whip-crack-pop 0.7s ease-out 0.28s both;
+    3px 3px 0 rgba(0, 0, 0, 0.2);
+  animation: code-whip-crack-pop 0.65s ease-out 0.34s both;
   white-space: nowrap;
 }
 
 .code-whip-spark {
   position: absolute;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   background: #fbbf24;
-  animation: code-whip-spark-fly 0.7s ease-out 0.3s both;
+  animation: code-whip-spark-fly 0.65s ease-out 0.36s both;
 }
 
 .code-whip-spark-1 {
-  left: 62%;
-  top: 40%;
+  left: 6px;
+  top: -8px;
 }
 
 .code-whip-spark-2 {
-  left: 68%;
-  top: 46%;
-  width: 10px;
-  height: 10px;
+  left: 14px;
+  top: 4px;
+  width: 9px;
+  height: 9px;
   background: #f97316;
-  animation-delay: 0.34s;
+  animation-delay: 0.4s;
 }
 
 .code-whip-spark-3 {
-  left: 56%;
-  top: 36%;
-  width: 12px;
-  height: 12px;
+  left: -10px;
+  top: -12px;
+  width: 10px;
+  height: 10px;
   background: #fde68a;
-  animation-delay: 0.36s;
+  animation-delay: 0.42s;
 }
 
 .code-whip-spark-4 {
-  left: 72%;
-  top: 38%;
-  width: 8px;
-  height: 8px;
+  left: 18px;
+  top: -18px;
+  width: 7px;
+  height: 7px;
   background: #fb7185;
-  animation-delay: 0.38s;
+  animation-delay: 0.44s;
 }
 
 @keyframes code-whip-flash {
@@ -3533,30 +3563,30 @@ button {
 
 @keyframes code-whip-swing {
   0% {
-    transform: translate(-18%, -8%) rotate(-86deg) scale(0.86);
+    transform: rotate(-92deg) scale(0.88);
     opacity: 0;
   }
   10% {
     opacity: 1;
   }
-  28% {
-    transform: translate(-8%, -2%) rotate(-48deg) scale(1);
+  26% {
+    transform: rotate(-58deg) scale(1);
   }
-  42% {
-    transform: translate(4%, 2%) rotate(22deg) scale(1.08);
+  38% {
+    transform: rotate(8deg) scale(1.06);
   }
-  58% {
-    transform: translate(2%, 0) rotate(8deg) scale(1);
+  52% {
+    transform: rotate(-2deg) scale(1);
   }
   100% {
-    transform: translate(6%, -4%) rotate(2deg) scale(0.96);
+    transform: rotate(4deg) scale(0.97);
     opacity: 0;
   }
 }
 
 @keyframes code-whip-unfurl {
   from {
-    stroke-dashoffset: 520;
+    stroke-dashoffset: 620;
   }
   to {
     stroke-dashoffset: 0;
@@ -3572,6 +3602,28 @@ button {
   }
 }
 
+@keyframes code-whip-avatar-hit {
+  0%,
+  100% {
+    transform: translate(0, 0) rotate(0) scale(1);
+  }
+  14% {
+    transform: translate(-7px, 3px) rotate(-16deg) scale(0.9);
+  }
+  30% {
+    transform: translate(8px, -3px) rotate(14deg) scale(1.12);
+  }
+  46% {
+    transform: translate(-5px, 2px) rotate(-10deg) scale(0.96);
+  }
+  62% {
+    transform: translate(4px, -1px) rotate(7deg);
+  }
+  78% {
+    transform: translate(-2px, 0) rotate(-3deg);
+  }
+}
+
 @keyframes code-whip-crack-pop {
   0% {
     transform: scale(0.2) rotate(-10deg);
@@ -3582,7 +3634,18 @@ button {
     opacity: 1;
   }
   100% {
-    transform: scale(1) translateY(-24px);
+    transform: scale(1) translateY(-18px);
+    opacity: 0;
+  }
+}
+
+@keyframes code-whip-impact-ring {
+  0% {
+    transform: scale(0.45);
+    opacity: 0.95;
+  }
+  100% {
+    transform: scale(1.7);
     opacity: 0;
   }
 }
@@ -3593,7 +3656,7 @@ button {
     opacity: 1;
   }
   100% {
-    transform: translate(48px, -56px) scale(0);
+    transform: translate(36px, -42px) scale(0);
     opacity: 0;
   }
 }
@@ -3602,7 +3665,8 @@ button {
   .code-whip-stage,
   .code-whip-crack,
   .code-whip-spark,
-  .code-whip-flash {
+  .code-whip-flash,
+  .code-whip-impact {
     animation-duration: 0.25s !important;
   }
 
@@ -3611,8 +3675,22 @@ button {
     opacity: 0.85;
   }
 
+  .msg-avatar-whip-target.whip-hit .msg-avatar {
+    animation: code-whip-avatar-hit-reduced 0.2s ease-out both;
+  }
+
   .code-whip-crack {
-    font-size: 36px;
+    font-size: 28px;
+  }
+}
+
+@keyframes code-whip-avatar-hit-reduced {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(2px, 0);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3446,8 +3446,8 @@ button {
   width: var(--whip-w);
   height: var(--whip-h);
   /* Tip sits far left of the SVG; pin that tip onto the avatar. */
-  margin-left: calc(var(--whip-w) * 0.14);
-  margin-top: calc(var(--whip-h) * -0.94);
+  margin-left: calc(var(--whip-w) * 0.2);
+  margin-top: calc(var(--whip-h) * -0.96);
   transform-origin: 94% 70%;
   animation: code-whip-swing 2.3s cubic-bezier(0.22, 0.7, 0.18, 1) both;
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
@@ -3461,8 +3461,8 @@ button {
 
 .code-whip-cord,
 .code-whip-cord-thin {
-  stroke-dasharray: 1200;
-  stroke-dashoffset: 1200;
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
   animation: code-whip-unfurl 0.55s ease-out both;
 }
 
@@ -3603,7 +3603,7 @@ button {
 
 @keyframes code-whip-unfurl {
   from {
-    stroke-dashoffset: 1200;
+    stroke-dashoffset: 1000;
   }
   to {
     stroke-dashoffset: 0;

--- a/styles.css
+++ b/styles.css
@@ -3414,7 +3414,7 @@ button {
 }
 
 .msg-avatar-whip-target.whip-hit .msg-avatar {
-  animation: code-whip-avatar-hit 0.7s cubic-bezier(0.36, 0.07, 0.19, 0.97) 0.34s both;
+  animation: code-whip-avatar-hit 0.85s cubic-bezier(0.36, 0.07, 0.19, 0.97) 1.05s both;
 }
 
 .code-whip-overlay {
@@ -3434,22 +3434,22 @@ button {
     rgba(239, 68, 68, 0.1) 34%,
     transparent 68%
   );
-  animation: code-whip-flash 1.3s ease-out both;
+  animation: code-whip-flash 2.3s ease-out both;
 }
 
 .code-whip-stage {
-  --whip-w: min(88vw, 560px);
-  --whip-h: calc(var(--whip-w) * 0.615);
+  --whip-w: min(96vw, 720px);
+  --whip-h: calc(var(--whip-w) * 0.5625);
   position: absolute;
   left: var(--whip-hit-x, 50%);
   top: var(--whip-hit-y, 40%);
   width: var(--whip-w);
   height: var(--whip-h);
-  /* Tip sits near the left of the SVG; pin that tip onto the avatar. */
-  margin-left: calc(var(--whip-w) * 0.02);
-  margin-top: calc(var(--whip-h) * -0.645);
-  transform-origin: 91% 74%;
-  animation: code-whip-swing 1.3s cubic-bezier(0.16, 0.84, 0.18, 1) both;
+  /* Tip sits near the far left of the SVG; pin that tip onto the avatar. */
+  margin-left: calc(var(--whip-w) * 0.12);
+  margin-top: calc(var(--whip-h) * -0.82);
+  transform-origin: 92% 76%;
+  animation: code-whip-swing 2.3s cubic-bezier(0.22, 0.7, 0.18, 1) both;
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
 
@@ -3461,15 +3461,15 @@ button {
 
 .code-whip-cord,
 .code-whip-cord-thin {
-  stroke-dasharray: 620;
-  stroke-dashoffset: 620;
-  animation: code-whip-unfurl 0.42s ease-out both;
+  stroke-dasharray: 900;
+  stroke-dashoffset: 900;
+  animation: code-whip-unfurl 0.55s ease-out both;
 }
 
 .code-whip-tip,
 .code-whip-tip-dot {
   opacity: 0;
-  animation: code-whip-tip 0.42s ease-out both;
+  animation: code-whip-tip 0.55s ease-out both;
 }
 
 .code-whip-hit-fx {
@@ -3490,7 +3490,7 @@ button {
   border-radius: 50%;
   border: 3px solid rgba(239, 68, 68, 0.9);
   opacity: 0;
-  animation: code-whip-impact-ring 0.45s ease-out 0.34s both;
+  animation: code-whip-impact-ring 0.5s ease-out 1.05s both;
 }
 
 .code-whip-crack {
@@ -3504,7 +3504,7 @@ button {
   text-shadow:
     0 2px 0 #fff,
     3px 3px 0 rgba(0, 0, 0, 0.2);
-  animation: code-whip-crack-pop 0.65s ease-out 0.34s both;
+  animation: code-whip-crack-pop 0.75s ease-out 1.05s both;
   white-space: nowrap;
 }
 
@@ -3514,7 +3514,7 @@ button {
   height: 12px;
   border-radius: 50%;
   background: #fbbf24;
-  animation: code-whip-spark-fly 0.65s ease-out 0.36s both;
+  animation: code-whip-spark-fly 0.75s ease-out 1.08s both;
 }
 
 .code-whip-spark-1 {
@@ -3528,7 +3528,7 @@ button {
   width: 9px;
   height: 9px;
   background: #f97316;
-  animation-delay: 0.4s;
+  animation-delay: 1.12s;
 }
 
 .code-whip-spark-3 {
@@ -3537,7 +3537,7 @@ button {
   width: 10px;
   height: 10px;
   background: #fde68a;
-  animation-delay: 0.42s;
+  animation-delay: 1.14s;
 }
 
 .code-whip-spark-4 {
@@ -3546,14 +3546,20 @@ button {
   width: 7px;
   height: 7px;
   background: #fb7185;
-  animation-delay: 0.44s;
+  animation-delay: 1.16s;
 }
 
 @keyframes code-whip-flash {
   0% {
     opacity: 0;
   }
-  18% {
+  8% {
+    opacity: 0.35;
+  }
+  35% {
+    opacity: 0.2;
+  }
+  46% {
     opacity: 1;
   }
   100% {
@@ -3561,32 +3567,43 @@ button {
   }
 }
 
+/* Wind-up (抡鞭) then crack onto the avatar tip pin. */
 @keyframes code-whip-swing {
   0% {
-    transform: rotate(92deg) scale(0.88);
+    transform: rotate(118deg) scale(0.9);
     opacity: 0;
   }
-  10% {
+  6% {
     opacity: 1;
   }
-  26% {
-    transform: rotate(58deg) scale(1);
+  18% {
+    transform: rotate(98deg) scale(1);
   }
-  38% {
-    transform: rotate(-8deg) scale(1.06);
+  32% {
+    transform: rotate(128deg) scale(1.02);
   }
-  52% {
-    transform: rotate(2deg) scale(1);
+  42% {
+    transform: rotate(108deg) scale(1.04);
+  }
+  48% {
+    transform: rotate(-10deg) scale(1.08);
+  }
+  56% {
+    transform: rotate(4deg) scale(1);
+  }
+  72% {
+    transform: rotate(-2deg) scale(0.99);
+    opacity: 1;
   }
   100% {
-    transform: rotate(-4deg) scale(0.97);
+    transform: rotate(-6deg) scale(0.96);
     opacity: 0;
   }
 }
 
 @keyframes code-whip-unfurl {
   from {
-    stroke-dashoffset: 620;
+    stroke-dashoffset: 900;
   }
   to {
     stroke-dashoffset: 0;

--- a/styles.css
+++ b/styles.css
@@ -3450,7 +3450,10 @@ button {
   margin-top: calc(var(--whip-h) * -0.767);
   /* Pivot near the handle/wrist so wind-up stays in the chat viewport. */
   transform-origin: 88% 62%;
-  animation: code-whip-swing 2.3s cubic-bezier(0.22, 0.7, 0.18, 1) both;
+  /* transform + opacity are set imperatively per frame from
+     computeArmSwing() in CodeWhipOverlay, so the arm's swing and the
+     rope's wave share one continuous, physically-motivated timeline
+     instead of running as two independently-timed animations. */
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
 
@@ -3575,42 +3578,6 @@ button {
   }
 }
 
-/*
- * Coarse arm swing only — the rope itself (driven by whipMotion.ts) now
- * carries most of the visible "life", so this just needs a gentle wind-up
- * and a moderate forward snap timed to land near WHIP_HIT_AT_MS (~46%).
- * Kept compact so the tip never leaves the chat viewport.
- */
-@keyframes code-whip-swing {
-  0% {
-    transform: rotate(26deg) scale(0.96);
-    opacity: 0;
-  }
-  6% {
-    opacity: 1;
-  }
-  20% {
-    transform: rotate(20deg) scale(1);
-  }
-  34% {
-    transform: rotate(28deg) scale(1.01);
-  }
-  46% {
-    transform: rotate(-6deg) scale(1.03);
-  }
-  56% {
-    transform: rotate(2deg) scale(1);
-  }
-  72% {
-    transform: rotate(-1deg) scale(0.99);
-    opacity: 1;
-  }
-  100% {
-    transform: rotate(-2deg) scale(0.97);
-    opacity: 0;
-  }
-}
-
 @keyframes code-whip-avatar-hit {
   0%,
   100% {
@@ -3671,7 +3638,6 @@ button {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .code-whip-stage,
   .code-whip-crack,
   .code-whip-spark,
   .code-whip-flash,
@@ -3681,7 +3647,7 @@ button {
 
   .code-whip-stage {
     transform: none !important;
-    opacity: 0.85;
+    opacity: 0.85 !important;
   }
 
   .msg-avatar-whip-target.whip-hit .msg-avatar {

--- a/styles.css
+++ b/styles.css
@@ -3461,52 +3461,19 @@ button {
 
 .code-whip-cord,
 .code-whip-cord-thin {
-  stroke-dasharray: 1000;
-  stroke-dashoffset: 1000;
-  animation: code-whip-unfurl 0.7s ease-out both;
+  /* Keep tip visible; snake motion comes from path morph, not dash hide. */
+  opacity: 1;
 }
 
 .code-whip-tip {
-  opacity: 0;
-  animation: code-whip-tip 0.55s ease-out both;
-  transform-box: fill-box;
-  transform-origin: right center;
-}
-
-.code-whip-tip-dot {
-  opacity: 0;
-  animation: code-whip-tip 0.55s ease-out both;
-}
-
-.code-whip-seg {
-  transform-box: fill-box;
-  transform-origin: right center;
-}
-
-.code-whip-seg-1 {
-  animation: code-whip-snake-1 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
+  opacity: 1;
   transform-origin: 586px 194px;
-}
-
-.code-whip-seg-2 {
-  animation: code-whip-snake-2 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
-  transform-origin: 420px 120px;
-}
-
-.code-whip-seg-3 {
-  animation: code-whip-snake-3 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
-  transform-origin: 220px 150px;
-}
-
-.code-whip-seg-4 {
-  animation: code-whip-snake-4 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
-  transform-origin: 40px 230px;
+  animation: code-whip-tip-wave 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
 }
 
 .code-whip-cracker {
-  animation: code-whip-cracker-flick 2.3s ease-out both;
   transform-origin: -118px 332px;
-  transform-box: fill-box;
+  animation: code-whip-cracker-flick 2.3s ease-out both;
 }
 
 .code-whip-hit-fx {
@@ -3647,115 +3614,27 @@ button {
   }
 }
 
-@keyframes code-whip-tip {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-/* Snake wave: each segment lags the previous, handle → tip */
-@keyframes code-whip-snake-1 {
+@keyframes code-whip-tip-wave {
   0%,
-  8% {
-    transform: rotate(0deg);
-  }
-  18% {
-    transform: rotate(7deg);
-  }
-  28% {
-    transform: rotate(-5deg);
-  }
-  38% {
-    transform: rotate(4deg);
-  }
-  48% {
-    transform: rotate(-8deg);
-  }
-  58% {
-    transform: rotate(2deg);
-  }
-  72%,
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
-@keyframes code-whip-snake-2 {
-  0%,
-  12% {
+  10% {
     transform: rotate(0deg);
   }
   22% {
-    transform: rotate(-9deg);
-  }
-  32% {
-    transform: rotate(7deg);
-  }
-  42% {
-    transform: rotate(-5deg);
-  }
-  50% {
-    transform: rotate(10deg);
-  }
-  60% {
-    transform: rotate(-3deg);
-  }
-  76%,
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
-@keyframes code-whip-snake-3 {
-  0%,
-  16% {
-    transform: rotate(0deg);
-  }
-  26% {
-    transform: rotate(11deg);
-  }
-  36% {
-    transform: rotate(-9deg);
-  }
-  46% {
     transform: rotate(6deg);
   }
-  52% {
-    transform: rotate(-12deg);
+  34% {
+    transform: rotate(-5deg);
   }
-  64% {
+  46% {
     transform: rotate(4deg);
   }
-  80%,
-  100% {
-    transform: rotate(0deg);
+  52% {
+    transform: rotate(-7deg);
   }
-}
-
-@keyframes code-whip-snake-4 {
-  0%,
-  20% {
-    transform: rotate(0deg);
+  64% {
+    transform: rotate(2deg);
   }
-  30% {
-    transform: rotate(-13deg);
-  }
-  40% {
-    transform: rotate(12deg);
-  }
-  48% {
-    transform: rotate(-8deg);
-  }
-  54% {
-    transform: rotate(14deg);
-  }
-  68% {
-    transform: rotate(-4deg);
-  }
-  84%,
+  78%,
   100% {
     transform: rotate(0deg);
   }
@@ -3767,13 +3646,13 @@ button {
     transform: rotate(0deg);
   }
   48% {
-    transform: rotate(18deg);
+    transform: rotate(16deg);
   }
   54% {
-    transform: rotate(-22deg);
+    transform: rotate(-20deg);
   }
   62% {
-    transform: rotate(8deg);
+    transform: rotate(7deg);
   }
   72%,
   100% {
@@ -3846,7 +3725,7 @@ button {
   .code-whip-spark,
   .code-whip-flash,
   .code-whip-impact,
-  .code-whip-seg,
+  .code-whip-tip,
   .code-whip-cracker {
     animation-duration: 0.25s !important;
   }
@@ -3856,7 +3735,7 @@ button {
     opacity: 0.85;
   }
 
-  .code-whip-seg,
+  .code-whip-tip,
   .code-whip-cracker {
     animation: none !important;
   }

--- a/styles.css
+++ b/styles.css
@@ -3414,74 +3414,134 @@ button {
 }
 
 .whip-hit .msg-avatar {
-  animation: whip-shake 0.45s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+  animation: whip-shake 0.55s cubic-bezier(0.36, 0.07, 0.19, 0.97) 0.22s both;
 }
 
-.whip-arc {
+.whip-lash {
   position: absolute;
-  inset: -10px -14px auto auto;
-  width: 28px;
-  height: 28px;
-  border: 2px solid transparent;
-  border-top-color: #f59e0b;
-  border-right-color: #f59e0b;
-  border-radius: 50%;
-  transform-origin: 20% 80%;
-  animation: whip-arc-swing 0.15s ease-out both;
+  left: -18px;
+  top: -58px;
+  width: 120px;
+  height: 80px;
+  transform-origin: 12px 62px;
+  animation: whip-swing 0.75s cubic-bezier(0.2, 0.8, 0.2, 1) both;
   pointer-events: none;
+  z-index: 3;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.25));
+}
+
+.whip-lash-svg {
+  display: block;
+  overflow: visible;
+}
+
+.whip-lash-cord {
+  stroke-dasharray: 140;
+  stroke-dashoffset: 140;
+  animation: whip-cord-unfurl 0.28s ease-out both;
+}
+
+.whip-lash-tip {
+  opacity: 0;
+  animation: whip-tip-appear 0.28s ease-out both;
 }
 
 .whip-crack {
   position: absolute;
-  left: 100%;
-  top: -6px;
-  margin-left: 4px;
-  font-size: 14px;
-  font-weight: 800;
+  left: 50%;
+  top: -18px;
+  margin-left: 10px;
+  font-size: 22px;
+  font-weight: 900;
+  letter-spacing: 0.02em;
   color: #ef4444;
-  text-shadow: 0 1px 0 #fff, 1px 1px 0 rgba(0, 0, 0, 0.15);
-  animation: whip-crack-pop 0.45s ease-out both;
+  text-shadow:
+    0 1px 0 #fff,
+    2px 2px 0 rgba(0, 0, 0, 0.18);
+  animation: whip-crack-pop 0.5s ease-out 0.22s both;
   pointer-events: none;
   white-space: nowrap;
+  z-index: 4;
+}
+
+.whip-impact {
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 3px solid rgba(239, 68, 68, 0.85);
+  opacity: 0;
+  animation: whip-impact-ring 0.4s ease-out 0.22s both;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .whip-spark {
   position: absolute;
-  width: 5px;
-  height: 5px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: #fbbf24;
   pointer-events: none;
-  animation: whip-spark-fly 0.5s ease-out both;
+  animation: whip-spark-fly 0.55s ease-out 0.22s both;
+  z-index: 4;
 }
 
 .whip-spark-1 {
-  top: 2px;
-  right: -2px;
-  animation-delay: 0.15s;
+  top: 0;
+  right: -4px;
 }
 
 .whip-spark-2 {
-  top: 12px;
-  right: -8px;
-  animation-delay: 0.18s;
+  top: 14px;
+  right: -10px;
   background: #f97316;
+  animation-delay: 0.26s;
 }
 
 .whip-spark-3 {
-  top: -2px;
-  right: 8px;
-  animation-delay: 0.2s;
+  top: -6px;
+  right: 10px;
   background: #fde68a;
+  animation-delay: 0.28s;
 }
 
-@keyframes whip-arc-swing {
+@keyframes whip-swing {
+  0% {
+    transform: rotate(-78deg) scale(0.92);
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  28% {
+    transform: rotate(-52deg) scale(1);
+  }
+  42% {
+    transform: rotate(18deg) scale(1.05);
+  }
+  58% {
+    transform: rotate(8deg) scale(1);
+  }
+  100% {
+    transform: rotate(4deg) scale(0.98);
+    opacity: 0;
+  }
+}
+
+@keyframes whip-cord-unfurl {
   from {
-    transform: rotate(-40deg) scale(0.6);
+    stroke-dashoffset: 140;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes whip-tip-appear {
+  from {
     opacity: 0;
   }
   to {
-    transform: rotate(25deg) scale(1);
     opacity: 1;
   }
 }
@@ -3489,36 +3549,47 @@ button {
 @keyframes whip-shake {
   0%,
   100% {
-    transform: translate(0, 0) rotate(0);
+    transform: translate(0, 0) rotate(0) scale(1);
   }
-  15% {
-    transform: translate(-3px, 1px) rotate(-8deg);
+  12% {
+    transform: translate(-5px, 2px) rotate(-14deg) scale(0.94);
   }
-  30% {
-    transform: translate(4px, -1px) rotate(7deg);
+  28% {
+    transform: translate(6px, -2px) rotate(12deg) scale(1.06);
   }
-  45% {
-    transform: translate(-3px, 1px) rotate(-6deg);
+  44% {
+    transform: translate(-4px, 2px) rotate(-9deg) scale(0.98);
   }
   60% {
-    transform: translate(2px, 0) rotate(4deg);
+    transform: translate(3px, -1px) rotate(6deg);
   }
-  75% {
-    transform: translate(-1px, 0) rotate(-2deg);
+  76% {
+    transform: translate(-2px, 0) rotate(-3deg);
   }
 }
 
 @keyframes whip-crack-pop {
   0% {
-    transform: scale(0.4);
+    transform: scale(0.2) rotate(-8deg);
     opacity: 0;
   }
-  30% {
-    transform: scale(1.35);
+  28% {
+    transform: scale(1.55) rotate(4deg);
     opacity: 1;
   }
   100% {
-    transform: scale(1) translateY(-6px);
+    transform: scale(1) translateY(-10px) rotate(0);
+    opacity: 0;
+  }
+}
+
+@keyframes whip-impact-ring {
+  0% {
+    transform: scale(0.55);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1.55);
     opacity: 0;
   }
 }
@@ -3529,14 +3600,15 @@ button {
     opacity: 1;
   }
   100% {
-    transform: translate(10px, -12px) scale(0);
+    transform: translate(14px, -16px) scale(0);
     opacity: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .whip-arc,
+  .whip-lash,
   .whip-crack,
+  .whip-impact,
   .whip-spark {
     display: none !important;
   }

--- a/styles.css
+++ b/styles.css
@@ -3382,6 +3382,180 @@ button {
   transition: transform 0.2s ease;
 }
 
+.msg-avatar-whip-target {
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: default;
+}
+
+.msg-avatar-whip-target .msg-avatar {
+  width: 100%;
+  height: 100%;
+  box-shadow: none;
+}
+
+.msg-avatar-whip-target.whipable {
+  cursor: pointer;
+}
+
+.msg-avatar-whip-target.whipable:hover .msg-avatar {
+  transform: scale(1.12);
+}
+
+.msg-avatar-whip-target:disabled {
+  cursor: default;
+}
+
+.whip-hit .msg-avatar {
+  animation: whip-shake 0.45s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
+.whip-arc {
+  position: absolute;
+  inset: -10px -14px auto auto;
+  width: 28px;
+  height: 28px;
+  border: 2px solid transparent;
+  border-top-color: #f59e0b;
+  border-right-color: #f59e0b;
+  border-radius: 50%;
+  transform-origin: 20% 80%;
+  animation: whip-arc-swing 0.15s ease-out both;
+  pointer-events: none;
+}
+
+.whip-crack {
+  position: absolute;
+  left: 100%;
+  top: -6px;
+  margin-left: 4px;
+  font-size: 14px;
+  font-weight: 800;
+  color: #ef4444;
+  text-shadow: 0 1px 0 #fff, 1px 1px 0 rgba(0, 0, 0, 0.15);
+  animation: whip-crack-pop 0.45s ease-out both;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.whip-spark {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fbbf24;
+  pointer-events: none;
+  animation: whip-spark-fly 0.5s ease-out both;
+}
+
+.whip-spark-1 {
+  top: 2px;
+  right: -2px;
+  animation-delay: 0.15s;
+}
+
+.whip-spark-2 {
+  top: 12px;
+  right: -8px;
+  animation-delay: 0.18s;
+  background: #f97316;
+}
+
+.whip-spark-3 {
+  top: -2px;
+  right: 8px;
+  animation-delay: 0.2s;
+  background: #fde68a;
+}
+
+@keyframes whip-arc-swing {
+  from {
+    transform: rotate(-40deg) scale(0.6);
+    opacity: 0;
+  }
+  to {
+    transform: rotate(25deg) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes whip-shake {
+  0%,
+  100% {
+    transform: translate(0, 0) rotate(0);
+  }
+  15% {
+    transform: translate(-3px, 1px) rotate(-8deg);
+  }
+  30% {
+    transform: translate(4px, -1px) rotate(7deg);
+  }
+  45% {
+    transform: translate(-3px, 1px) rotate(-6deg);
+  }
+  60% {
+    transform: translate(2px, 0) rotate(4deg);
+  }
+  75% {
+    transform: translate(-1px, 0) rotate(-2deg);
+  }
+}
+
+@keyframes whip-crack-pop {
+  0% {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+  30% {
+    transform: scale(1.35);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) translateY(-6px);
+    opacity: 0;
+  }
+}
+
+@keyframes whip-spark-fly {
+  0% {
+    transform: translate(0, 0) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(10px, -12px) scale(0);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .whip-arc,
+  .whip-crack,
+  .whip-spark {
+    display: none !important;
+  }
+
+  .whip-hit .msg-avatar {
+    animation: whip-shake-reduced 0.2s ease-out both;
+  }
+}
+
+@keyframes whip-shake-reduced {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(2px, 0);
+  }
+}
+
 .msg:hover .msg-avatar {
   transform: scale(1.05);
 }

--- a/styles.css
+++ b/styles.css
@@ -3448,12 +3448,10 @@ button {
   /* Cracker contact point (~96,230 of the 560x300 viewBox) pins onto the avatar. */
   margin-left: calc(var(--whip-w) * -0.171);
   margin-top: calc(var(--whip-h) * -0.767);
-  /* Pivot near the handle/wrist so wind-up stays in the chat viewport. */
+  /* Pivot near the handle/wrist; the Verlet root swings in SVG space so
+     the stage itself no longer needs an independent CSS rotate. */
   transform-origin: 88% 62%;
-  /* transform + opacity are set imperatively per frame from
-     computeArmSwing() in CodeWhipOverlay, so the arm's swing and the
-     rope's wave share one continuous, physically-motivated timeline
-     instead of running as two independently-timed animations. */
+  /* Opacity is set imperatively per frame from computeStageFade(). */
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
 
@@ -3468,11 +3466,9 @@ button {
 }
 
 /*
- * The rope itself is driven frame-by-frame from JS (see whipMotion.ts /
- * CodeWhipOverlay) using a continuous traveling-wave formula rather than
- * discrete CSS keyframes, so it flows like a real rope/snake instead of a
- * jointed arm. `.code-whip-base` / `.code-whip-rope` just need their base
- * stroke styling here; their `d` attribute is set imperatively.
+ * Soft lash is a Verlet rope (whipMotion.ts) stepped each RAF frame from
+ * CodeWhipOverlay. Paths are set imperatively; these rules only style the
+ * stroke taper layers.
  */
 .code-whip-base,
 .code-whip-rope {

--- a/styles.css
+++ b/styles.css
@@ -3439,16 +3439,16 @@ button {
 
 .code-whip-stage {
   --whip-w: min(78vw, 520px);
-  --whip-h: calc(var(--whip-w) * 0.535);
+  --whip-h: calc(var(--whip-w) * 0.536);
   position: absolute;
   left: var(--whip-hit-x, 50%);
   top: var(--whip-hit-y, 40%);
   width: var(--whip-w);
   height: var(--whip-h);
-  /* Tip (~4% from left, ~75% down) pins onto the avatar. */
-  margin-left: calc(var(--whip-w) * -0.04);
-  margin-top: calc(var(--whip-h) * -0.75);
-  /* Pivot near the handle so wind-up stays in the chat viewport. */
+  /* Cracker contact point (~96,230 of the 560x300 viewBox) pins onto the avatar. */
+  margin-left: calc(var(--whip-w) * -0.171);
+  margin-top: calc(var(--whip-h) * -0.767);
+  /* Pivot near the handle/wrist so wind-up stays in the chat viewport. */
   transform-origin: 88% 62%;
   animation: code-whip-swing 2.3s cubic-bezier(0.22, 0.7, 0.18, 1) both;
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
@@ -3460,20 +3460,35 @@ button {
   overflow: visible;
 }
 
-.code-whip-cord,
-.code-whip-cord-thin {
-  /* Keep tip visible; snake motion comes from path morph, not dash hide. */
+.code-whip-tip {
   opacity: 1;
 }
 
-.code-whip-tip {
-  opacity: 1;
-  transform-origin: 430px 152px;
-  animation: code-whip-tip-wave 2.3s cubic-bezier(0.33, 0.1, 0.25, 1) both;
+/* Kinematic chain: each joint pivots at its own start point (in the SVG's
+   local coordinate space) and rotates independently, so rotation composes
+   naturally down the chain — a real traveling whip wave, not a path morph. */
+.code-whip-joint-1 {
+  transform-origin: 372px 150px;
+  animation: code-whip-joint-1 2.3s ease-in-out both;
+}
+
+.code-whip-joint-2 {
+  transform-origin: 312px 158px;
+  animation: code-whip-joint-2 2.3s ease-in-out both;
+}
+
+.code-whip-joint-3 {
+  transform-origin: 246px 178px;
+  animation: code-whip-joint-3 2.3s ease-in-out both;
+}
+
+.code-whip-joint-4 {
+  transform-origin: 176px 204px;
+  animation: code-whip-joint-4 2.3s ease-in-out both;
 }
 
 .code-whip-cracker {
-  transform-origin: 40px 212px;
+  transform-origin: 108px 226px;
   animation: code-whip-cracker-flick 2.3s ease-out both;
 }
 
@@ -3615,7 +3630,14 @@ button {
   }
 }
 
-@keyframes code-whip-tip-wave {
+/*
+ * Traveling whip wave: joint-1 (near handle) leads with a small, early
+ * ripple; each later joint has a larger swing that peaks progressively
+ * later, so the motion visibly cascades from handle to tip and lands the
+ * sharp "crack" at joint-4 / the cracker right around WHIP_HIT_AT_MS
+ * (~46% of the 2.3s effect).
+ */
+@keyframes code-whip-joint-1 {
   0%,
   10% {
     transform: rotate(0deg);
@@ -3623,19 +3645,112 @@ button {
   22% {
     transform: rotate(4deg);
   }
-  34% {
-    transform: rotate(-3deg);
+  30% {
+    transform: rotate(-5deg);
   }
-  46% {
-    transform: rotate(3deg);
+  38% {
+    transform: rotate(6deg);
+  }
+  44% {
+    transform: rotate(-6deg);
   }
   52% {
+    transform: rotate(3deg);
+  }
+  62% {
+    transform: rotate(-2deg);
+  }
+  76%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes code-whip-joint-2 {
+  0%,
+  14% {
+    transform: rotate(0deg);
+  }
+  26% {
+    transform: rotate(-6deg);
+  }
+  34% {
+    transform: rotate(8deg);
+  }
+  41% {
+    transform: rotate(-9deg);
+  }
+  46% {
+    transform: rotate(9deg);
+  }
+  54% {
     transform: rotate(-5deg);
   }
   64% {
     transform: rotate(2deg);
   }
-  78%,
+  80%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes code-whip-joint-3 {
+  0%,
+  18% {
+    transform: rotate(0deg);
+  }
+  30% {
+    transform: rotate(9deg);
+  }
+  38% {
+    transform: rotate(-12deg);
+  }
+  44% {
+    transform: rotate(13deg);
+  }
+  48% {
+    transform: rotate(-15deg);
+  }
+  56% {
+    transform: rotate(7deg);
+  }
+  68% {
+    transform: rotate(-3deg);
+  }
+  84%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes code-whip-joint-4 {
+  0%,
+  22% {
+    transform: rotate(0deg);
+  }
+  33% {
+    transform: rotate(-11deg);
+  }
+  40% {
+    transform: rotate(15deg);
+  }
+  44% {
+    transform: rotate(-20deg);
+  }
+  46% {
+    transform: rotate(26deg);
+  }
+  52% {
+    transform: rotate(-16deg);
+  }
+  60% {
+    transform: rotate(8deg);
+  }
+  70% {
+    transform: rotate(-4deg);
+  }
+  86%,
   100% {
     transform: rotate(0deg);
   }
@@ -3643,19 +3758,25 @@ button {
 
 @keyframes code-whip-cracker-flick {
   0%,
-  42% {
+  30% {
     transform: rotate(0deg);
   }
-  48% {
-    transform: rotate(16deg);
+  38% {
+    transform: rotate(-14deg);
   }
-  54% {
-    transform: rotate(-20deg);
+  44% {
+    transform: rotate(20deg);
   }
-  62% {
-    transform: rotate(7deg);
+  46% {
+    transform: rotate(-30deg);
   }
-  72%,
+  50% {
+    transform: rotate(14deg);
+  }
+  58% {
+    transform: rotate(-6deg);
+  }
+  70%,
   100% {
     transform: rotate(0deg);
   }
@@ -3725,9 +3846,7 @@ button {
   .code-whip-crack,
   .code-whip-spark,
   .code-whip-flash,
-  .code-whip-impact,
-  .code-whip-tip,
-  .code-whip-cracker {
+  .code-whip-impact {
     animation-duration: 0.25s !important;
   }
 
@@ -3736,7 +3855,10 @@ button {
     opacity: 0.85;
   }
 
-  .code-whip-tip,
+  .code-whip-joint-1,
+  .code-whip-joint-2,
+  .code-whip-joint-3,
+  .code-whip-joint-4,
   .code-whip-cracker {
     animation: none !important;
   }

--- a/styles.css
+++ b/styles.css
@@ -3438,17 +3438,17 @@ button {
 }
 
 .code-whip-stage {
-  --whip-w: min(96vw, 720px);
-  --whip-h: calc(var(--whip-w) * 0.5625);
+  --whip-w: min(98vw, 780px);
+  --whip-h: calc(var(--whip-w) * 0.5);
   position: absolute;
   left: var(--whip-hit-x, 50%);
   top: var(--whip-hit-y, 40%);
   width: var(--whip-w);
   height: var(--whip-h);
-  /* Tip sits further left of the SVG; pin that tip onto the avatar. */
-  margin-left: calc(var(--whip-w) * 0.22);
+  /* Tip sits far left of the SVG; pin that tip onto the avatar. */
+  margin-left: calc(var(--whip-w) * 0.14);
   margin-top: calc(var(--whip-h) * -0.94);
-  transform-origin: 93% 76%;
+  transform-origin: 94% 70%;
   animation: code-whip-swing 2.3s cubic-bezier(0.22, 0.7, 0.18, 1) both;
   filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.32));
 }
@@ -3461,8 +3461,8 @@ button {
 
 .code-whip-cord,
 .code-whip-cord-thin {
-  stroke-dasharray: 1100;
-  stroke-dashoffset: 1100;
+  stroke-dasharray: 1200;
+  stroke-dashoffset: 1200;
   animation: code-whip-unfurl 0.55s ease-out both;
 }
 
@@ -3603,7 +3603,7 @@ button {
 
 @keyframes code-whip-unfurl {
   from {
-    stroke-dashoffset: 1100;
+    stroke-dashoffset: 1200;
   }
   to {
     stroke-dashoffset: 0;

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -21,5 +21,5 @@ test("styles define whip-hit comedy effect and reduced-motion fallback", () => {
   assert.match(css, /\.whip-hit/);
   assert.match(css, /@keyframes whip/);
   assert.match(css, /prefers-reduced-motion/);
-  assert.match(css, /whip-crack|啪/);
+  assert.match(css, /whip-crack/);
 });

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -13,28 +13,27 @@ test("MessageBubble aims whip at avatar coordinates", () => {
   assert.match(src, /whip-hit/);
 });
 
-test("ChatView mounts a full-chat code whip overlay with a jointed lash", () => {
+test("ChatView mounts a full-chat code whip overlay driven by whipMotion", () => {
   const chat = read("../src/components/CLI/ChatView.tsx");
   const overlay = read("../src/components/CLI/CodeWhipOverlay.tsx");
   assert.match(chat, /CodeWhipOverlay/);
   assert.match(overlay, /code-whip-overlay/);
   assert.match(overlay, /code-whip-svg/);
   assert.match(overlay, /whip-grip-grad/);
-  assert.match(overlay, /code-whip-joint code-whip-joint-1/);
-  assert.match(overlay, /code-whip-joint code-whip-joint-4/);
+  assert.match(overlay, /computeWhipFrame/);
+  assert.match(overlay, /requestAnimationFrame/);
+  assert.match(overlay, /prefers-reduced-motion/);
   assert.match(overlay, /code-whip-cracker/);
   assert.match(overlay, /--whip-hit-x/);
 });
 
-test("styles chain per-joint whip waves into a crack timed at avatar hit", () => {
+test("styles support the JS-driven rope wave and avatar hit shake", () => {
   const css = read("../styles.css");
   assert.match(css, /\.code-whip-overlay/);
   assert.match(css, /@keyframes code-whip-swing/);
   assert.match(css, /@keyframes code-whip-avatar-hit/);
-  assert.match(css, /@keyframes code-whip-joint-1/);
-  assert.match(css, /@keyframes code-whip-joint-4/);
-  assert.match(css, /@keyframes code-whip-cracker-flick/);
-  assert.match(css, /\.code-whip-joint-4\s*\{[^}]*transform-origin/);
+  assert.match(css, /\.code-whip-base/);
+  assert.match(css, /\.code-whip-rope/);
   assert.match(css, /\.msg-avatar-whip-target\.whip-hit/);
   assert.match(css, /--whip-hit-x/);
 });

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -4,12 +4,13 @@ import fs from "node:fs";
 
 const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
 
-test("MessageBubble allows whipping any assistant avatar", () => {
+test("MessageBubble aims whip at avatar coordinates", () => {
   const src = read("../src/components/CLI/MessageBubble.tsx");
   assert.match(src, /canWhip = message\.role === "assistant"/);
   assert.match(src, /useWhipEffectStore/);
-  assert.match(src, /handleWhip/);
-  assert.match(src, /\.trigger\(\)/);
+  assert.match(src, /getBoundingClientRect/);
+  assert.match(src, /targetMessageId === message\.id/);
+  assert.match(src, /whip-hit/);
 });
 
 test("ChatView mounts a full-chat code whip overlay", () => {
@@ -18,20 +19,23 @@ test("ChatView mounts a full-chat code whip overlay", () => {
   assert.match(chat, /CodeWhipOverlay/);
   assert.match(overlay, /code-whip-overlay/);
   assert.match(overlay, /code-whip-svg/);
-  assert.match(overlay, /useWhipEffectStore/);
+  assert.match(overlay, /whip-handle-grad/);
+  assert.match(overlay, /--whip-hit-x/);
 });
 
-test("styles define livestream-style center whip effect", () => {
+test("styles aim whip tip at avatar and shake hit avatar", () => {
   const css = read("../styles.css");
   assert.match(css, /\.code-whip-overlay/);
   assert.match(css, /@keyframes code-whip-swing/);
-  assert.match(css, /\.code-whip-crack/);
-  assert.match(css, /prefers-reduced-motion/);
+  assert.match(css, /@keyframes code-whip-avatar-hit/);
+  assert.match(css, /\.msg-avatar-whip-target\.whip-hit/);
+  assert.match(css, /--whip-hit-x/);
 });
 
-test("whip effect store exposes trigger cooldown", () => {
+test("whip effect store tracks target message and point", () => {
   const src = read("../src/store/whipEffectStore.ts");
   assert.match(src, /WHIP_EFFECT_MS/);
+  assert.match(src, /targetMessageId/);
+  assert.match(src, /WhipTargetPoint/);
   assert.match(src, /trigger:/);
-  assert.match(src, /active: true/);
 });

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -19,8 +19,8 @@ test("ChatView mounts a full-chat code whip overlay", () => {
   assert.match(chat, /CodeWhipOverlay/);
   assert.match(overlay, /code-whip-overlay/);
   assert.match(overlay, /code-whip-svg/);
-  assert.match(overlay, /whip-grip-grad|whip-lash-grad/);
-  assert.match(overlay, /code-whip-seg/);
+  assert.match(overlay, /whip-grip-grad|whip-tip-grad/);
+  assert.match(overlay, /code-whip-cord/);
   assert.match(overlay, /--whip-hit-x/);
 });
 
@@ -29,7 +29,7 @@ test("styles aim whip tip at avatar and shake hit avatar", () => {
   assert.match(css, /\.code-whip-overlay/);
   assert.match(css, /@keyframes code-whip-swing/);
   assert.match(css, /@keyframes code-whip-avatar-hit/);
-  assert.match(css, /@keyframes code-whip-snake/);
+  assert.match(css, /@keyframes code-whip-tip-wave/);
   assert.match(css, /\.msg-avatar-whip-target\.whip-hit/);
   assert.match(css, /--whip-hit-x/);
 });

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -4,30 +4,34 @@ import fs from "node:fs";
 
 const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
 
-test("MessageBubble gates code whip to running/starting assistant avatars", () => {
+test("MessageBubble allows whipping any assistant avatar", () => {
   const src = read("../src/components/CLI/MessageBubble.tsx");
-  assert.match(src, /whipNonce/);
-  assert.match(src, /whipping/);
-  assert.match(src, /whip-hit/);
-  assert.match(
-    src,
-    /status === "running" \|\| message\.status === "starting"/
-  );
-  assert.match(src, /handleWhip|onWhip|whipAvatar/);
+  assert.match(src, /canWhip = message\.role === "assistant"/);
+  assert.match(src, /useWhipEffectStore/);
+  assert.match(src, /handleWhip/);
+  assert.match(src, /\.trigger\(\)/);
 });
 
-test("styles define whip-hit comedy effect and reduced-motion fallback", () => {
+test("ChatView mounts a full-chat code whip overlay", () => {
+  const chat = read("../src/components/CLI/ChatView.tsx");
+  const overlay = read("../src/components/CLI/CodeWhipOverlay.tsx");
+  assert.match(chat, /CodeWhipOverlay/);
+  assert.match(overlay, /code-whip-overlay/);
+  assert.match(overlay, /code-whip-svg/);
+  assert.match(overlay, /useWhipEffectStore/);
+});
+
+test("styles define livestream-style center whip effect", () => {
   const css = read("../styles.css");
-  assert.match(css, /\.whip-hit/);
-  assert.match(css, /@keyframes whip-swing/);
+  assert.match(css, /\.code-whip-overlay/);
+  assert.match(css, /@keyframes code-whip-swing/);
+  assert.match(css, /\.code-whip-crack/);
   assert.match(css, /prefers-reduced-motion/);
-  assert.match(css, /whip-crack/);
-  assert.match(css, /\.whip-lash/);
 });
 
-test("MessageBubble renders a big SVG whip lash on hit", () => {
-  const src = read("../src/components/CLI/MessageBubble.tsx");
-  assert.match(src, /whip-lash/);
-  assert.match(src, /whip-lash-svg/);
-  assert.match(src, /whip-lash-cord/);
+test("whip effect store exposes trigger cooldown", () => {
+  const src = read("../src/store/whipEffectStore.ts");
+  assert.match(src, /WHIP_EFFECT_MS/);
+  assert.match(src, /trigger:/);
+  assert.match(src, /active: true/);
 });

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -20,26 +20,28 @@ test("ChatView mounts a full-chat code whip overlay driven by whipMotion", () =>
   assert.match(overlay, /code-whip-overlay/);
   assert.match(overlay, /code-whip-svg/);
   assert.match(overlay, /whip-grip-grad/);
-  assert.match(overlay, /computeWhipFrame/);
-  assert.match(overlay, /computeArmSwing/);
+  assert.match(overlay, /createWhipSimulation/);
+  assert.match(overlay, /swingProgress/);
   assert.match(overlay, /requestAnimationFrame/);
   assert.match(overlay, /prefers-reduced-motion/);
   assert.match(overlay, /code-whip-cracker/);
   assert.match(overlay, /--whip-hit-x/);
 });
 
-test("the arm swing and rope wave share one JS-driven timeline, not two", () => {
+test("Verlet handle path drives the rope; stage has no CSS swing keyframes", () => {
   const overlay = read("../src/components/CLI/CodeWhipOverlay.tsx");
   const styles = read("../styles.css");
-  // The stage's transform/opacity must be set imperatively alongside the
-  // rope, not via a separate CSS keyframe animation running independently.
-  assert.match(overlay, /stageRef\.current\.style\.transform/);
+  const motion = read("../src/utils/whipMotion.ts");
+  // Soft rope is a Verlet sim; decorative handle translates with the root.
+  assert.match(motion, /CONSTRAINT_ITERS|constraint/i);
+  assert.match(motion, /handlePos/);
+  assert.match(overlay, /handleRef/);
   assert.match(overlay, /stageRef\.current\.style\.opacity/);
   assert.doesNotMatch(styles, /@keyframes code-whip-swing/);
   assert.doesNotMatch(styles, /\.code-whip-stage\s*\{[^}]*\banimation:/);
 });
 
-test("styles support the JS-driven rope wave and avatar hit shake", () => {
+test("styles support the JS-driven Verlet rope and avatar hit shake", () => {
   const css = read("../styles.css");
   assert.match(css, /\.code-whip-overlay/);
   assert.match(css, /@keyframes code-whip-avatar-hit/);

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -19,7 +19,7 @@ test("ChatView mounts a full-chat code whip overlay", () => {
   assert.match(chat, /CodeWhipOverlay/);
   assert.match(overlay, /code-whip-overlay/);
   assert.match(overlay, /code-whip-svg/);
-  assert.match(overlay, /whip-handle-grad/);
+  assert.match(overlay, /whip-grip-grad|whip-lash-grad/);
   assert.match(overlay, /--whip-hit-x/);
 });
 

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
+
+test("MessageBubble gates code whip to running/starting assistant avatars", () => {
+  const src = read("../src/components/CLI/MessageBubble.tsx");
+  assert.match(src, /whipNonce/);
+  assert.match(src, /whipping/);
+  assert.match(src, /whip-hit/);
+  assert.match(
+    src,
+    /status === "running" \|\| message\.status === "starting"/
+  );
+  assert.match(src, /handleWhip|onWhip|whipAvatar/);
+});
+
+test("styles define whip-hit comedy effect and reduced-motion fallback", () => {
+  const css = read("../styles.css");
+  assert.match(css, /\.whip-hit/);
+  assert.match(css, /@keyframes whip/);
+  assert.match(css, /prefers-reduced-motion/);
+  assert.match(css, /whip-crack|啪/);
+});

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -20,6 +20,7 @@ test("ChatView mounts a full-chat code whip overlay", () => {
   assert.match(overlay, /code-whip-overlay/);
   assert.match(overlay, /code-whip-svg/);
   assert.match(overlay, /whip-grip-grad|whip-lash-grad/);
+  assert.match(overlay, /code-whip-seg/);
   assert.match(overlay, /--whip-hit-x/);
 });
 
@@ -28,6 +29,7 @@ test("styles aim whip tip at avatar and shake hit avatar", () => {
   assert.match(css, /\.code-whip-overlay/);
   assert.match(css, /@keyframes code-whip-swing/);
   assert.match(css, /@keyframes code-whip-avatar-hit/);
+  assert.match(css, /@keyframes code-whip-snake/);
   assert.match(css, /\.msg-avatar-whip-target\.whip-hit/);
   assert.match(css, /--whip-hit-x/);
 });

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -21,16 +21,27 @@ test("ChatView mounts a full-chat code whip overlay driven by whipMotion", () =>
   assert.match(overlay, /code-whip-svg/);
   assert.match(overlay, /whip-grip-grad/);
   assert.match(overlay, /computeWhipFrame/);
+  assert.match(overlay, /computeArmSwing/);
   assert.match(overlay, /requestAnimationFrame/);
   assert.match(overlay, /prefers-reduced-motion/);
   assert.match(overlay, /code-whip-cracker/);
   assert.match(overlay, /--whip-hit-x/);
 });
 
+test("the arm swing and rope wave share one JS-driven timeline, not two", () => {
+  const overlay = read("../src/components/CLI/CodeWhipOverlay.tsx");
+  const styles = read("../styles.css");
+  // The stage's transform/opacity must be set imperatively alongside the
+  // rope, not via a separate CSS keyframe animation running independently.
+  assert.match(overlay, /stageRef\.current\.style\.transform/);
+  assert.match(overlay, /stageRef\.current\.style\.opacity/);
+  assert.doesNotMatch(styles, /@keyframes code-whip-swing/);
+  assert.doesNotMatch(styles, /\.code-whip-stage\s*\{[^}]*\banimation:/);
+});
+
 test("styles support the JS-driven rope wave and avatar hit shake", () => {
   const css = read("../styles.css");
   assert.match(css, /\.code-whip-overlay/);
-  assert.match(css, /@keyframes code-whip-swing/);
   assert.match(css, /@keyframes code-whip-avatar-hit/);
   assert.match(css, /\.code-whip-base/);
   assert.match(css, /\.code-whip-rope/);

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -19,7 +19,15 @@ test("MessageBubble gates code whip to running/starting assistant avatars", () =
 test("styles define whip-hit comedy effect and reduced-motion fallback", () => {
   const css = read("../styles.css");
   assert.match(css, /\.whip-hit/);
-  assert.match(css, /@keyframes whip/);
+  assert.match(css, /@keyframes whip-swing/);
   assert.match(css, /prefers-reduced-motion/);
   assert.match(css, /whip-crack/);
+  assert.match(css, /\.whip-lash/);
+});
+
+test("MessageBubble renders a big SVG whip lash on hit", () => {
+  const src = read("../src/components/CLI/MessageBubble.tsx");
+  assert.match(src, /whip-lash/);
+  assert.match(src, /whip-lash-svg/);
+  assert.match(src, /whip-lash-cord/);
 });

--- a/tests/code-whip.test.mjs
+++ b/tests/code-whip.test.mjs
@@ -13,23 +13,28 @@ test("MessageBubble aims whip at avatar coordinates", () => {
   assert.match(src, /whip-hit/);
 });
 
-test("ChatView mounts a full-chat code whip overlay", () => {
+test("ChatView mounts a full-chat code whip overlay with a jointed lash", () => {
   const chat = read("../src/components/CLI/ChatView.tsx");
   const overlay = read("../src/components/CLI/CodeWhipOverlay.tsx");
   assert.match(chat, /CodeWhipOverlay/);
   assert.match(overlay, /code-whip-overlay/);
   assert.match(overlay, /code-whip-svg/);
-  assert.match(overlay, /whip-grip-grad|whip-tip-grad/);
-  assert.match(overlay, /code-whip-cord/);
+  assert.match(overlay, /whip-grip-grad/);
+  assert.match(overlay, /code-whip-joint code-whip-joint-1/);
+  assert.match(overlay, /code-whip-joint code-whip-joint-4/);
+  assert.match(overlay, /code-whip-cracker/);
   assert.match(overlay, /--whip-hit-x/);
 });
 
-test("styles aim whip tip at avatar and shake hit avatar", () => {
+test("styles chain per-joint whip waves into a crack timed at avatar hit", () => {
   const css = read("../styles.css");
   assert.match(css, /\.code-whip-overlay/);
   assert.match(css, /@keyframes code-whip-swing/);
   assert.match(css, /@keyframes code-whip-avatar-hit/);
-  assert.match(css, /@keyframes code-whip-tip-wave/);
+  assert.match(css, /@keyframes code-whip-joint-1/);
+  assert.match(css, /@keyframes code-whip-joint-4/);
+  assert.match(css, /@keyframes code-whip-cracker-flick/);
+  assert.match(css, /\.code-whip-joint-4\s*\{[^}]*transform-origin/);
   assert.match(css, /\.msg-avatar-whip-target\.whip-hit/);
   assert.match(css, /--whip-hit-x/);
 });

--- a/tests/whip-motion.test.mjs
+++ b/tests/whip-motion.test.mjs
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+async function loadWhipMotion() {
+  const source = fs.readFileSync(
+    new URL("../src/utils/whipMotion.ts", import.meta.url),
+    "utf8"
+  );
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(`data:text/javascript;base64,${Buffer.from(output).toString("base64")}`);
+}
+
+test("computeWhipFrame starts at the rest shape before any wave arrives", async () => {
+  const { computeWhipFrame, WHIP_ATTACH_POINT } = await loadWhipMotion();
+  const frame = computeWhipFrame(0);
+  assert.ok(frame.ropeD.startsWith(`M${WHIP_ATTACH_POINT.x} ${WHIP_ATTACH_POINT.y}`));
+  assert.ok(Number.isFinite(frame.tipX));
+  assert.ok(Number.isFinite(frame.tipY));
+  // At t=0 no joint's wave has arrived yet, so the tip sits at the rest
+  // bezier's endpoint (96, 230).
+  assert.ok(Math.abs(frame.tipX - 96) < 1);
+  assert.ok(Math.abs(frame.tipY - 230) < 1);
+});
+
+test("computeWhipFrame produces continuous motion as the wave travels", async () => {
+  const { computeWhipFrame } = await loadWhipMotion();
+  const rest = computeWhipFrame(0);
+  const mid = computeWhipFrame(400);
+  const nearCrack = computeWhipFrame(1050);
+  // Upstream joints have already started bending well before the wave
+  // reaches the tip itself, so the tip position visibly moves early too.
+  assert.notEqual(mid.tipX.toFixed(3), rest.tipX.toFixed(3));
+  assert.notEqual(mid.tipY.toFixed(3), rest.tipY.toFixed(3));
+  assert.notEqual(nearCrack.ropeD, rest.ropeD);
+  assert.notEqual(nearCrack.ropeD, mid.ropeD);
+});
+
+test("computeWhipFrame respects a custom crackAtMs", async () => {
+  const { computeWhipFrame, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
+  assert.equal(DEFAULT_CRACK_AT_MS, 1050);
+  const withDefault = computeWhipFrame(300);
+  const withCustom = computeWhipFrame(300, 5000);
+  // A much later crackAtMs means the wave hasn't reached most joints yet
+  // at t=300ms, so the shape should differ from the default timing.
+  assert.notEqual(withDefault.ropeD, withCustom.ropeD);
+});
+
+test("computeWhipFrame stays finite across the full effect duration", async () => {
+  const { computeWhipFrame } = await loadWhipMotion();
+  for (let t = 0; t <= 2300; t += 50) {
+    const frame = computeWhipFrame(t);
+    assert.ok(Number.isFinite(frame.tipX), `tipX finite at t=${t}`);
+    assert.ok(Number.isFinite(frame.tipY), `tipY finite at t=${t}`);
+    assert.ok(Number.isFinite(frame.tipAngle), `tipAngle finite at t=${t}`);
+    assert.match(frame.ropeD, /^M\d/);
+    assert.match(frame.baseD, /^M\d/);
+  }
+});
+
+test("computeWhipFrame settles back near the rest tip after the ring-down", async () => {
+  const { computeWhipFrame } = await loadWhipMotion();
+  const settled = computeWhipFrame(2300);
+  assert.ok(Math.abs(settled.tipX - 96) < 6);
+  assert.ok(Math.abs(settled.tipY - 230) < 6);
+});

--- a/tests/whip-motion.test.mjs
+++ b/tests/whip-motion.test.mjs
@@ -14,94 +14,107 @@ async function loadWhipMotion() {
       target: ts.ScriptTarget.ES2022
     }
   }).outputText;
-  return import(`data:text/javascript;base64,${Buffer.from(output).toString("base64")}`);
+  return import(
+    `data:text/javascript;base64,${Buffer.from(output).toString("base64")}`
+  );
 }
 
-test("computeWhipFrame starts at the rest shape before any wave arrives", async () => {
-  const { computeWhipFrame, WHIP_ATTACH_POINT } = await loadWhipMotion();
-  const frame = computeWhipFrame(0);
+test("handlePos winds up right, snaps left, then recovers", async () => {
+  const { handlePos, WHIP_ATTACH_POINT } = await loadWhipMotion();
+  const rest = handlePos(0);
+  assert.equal(rest.x, WHIP_ATTACH_POINT.x);
+  assert.equal(rest.y, WHIP_ATTACH_POINT.y);
+
+  const windup = handlePos(0.35);
+  assert.ok(windup.x > WHIP_ATTACH_POINT.x, "wind-up pulls the grip right");
+  assert.ok(windup.y < WHIP_ATTACH_POINT.y, "wind-up lifts the grip");
+
+  const snap = handlePos(0.6);
+  assert.ok(snap.x < WHIP_ATTACH_POINT.x, "snap throws the grip left toward the tip");
+  assert.ok(snap.x < windup.x, "snap travels past the wind-up peak");
+
+  const end = handlePos(1);
+  assert.ok(Math.abs(end.x - WHIP_ATTACH_POINT.x) < 2);
+  assert.ok(Math.abs(end.y - WHIP_ATTACH_POINT.y) < 2);
+});
+
+test("swingProgress maps crackAtMs onto the snap phase (~0.6)", async () => {
+  const { swingProgress, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
+  assert.ok(Math.abs(swingProgress(0) - 0) < 1e-9);
+  const atCrack = swingProgress(DEFAULT_CRACK_AT_MS);
+  assert.ok(Math.abs(atCrack - 0.6) < 1e-6, `expected ~0.6, got ${atCrack}`);
+  assert.ok(swingProgress(DEFAULT_CRACK_AT_MS * 0.42) < 0.36);
+  assert.ok(swingProgress(2300) >= 0.99);
+});
+
+test("Verlet sim starts hanging from the attach point", async () => {
+  const { createWhipSimulation, WHIP_ATTACH_POINT } = await loadWhipMotion();
+  const sim = createWhipSimulation();
+  const frame = sim.step(0);
   assert.ok(frame.ropeD.startsWith(`M${WHIP_ATTACH_POINT.x} ${WHIP_ATTACH_POINT.y}`));
   assert.ok(Number.isFinite(frame.tipX));
   assert.ok(Number.isFinite(frame.tipY));
-  // At t=0 no joint's wave has arrived yet, so the tip sits at the rest
-  // bezier's endpoint (96, 230).
-  assert.ok(Math.abs(frame.tipX - 96) < 1);
-  assert.ok(Math.abs(frame.tipY - 230) < 1);
+  assert.ok(frame.tipX < WHIP_ATTACH_POINT.x, "tip hangs to the left of the grip");
+  assert.ok(frame.tipY > WHIP_ATTACH_POINT.y, "tip hangs below the grip");
 });
 
-test("computeWhipFrame produces continuous motion as the wave travels", async () => {
-  const { computeWhipFrame } = await loadWhipMotion();
-  const rest = computeWhipFrame(0);
-  const mid = computeWhipFrame(400);
-  const nearCrack = computeWhipFrame(1050);
-  // Upstream joints have already started bending well before the wave
-  // reaches the tip itself, so the tip position visibly moves early too.
-  assert.notEqual(mid.tipX.toFixed(3), rest.tipX.toFixed(3));
-  assert.notEqual(mid.tipY.toFixed(3), rest.tipY.toFixed(3));
-  assert.notEqual(nearCrack.ropeD, rest.ropeD);
-  assert.notEqual(nearCrack.ropeD, mid.ropeD);
+test("Verlet sim produces continuous motion through the swing", async () => {
+  const { createWhipSimulation } = await loadWhipMotion();
+  const sim = createWhipSimulation();
+  const a = sim.step(0);
+  const b = sim.step(0.2);
+  const c = sim.step(0.5);
+  assert.notEqual(b.ropeD, a.ropeD);
+  assert.notEqual(c.ropeD, b.ropeD);
+  assert.ok(Number.isFinite(c.tipSpeed));
 });
 
-test("computeWhipFrame respects a custom crackAtMs", async () => {
-  const { computeWhipFrame, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
-  assert.equal(DEFAULT_CRACK_AT_MS, 1050);
-  const withDefault = computeWhipFrame(300);
-  const withCustom = computeWhipFrame(300, 5000);
-  // A much later crackAtMs means the wave hasn't reached most joints yet
-  // at t=300ms, so the shape should differ from the default timing.
-  assert.notEqual(withDefault.ropeD, withCustom.ropeD);
+test("tip speed peaks during the forward snap", async () => {
+  const { createWhipSimulation } = await loadWhipMotion();
+  const sim = createWhipSimulation();
+  let peak = 0;
+  let peakP = 0;
+  for (let i = 0; i <= 60; i += 1) {
+    const p = i / 60;
+    const frame = sim.step(p);
+    if (frame.tipSpeed > peak) {
+      peak = frame.tipSpeed;
+      peakP = p;
+    }
+  }
+  assert.ok(peak > 20, `expected a real crack-speed peak, got ${peak}`);
+  // Snap phase is 0.35→0.6; peak should land in/near that window.
+  assert.ok(peakP >= 0.3 && peakP <= 0.75, `peak at progress ${peakP}`);
 });
 
 test("computeWhipFrame stays finite across the full effect duration", async () => {
   const { computeWhipFrame } = await loadWhipMotion();
-  for (let t = 0; t <= 2300; t += 50) {
+  for (let t = 0; t <= 2300; t += 100) {
     const frame = computeWhipFrame(t);
     assert.ok(Number.isFinite(frame.tipX), `tipX finite at t=${t}`);
     assert.ok(Number.isFinite(frame.tipY), `tipY finite at t=${t}`);
     assert.ok(Number.isFinite(frame.tipAngle), `tipAngle finite at t=${t}`);
-    assert.match(frame.ropeD, /^M\d/);
-    assert.match(frame.baseD, /^M\d/);
+    assert.match(frame.ropeD, /^M[\d.-]/);
+    assert.match(frame.baseD, /^M[\d.-]/);
+    assert.ok(frame.opacity >= 0 && frame.opacity <= 1);
   }
 });
 
-test("computeWhipFrame settles back near the rest tip after the ring-down", async () => {
-  const { computeWhipFrame } = await loadWhipMotion();
-  const settled = computeWhipFrame(2300);
-  assert.ok(Math.abs(settled.tipX - 96) < 6);
-  assert.ok(Math.abs(settled.tipY - 230) < 6);
-});
+test("computeStageFade fades in then out; no independent arm rotation", async () => {
+  const { computeStageFade, computeArmSwing } = await loadWhipMotion();
+  const start = computeStageFade(0, 2300);
+  assert.ok(start.opacity < 0.05);
+  assert.equal(start.deg, 0);
 
-test("computeArmSwing fades in, winds up, then snaps negative right at the crack", async () => {
-  const { computeArmSwing, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
-  const start = computeArmSwing(0, DEFAULT_CRACK_AT_MS, 2300);
-  assert.ok(start.opacity < 0.05, "starts nearly invisible (fade-in)");
-  assert.ok(Math.abs(start.deg) < 1, "starts with no rotation");
+  const mid = computeStageFade(800, 2300);
+  assert.equal(mid.opacity, 1);
+  assert.equal(mid.deg, 0);
 
-  const windupPeak = computeArmSwing(
-    DEFAULT_CRACK_AT_MS * 0.42,
-    DEFAULT_CRACK_AT_MS,
-    2300
-  );
-  assert.ok(windupPeak.deg > 15, "wound up into a positive lean-back angle");
+  const end = computeStageFade(2300, 2300);
+  assert.ok(end.opacity < 0.05);
 
-  const atCrack = computeArmSwing(DEFAULT_CRACK_AT_MS, DEFAULT_CRACK_AT_MS, 2300);
-  assert.ok(atCrack.deg < 0, "the crack lands on a negative (forward) angle");
-  assert.ok(atCrack.deg < windupPeak.deg, "swung forward past the wind-up peak");
-});
-
-test("computeArmSwing settles and fades out by the end of the effect", async () => {
-  const { computeArmSwing, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
-  const end = computeArmSwing(2300, DEFAULT_CRACK_AT_MS, 2300);
-  assert.ok(end.opacity < 0.05, "fades out by the end");
-  assert.ok(Math.abs(end.deg) < 6, "settles close to a small resting angle");
-});
-
-test("computeArmSwing stays finite across the full effect duration", async () => {
-  const { computeArmSwing, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
-  for (let t = 0; t <= 2300; t += 25) {
-    const swing = computeArmSwing(t, DEFAULT_CRACK_AT_MS, 2300);
-    assert.ok(Number.isFinite(swing.deg), `deg finite at t=${t}`);
-    assert.ok(Number.isFinite(swing.scale), `scale finite at t=${t}`);
-    assert.ok(swing.opacity >= 0 && swing.opacity <= 1, `opacity in [0,1] at t=${t}`);
-  }
+  // Back-compat alias still exports and matches the fade helper.
+  const alias = computeArmSwing(800, 1050, 2300);
+  assert.equal(alias.deg, 0);
+  assert.equal(alias.opacity, 1);
 });

--- a/tests/whip-motion.test.mjs
+++ b/tests/whip-motion.test.mjs
@@ -19,19 +19,33 @@ async function loadWhipMotion() {
   );
 }
 
-test("handlePos winds up right, snaps left, then recovers", async () => {
+test("handlePos winds up over the top, then cracks through a big circular throw", async () => {
   const { handlePos, WHIP_ATTACH_POINT } = await loadWhipMotion();
   const rest = handlePos(0);
   assert.equal(rest.x, WHIP_ATTACH_POINT.x);
   assert.equal(rest.y, WHIP_ATTACH_POINT.y);
 
   const windup = handlePos(0.35);
-  assert.ok(windup.x > WHIP_ATTACH_POINT.x, "wind-up pulls the grip right");
-  assert.ok(windup.y < WHIP_ATTACH_POINT.y, "wind-up lifts the grip");
+  assert.ok(windup.y < WHIP_ATTACH_POINT.y - 40, "wind-up lifts the grip high");
+  assert.ok(windup.x < WHIP_ATTACH_POINT.x, "wind-up leans back toward the pivot");
+
+  // Mid-snap should still be high/left — the long way over the top.
+  const midSnap = handlePos(0.5);
+  assert.ok(midSnap.x < windup.x, "snap continues left over the top");
 
   const snap = handlePos(0.6);
-  assert.ok(snap.x < WHIP_ATTACH_POINT.x, "snap throws the grip left toward the tip");
-  assert.ok(snap.x < windup.x, "snap travels past the wind-up peak");
+  assert.ok(snap.y > WHIP_ATTACH_POINT.y, "crack lands below rest after the circular throw");
+  assert.ok(snap.x < WHIP_ATTACH_POINT.x, "crack still aims left toward the tip");
+
+  // Arc length of the throw should be large ("抡圆了"), not a short jab.
+  let arc = 0;
+  let prev = handlePos(0.35);
+  for (let i = 1; i <= 20; i += 1) {
+    const cur = handlePos(0.35 + (0.25 * i) / 20);
+    arc += Math.hypot(cur.x - prev.x, cur.y - prev.y);
+    prev = cur;
+  }
+  assert.ok(arc > 350, `expected a long circular snap arc, got ${arc.toFixed(0)}`);
 
   const end = handlePos(1);
   assert.ok(Math.abs(end.x - WHIP_ATTACH_POINT.x) < 2);
@@ -69,22 +83,25 @@ test("Verlet sim produces continuous motion through the swing", async () => {
   assert.ok(Number.isFinite(c.tipSpeed));
 });
 
-test("tip speed peaks during the forward snap", async () => {
+test("tip speed peaks hard during the forward snap", async () => {
   const { createWhipSimulation } = await loadWhipMotion();
   const sim = createWhipSimulation();
   let peak = 0;
   let peakP = 0;
-  for (let i = 0; i <= 60; i += 1) {
-    const p = i / 60;
+  let cracked = false;
+  for (let i = 0; i <= 90; i += 1) {
+    const p = i / 90;
     const frame = sim.step(p);
+    if (frame.cracked) cracked = true;
     if (frame.tipSpeed > peak) {
       peak = frame.tipSpeed;
       peakP = p;
     }
   }
-  assert.ok(peak > 20, `expected a real crack-speed peak, got ${peak}`);
-  // Snap phase is 0.35→0.6; peak should land in/near that window.
-  assert.ok(peakP >= 0.3 && peakP <= 0.75, `peak at progress ${peakP}`);
+  assert.ok(peak > 40, `expected a hard crack-speed peak, got ${peak}`);
+  // Soft rope lags the handle, so the tip peak lands near/just after snap.
+  assert.ok(peakP >= 0.4 && peakP <= 0.9, `peak at progress ${peakP}`);
+  assert.equal(cracked, true, "tip speed should trigger a crack burst");
 });
 
 test("computeWhipFrame stays finite across the full effect duration", async () => {

--- a/tests/whip-motion.test.mjs
+++ b/tests/whip-motion.test.mjs
@@ -19,33 +19,57 @@ async function loadWhipMotion() {
   );
 }
 
-test("handlePos winds up over the top, then cracks through a big circular throw", async () => {
+test("handlePos raises overhead then lashes straight down, not a windmill", async () => {
   const { handlePos, WHIP_ATTACH_POINT } = await loadWhipMotion();
   const rest = handlePos(0);
   assert.equal(rest.x, WHIP_ATTACH_POINT.x);
   assert.equal(rest.y, WHIP_ATTACH_POINT.y);
 
-  const windup = handlePos(0.35);
-  assert.ok(windup.y < WHIP_ATTACH_POINT.y - 40, "wind-up lifts the grip high");
-  assert.ok(windup.x < WHIP_ATTACH_POINT.x, "wind-up leans back toward the pivot");
+  // Wind-up raises the grip high overhead to load a downward lash.
+  const windup = handlePos(0.32);
+  assert.ok(
+    windup.y < WHIP_ATTACH_POINT.y - 100,
+    "wind-up lifts the grip overhead"
+  );
+  assert.ok(
+    windup.x > WHIP_ATTACH_POINT.x,
+    "wind-up stays back, away from the target"
+  );
 
-  // Mid-snap should still be high/left — the long way over the top.
-  const midSnap = handlePos(0.5);
-  assert.ok(midSnap.x < windup.x, "snap continues left over the top");
+  // The lash drives the grip straight down toward the avatar.
+  const lash = handlePos(0.45);
+  assert.ok(lash.y > windup.y, "lash drives the grip downward");
+  assert.ok(lash.x < windup.x, "lash also drifts toward the target");
+  const snap = handlePos(0.58);
+  assert.ok(
+    snap.y > WHIP_ATTACH_POINT.y + 100,
+    "crack lands near the bottom of the throw"
+  );
+  assert.ok(snap.x < WHIP_ATTACH_POINT.x, "crack lands left toward the avatar");
 
-  const snap = handlePos(0.6);
-  assert.ok(snap.y > WHIP_ATTACH_POINT.y, "crack lands below rest after the circular throw");
-  assert.ok(snap.x < WHIP_ATTACH_POINT.x, "crack still aims left toward the tip");
+  // The hand halts hard just past the crack: the halt segment is far
+  // shorter than the lash segment, then the grip reverses a touch. That
+  // abrupt stop is what lets the soft tip overshoot and crack.
+  const lashSeg = Math.hypot(
+    handlePos(0.58).x - handlePos(0.5).x,
+    handlePos(0.58).y - handlePos(0.5).y
+  );
+  const haltSeg = Math.hypot(
+    handlePos(0.63).x - handlePos(0.58).x,
+    handlePos(0.63).y - handlePos(0.58).y
+  );
+  assert.ok(
+    haltSeg < lashSeg * 0.5,
+    `expected an abrupt halt, lash=${lashSeg.toFixed(0)} halt=${haltSeg.toFixed(0)}`
+  );
+  assert.ok(handlePos(0.63).y < snap.y, "slight pull-back up after the halt");
 
-  // Arc length of the throw should be large ("抡圆了"), not a short jab.
-  let arc = 0;
-  let prev = handlePos(0.35);
-  for (let i = 1; i <= 20; i += 1) {
-    const cur = handlePos(0.35 + (0.25 * i) / 20);
-    arc += Math.hypot(cur.x - prev.x, cur.y - prev.y);
-    prev = cur;
-  }
-  assert.ok(arc > 350, `expected a long circular snap arc, got ${arc.toFixed(0)}`);
+  // Recovery eases straight back to rest — no unwinding lap around a pivot.
+  const mid = handlePos(0.8);
+  assert.ok(
+    mid.x > handlePos(0.63).x && mid.x < WHIP_ATTACH_POINT.x,
+    "recover heads straight back to rest"
+  );
 
   const end = handlePos(1);
   assert.ok(Math.abs(end.x - WHIP_ATTACH_POINT.x) < 2);

--- a/tests/whip-motion.test.mjs
+++ b/tests/whip-motion.test.mjs
@@ -70,3 +70,38 @@ test("computeWhipFrame settles back near the rest tip after the ring-down", asyn
   assert.ok(Math.abs(settled.tipX - 96) < 6);
   assert.ok(Math.abs(settled.tipY - 230) < 6);
 });
+
+test("computeArmSwing fades in, winds up, then snaps negative right at the crack", async () => {
+  const { computeArmSwing, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
+  const start = computeArmSwing(0, DEFAULT_CRACK_AT_MS, 2300);
+  assert.ok(start.opacity < 0.05, "starts nearly invisible (fade-in)");
+  assert.ok(Math.abs(start.deg) < 1, "starts with no rotation");
+
+  const windupPeak = computeArmSwing(
+    DEFAULT_CRACK_AT_MS * 0.42,
+    DEFAULT_CRACK_AT_MS,
+    2300
+  );
+  assert.ok(windupPeak.deg > 15, "wound up into a positive lean-back angle");
+
+  const atCrack = computeArmSwing(DEFAULT_CRACK_AT_MS, DEFAULT_CRACK_AT_MS, 2300);
+  assert.ok(atCrack.deg < 0, "the crack lands on a negative (forward) angle");
+  assert.ok(atCrack.deg < windupPeak.deg, "swung forward past the wind-up peak");
+});
+
+test("computeArmSwing settles and fades out by the end of the effect", async () => {
+  const { computeArmSwing, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
+  const end = computeArmSwing(2300, DEFAULT_CRACK_AT_MS, 2300);
+  assert.ok(end.opacity < 0.05, "fades out by the end");
+  assert.ok(Math.abs(end.deg) < 6, "settles close to a small resting angle");
+});
+
+test("computeArmSwing stays finite across the full effect duration", async () => {
+  const { computeArmSwing, DEFAULT_CRACK_AT_MS } = await loadWhipMotion();
+  for (let t = 0; t <= 2300; t += 25) {
+    const swing = computeArmSwing(t, DEFAULT_CRACK_AT_MS, 2300);
+    assert.ok(Number.isFinite(swing.deg), `deg finite at t=${t}`);
+    assert.ok(Number.isFinite(swing.scale), `scale finite at t=${t}`);
+    assert.ok(swing.opacity >= 0 && swing.opacity <= 1, `opacity in [0,1] at t=${t}`);
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

聊天页「码鞭」彩蛋：点击助手头像触发全屏挥鞭特效，瞄准头像并带命中抖动。纯视觉，不影响 agent 执行。

### 最新：抡圆了甩（大圆弧 + 更大力度）

- 手柄绕肩部枢轴走 ~250° 过顶圆弧（后拉抬起 → 加速抡过 → 回收）
- 前甩用 quartic ease-in，角速度在 crack 时刻拉满
- 鞭梢峰值速度更高，稳定触发炸裂粒子
- 底层仍是 Verlet 软绳（距离约束 + 重力/阻尼）

### 入口与交互

- 任意助手消息头像可点（含空闲）
- 冷却期内不可重复触发
- `prefers-reduced-motion` 时定格中段姿态

## Test plan

- [x] `npm test`
- [ ] 手动：点助手头像，确认抡圆过顶、甩鞭更有力
- [ ] 手动：命中时刻头像抖动 +「啪」字与火花
- [ ] 手动：快速连点确认冷却
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6673a03-d625-4b94-b4c1-c835a6f69d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6673a03-d625-4b94-b4c1-c835a6f69d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

