### PR TITLE
feat: optimize Draft preview agent bridge guide

### DIFF
--- a/electron/agentBridge.ts
+++ b/electron/agentBridge.ts
@@ -19,6 +19,11 @@ export interface BridgeAction {
  */
 export const DEFAULT_BRIDGE_PORT = 17878;
 export let BRIDGE_PORT = DEFAULT_BRIDGE_PORT;
+let hasActiveBridgePort = false;
+let resolveActiveBridgePort: ((port: number) => void) | undefined;
+const activeBridgePortReady = new Promise<number>((resolve) => {
+  resolveActiveBridgePort = resolve;
+});
 
 export function getActiveBridgePort(): number {
   return BRIDGE_PORT;
@@ -26,6 +31,29 @@ export function getActiveBridgePort(): number {
 
 export function setActiveBridgePort(port: number): void {
   BRIDGE_PORT = port;
+  if (!hasActiveBridgePort) {
+    hasActiveBridgePort = true;
+    resolveActiveBridgePort?.(port);
+    resolveActiveBridgePort = undefined;
+  }
+}
+
+export async function waitForActiveBridgePort(timeoutMs = 10_000): Promise<number> {
+  if (hasActiveBridgePort) return BRIDGE_PORT;
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      activeBridgePortReady,
+      new Promise<number>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("FreeBuddy Draft bridge did not start in time.")),
+          timeoutMs
+        );
+      })
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 export const BRIDGE_ACTIONS: BridgeAction[] = [

--- a/electron/agentBridge.ts
+++ b/electron/agentBridge.ts
@@ -17,7 +17,16 @@ export interface BridgeAction {
  *  - HTTP routing (previewServer.ts -> parseBridgeRequest)
  *  - the capability list injected into workspace guide files (agentGuides.ts)
  */
-export const BRIDGE_PORT = 17878;
+export const DEFAULT_BRIDGE_PORT = 17878;
+export let BRIDGE_PORT = DEFAULT_BRIDGE_PORT;
+
+export function getActiveBridgePort(): number {
+  return BRIDGE_PORT;
+}
+
+export function setActiveBridgePort(port: number): void {
+  BRIDGE_PORT = port;
+}
 
 export const BRIDGE_ACTIONS: BridgeAction[] = [
   {
@@ -141,6 +150,7 @@ export function buildBridgeSection(port: number): string {
     `curl -s "http://127.0.0.1:${port}/freebuddy/navigate?to=%2Ftmp%2Fposter.png"`,
     `curl -s "http://127.0.0.1:${port}/freebuddy/navigate?to=freebuddy-file%3A%2F%2Fopen%3Fpath%3D%252Ftmp%252Fposter.png"`,
     "```",
+    "",
     "",
     "Available actions:",
     ""

--- a/electron/agentGuides.ts
+++ b/electron/agentGuides.ts
@@ -1,13 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { BRIDGE_PORT, buildBridgeSection } from "./agentBridge.js";
+import { getActiveBridgePort, buildBridgeSection } from "./agentBridge.js";
+import { startWatchingFileBridge } from "./fileBridge.js";
 
-const GUIDE_FILES = ["AGENTS.md", "CLAUDE.md", ".cursorrules"];
+const ROOT_GUIDE_FILES = ["AGENTS.md", "CLAUDE.md", ".cursorrules"];
 const FB_SIGNATURE = "auto-created by FreeBuddy";
 
-function buildGuideContent(): string {
-  const bridge = buildBridgeSection(BRIDGE_PORT);
+function buildDetailedGuideContent(port: number): string {
+  const bridge = buildBridgeSection(port);
   return `# FreeBuddy Workspace Guide
 
 You are working inside **FreeBuddy**, a local-first desktop app that runs you
@@ -28,26 +29,123 @@ When the task involves building or changing anything visual or document-like:
 - For generated visual assets, navigate to the workspace-relative image path such as \`assets%2Fmockup.png\`; if the image is outside the workspace, pass its absolute path directly or use \`freebuddy-file://open?path=<absolute path>\`.
 - Report build/dev-server/status or errors through the bridge so the user can see what happened.
 
+## Communication Channels (Zero-Network File Bridge & Local HTTP Bridge)
+
+To trigger preview/navigate/status/notify actions in FreeBuddy, you can use either of the following two channels:
+
+### 1. Preferred Channel (Zero-Network File-based Bridge)
+If you are running in a restricted sandbox/container environment, or on a system where network curl commands are restricted or flaky (like Windows), write a simple JSON file to \`.freebuddy/bridge.json\`.
+FreeBuddy watches this directory, executes your action, and will automatically delete the file for you.
+
+To use it, write a file at \`.freebuddy/bridge.json\` with this exact format:
+\`\`\`json
+{
+  "action": "navigate",
+  "params": {
+    "to": "http://127.0.0.1:5173/"
+  }
+}
+\`\`\`
+
+You can also trigger action "preview" (without parameters) like this:
+\`\`\`json
+{
+  "action": "preview"
+}
+\`\`\`
+
+Supported actions for the file-based bridge are: "preview", "navigate", "entry", "status", "error", "notify".
+
+### 2. Alternative Channel (Local HTTP Bridge)
 ${bridge}
 
 > This file was ${FB_SIGNATURE} and is safe to edit or delete.
 `;
 }
 
+export interface AgentGuideStatus {
+  path: string;
+  action: "created" | "updated";
+}
+
+async function ensureGitignore(cwd: string): Promise<void> {
+  const gitignorePath = path.join(cwd, ".gitignore");
+  let content = "";
+  let exists = false;
+  try {
+    content = await fs.readFile(gitignorePath, "utf8");
+    exists = true;
+  } catch (err: any) {
+    if (err.code !== "ENOENT") {
+      console.warn(`[FreeBuddy] Failed to read .gitignore at ${gitignorePath}:`, err);
+    }
+    exists = false;
+  }
+
+  const rule = ".freebuddy/";
+  if (exists) {
+    const lines = content.split(/\r?\n/);
+    const hasRule = lines.some((line) => {
+      const cleaned = line.replace(/#.*$/, "").trim();
+      return cleaned === rule || cleaned === ".freebuddy" || cleaned === rule.slice(0, -1);
+    });
+    if (!hasRule) {
+      const separator = content.endsWith("\n") ? "" : "\n";
+      try {
+        await fs.writeFile(gitignorePath, content + separator + rule + "\n", "utf8");
+      } catch (err: any) {
+        console.warn(`[FreeBuddy] Failed to append rule to .gitignore at ${gitignorePath}:`, err);
+      }
+    }
+  } else {
+    try {
+      await fs.writeFile(gitignorePath, rule + "\n", "utf8");
+    } catch (err: any) {
+      console.warn(`[FreeBuddy] Failed to create .gitignore with rule at ${gitignorePath}:`, err);
+    }
+  }
+}
+
 export async function ensureAgentGuides(
   cwd: string
-): Promise<string[]> {
-  const written: string[] = [];
+): Promise<AgentGuideStatus[]> {
+  const written: AgentGuideStatus[] = [];
   if (!cwd || !path.isAbsolute(cwd)) return written;
 
-  const content = buildGuideContent();
-  for (const name of GUIDE_FILES) {
+  // Start watching the file bridge for this cwd
+  void startWatchingFileBridge(cwd).catch((err: any) => {
+    console.warn(`[FreeBuddy] Failed to start file bridge watcher for ${cwd}:`, err);
+  });
+
+  const activePort = getActiveBridgePort();
+  const detailedContent = buildDetailedGuideContent(activePort);
+
+  // 1. Ensure .gitignore excludes .freebuddy/
+  try {
+    await ensureGitignore(cwd);
+  } catch (err: any) {
+    console.warn(`[FreeBuddy] ensureGitignore encountered unexpected error:`, err);
+  }
+
+  // 2. Ensure .freebuddy/ folder exists
+  const freebuddyDir = path.join(cwd, ".freebuddy");
+  try {
+    await fs.mkdir(freebuddyDir, { recursive: true });
+  } catch (err: any) {
+    console.warn(`[FreeBuddy] Failed to create .freebuddy directory at ${freebuddyDir}:`, err);
+  }
+
+  // 3. Write guides to root files (AGENTS.md, CLAUDE.md, .cursorrules)
+  for (const name of ROOT_GUIDE_FILES) {
     const full = path.join(cwd, name);
     let exists = false;
     try {
       await fs.access(full);
       exists = true;
-    } catch {
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        console.warn(`[FreeBuddy] Failed to check access for ${full}:`, err);
+      }
       exists = false;
     }
     if (exists) {
@@ -55,19 +153,58 @@ export async function ensureAgentGuides(
       try {
         const current = await fs.readFile(full, "utf8");
         if (current.includes(FB_SIGNATURE)) {
-          await fs.writeFile(full, content, "utf8");
+          if (current !== detailedContent) {
+            await fs.writeFile(full, detailedContent, "utf8");
+            written.push({ path: name, action: "updated" });
+          }
         }
-      } catch {
-        // ignore read/write errors
+      } catch (err: any) {
+        console.warn(`[FreeBuddy] Failed to update guide file at ${full}:`, err);
       }
     } else {
       try {
-        await fs.writeFile(full, content, "utf8");
-        written.push(name);
-      } catch {
-        // ignore write errors (permissions, read-only, etc.)
+        await fs.writeFile(full, detailedContent, "utf8");
+        written.push({ path: name, action: "created" });
+      } catch (err: any) {
+        console.warn(`[FreeBuddy] Failed to create guide file at ${full}:`, err);
       }
     }
+  }
+
+  // 4. Write to .cursor/rules/freebuddy.md if .cursor/ directory exists or we can write to it
+  const cursorRulesDir = path.join(cwd, ".cursor", "rules");
+  const cursorRuleFile = path.join(cursorRulesDir, "freebuddy.md");
+  try {
+    await fs.mkdir(cursorRulesDir, { recursive: true });
+    let exists = false;
+    try {
+      await fs.access(cursorRuleFile);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      try {
+        const current = await fs.readFile(cursorRuleFile, "utf8");
+        if (current !== detailedContent) {
+          await fs.writeFile(cursorRuleFile, detailedContent, "utf8");
+          written.push({
+            path: path.join(".cursor", "rules", "freebuddy.md"),
+            action: "updated"
+          });
+        }
+      } catch (err: any) {
+        console.warn(`[FreeBuddy] Failed to read/update Cursor rule file at ${cursorRuleFile}:`, err);
+      }
+    } else {
+      await fs.writeFile(cursorRuleFile, detailedContent, "utf8");
+      written.push({
+        path: path.join(".cursor", "rules", "freebuddy.md"),
+        action: "created"
+      });
+    }
+  } catch (err: any) {
+    console.warn(`[FreeBuddy] Failed to write Cursor rule file at ${cursorRuleFile}:`, err);
   }
 
   return written;

--- a/electron/agentGuides.ts
+++ b/electron/agentGuides.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { getActiveBridgePort, buildBridgeSection } from "./agentBridge.js";
-import { startWatchingFileBridge } from "./fileBridge.js";
+import {
+  startWatchingFileBridge,
+  stopWatchingFileBridge
+} from "./fileBridge.js";
 
 const ROOT_GUIDE_FILES = ["AGENTS.md", "CLAUDE.md", ".cursorrules"];
 const FB_SIGNATURE = "auto-created by FreeBuddy";
@@ -68,6 +71,11 @@ export interface AgentGuideStatus {
   action: "created" | "updated";
 }
 
+export interface AgentGuideOptions {
+  /** ACP sessions receive Draft as a native MCP tool and do not need repo files. */
+  nativeDraftTools?: boolean;
+}
+
 async function ensureGitignore(cwd: string): Promise<void> {
   const gitignorePath = path.join(cwd, ".gitignore");
   let content = "";
@@ -107,10 +115,16 @@ async function ensureGitignore(cwd: string): Promise<void> {
 }
 
 export async function ensureAgentGuides(
-  cwd: string
+  cwd: string,
+  options: AgentGuideOptions = {}
 ): Promise<AgentGuideStatus[]> {
   const written: AgentGuideStatus[] = [];
   if (!cwd || !path.isAbsolute(cwd)) return written;
+
+  if (options.nativeDraftTools) {
+    stopWatchingFileBridge();
+    return written;
+  }
 
   // Start watching the file bridge for this cwd
   void startWatchingFileBridge(cwd).catch((err: any) => {

--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import type { AcpStdioMcpServer } from "../shared/draftToolProtocol.js";
+
 export type AcpRequestId = number | string | null;
 
 export interface AcpMessage {
@@ -168,7 +170,8 @@ export function buildInitializeRequest(id: AcpRequestId): AcpMessage {
 
 export function buildSessionNewRequest(
   id: AcpRequestId,
-  cwd?: string
+  cwd?: string,
+  mcpServers: AcpStdioMcpServer[] = []
 ): AcpMessage {
   return {
     jsonrpc: "2.0",
@@ -176,7 +179,7 @@ export function buildSessionNewRequest(
     method: "session/new",
     params: {
       cwd: cwd || process.cwd(),
-      mcpServers: []
+      mcpServers
     }
   };
 }
@@ -184,7 +187,8 @@ export function buildSessionNewRequest(
 export function buildSessionResumeRequest(
   id: AcpRequestId,
   sessionId: string,
-  cwd?: string
+  cwd?: string,
+  mcpServers: AcpStdioMcpServer[] = []
 ): AcpMessage {
   return {
     jsonrpc: "2.0",
@@ -193,7 +197,7 @@ export function buildSessionResumeRequest(
     params: {
       sessionId,
       cwd: cwd || process.cwd(),
-      mcpServers: []
+      mcpServers
     }
   };
 }
@@ -201,7 +205,8 @@ export function buildSessionResumeRequest(
 export function buildSessionLoadRequest(
   id: AcpRequestId,
   sessionId: string,
-  cwd?: string
+  cwd?: string,
+  mcpServers: AcpStdioMcpServer[] = []
 ): AcpMessage {
   return {
     jsonrpc: "2.0",
@@ -210,7 +215,7 @@ export function buildSessionLoadRequest(
     params: {
       sessionId,
       cwd: cwd || process.cwd(),
-      mcpServers: []
+      mcpServers
     }
   };
 }

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { randomUUID } from "node:crypto";
 import { type ChildProcessByStdio } from "node:child_process";
 import type { Readable, Writable } from "node:stream";
+import type { WebContents } from "electron";
 
 import {
   acpSessionListToItems,
@@ -40,6 +41,11 @@ import {
   type Running
 } from "./runtimeShared.js";
 import { killProcessTree } from "./process-kill.js";
+import {
+  registerDraftToolSession,
+  unregisterDraftToolSession
+} from "../draftToolService.js";
+import type { AcpStdioMcpServer } from "../shared/draftToolProtocol.js";
 
 function writeAcp(
   child: ChildProcessByStdio<Writable, Readable, Readable>,
@@ -50,6 +56,7 @@ function writeAcp(
 
 export interface AcpRuntimeInput {
   child: ChildProcessByStdio<Writable, Readable, Readable>;
+  webContents: WebContents;
   args: CliRunArgs;
   pid: number;
   logStream: fs.WriteStream | null;
@@ -62,6 +69,7 @@ export interface AcpRuntimeInput {
 
 export async function runAcpAgent({
   child,
+  webContents,
   args,
   pid,
   logStream,
@@ -76,6 +84,7 @@ export async function runAcpAgent({
   let finished = false;
   let promptStarted = false;
   let promptHadContent = false;
+  let mcpServers: AcpStdioMcpServer[] = [];
   const replayMessageIds = new Set(args.knownStreamMessageIds ?? []);
   const terminalManager = createAcpTerminalManager({
     defaultCwd: args.cwd,
@@ -123,6 +132,7 @@ export async function runAcpAgent({
     finished = true;
     terminalManager.dispose();
     running.delete(args.sessionId);
+    unregisterDraftToolSession(args.sessionId);
     clearPermissionResolversForSession(args.sessionId);
     if (errorMessage) emit({ type: "error", message: errorMessage });
     emit({ type: "done", exitCode });
@@ -531,18 +541,20 @@ export async function runAcpAgent({
 
     if (toolSessionId && agentCaps?.loadSession) {
       const loaded = await request(
-        buildSessionLoadRequest(nextId(), toolSessionId, args.cwd)
+        buildSessionLoadRequest(nextId(), toolSessionId, args.cwd, mcpServers)
       );
       activeAcpSessionId = toolSessionId;
       emitSetupItems(loaded);
     } else if (toolSessionId && agentCaps?.sessionCapabilities?.resume) {
       const resumed = await request(
-        buildSessionResumeRequest(nextId(), toolSessionId, args.cwd)
+        buildSessionResumeRequest(nextId(), toolSessionId, args.cwd, mcpServers)
       );
       activeAcpSessionId = toolSessionId;
       emitSetupItems(resumed);
     } else {
-      const created = await request(buildSessionNewRequest(nextId(), args.cwd));
+      const created = await request(
+        buildSessionNewRequest(nextId(), args.cwd, mcpServers)
+      );
       activeAcpSessionId = created?.sessionId ?? created?.session_id;
       emitSetupItems(created);
     }
@@ -612,6 +624,17 @@ export async function runAcpAgent({
     const init = await request(buildInitializeRequest(nextId()));
     agentCaps = init?.agentCapabilities ?? {};
     authMethods = Array.isArray(init?.authMethods) ? init.authMethods : [];
+
+    if (args.conversationId && args.cwd) {
+      mcpServers = [
+        await registerDraftToolSession({
+          taskSessionId: args.sessionId,
+          conversationId: args.conversationId,
+          cwd: args.cwd,
+          webContents
+        })
+      ];
+    }
 
     try {
       await establishSession();

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -73,6 +73,8 @@ import { tMain } from "./i18n.js";
 import { setApplicationMenuForLanguage } from "../menu.js";
 import { registerWorkflowIpc } from "./workflowIpc.js";
 import { readCodexUsage } from "./codexUsage.js";
+import { resolveDraftToolRequest } from "../draftToolService.js";
+import type { DraftToolResolution } from "../shared/draftToolProtocol.js";
 
 function senderWindow(event: IpcMainInvokeEvent): BrowserWindow | null {
   return BrowserWindow.fromWebContents(event.sender);
@@ -239,6 +241,11 @@ export function registerCliIpc() {
     return { sessionId: args.sessionId };
   });
   ipcMain.handle("cli:kill", (_e, sessionId: string) => cliKill(sessionId));
+  ipcMain.handle(
+    "draft-tool:resolve",
+    (event, resolution: DraftToolResolution) =>
+      resolveDraftToolRequest(event.sender, resolution)
+  );
 
   ipcMain.handle(
     "cli:permissionDecision",
@@ -327,8 +334,15 @@ export function registerCliIpc() {
     return true;
   });
 
-  ipcMain.handle("cli:ensureAgentGuides", (_e, cwd: string) =>
-    ensureAgentGuides(cwd ?? "")
+  ipcMain.handle(
+    "cli:ensureAgentGuides",
+    (
+      _e,
+      input: { cwd?: string; options?: { nativeDraftTools?: boolean } } | string
+    ) =>
+      typeof input === "string"
+        ? ensureAgentGuides(input)
+        : ensureAgentGuides(input?.cwd ?? "", input?.options)
   );
 
   // ---- Conversations -----------------------------------------------------

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -247,6 +247,7 @@ export async function cliRun(
   if (built.protocol === "acp") {
     await runAcpAgent({
       child,
+      webContents,
       args,
       pid,
       logStream,

--- a/electron/cli/runtimeShared.ts
+++ b/electron/cli/runtimeShared.ts
@@ -15,6 +15,8 @@ export interface CliPromptAttachment {
 
 export interface CliRunArgs {
   sessionId: string;
+  /** FreeBuddy conversation that owns UI-scoped tools such as Draft. */
+  conversationId?: string;
   agentId: string;
   agentName: string;
   adapter: CLIAdapterId;

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -65,6 +65,7 @@ export interface ResolvedAgent {
 export interface StepExecutor {
   run(args: {
     sessionId: string;
+    conversationId?: string;
     agentId: string;
     agentName: string;
     adapter: string;
@@ -943,6 +944,7 @@ export class WorkflowRuntime {
     try {
       await this.deps.executor.run({
         sessionId,
+        conversationId: run.conversationId,
         agentId: step.agentId,
         agentName: resolved.agentName,
         adapter: resolved.adapter,
@@ -1091,6 +1093,7 @@ export function createCliStepExecutor(
       }
       const runArgs: CliRunArgs = {
         sessionId: args.sessionId,
+        conversationId: args.conversationId,
         agentId: args.agentId,
         agentName: args.agentName,
         adapter: args.adapter as any,

--- a/electron/draftToolService.ts
+++ b/electron/draftToolService.ts
@@ -1,0 +1,322 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+import type { WebContents } from "electron";
+
+import { waitForActiveBridgePort } from "./agentBridge.js";
+import { safeSendToWebContents } from "./cli/ipcSend.js";
+import type {
+  AcpStdioMcpServer,
+  DraftCaptureRect,
+  DraftConsoleEntry,
+  DraftToolAction,
+  DraftToolEvent,
+  DraftToolResolution,
+  DraftToolResult
+} from "./shared/draftToolProtocol.js";
+
+const DRAFT_TOOL_PATH = "/freebuddy/draft-tool";
+const MAX_REQUEST_BYTES = 64 * 1024;
+const RENDERER_TIMEOUT_MS = 15_000;
+
+interface DraftToolBinding {
+  token: string;
+  taskSessionId: string;
+  conversationId: string;
+  cwd: string;
+  webContents: WebContents;
+}
+
+interface PendingDraftToolRequest {
+  binding: DraftToolBinding;
+  action: DraftToolAction;
+  params: Record<string, unknown>;
+  resolve: (result: DraftToolResult) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+const bindingsByToken = new Map<string, DraftToolBinding>();
+const tokensByTaskSession = new Map<string, string>();
+const pendingRequests = new Map<string, PendingDraftToolRequest>();
+const consoleEntriesByWebContents = new Map<number, DraftConsoleEntry[]>();
+const observedWebContents = new Set<number>();
+
+function isDraftToolAction(value: unknown): value is DraftToolAction {
+  return value === "show" || value === "inspect" || value === "report";
+}
+
+function createCapabilityToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function draftMcpServerPath(): string {
+  return fileURLToPath(new URL("./mcp/draftMcpServer.js", import.meta.url));
+}
+
+function rejectPendingForToken(token: string, message: string): void {
+  for (const [requestId, pending] of pendingRequests) {
+    if (pending.binding.token !== token) continue;
+    clearTimeout(pending.timeout);
+    pendingRequests.delete(requestId);
+    pending.reject(new Error(message));
+  }
+}
+
+function observePreviewConsole(webContents: WebContents): void {
+  if (observedWebContents.has(webContents.id)) return;
+  observedWebContents.add(webContents.id);
+  consoleEntriesByWebContents.set(webContents.id, []);
+  webContents.on("console-message", (details) => {
+    if (!details.frame || details.frame === webContents.mainFrame) return;
+    const entries = consoleEntriesByWebContents.get(webContents.id);
+    if (!entries) return;
+    entries.push({
+      level: details.level,
+      message: details.message,
+      source: details.sourceId || details.frame.url || undefined,
+      line: details.lineNumber || undefined,
+      timestamp: new Date().toISOString()
+    });
+    if (entries.length > 100) entries.splice(0, entries.length - 100);
+  });
+  webContents.once("destroyed", () => {
+    observedWebContents.delete(webContents.id);
+    consoleEntriesByWebContents.delete(webContents.id);
+  });
+}
+
+function sanitizedCaptureRect(rect: DraftCaptureRect): DraftCaptureRect | undefined {
+  const x = Math.max(0, Math.floor(rect.x));
+  const y = Math.max(0, Math.floor(rect.y));
+  const width = Math.min(4096, Math.ceil(rect.width));
+  const height = Math.min(4096, Math.ceil(rect.height));
+  if (width < 1 || height < 1) return undefined;
+  return { x, y, width, height };
+}
+
+async function enrichDraftToolResult(
+  pending: Pick<PendingDraftToolRequest, "binding" | "action" | "params">,
+  result: DraftToolResult
+): Promise<DraftToolResult> {
+  const { captureRect, ...publicResult } = result;
+  if (pending.action !== "inspect") return publicResult;
+
+  const enriched: DraftToolResult = { ...publicResult };
+  if (pending.params.console !== false) {
+    enriched.diagnostics = {
+      console: (consoleEntriesByWebContents.get(pending.binding.webContents.id) ?? [])
+        .slice(-20)
+    };
+  }
+
+  if (pending.params.screenshot === true) {
+    const rect = captureRect ? sanitizedCaptureRect(captureRect) : undefined;
+    if (!rect || !publicResult.visible) {
+      enriched.screenshotError =
+        "Draft must be visible in the active conversation before it can be captured.";
+    } else {
+      try {
+        const image = await pending.binding.webContents.capturePage(rect);
+        const size = image.getSize();
+        enriched.screenshot = {
+          mimeType: "image/png",
+          data: image.toPNG().toString("base64"),
+          width: size.width,
+          height: size.height
+        };
+      } catch (error) {
+        enriched.screenshotError =
+          (error as Error)?.message || "Failed to capture Draft preview.";
+      }
+    }
+  }
+
+  return enriched;
+}
+
+export async function registerDraftToolSession(input: {
+  taskSessionId: string;
+  conversationId: string;
+  cwd: string;
+  webContents: WebContents;
+}): Promise<AcpStdioMcpServer> {
+  unregisterDraftToolSession(input.taskSessionId);
+
+  const port = await waitForActiveBridgePort();
+  const token = createCapabilityToken();
+  const binding: DraftToolBinding = { ...input, token };
+  observePreviewConsole(input.webContents);
+  bindingsByToken.set(token, binding);
+  tokensByTaskSession.set(input.taskSessionId, token);
+
+  return {
+    name: "freebuddy-draft",
+    command: process.execPath,
+    args: [draftMcpServerPath()],
+    env: [
+      { name: "ELECTRON_RUN_AS_NODE", value: "1" },
+      {
+        name: "FREEBUDDY_DRAFT_ENDPOINT",
+        value: `http://127.0.0.1:${port}${DRAFT_TOOL_PATH}`
+      },
+      { name: "FREEBUDDY_DRAFT_TOKEN", value: token },
+      {
+        name: "FB_APP_VERSION",
+        value: process.env.FB_APP_VERSION || "0.1.0"
+      }
+    ]
+  };
+}
+
+export function unregisterDraftToolSession(taskSessionId: string): void {
+  const token = tokensByTaskSession.get(taskSessionId);
+  if (!token) return;
+  tokensByTaskSession.delete(taskSessionId);
+  bindingsByToken.delete(token);
+  rejectPendingForToken(token, "Draft tool session ended before the request completed.");
+}
+
+async function dispatchDraftToolRequest(
+  binding: DraftToolBinding,
+  action: DraftToolAction,
+  params: Record<string, unknown>
+): Promise<DraftToolResult> {
+  if (action === "show") {
+    consoleEntriesByWebContents.set(binding.webContents.id, []);
+  }
+  const requestId = randomUUID();
+  const event: DraftToolEvent = {
+    requestId,
+    conversationId: binding.conversationId,
+    cwd: binding.cwd,
+    action,
+    params
+  };
+
+  const rendererResult = await new Promise<DraftToolResult>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pendingRequests.delete(requestId);
+      reject(new Error("Timed out waiting for the Draft preview renderer."));
+    }, RENDERER_TIMEOUT_MS);
+
+    pendingRequests.set(requestId, {
+      binding,
+      action,
+      params,
+      resolve,
+      reject,
+      timeout
+    });
+    const sent = safeSendToWebContents(
+      binding.webContents,
+      "freebuddy://draft-tool",
+      event
+    );
+    if (!sent) {
+      clearTimeout(timeout);
+      pendingRequests.delete(requestId);
+      reject(new Error("FreeBuddy renderer is not available."));
+    }
+  });
+  return enrichDraftToolResult({ binding, action, params }, rendererResult);
+}
+
+export function resolveDraftToolRequest(
+  sender: WebContents,
+  resolution: DraftToolResolution
+): boolean {
+  if (!resolution || typeof resolution.requestId !== "string") return false;
+  const pending = pendingRequests.get(resolution.requestId);
+  if (!pending || pending.binding.webContents.id !== sender.id) return false;
+  if (
+    !resolution.result ||
+    resolution.result.conversationId !== pending.binding.conversationId
+  ) {
+    return false;
+  }
+
+  clearTimeout(pending.timeout);
+  pendingRequests.delete(resolution.requestId);
+  pending.resolve(resolution.result);
+  return true;
+}
+
+function sendJson(
+  res: ServerResponse,
+  statusCode: number,
+  payload: Record<string, unknown>
+): void {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_REQUEST_BYTES) {
+      throw new Error("Draft tool request body is too large.");
+    }
+    chunks.push(buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+function bearerToken(req: IncomingMessage): string | undefined {
+  const value = req.headers.authorization;
+  if (!value?.startsWith("Bearer ")) return undefined;
+  return value.slice("Bearer ".length).trim() || undefined;
+}
+
+export async function handleDraftToolHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<boolean> {
+  let url: URL;
+  try {
+    url = new URL(req.url || "/", "http://127.0.0.1");
+  } catch {
+    return false;
+  }
+  if (url.pathname !== DRAFT_TOOL_PATH) return false;
+
+  if (req.method !== "POST") {
+    sendJson(res, 405, { ok: false, error: "method_not_allowed" });
+    return true;
+  }
+
+  const token = bearerToken(req);
+  const binding = token ? bindingsByToken.get(token) : undefined;
+  if (!binding) {
+    sendJson(res, 401, { ok: false, error: "invalid_capability_token" });
+    return true;
+  }
+
+  try {
+    const body = (await readJsonBody(req)) as Record<string, unknown>;
+    if (!body || !isDraftToolAction(body.action)) {
+      sendJson(res, 400, { ok: false, error: "invalid_action" });
+      return true;
+    }
+    const params =
+      body.params && typeof body.params === "object" && !Array.isArray(body.params)
+        ? (body.params as Record<string, unknown>)
+        : {};
+    if (!token || bindingsByToken.get(token) !== binding) {
+      sendJson(res, 410, { ok: false, error: "draft_tool_session_ended" });
+      return true;
+    }
+    const result = await dispatchDraftToolRequest(binding, body.action, params);
+    sendJson(res, 200, result as unknown as Record<string, unknown>);
+  } catch (error) {
+    sendJson(res, 500, {
+      ok: false,
+      error: (error as Error)?.message || String(error)
+    });
+  }
+  return true;
+}

--- a/electron/fileBridge.ts
+++ b/electron/fileBridge.ts
@@ -1,0 +1,216 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import type { WebContents } from "electron";
+import { safeSendToWebContents } from "./cli/ipcSend.js";
+import { isKnownBridgeAction } from "./agentBridge.js";
+
+let activeWatcher: fs.FSWatcher | null = null;
+let backupPollInterval: NodeJS.Timeout | null = null;
+let currentCwd: string | null = null;
+let webContentsGetter: (() => WebContents | null) | null = null;
+
+const processingFiles = new Set<string>();
+
+let retryCount = 0;
+const MAX_RETRIES = 5;
+const RETRY_DELAY_MS = 3000;
+let retryTimeout: NodeJS.Timeout | null = null;
+
+export function initFileBridge(getter: () => WebContents | null): void {
+  webContentsGetter = getter;
+}
+
+export function stopWatchingFileBridge(): void {
+  if (retryTimeout) {
+    clearTimeout(retryTimeout);
+    retryTimeout = null;
+  }
+  retryCount = 0;
+
+  if (backupPollInterval) {
+    clearInterval(backupPollInterval);
+    backupPollInterval = null;
+  }
+
+  if (activeWatcher) {
+    try {
+      activeWatcher.close();
+    } catch (err: any) {
+      console.warn("[FreeBuddy] Failed to close file bridge watcher:", err);
+    }
+    activeWatcher = null;
+  }
+  currentCwd = null;
+}
+
+async function handleBridgeFile(bridgeJsonPath: string): Promise<void> {
+  if (processingFiles.has(bridgeJsonPath)) {
+    return;
+  }
+  processingFiles.add(bridgeJsonPath);
+
+  try {
+    // Read the file
+    const raw = await fsPromises.readFile(bridgeJsonPath, "utf8");
+    if (!raw.trim()) return;
+
+    // Parse JSON
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && typeof parsed.action === "string") {
+      const action = parsed.action;
+      const params = parsed.params ?? {};
+
+      if (isKnownBridgeAction(action)) {
+        if (process.env.NODE_ENV === "development" || process.env.DEBUG) {
+          console.debug(`[FreeBuddy] File-based bridge triggered: ${action}`, params);
+        }
+        if (webContentsGetter) {
+          safeSendToWebContents(webContentsGetter(), "freebuddy://bridge", { action, params });
+        }
+      }
+    }
+  } catch (err: any) {
+    console.warn("[FreeBuddy] File-based bridge failed to process bridge.json:", err);
+  } finally {
+    // Always delete the bridge file to avoid reprocessing and to keep workspace clean
+    try {
+      await fsPromises.unlink(bridgeJsonPath);
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        console.warn(`[FreeBuddy] Failed to delete bridge.json at ${bridgeJsonPath}:`, err);
+      }
+    }
+    processingFiles.delete(bridgeJsonPath);
+  }
+}
+
+function setupWatcher(cwd: string): void {
+  if (currentCwd !== cwd) return; // If active directory changed during retry wait, do not set up
+
+  const freebuddyDir = path.join(cwd, ".freebuddy");
+  const bridgeJsonPath = path.join(freebuddyDir, "bridge.json");
+
+  try {
+    if (activeWatcher) {
+      try {
+        activeWatcher.close();
+      } catch (err: any) {
+        console.warn("[FreeBuddy] Error closing previous watcher:", err);
+      }
+      activeWatcher = null;
+    }
+
+    if (backupPollInterval) {
+      clearInterval(backupPollInterval);
+      backupPollInterval = null;
+    }
+
+    activeWatcher = fs.watch(freebuddyDir, async (eventType, filename) => {
+      if (filename === "bridge.json") {
+        // Check if file exists (it could be a deletion event, so fs.access verifies)
+        try {
+          await fsPromises.access(bridgeJsonPath, fs.constants.F_OK);
+          // File exists, process it
+          await handleBridgeFile(bridgeJsonPath);
+        } catch {
+          // File was deleted or is inaccessible, ignore
+        }
+      }
+    });
+
+    activeWatcher.on("error", (err: any) => {
+      console.warn(`[FreeBuddy] File bridge watcher encountered error on ${freebuddyDir}:`, err);
+      scheduleWatcherRetry(cwd);
+    });
+
+    // Start a backup polling check to guarantee cross-platform support (e.g. Linux fs.watch limits, containers)
+    backupPollInterval = setInterval(async () => {
+      if (currentCwd !== cwd) return;
+      try {
+        await fsPromises.access(bridgeJsonPath, fs.constants.F_OK);
+        await handleBridgeFile(bridgeJsonPath);
+      } catch {
+        // File does not exist, ignore
+      }
+    }, 2000);
+
+    // Reset retryCount after 5s of successful running
+    const currentAttempt = retryCount;
+    setTimeout(() => {
+      if (currentCwd === cwd && retryCount === currentAttempt && activeWatcher) {
+        retryCount = 0;
+      }
+    }, 5000);
+
+  } catch (err: any) {
+    console.warn(`[FreeBuddy] Failed to watch .freebuddy directory for file bridge at ${freebuddyDir}:`, err);
+    scheduleWatcherRetry(cwd);
+  }
+}
+
+function scheduleWatcherRetry(cwd: string): void {
+  if (currentCwd !== cwd) return;
+
+  if (activeWatcher) {
+    try {
+      activeWatcher.close();
+    } catch {
+      // ignore
+    }
+    activeWatcher = null;
+  }
+
+  if (backupPollInterval) {
+    clearInterval(backupPollInterval);
+    backupPollInterval = null;
+  }
+
+  if (retryTimeout) {
+    clearTimeout(retryTimeout);
+    retryTimeout = null;
+  }
+
+  if (retryCount < MAX_RETRIES) {
+    retryCount++;
+    console.warn(`[FreeBuddy] Scheduling file bridge watcher retry ${retryCount}/${MAX_RETRIES} in ${RETRY_DELAY_MS}ms for ${cwd}`);
+    retryTimeout = setTimeout(() => {
+      setupWatcher(cwd);
+    }, RETRY_DELAY_MS);
+  } else {
+    console.error(`[FreeBuddy] File bridge watcher reached max retries (${MAX_RETRIES}) for ${cwd}. Giving up.`);
+  }
+}
+
+export async function startWatchingFileBridge(cwd: string): Promise<void> {
+  if (!cwd || !path.isAbsolute(cwd)) return;
+  if (currentCwd === cwd) return; // Already watching this cwd
+
+  stopWatchingFileBridge();
+  currentCwd = cwd;
+
+  const freebuddyDir = path.join(cwd, ".freebuddy");
+  const bridgeJsonPath = path.join(freebuddyDir, "bridge.json");
+
+  // Ensure .freebuddy folder exists
+  try {
+    await fsPromises.mkdir(freebuddyDir, { recursive: true });
+  } catch (err: any) {
+    console.warn(`[FreeBuddy] Failed to create .freebuddy directory at ${freebuddyDir}:`, err);
+  }
+
+  // Initial check: if bridge.json somehow exists at startup, process it
+  try {
+    const stat = await fsPromises.stat(bridgeJsonPath);
+    if (stat.isFile()) {
+      await handleBridgeFile(bridgeJsonPath);
+    }
+  } catch (err: any) {
+    if (err.code !== "ENOENT") {
+      console.warn(`[FreeBuddy] Failed to check/process bridge.json at startup:`, err);
+    }
+  }
+
+  // Start the watch
+  setupWatcher(cwd);
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,7 @@ import { safeSendToWebContents } from "./cli/ipcSend.js";
 import { handleFreebuddyFileRequest } from "./freebuddyFileProtocol.js";
 import { handleDraftRequest } from "./draftProtocol.js";
 import { startPreviewServer } from "./previewServer.js";
+import { initFileBridge } from "./fileBridge.js";
 import { getDb } from "./cli/db.js";
 import { cleanupOrphanManagedAttachments } from "./cli/attachments.js";
 import { seedBuiltinWorkflowTeams } from "./cli/workflowTeams.js";
@@ -238,6 +239,9 @@ app.whenReady().then(async () => {
   registerLocalFileProtocol();
   registerDraftProtocol();
   startPreviewServer(() =>
+    mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null
+  );
+  initFileBridge(() =>
     mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null
   );
   getDb();

--- a/electron/mcp/draftMcpServer.ts
+++ b/electron/mcp/draftMcpServer.ts
@@ -1,0 +1,224 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+type DraftToolAction = "show" | "inspect" | "report";
+
+interface DraftToolResponse {
+  ok?: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+function bridgeEnvironment(): { endpoint: string; token: string } {
+  const endpoint = process.env.FREEBUDDY_DRAFT_ENDPOINT?.trim();
+  const token = process.env.FREEBUDDY_DRAFT_TOKEN?.trim();
+  if (!endpoint || !token) {
+    throw new Error("FreeBuddy Draft tool environment is incomplete.");
+  }
+  return { endpoint, token };
+}
+
+export async function invokeDraftBridge(
+  action: DraftToolAction,
+  params: Record<string, unknown>
+): Promise<DraftToolResponse> {
+  const { endpoint, token } = bridgeEnvironment();
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ action, params }),
+    signal: AbortSignal.timeout(20_000)
+  });
+  const result = (await response.json().catch(() => ({
+    ok: false,
+    error: `Draft bridge returned HTTP ${response.status}`
+  }))) as DraftToolResponse;
+  if (!response.ok) {
+    throw new Error(result.error || `Draft bridge returned HTTP ${response.status}`);
+  }
+  return result;
+}
+
+function toolResult(result: DraftToolResponse) {
+  const screenshot =
+    result.screenshot && typeof result.screenshot === "object"
+      ? (result.screenshot as {
+          mimeType?: unknown;
+          data?: unknown;
+          width?: unknown;
+          height?: unknown;
+        })
+      : undefined;
+  const structuredContent = screenshot
+    ? {
+        ...result,
+        screenshot: {
+          mimeType: screenshot.mimeType,
+          width: screenshot.width,
+          height: screenshot.height
+        }
+      }
+    : result;
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(structuredContent, null, 2)
+      },
+      ...(typeof screenshot?.data === "string" &&
+      typeof screenshot?.mimeType === "string"
+        ? [
+            {
+              type: "image" as const,
+              data: screenshot.data,
+              mimeType: screenshot.mimeType
+            }
+          ]
+        : [])
+    ],
+    structuredContent,
+    ...(result.ok === false ? { isError: true } : {})
+  };
+}
+
+function toolError(error: unknown) {
+  return toolResult({
+    ok: false,
+    error: (error as Error)?.message || String(error)
+  });
+}
+
+export function createDraftMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "freebuddy-draft",
+    version: process.env.FB_APP_VERSION || "0.1.0"
+  });
+
+  server.registerTool(
+    "draft_show",
+    {
+      title: "Show Draft Preview",
+      description:
+        "Open or update FreeBuddy Draft for the current conversation. Use after creating or changing a web page, Markdown document, image, PDF, or localhost dev server.",
+      inputSchema: {
+        target: z
+          .string()
+          .trim()
+          .min(1)
+          .optional()
+          .describe(
+            "Workspace-relative file, absolute local preview file, freebuddy-file URL, or http(s) localhost URL. Omit to open the existing target."
+          ),
+        open: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Open the Draft panel when this conversation is active."),
+        waitForReady: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Wait briefly for the preview to load before returning.")
+      },
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      }
+    },
+    async (args) => {
+      try {
+        return toolResult(await invokeDraftBridge("show", args));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "draft_inspect",
+    {
+      title: "Inspect Draft Preview",
+      description:
+        "Inspect the current Draft target, visibility, load state, recent preview console messages, and optionally capture the visible Draft as an image. Use after draft_show to verify visual output and diagnose runtime errors.",
+      inputSchema: {
+        screenshot: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Capture the visible Draft preview and return it as image content."),
+        console: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Include recent console messages from the preview iframe.")
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      }
+    },
+    async (args) => {
+      try {
+        return toolResult(await invokeDraftBridge("inspect", args));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "draft_report",
+    {
+      title: "Report Draft Status",
+      description:
+        "Show a concise preview, build, or dev-server status message inside FreeBuddy.",
+      inputSchema: {
+        level: z
+          .enum(["status", "success", "error"])
+          .optional()
+          .default("status"),
+        message: z.string().trim().min(1).max(1000)
+      },
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false
+      }
+    },
+    async (args) => {
+      try {
+        return toolResult(await invokeDraftBridge("report", args));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
+  return server;
+}
+
+export async function runDraftMcpServer(): Promise<void> {
+  const server = createDraftMcpServer();
+  await server.connect(new StdioServerTransport());
+}
+
+const isMainModule =
+  Boolean(process.argv[1]) &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMainModule) {
+  runDraftMcpServer().catch((error) => {
+    console.error("[FreeBuddy Draft MCP]", error);
+    process.exitCode = 1;
+  });
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,6 +1,10 @@
 import { contextBridge, ipcRenderer, webUtils, type IpcRendererEvent } from "electron";
 
 import { collectPreparedAttachmentsUntilLimit, managedPathsToDiscardAfterPrepare } from "./shared/collectPreparedAttachmentsUntilLimit.js";
+import type {
+  DraftToolEvent,
+  DraftToolResolution
+} from "./shared/draftToolProtocol.js";
 
 const cli = {
   listAdapters: () => ipcRenderer.invoke("cli:listAdapters"),
@@ -184,8 +188,8 @@ const cli = {
   openDraftExternal: (url: string) =>
     ipcRenderer.invoke("cli:openDraftExternal", url),
 
-  ensureAgentGuides: (cwd: string) =>
-    ipcRenderer.invoke("cli:ensureAgentGuides", cwd),
+  ensureAgentGuides: (cwd: string, options?: { nativeDraftTools?: boolean }) =>
+    ipcRenderer.invoke("cli:ensureAgentGuides", { cwd, options }),
 
   onEvent(sessionId: string, cb: (event: unknown) => void): () => void {
     const channel = `cli://${sessionId}`;
@@ -210,6 +214,14 @@ const window = {
     ) => cb(payload);
     ipcRenderer.on("freebuddy://bridge", handler);
     return () => ipcRenderer.off("freebuddy://bridge", handler);
+  },
+  onDraftTool(cb: (event: DraftToolEvent) => void): () => void {
+    const handler = (_e: IpcRendererEvent, payload: DraftToolEvent) => cb(payload);
+    ipcRenderer.on("freebuddy://draft-tool", handler);
+    return () => ipcRenderer.off("freebuddy://draft-tool", handler);
+  },
+  resolveDraftTool(resolution: DraftToolResolution): Promise<boolean> {
+    return ipcRenderer.invoke("draft-tool:resolve", resolution);
   }
 };
 

--- a/electron/previewServer.ts
+++ b/electron/previewServer.ts
@@ -8,6 +8,7 @@ import {
   isKnownBridgeAction,
   parseBridgeRequest
 } from "./agentBridge.js";
+import { handleDraftToolHttpRequest } from "./draftToolService.js";
 
 let previewServer: http.Server | null = null;
 
@@ -26,15 +27,27 @@ export function startPreviewServer(
     }
 
     const server = http.createServer((req, res) => {
-      const parsed = parseBridgeRequest(req.url || "");
-      if (parsed && isKnownBridgeAction(parsed.action)) {
-        safeSendToWebContents(getWebContents(), "freebuddy://bridge", parsed);
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: true, action: parsed.action }));
-        return;
-      }
-      res.writeHead(404);
-      res.end("not found");
+      void (async () => {
+        if (await handleDraftToolHttpRequest(req, res)) return;
+        const parsed = parseBridgeRequest(req.url || "");
+        if (parsed && isKnownBridgeAction(parsed.action)) {
+          safeSendToWebContents(getWebContents(), "freebuddy://bridge", parsed);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, action: parsed.action }));
+          return;
+        }
+        res.writeHead(404);
+        res.end("not found");
+      })().catch((error) => {
+        if (res.headersSent) return;
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            ok: false,
+            error: (error as Error)?.message || String(error)
+          })
+        );
+      });
     });
 
     server.on("error", (err: any) => {

--- a/electron/previewServer.ts
+++ b/electron/previewServer.ts
@@ -2,7 +2,12 @@ import http from "node:http";
 import type { WebContents } from "electron";
 
 import { safeSendToWebContents } from "./cli/ipcSend.js";
-import { BRIDGE_PORT, isKnownBridgeAction, parseBridgeRequest } from "./agentBridge.js";
+import {
+  DEFAULT_BRIDGE_PORT,
+  setActiveBridgePort,
+  isKnownBridgeAction,
+  parseBridgeRequest
+} from "./agentBridge.js";
 
 let previewServer: http.Server | null = null;
 
@@ -10,21 +15,43 @@ export function startPreviewServer(
   getWebContents: () => WebContents | null
 ): void {
   if (previewServer) return;
-  const server = http.createServer((req, res) => {
-    const parsed = parseBridgeRequest(req.url || "");
-    if (parsed && isKnownBridgeAction(parsed.action)) {
-      safeSendToWebContents(getWebContents(), "freebuddy://bridge", parsed);
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true, action: parsed.action }));
+
+  let currentPort = DEFAULT_BRIDGE_PORT;
+  const maxPort = DEFAULT_BRIDGE_PORT + 100;
+
+  function tryListen(port: number): void {
+    if (port > maxPort) {
+      console.error("[FreeBuddy] Preview Server: Could not bind to any port in range.");
       return;
     }
-    res.writeHead(404);
-    res.end("not found");
-  });
-  server.on("error", () => {
-    // listen failed (port in use) — bridge unavailable; actions fall back to manual UI
-  });
-  server.listen(BRIDGE_PORT, "127.0.0.1", () => {
-    previewServer = server;
-  });
+
+    const server = http.createServer((req, res) => {
+      const parsed = parseBridgeRequest(req.url || "");
+      if (parsed && isKnownBridgeAction(parsed.action)) {
+        safeSendToWebContents(getWebContents(), "freebuddy://bridge", parsed);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, action: parsed.action }));
+        return;
+      }
+      res.writeHead(404);
+      res.end("not found");
+    });
+
+    server.on("error", (err: any) => {
+      if (err.code === "EADDRINUSE") {
+        server.close();
+        tryListen(port + 1);
+      } else {
+        console.error(`[FreeBuddy] Preview Server error on port ${port}:`, err);
+      }
+    });
+
+    server.listen(port, "127.0.0.1", () => {
+      previewServer = server;
+      setActiveBridgePort(port);
+      console.log(`[FreeBuddy] Preview Server listening on 127.0.0.1:${port}`);
+    });
+  }
+
+  tryListen(currentPort);
 }

--- a/electron/shared/draftToolProtocol.ts
+++ b/electron/shared/draftToolProtocol.ts
@@ -1,0 +1,63 @@
+export type DraftToolAction = "show" | "inspect" | "report";
+
+export type DraftLoadState = "idle" | "loading" | "ready" | "error";
+
+export interface DraftCaptureRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DraftScreenshot {
+  mimeType: "image/png";
+  data: string;
+  width: number;
+  height: number;
+}
+
+export interface DraftConsoleEntry {
+  level: "debug" | "info" | "warning" | "error";
+  message: string;
+  source?: string;
+  line?: number;
+  timestamp: string;
+}
+
+export interface DraftToolEvent {
+  requestId: string;
+  conversationId: string;
+  cwd: string;
+  action: DraftToolAction;
+  params: Record<string, unknown>;
+}
+
+export interface DraftToolResult {
+  ok: boolean;
+  conversationId: string;
+  cwd: string;
+  target?: string;
+  resolvedUrl?: string;
+  loadState?: DraftLoadState;
+  visible?: boolean;
+  message?: string;
+  error?: string;
+  updatedAt?: string;
+  diagnostics?: { console: DraftConsoleEntry[] };
+  screenshot?: DraftScreenshot;
+  screenshotError?: string;
+  /** Renderer-only capture hint, stripped before the result reaches the agent. */
+  captureRect?: DraftCaptureRect;
+}
+
+export interface DraftToolResolution {
+  requestId: string;
+  result: DraftToolResult;
+}
+
+export interface AcpStdioMcpServer {
+  name: string;
+  command: string;
+  args: string[];
+  env: Array<{ name: string; value: string }>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@lobehub/icons": "^5.10.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "antd": "^6.4.5",
         "better-sqlite3": "^12.11.1",
         "cross-spawn": "^7.0.6",
@@ -21,6 +22,7 @@
         "react-dom": "^19.2.3",
         "react-i18next": "^17.0.8",
         "shell-env": "^4.0.3",
+        "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -1773,6 +1775,28 @@
         "designmd": "dist/index.js"
       }
     },
+    "node_modules/@google/design.md/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmmirror.com/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/@iconify/types/-/types-2.0.0.tgz",
@@ -2166,6 +2190,46 @@
       "peer": true,
       "dependencies": {
         "@chevrotain/types": "~11.1.1"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@noble/hashes": {
@@ -4660,6 +4724,44 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.17.0.tgz",
@@ -4718,7 +4820,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4729,6 +4830,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -5240,6 +5358,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmmirror.com/boolean/-/boolean-3.2.0.tgz",
@@ -5414,6 +5585,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
@@ -5457,7 +5637,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5465,6 +5644,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -5795,6 +5990,28 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5802,12 +6019,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmmirror.com/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -6586,6 +6838,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmmirror.com/dequal/-/dequal-2.0.3.tgz",
@@ -6771,7 +7032,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6824,6 +7084,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -7132,6 +7398,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -7184,7 +7459,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7203,7 +7477,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7332,6 +7605,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -7440,6 +7719,36 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmmirror.com/execa/-/execa-5.1.1.tgz",
@@ -7490,6 +7799,92 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmmirror.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -7551,7 +7946,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7678,6 +8072,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/find-root/-/find-root-1.1.0.tgz",
@@ -7720,6 +8135,15 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.40.0",
       "resolved": "https://registry.npmmirror.com/framer-motion/-/framer-motion-12.40.0.tgz",
@@ -7746,6 +8170,15 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -7837,7 +8270,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7862,7 +8294,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8022,7 +8453,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8098,7 +8528,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8427,6 +8856,15 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/hono": {
+      "version": "4.12.29",
+      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.29.tgz",
+      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -8497,6 +8935,26 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -8697,6 +9155,24 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -8816,6 +9292,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/is-stream/-/is-stream-2.0.1.tgz",
@@ -8892,6 +9374,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmmirror.com/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "3.0.8",
       "resolved": "https://registry.npmmirror.com/js-cookie/-/js-cookie-3.0.8.tgz",
@@ -8956,8 +9447,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmmirror.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -9267,7 +9763,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9669,6 +10164,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -10754,6 +11270,15 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.92.0",
       "resolved": "https://registry.npmmirror.com/node-abi/-/node-abi-3.92.0.tgz",
@@ -10938,9 +11463,20 @@
       "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
@@ -10965,6 +11501,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/on-change?sponsor=1"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmmirror.com/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -11111,6 +11659,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmmirror.com/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -11142,6 +11699,16 @@
       "resolved": "https://registry.npmmirror.com/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11191,6 +11758,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkijs": {
@@ -11456,6 +12032,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmmirror.com/pump/-/pump-3.0.4.tgz",
@@ -11484,6 +12073,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/query-string": {
@@ -11515,6 +12120,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -12432,7 +13081,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12629,6 +13277,22 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmmirror.com/rw/-/rw-1.3.3.tgz",
@@ -12660,8 +13324,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.4",
@@ -12726,6 +13389,57 @@
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "license": "MIT"
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmmirror.com/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -12741,6 +13455,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmmirror.com/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-value": {
@@ -12768,6 +13501,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -12855,6 +13594,78 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -13042,6 +13853,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string_decoder": {
@@ -13461,6 +14281,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -13542,6 +14371,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -13716,6 +14601,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unzipper": {
       "version": "0.12.3",
       "resolved": "https://registry.npmmirror.com/unzipper/-/unzipper-0.12.3.tgz",
@@ -13860,6 +14754,15 @@
       "integrity": "sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -14203,13 +15106,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@lobehub/icons": "^5.10.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "antd": "^6.4.5",
     "better-sqlite3": "^12.11.1",
     "cross-spawn": "^7.0.6",
@@ -39,6 +40,7 @@
     "react-dom": "^19.2.3",
     "react-i18next": "^17.0.8",
     "shell-env": "^4.0.3",
+    "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/src/components/AgentBridge/AgentBridgeListener.tsx
+++ b/src/components/AgentBridge/AgentBridgeListener.tsx
@@ -1,5 +1,9 @@
 import { useEffect } from "react";
 
+import type {
+  DraftToolEvent,
+  DraftToolResult
+} from "@/services/cli/types";
 import { useAgentBridgeStore } from "@/store/agentBridgeStore";
 import { useConversationStore } from "@/store/conversationStore";
 import { useDetailLayoutStore } from "@/store/detailLayoutStore";
@@ -13,6 +17,126 @@ export function AgentBridgeListener() {
   const notify = useAgentBridgeStore((s) => s.notify);
 
   useEffect(() => {
+    const captureRect = () => {
+      const element = document.querySelector<HTMLElement>(".draft-frame-wrap");
+      if (!element) return undefined;
+      const rect = element.getBoundingClientRect();
+      if (rect.width < 1 || rect.height < 1) return undefined;
+      return {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height
+      };
+    };
+
+    const draftResult = (
+      conversationId: string,
+      cwd: string,
+      overrides: Partial<DraftToolResult> = {}
+    ): DraftToolResult => {
+      const entry = useDraftPreviewStore.getState().byConv[conversationId];
+      const activeId = useConversationStore.getState().activeId;
+      const visible =
+        activeId === conversationId &&
+        useDetailLayoutStore.getState().activeTab === "preview";
+      return {
+        ok: entry?.loadState !== "error",
+        conversationId,
+        cwd,
+        target: entry?.manualEntry,
+        resolvedUrl: entry?.url,
+        loadState: entry?.loadState ?? "idle",
+        visible,
+        error: entry?.error,
+        updatedAt: entry?.updatedAt,
+        ...overrides
+      };
+    };
+
+    const waitForDraft = async (
+      conversationId: string,
+      timeoutMs = 8_000
+    ): Promise<void> => {
+      const current = useDraftPreviewStore.getState().byConv[conversationId];
+      if (current?.loadState === "ready" || current?.loadState === "error") return;
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          unsubscribe();
+          resolve();
+        };
+        const unsubscribe = useDraftPreviewStore.subscribe((state) => {
+          const entry = state.byConv[conversationId];
+          if (entry?.loadState === "ready" || entry?.loadState === "error") {
+            finish();
+          }
+        });
+        const timeout = window.setTimeout(finish, timeoutMs);
+      });
+    };
+
+    const handleDraftTool = async (event: DraftToolEvent) => {
+      const { requestId, conversationId, cwd, action, params } = event;
+      let result: DraftToolResult;
+      try {
+        await useDraftPreviewStore.getState().ensureFor(conversationId, cwd);
+        if (action === "show") {
+          const target = typeof params.target === "string" ? params.target.trim() : "";
+          if (target) {
+            useDraftPreviewStore.getState().setPreviewTarget(conversationId, target);
+          }
+          const isActive = useConversationStore.getState().activeId === conversationId;
+          const shouldOpen = params.open !== false;
+          if (isActive && shouldOpen) {
+            useDetailLayoutStore.getState().setActiveTab("preview");
+          }
+          const entry = useDraftPreviewStore.getState().byConv[conversationId];
+          if (!entry?.url) {
+            result = draftResult(conversationId, cwd, {
+              ok: false,
+              error:
+                "Draft has no preview target. Pass a workspace-relative file or localhost URL to draft_show."
+            });
+          } else if (params.waitForReady !== false && isActive) {
+            await waitForDraft(conversationId);
+            result = draftResult(conversationId, cwd, {
+              message: "Draft preview updated."
+            });
+          } else {
+            result = draftResult(conversationId, cwd, {
+              message:
+                isActive || !shouldOpen
+                  ? "Draft preview updated."
+                  : "Draft target updated for a background conversation; it will be visible when that conversation is opened."
+            });
+          }
+        } else if (action === "inspect") {
+          result = draftResult(conversationId, cwd, {
+            captureRect: params.screenshot === true ? captureRect() : undefined
+          });
+        } else {
+          const message =
+            typeof params.message === "string" ? params.message.trim() : "";
+          if (message) notify(message);
+          result = draftResult(conversationId, cwd, {
+            ok: Boolean(message),
+            message: message || undefined,
+            error: message ? undefined : "Draft report requires a message."
+          });
+        }
+      } catch (error) {
+        result = draftResult(conversationId, cwd, {
+          ok: false,
+          error: (error as Error)?.message || String(error)
+        });
+      }
+      await window.freebuddy?.window?.resolveDraftTool?.({ requestId, result });
+    };
+
     const setTarget = (to: string | undefined, openPreview: boolean) => {
       const convId = useConversationStore.getState().activeId;
       if (to && convId) {
@@ -51,8 +175,12 @@ export function AgentBridgeListener() {
         return;
       }
     });
+    const offDraftTool = window.freebuddy?.window?.onDraftTool?.((event) => {
+      void handleDraftTool(event);
+    });
     return () => {
       off?.();
+      offDraftTool?.();
     };
   }, [notify]);
 

--- a/src/components/Draft/DraftCanvas.tsx
+++ b/src/components/Draft/DraftCanvas.tsx
@@ -212,11 +212,20 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
     setError(null);
     setMarkdown(null);
     setDocumentText(null);
-  }, [entry?.url]);
+    if (activeId) {
+      useDraftPreviewStore.getState().setLoadState(activeId, "loading");
+    }
+  }, [activeId, entry?.url]);
+
+  useEffect(() => {
+    if (!activeId || !entry?.url || !isExternalOnly) return;
+    setIsLoading(false);
+    useDraftPreviewStore.getState().setLoadState(activeId, "ready");
+  }, [activeId, entry?.url, isExternalOnly]);
 
   useEffect(() => {
     const rel = documentRel(entry?.manualEntry);
-    if (!entry?.url || (!isMarkdown && !isDocument) || !cwd || !rel) return;
+    if (!activeId || !entry?.url || (!isMarkdown && !isDocument) || !cwd || !rel) return;
     let cancelled = false;
     setIsLoading(true);
     setError(null);
@@ -233,6 +242,7 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
           setMarkdown(null);
         }
         setIsLoading(false);
+        useDraftPreviewStore.getState().setLoadState(activeId, "ready");
       })
       .catch(() => {
         if (cancelled) return;
@@ -240,6 +250,9 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
         setDocumentText(null);
         setIsLoading(false);
         setError(t("draft.loadError"));
+        useDraftPreviewStore
+          .getState()
+          .setLoadState(activeId, "error", t("draft.loadError"));
       });
     return () => {
       cancelled = true;
@@ -416,10 +429,20 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
                     transformOrigin: "center center"
                   }}
                   draggable={false}
-                  onLoad={() => setIsLoading(false)}
+                  onLoad={() => {
+                    setIsLoading(false);
+                    if (activeId) {
+                      useDraftPreviewStore.getState().setLoadState(activeId, "ready");
+                    }
+                  }}
                   onError={() => {
                     setIsLoading(false);
                     setError(t("draft.loadError"));
+                    if (activeId) {
+                      useDraftPreviewStore
+                        .getState()
+                        .setLoadState(activeId, "error", t("draft.loadError"));
+                    }
                   }}
                 />
               </div>
@@ -429,10 +452,20 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
                 src={pdfUrl}
                 className="draft-pdf"
                 type="application/pdf"
-                onLoad={() => setIsLoading(false)}
+                onLoad={() => {
+                  setIsLoading(false);
+                  if (activeId) {
+                    useDraftPreviewStore.getState().setLoadState(activeId, "ready");
+                  }
+                }}
                 onError={() => {
                   setIsLoading(false);
                   setError(t("draft.loadError"));
+                  if (activeId) {
+                    useDraftPreviewStore
+                      .getState()
+                      .setLoadState(activeId, "error", t("draft.loadError"));
+                  }
                 }}
               />
             ) : (
@@ -452,10 +485,18 @@ export function DraftCanvas({ onClose }: { onClose?: () => void }) {
                 onLoad={() => {
                   setIsLoading(false);
                   focusFrame();
+                  if (activeId) {
+                    useDraftPreviewStore.getState().setLoadState(activeId, "ready");
+                  }
                 }}
                 onError={() => {
                   setIsLoading(false);
                   setError(t("draft.loadError"));
+                  if (activeId) {
+                    useDraftPreviewStore
+                      .getState()
+                      .setLoadState(activeId, "error", t("draft.loadError"));
+                  }
                 }}
               />
             )}

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -203,7 +203,7 @@ export const cliClient = {
   openDraftExternal(url: string): Promise<boolean> {
     return api().openDraftExternal(url);
   },
-  ensureAgentGuides(cwd: string): Promise<string[]> {
+  ensureAgentGuides(cwd: string): Promise<{ path: string; action: "created" | "updated" }[]> {
     return api().ensureAgentGuides(cwd);
   },
 

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -203,8 +203,11 @@ export const cliClient = {
   openDraftExternal(url: string): Promise<boolean> {
     return api().openDraftExternal(url);
   },
-  ensureAgentGuides(cwd: string): Promise<{ path: string; action: "created" | "updated" }[]> {
-    return api().ensureAgentGuides(cwd);
+  ensureAgentGuides(
+    cwd: string,
+    options?: { nativeDraftTools?: boolean }
+  ): Promise<{ path: string; action: "created" | "updated" }[]> {
+    return api().ensureAgentGuides(cwd, options);
   },
 
   getSetting(key: string): Promise<string | null> {

--- a/src/services/cli/types.ts
+++ b/src/services/cli/types.ts
@@ -44,6 +44,8 @@ export interface CliPromptAttachment {
 
 export interface CliRunArgs {
   sessionId: string;
+  /** FreeBuddy conversation that owns UI-scoped tools such as Draft. */
+  conversationId?: string;
   agentId: string;
   agentName: string;
   adapter: CLIAdapterId;
@@ -64,6 +66,63 @@ export interface CliRunArgs {
   timeoutMs?: number;
   userMessageId?: string;
   knownStreamMessageIds?: string[];
+}
+
+export type DraftToolAction = "show" | "inspect" | "report";
+
+export type DraftLoadState = "idle" | "loading" | "ready" | "error";
+
+export interface DraftCaptureRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DraftScreenshot {
+  mimeType: "image/png";
+  data: string;
+  width: number;
+  height: number;
+}
+
+export interface DraftConsoleEntry {
+  level: "debug" | "info" | "warning" | "error";
+  message: string;
+  source?: string;
+  line?: number;
+  timestamp: string;
+}
+
+export interface DraftToolEvent {
+  requestId: string;
+  conversationId: string;
+  cwd: string;
+  action: DraftToolAction;
+  params: Record<string, unknown>;
+}
+
+export interface DraftToolResult {
+  ok: boolean;
+  conversationId: string;
+  cwd: string;
+  target?: string;
+  resolvedUrl?: string;
+  loadState?: DraftLoadState;
+  visible?: boolean;
+  message?: string;
+  error?: string;
+  updatedAt?: string;
+  diagnostics?: { console: DraftConsoleEntry[] };
+  screenshot?: DraftScreenshot;
+  screenshotError?: string;
+  /** Renderer-only capture hint, stripped before the result reaches the agent. */
+  captureRect?: DraftCaptureRect;
+}
+
+export interface DraftToolResolution {
+  requestId: string;
+  result: DraftToolResult;
 }
 
 export interface CliPermissionOption {

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -408,8 +408,11 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     if (id) {
       const conv = get().conversations.find((c) => c.id === id);
       if (conv?.cwd) {
-        void cliClient.ensureAgentGuides(conv.cwd).catch(() => {
+        void cliClient.ensureAgentGuides(conv.cwd).catch((err) => {
           // best-effort: guide files are optional
+          if (import.meta.env?.DEV) {
+            console.warn("[FreeBuddy] Failed to ensure agent guides:", err);
+          }
         });
       }
     }
@@ -499,8 +502,11 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       await get().loadMessages(cid, messageIds);
     });
     if (cwd) {
-      void cliClient.ensureAgentGuides(cwd).catch(() => {
+      void cliClient.ensureAgentGuides(cwd).catch((err) => {
         // best-effort: guide files are optional
+        if (import.meta.env?.DEV) {
+          console.warn("[FreeBuddy] Failed to ensure agent guides:", err);
+        }
       });
     }
     return conv;

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -408,7 +408,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     if (id) {
       const conv = get().conversations.find((c) => c.id === id);
       if (conv?.cwd) {
-        void cliClient.ensureAgentGuides(conv.cwd).catch((err) => {
+        void cliClient.ensureAgentGuides(conv.cwd, {
+          nativeDraftTools:
+            useCliExecutorStore.getState().resolve(conv.adapter)?.protocol === "acp"
+        }).catch((err) => {
           // best-effort: guide files are optional
           if (import.meta.env?.DEV) {
             console.warn("[FreeBuddy] Failed to ensure agent guides:", err);
@@ -502,7 +505,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       await get().loadMessages(cid, messageIds);
     });
     if (cwd) {
-      void cliClient.ensureAgentGuides(cwd).catch((err) => {
+      void cliClient.ensureAgentGuides(cwd, {
+        nativeDraftTools:
+          useCliExecutorStore.getState().resolve(conv.adapter)?.protocol === "acp"
+      }).catch((err) => {
         // best-effort: guide files are optional
         if (import.meta.env?.DEV) {
           console.warn("[FreeBuddy] Failed to ensure agent guides:", err);
@@ -740,6 +746,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
 
     const runArgs: CliRunArgs = {
       sessionId: taskSessionId,
+      conversationId,
       agentId: member.id,
       agentName: member.name,
       adapter: member.cli.adapter,

--- a/src/store/draftPreviewStore.ts
+++ b/src/store/draftPreviewStore.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 
+import type { DraftLoadState } from "@/services/cli/types";
+
 export interface DraftPreviewEntry {
   cwd: string;
   /** User/agent-set preview target: relative path, local file, or HTTP(S) URL. */
@@ -10,6 +12,10 @@ export interface DraftPreviewEntry {
   reloadNonce: number;
   /** Fully composed preview url, empty when no target. */
   url: string;
+  /** Renderer-observed load state used by the Draft MCP tool. */
+  loadState: DraftLoadState;
+  error?: string;
+  updatedAt: string;
 }
 
 interface DraftPreviewState {
@@ -21,6 +27,7 @@ interface DraftPreviewState {
   clearManualEntry(convId: string): void;
   reload(convId: string): void;
   scheduleReload(convId: string, delay?: number): void;
+  setLoadState(convId: string, state: DraftLoadState, error?: string): void;
 }
 
 const LOCAL_PREVIEW_EXTENSIONS = new Set([
@@ -111,7 +118,10 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
             manualEntry,
             ready: true,
             reloadNonce: nonce,
-            url: composeDraftPreviewUrl(cwd ?? "", manualEntry, nonce)
+            url: composeDraftPreviewUrl(cwd ?? "", manualEntry, nonce),
+            loadState: manualEntry ? existing?.loadState ?? "loading" : "idle",
+            error: existing?.error,
+            updatedAt: existing?.updatedAt ?? new Date().toISOString()
           }
         }
       };
@@ -135,7 +145,10 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
             manualEntry: target,
             ready: true,
             reloadNonce: nonce,
-            url: composeDraftPreviewUrl(cwd, target, nonce)
+            url: composeDraftPreviewUrl(cwd, target, nonce),
+            loadState: "loading",
+            error: undefined,
+            updatedAt: new Date().toISOString()
           }
         }
       };
@@ -154,7 +167,10 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
             ...entry,
             manualEntry: undefined,
             reloadNonce: nonce,
-            url: composeDraftPreviewUrl(entry.cwd, undefined, nonce)
+            url: composeDraftPreviewUrl(entry.cwd, undefined, nonce),
+            loadState: "idle",
+            error: undefined,
+            updatedAt: new Date().toISOString()
           }
         }
       };
@@ -172,7 +188,10 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
           [convId]: {
             ...entry,
             reloadNonce: nonce,
-            url: composeDraftPreviewUrl(entry.cwd, entryOf(entry), nonce)
+            url: composeDraftPreviewUrl(entry.cwd, entryOf(entry), nonce),
+            loadState: "loading",
+            error: undefined,
+            updatedAt: new Date().toISOString()
           }
         }
       };
@@ -191,5 +210,23 @@ export const useDraftPreviewStore = create<DraftPreviewState>((set, get) => ({
       get().reload(convId);
     }, delay);
     set((s) => ({ timers: { ...s.timers, [convId]: t } }));
+  },
+
+  setLoadState(convId, loadState, error) {
+    set((s) => {
+      const entry = s.byConv[convId];
+      if (!entry) return s;
+      return {
+        byConv: {
+          ...s.byConv,
+          [convId]: {
+            ...entry,
+            loadState,
+            error: error || undefined,
+            updatedAt: new Date().toISOString()
+          }
+        }
+      };
+    });
   }
 }));

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -22,7 +22,9 @@ import type {
   CreateConversationInput,
   ListConversationsArgs,
   AppendMessageInput,
-  UpdateMessageInput
+  UpdateMessageInput,
+  DraftToolEvent,
+  DraftToolResolution
 } from "@/services/cli/types";
 import type {
   WorkflowPlan,
@@ -143,7 +145,10 @@ declare global {
     resolveDraftEntry(cwd: string): Promise<string | null>;
     readDraftMarkdown(cwd: string, rel: string): Promise<string | null>;
     openDraftExternal(url: string): Promise<boolean>;
-    ensureAgentGuides(cwd: string): Promise<{ path: string; action: "created" | "updated" }[]>;
+    ensureAgentGuides(
+      cwd: string,
+      options?: { nativeDraftTools?: boolean }
+    ): Promise<{ path: string; action: "created" | "updated" }[]>;
 
     onEvent(sessionId: string, cb: (event: CliEvent) => void): () => void;
   }
@@ -153,6 +158,8 @@ declare global {
     onBridge(
       cb: (event: { action: string; params: Record<string, string> }) => void
     ): () => void;
+    onDraftTool(cb: (event: DraftToolEvent) => void): () => void;
+    resolveDraftTool(resolution: DraftToolResolution): Promise<boolean>;
   }
 
   interface FreebuddySettings {

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -143,7 +143,7 @@ declare global {
     resolveDraftEntry(cwd: string): Promise<string | null>;
     readDraftMarkdown(cwd: string, rel: string): Promise<string | null>;
     openDraftExternal(url: string): Promise<boolean>;
-    ensureAgentGuides(cwd: string): Promise<string[]>;
+    ensureAgentGuides(cwd: string): Promise<{ path: string; action: "created" | "updated" }[]>;
 
     onEvent(sessionId: string, cb: (event: CliEvent) => void): () => void;
   }

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -10,7 +10,9 @@ import {
   buildInitializeRequest,
   buildPromptContentBlocks,
   buildSessionLoadRequest,
+  buildSessionNewRequest,
   buildSessionPromptRequest,
+  buildSessionResumeRequest,
   buildSessionSetConfigOptionRequest,
   contentBlockToItems,
   parseAcpLine,
@@ -325,6 +327,45 @@ test("buildSessionLoadRequest loads Cursor-style ACP sessions", () => {
       mcpServers: []
     }
   });
+});
+
+test("ACP session lifecycle injects FreeBuddy stdio MCP servers", () => {
+  const mcpServers = [
+    {
+      name: "freebuddy-draft",
+      command: "/Applications/FreeBuddy",
+      args: ["/app/dist-electron/mcp/draftMcpServer.js"],
+      env: [
+        { name: "ELECTRON_RUN_AS_NODE", value: "1" },
+        { name: "FREEBUDDY_DRAFT_TOKEN", value: "token" }
+      ]
+    }
+  ];
+
+  assert.deepEqual(buildSessionNewRequest(1, "/tmp/project", mcpServers), {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "session/new",
+    params: { cwd: "/tmp/project", mcpServers }
+  });
+  assert.deepEqual(
+    buildSessionResumeRequest(2, "sess-1", "/tmp/project", mcpServers),
+    {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "session/resume",
+      params: { sessionId: "sess-1", cwd: "/tmp/project", mcpServers }
+    }
+  );
+  assert.deepEqual(
+    buildSessionLoadRequest(3, "sess-1", "/tmp/project", mcpServers),
+    {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "session/load",
+      params: { sessionId: "sess-1", cwd: "/tmp/project", mcpServers }
+    }
+  );
 });
 
 test("ACP runtime reports missing saved sessions separately from auth failures", () => {

--- a/tests/draft-mcp.test.mjs
+++ b/tests/draft-mcp.test.mjs
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createDraftMcpServer } from "../dist-electron/mcp/draftMcpServer.js";
+
+test("Draft MCP exposes structured tools and forwards calls to FreeBuddy", async (t) => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  process.env.FREEBUDDY_DRAFT_ENDPOINT =
+    "http://127.0.0.1:17878/freebuddy/draft-tool";
+  process.env.FREEBUDDY_DRAFT_TOKEN = "test-token";
+  globalThis.fetch = async (input, init) => {
+    const parsed = JSON.parse(String(init?.body));
+    calls.push({
+      endpoint: String(input),
+      authorization: new Headers(init?.headers).get("Authorization"),
+      action: parsed.action,
+      params: parsed.params
+    });
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        conversationId: "conv-1",
+        cwd: "/tmp/project",
+        target: parsed.params?.target,
+        resolvedUrl: "http://127.0.0.1:5173/",
+        loadState: "ready",
+        visible: true,
+        ...(parsed.action === "inspect" && parsed.params?.screenshot
+          ? {
+              screenshot: {
+                mimeType: "image/png",
+                data: "iVBORw0KGgo=",
+                width: 100,
+                height: 80
+              }
+            }
+          : {})
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.FREEBUDDY_DRAFT_ENDPOINT;
+    delete process.env.FREEBUDDY_DRAFT_TOKEN;
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = createDraftMcpServer();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "freebuddy-test", version: "1.0.0" });
+  await client.connect(clientTransport);
+  t.after(() => client.close());
+  t.after(() => server.close());
+
+  const listed = await client.listTools();
+  assert.deepEqual(
+    listed.tools.map((tool) => tool.name).sort(),
+    ["draft_inspect", "draft_report", "draft_show"]
+  );
+
+  const result = await client.callTool({
+    name: "draft_show",
+    arguments: {
+      target: "http://127.0.0.1:5173/",
+      open: true,
+      waitForReady: true
+    }
+  });
+  assert.equal(result.isError, undefined);
+  assert.equal(result.structuredContent?.loadState, "ready");
+  const inspected = await client.callTool({
+    name: "draft_inspect",
+    arguments: { screenshot: true, console: true }
+  });
+  assert.equal(inspected.structuredContent?.screenshot?.data, undefined);
+  assert.equal(
+    inspected.structuredContent?.screenshot?.width,
+    100,
+    JSON.stringify({ inspected, calls })
+  );
+  assert.equal(
+    inspected.content.some(
+      (entry) => entry.type === "image" && entry.data === "iVBORw0KGgo="
+    ),
+    true
+  );
+  assert.deepEqual(calls, [
+    {
+      endpoint: "http://127.0.0.1:17878/freebuddy/draft-tool",
+      authorization: "Bearer test-token",
+      action: "show",
+      params: {
+        target: "http://127.0.0.1:5173/",
+        open: true,
+        waitForReady: true
+      }
+    },
+    {
+      endpoint: "http://127.0.0.1:17878/freebuddy/draft-tool",
+      authorization: "Bearer test-token",
+      action: "inspect",
+      params: { screenshot: true, console: true }
+    }
+  ]);
+});

--- a/tests/draft-tool-contract.test.mjs
+++ b/tests/draft-tool-contract.test.mjs
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+
+import { ensureAgentGuides } from "../dist-electron/agentGuides.js";
+import { setActiveBridgePort } from "../dist-electron/agentBridge.js";
+import {
+  handleDraftToolHttpRequest,
+  registerDraftToolSession,
+  resolveDraftToolRequest,
+  unregisterDraftToolSession
+} from "../dist-electron/draftToolService.js";
+
+function read(relativePath) {
+  return fs.readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+test("native Draft tools do not write agent guide files into the workspace", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "freebuddy-draft-native-"));
+  try {
+    assert.deepEqual(
+      await ensureAgentGuides(cwd, { nativeDraftTools: true }),
+      []
+    );
+    assert.deepEqual(fs.readdirSync(cwd), []);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("Draft tool contract stays bound across ACP, preload, and renderer", () => {
+  const runtime = read("../electron/cli/acpRuntime.ts");
+  const preload = read("../electron/preload.ts");
+  const listener = read(
+    "../src/components/AgentBridge/AgentBridgeListener.tsx"
+  );
+  const store = read("../src/store/draftPreviewStore.ts");
+
+  assert.match(runtime, /registerDraftToolSession/);
+  assert.match(runtime, /conversationId: args\.conversationId/);
+  assert.match(preload, /freebuddy:\/\/draft-tool/);
+  assert.match(preload, /draft-tool:resolve/);
+  assert.match(listener, /event\.conversationId|conversationId/);
+  assert.match(listener, /waitForDraft/);
+  assert.match(store, /loadState: DraftLoadState/);
+  assert.match(store, /setLoadState/);
+});
+
+test("Draft tool capability token routes a request to its bound conversation", async () => {
+  setActiveBridgePort(17879);
+  const sent = [];
+  let consoleListener;
+  let webContents;
+  webContents = {
+    id: 42,
+    isDestroyed: () => false,
+    on(event, listener) {
+      if (event === "console-message") consoleListener = listener;
+      return webContents;
+    },
+    once: () => webContents,
+    capturePage: async () => ({
+      getSize: () => ({ width: 120, height: 90 }),
+      toPNG: () => Buffer.from("draft-png")
+    }),
+    mainFrame: {
+      isDestroyed: () => false,
+      send(channel, payload) {
+        sent.push({ channel, payload });
+        setImmediate(() => {
+          resolveDraftToolRequest(webContents, {
+            requestId: payload.requestId,
+            result: {
+              ok: true,
+              conversationId: payload.conversationId,
+              cwd: payload.cwd,
+              loadState: "ready",
+              visible: true,
+              captureRect: { x: 10, y: 20, width: 120, height: 90 }
+            }
+          });
+        });
+      }
+    }
+  };
+
+  const config = await registerDraftToolSession({
+    taskSessionId: "task-1",
+    conversationId: "conv-1",
+    cwd: "/tmp/project",
+    webContents
+  });
+  const token = config.env.find(
+    (entry) => entry.name === "FREEBUDDY_DRAFT_TOKEN"
+  )?.value;
+  assert.ok(token);
+  assert.equal(config.name, "freebuddy-draft");
+  assert.equal(path.isAbsolute(config.command), true);
+  assert.equal(path.isAbsolute(config.args[0]), true);
+  consoleListener?.({
+    frame: { url: "http://127.0.0.1:5173/" },
+    level: "error",
+    message: "ReferenceError: demo is not defined",
+    sourceId: "http://127.0.0.1:5173/src/main.ts",
+    lineNumber: 12
+  });
+
+  let statusCode = 0;
+  let responseBody = "";
+  const request = Readable.from([
+    JSON.stringify({
+      action: "inspect",
+      params: { screenshot: true, console: true }
+    })
+  ]);
+  Object.assign(request, {
+    url: "/freebuddy/draft-tool",
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` }
+  });
+  const response = {
+    writeHead(code) {
+      statusCode = code;
+    },
+    end(body = "") {
+      responseBody = String(body);
+    }
+  };
+
+  try {
+    assert.equal(
+      await handleDraftToolHttpRequest(request, response),
+      true
+    );
+    assert.equal(statusCode, 200);
+    const parsedResponse = JSON.parse(responseBody);
+    assert.equal(parsedResponse.conversationId, "conv-1");
+    assert.equal(parsedResponse.screenshot.mimeType, "image/png");
+    assert.equal(parsedResponse.screenshot.data, Buffer.from("draft-png").toString("base64"));
+    assert.equal(parsedResponse.diagnostics.console.length, 1);
+    assert.equal(parsedResponse.diagnostics.console[0].level, "error");
+    assert.match(parsedResponse.diagnostics.console[0].message, /demo is not defined/);
+    assert.equal(parsedResponse.captureRect, undefined);
+    assert.equal(sent[0].channel, "freebuddy://draft-tool");
+    assert.equal(sent[0].payload.conversationId, "conv-1");
+  } finally {
+    unregisterDraftToolSession("task-1");
+  }
+});

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -11,5 +11,5 @@
     "rootDir": "electron",
     "types": ["node"]
   },
-  "include": ["electron/main.ts", "electron/menu.ts", "electron/app-meta.ts", "electron/cli/**/*.ts", "electron/shared/**/*.ts"]
+  "include": ["electron/main.ts", "electron/menu.ts", "electron/app-meta.ts", "electron/cli/**/*.ts", "electron/mcp/**/*.ts", "electron/shared/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Add a zero-network file bridge (`.freebuddy/bridge.json`) so agents can trigger Draft preview/navigate/status actions without relying on `curl`
- Make the local HTTP bridge port fall back from `17878` when occupied, and inject the active port into agent guide files
- Ignore `.freebuddy/` in workspace `.gitignore`, and keep HTTP bridge as a compatible fallback channel

## Test plan
- [ ] Start FreeBuddy with port `17878` free; confirm preview server binds and guide curl examples use that port
- [ ] Occupy `17878`, restart; confirm bind falls back to `17879+` and guides reflect the active port
- [ ] Write `.freebuddy/bridge.json` with `{"action":"navigate","params":{"to":"README.md"}}` and confirm Draft navigates, then file is deleted
- [ ] Trigger the same action via `curl http://127.0.0.1:<port>/freebuddy/navigate?to=README.md`
- [ ] Open a workspace session and confirm `AGENTS.md` / `CLAUDE.md` / `.cursorrules` are created or updated only when FreeBuddy-signed
- [ ] Confirm `.freebuddy/` is added to `.gitignore` and not committed


Made with [Cursor](https://cursor.com)