### PR TITLE
feat: align ACP authentication flows

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,6 +18,7 @@ extraResources:
 
 asarUnpack:
   - node_modules/better-sqlite3/**/*
+  - node_modules/node-pty/**/*
 
 publish:
   - provider: github

--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -1,6 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import type {
+  AuthenticateRequest,
+  InitializeRequest,
+  LogoutRequest,
+  TerminalOutputResponse
+} from "@agentclientprotocol/sdk";
 
 import type { AcpStdioMcpServer } from "../shared/draftToolProtocol.js";
 
@@ -16,13 +22,55 @@ export interface AcpMessage {
 }
 
 /** An ACP authentication method advertised by an agent in `initialize`.
- *  FreeBuddy does not drive the auth flow; it only reads these to detect that
- *  authentication is required and surface a clear error. */
+ *  Stable ACP v1 supports agent-driven authentication. Draft agents may also
+ *  advertise richer method types, which are kept here so we can reject them
+ *  with an actionable error instead of pretending the client supports them. */
 export interface AcpAuthMethod {
   id: string;
   type?: "agent" | "env_var" | "terminal";
   name?: string;
   description?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  _meta?: Record<string, unknown>;
+}
+
+export function selectAcpAuthMethod(
+  methods: AcpAuthMethod[],
+  env: NodeJS.ProcessEnv = process.env
+): AcpAuthMethod | undefined {
+  const supported = methods.filter(
+    (method) =>
+      typeof method?.id === "string" &&
+      method.id.length > 0 &&
+      (method.type == null ||
+        method.type === "agent" ||
+        method.type === "terminal")
+  );
+  if (supported.length <= 1) return supported[0];
+
+  const apiKeyMethod = supported.find((method) =>
+    /api[-_ ]?key/i.test(`${method.id} ${method.name ?? ""}`)
+  );
+  const apiKeyMeta = apiKeyMethod?._meta?.["api-key"];
+  const provider =
+    apiKeyMeta && typeof apiKeyMeta === "object"
+      ? String((apiKeyMeta as Record<string, unknown>).provider ?? "").toLowerCase()
+      : "";
+  const hasApiKey =
+    provider === "openai"
+      ? Boolean(env.CODEX_API_KEY || env.OPENAI_API_KEY)
+      : provider === "anthropic"
+        ? Boolean(env.ANTHROPIC_API_KEY)
+        : false;
+  if (apiKeyMethod && hasApiKey) return apiKeyMethod;
+
+  const interactiveMethods = supported.filter((method) =>
+    /chat[-_ ]?gpt|oauth|browser|device|log[-_ ]?in|account|subscription|github|google|wechat|ioa/i.test(
+      `${method.id} ${method.name ?? ""} ${method.description ?? ""}`
+    )
+  );
+  return interactiveMethods.length === 1 ? interactiveMethods[0] : undefined;
 }
 
 export type AcpStreamItem =
@@ -145,7 +193,11 @@ export type AcpStreamItem =
 
 type AcpPlanEntry = Extract<AcpStreamItem, { kind: "plan" }>["entries"][number];
 
-export function buildInitializeRequest(id: AcpRequestId): AcpMessage {
+export function buildInitializeRequest(
+  id: AcpRequestId,
+  clientVersion =
+    process.env.FB_APP_VERSION || process.env.npm_package_version || "unknown"
+): AcpMessage & { params: InitializeRequest } {
   return {
     jsonrpc: "2.0",
     id,
@@ -153,18 +205,59 @@ export function buildInitializeRequest(id: AcpRequestId): AcpMessage {
     params: {
       protocolVersion: 1,
       clientCapabilities: {
-        // Opt in to receive terminal-type auth methods so we can detect when
-        // an agent requires authentication and surface a clear error. We do not
-        // drive the login flow; the user logs in via the agent's own CLI.
-        auth: { terminal: true },
-        terminal: true
+        terminal: true,
+        auth: { terminal: true }
       },
       clientInfo: {
         name: "freebuddy",
         title: "FreeBuddy",
-        version: "0.1.0"
+        version: clientVersion
       }
     }
+  };
+}
+
+export function buildAuthenticateRequest(
+  id: AcpRequestId,
+  methodId: string
+): AcpMessage & { params: AuthenticateRequest } {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "authenticate",
+    params: { methodId }
+  };
+}
+
+export function buildLogoutRequest(
+  id: AcpRequestId
+): AcpMessage & { params: LogoutRequest } {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "logout",
+    params: {}
+  };
+}
+
+export function buildTerminalOutputResponse(snapshot: {
+  output: string;
+  truncated: boolean;
+  exited: boolean;
+  exitCode?: number | null;
+  signal?: string | null;
+}): TerminalOutputResponse {
+  return {
+    output: snapshot.output,
+    truncated: snapshot.truncated,
+    ...(snapshot.exited
+      ? {
+          exitStatus: {
+            exitCode: snapshot.exitCode ?? null,
+            signal: snapshot.signal ?? null
+          }
+        }
+      : {})
   };
 }
 

--- a/electron/cli/acpAuth.ts
+++ b/electron/cli/acpAuth.ts
@@ -1,0 +1,185 @@
+import readline from "node:readline";
+import { type ChildProcessByStdio } from "node:child_process";
+import type { Readable, Writable } from "node:stream";
+import spawn from "cross-spawn";
+
+import {
+  buildCommand,
+  type CLIAdapterId
+} from "./adapters.js";
+import {
+  buildInitializeRequest,
+  buildLogoutRequest,
+  type AcpMessage
+} from "./acp.js";
+import { killProcessTree } from "./process-kill.js";
+import { mergeBuiltEnv } from "./runtime.js";
+import {
+  clearToolSessionsForAgent,
+  resolveCliByokEnv
+} from "./store.js";
+
+export interface CliAuthControlArgs {
+  agentId: string;
+  adapter: CLIAdapterId;
+  binary?: string;
+  extraArgs?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface CliAuthProbeResult {
+  authMethods: Array<{
+    methodId: string;
+    name: string;
+    description?: string;
+    type: "agent" | "terminal" | "env_var";
+  }>;
+  logoutSupported: boolean;
+}
+
+async function withAcpAgent<T>(
+  args: CliAuthControlArgs,
+  operation: (request: (message: AcpMessage) => Promise<any>) => Promise<T>
+): Promise<T> {
+  const built = buildCommand({
+    adapter: args.adapter,
+    binary: args.binary,
+    extraArgs: args.extraArgs,
+    prompt: "",
+    cwd: args.cwd
+  });
+  if (built.protocol !== "acp") {
+    throw new Error("Authentication control requires an ACP agent.");
+  }
+  const env = mergeBuiltEnv(
+    mergeBuiltEnv(
+      { ...process.env, ...(args.env ?? {}) },
+      resolveCliByokEnv(args.agentId, args.adapter)
+    ),
+    built.env
+  );
+  const child = spawn(built.bin, built.args, {
+    cwd: args.cwd,
+    env,
+    stdio: ["pipe", "pipe", "pipe"]
+  }) as ChildProcessByStdio<Writable, Readable, Readable>;
+  const pending = new Map<
+    string,
+    { resolve(value: any): void; reject(error: Error): void }
+  >();
+  const output = readline.createInterface({ input: child.stdout });
+  output.on("line", (line) => {
+    let message: AcpMessage;
+    try {
+      message = JSON.parse(line) as AcpMessage;
+    } catch {
+      return;
+    }
+    if (message.id == null) return;
+    const waiter = pending.get(String(message.id));
+    if (!waiter) return;
+    pending.delete(String(message.id));
+    if (message.error) {
+      const error = new Error(message.error.message);
+      (error as Error & { code?: number }).code = message.error.code;
+      waiter.reject(error);
+    } else {
+      waiter.resolve(message.result);
+    }
+  });
+  child.on("close", (code) => {
+    for (const waiter of pending.values()) {
+      waiter.reject(new Error(`ACP agent exited with code ${code ?? -1}.`));
+    }
+    pending.clear();
+  });
+  await new Promise<void>((resolve, reject) => {
+    child.once("spawn", resolve);
+    child.once("error", reject);
+  });
+  const request = (message: AcpMessage) =>
+    new Promise<any>((resolve, reject) => {
+      if (message.id == null) {
+        reject(new Error("ACP requests require an id."));
+        return;
+      }
+      const timer = setTimeout(() => {
+        pending.delete(String(message.id));
+        reject(new Error(`ACP ${message.method ?? "request"} timed out.`));
+      }, 10_000);
+      pending.set(String(message.id), {
+        resolve(value) {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject(error) {
+          clearTimeout(timer);
+          reject(error);
+        }
+      });
+      child.stdin.write(`${JSON.stringify(message)}\n`);
+    });
+
+  try {
+    return await operation(request);
+  } finally {
+    output.close();
+    try {
+      child.stdin.end();
+    } catch {
+      /* noop */
+    }
+    try {
+      killProcessTree(child, "term");
+    } catch {
+      /* noop */
+    }
+  }
+}
+
+export async function probeAcpAuthentication(
+  args: CliAuthControlArgs
+): Promise<CliAuthProbeResult> {
+  return withAcpAgent(args, async (request) => {
+    const initialized = await request(buildInitializeRequest(1));
+    if (initialized?.protocolVersion !== 1) {
+      throw new Error(
+        `Unsupported ACP protocol version ${String(initialized?.protocolVersion ?? "missing")}.`
+      );
+    }
+    const methods = Array.isArray(initialized?.authMethods)
+      ? initialized.authMethods
+      : [];
+    return {
+      authMethods: methods
+        .filter((method: any) => typeof method?.id === "string")
+        .map((method: any) => ({
+          methodId: method.id,
+          name: typeof method.name === "string" ? method.name : method.id,
+          ...(typeof method.description === "string"
+            ? { description: method.description }
+            : {}),
+          type:
+            method.type === "terminal" || method.type === "env_var"
+              ? method.type
+              : "agent"
+        })),
+      logoutSupported:
+        initialized?.agentCapabilities?.auth?.logout != null
+    };
+  });
+}
+
+export async function logoutAcpAgent(
+  args: CliAuthControlArgs
+): Promise<void> {
+  await withAcpAgent(args, async (request) => {
+    const initialized = await request(buildInitializeRequest(1));
+    if (initialized?.agentCapabilities?.auth?.logout == null) {
+      throw new Error("This ACP agent does not advertise logout support.");
+    }
+    await request(buildLogoutRequest(2));
+  });
+  clearToolSessionsForAgent(args.agentId);
+}

--- a/electron/cli/acpAuthTerminal.ts
+++ b/electron/cli/acpAuthTerminal.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from "node:crypto";
+import * as pty from "node-pty";
+
+import type { AcpAuthMethod } from "./acp.js";
+import type { CliEvent } from "./runtimeShared.js";
+
+interface ActiveAuthTerminal {
+  write(data: string): void;
+  cancel(): void;
+}
+
+const activeTerminals = new Map<string, ActiveAuthTerminal>();
+
+function authenticationFailureDetail(output: string): string | undefined {
+  const clean = output
+    // CSI and OSC sequences are useful to a terminal, but make task errors unreadable.
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g, "")
+    .replace(/\u001B\[[0-?]*[ -\/]*[@-~]/g, "")
+    .replace(/\r/g, "")
+    .trim();
+  const lines = clean
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return undefined;
+
+  const diagnostic =
+    [...lines]
+      .reverse()
+      .find((line) =>
+        /(?:error|fail|denied|invalid|expired|unable|reject|not found)/i.test(
+          line
+        )
+      ) ?? lines.at(-1);
+  return diagnostic
+    ?.replace(/([?&]user_code=)[^&\s]+/gi, "$1[redacted]")
+    .replace(/(enter code:\s*)\S+/gi, "$1[redacted]")
+    .slice(-800);
+}
+
+function key(sessionId: string, requestId: string) {
+  return `${sessionId}:${requestId}`;
+}
+
+export function writeAuthenticationTerminal(
+  sessionId: string,
+  requestId: string,
+  data: string
+): boolean {
+  const terminal = activeTerminals.get(key(sessionId, requestId));
+  if (!terminal) return false;
+  terminal.write(data);
+  return true;
+}
+
+export function cancelAuthenticationTerminal(
+  sessionId: string,
+  requestId: string
+): boolean {
+  const terminal = activeTerminals.get(key(sessionId, requestId));
+  if (!terminal) return false;
+  terminal.cancel();
+  return true;
+}
+
+export function clearAuthenticationTerminalsForSession(sessionId: string) {
+  for (const [terminalKey, terminal] of activeTerminals) {
+    if (!terminalKey.startsWith(`${sessionId}:`)) continue;
+    terminal.cancel();
+    activeTerminals.delete(terminalKey);
+  }
+}
+
+export async function runAuthenticationTerminal(options: {
+  sessionId: string;
+  agentName: string;
+  method: AcpAuthMethod;
+  command: {
+    bin: string;
+    args: string[];
+    cwd?: string;
+    env: Record<string, string | undefined>;
+  };
+  emit: (event: CliEvent) => void;
+}): Promise<void> {
+  const { sessionId, agentName, method, command, emit } = options;
+  const requestId = randomUUID();
+  const terminalKey = key(sessionId, requestId);
+  const env: Record<string, string> = {};
+  for (const [name, value] of Object.entries({
+    ...command.env,
+    ...(method.env ?? {})
+  })) {
+    if (value != null) env[name] = value;
+  }
+
+  emit({
+    type: "authentication-terminal-started",
+    request: {
+      requestId,
+      sessionId,
+      agentName,
+      methodName: method.name ?? method.id
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let output = "";
+    let terminal: pty.IPty;
+
+    const settle = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      activeTerminals.delete(terminalKey);
+      emit({ type: "authentication-terminal-resolved", requestId });
+      if (error) reject(error);
+      else resolve();
+    };
+
+    try {
+      terminal = pty.spawn(
+        command.bin,
+        [...command.args, ...(method.args ?? [])],
+        {
+          name: "xterm-256color",
+          cols: 100,
+          rows: 30,
+          cwd: command.cwd || process.cwd(),
+          env
+        }
+      );
+    } catch (error) {
+      settle(
+        new Error(
+          `Unable to start authentication terminal: ${(error as Error)?.message || String(error)}`
+        )
+      );
+      return;
+    }
+
+    activeTerminals.set(terminalKey, {
+      write(data) {
+        if (!settled) terminal.write(data);
+      },
+      cancel() {
+        if (settled) return;
+        try {
+          terminal.kill();
+        } catch {
+          /* noop */
+        }
+        settle(new Error("Authentication cancelled."));
+      }
+    });
+
+    terminal.onData((data) => {
+      output = `${output}${data}`.slice(-64 * 1024);
+      emit({
+        type: "authentication-terminal-update",
+        requestId,
+        output,
+        running: true
+      });
+    });
+    terminal.onExit(({ exitCode, signal }) => {
+      emit({
+        type: "authentication-terminal-update",
+        requestId,
+        output,
+        running: false,
+        exitCode,
+        signal: signal || undefined
+      });
+      if (exitCode === 0) settle();
+      else {
+        const detail = authenticationFailureDetail(output);
+        settle(
+          new Error(
+            `Authentication terminal exited with code ${exitCode}.${
+              detail ? ` ${detail}` : ""
+            }`
+          )
+        );
+      }
+    });
+  });
+}

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -9,6 +9,7 @@ import {
   acpSessionListToItems,
   acpSessionSetupToItems,
   acpUpdateToItems,
+  buildAuthenticateRequest,
   buildInitializeRequest,
   buildSessionCancelNotification,
   buildSessionCloseRequest,
@@ -18,7 +19,9 @@ import {
   buildSessionPromptRequest,
   buildSessionResumeRequest,
   buildSessionSetConfigOptionRequest,
+  buildTerminalOutputResponse,
   parseAcpLine,
+  selectAcpAuthMethod,
   shouldEmitAcpUpdate,
   shouldSkipUserMessageChunk,
   type AcpAuthMethod,
@@ -30,7 +33,9 @@ import { updateRuntimeRun } from "./check.js";
 import { saveToolSession } from "./store.js";
 import {
   appendLog,
+  clearAuthenticationResolversForSession,
   clearPermissionResolversForSession,
+  registerAuthenticationResolver,
   registerPermissionResolver,
   setTaskToolSessionId,
   updateTaskStatus,
@@ -46,6 +51,10 @@ import {
   unregisterDraftToolSession
 } from "../draftToolService.js";
 import type { AcpStdioMcpServer } from "../shared/draftToolProtocol.js";
+import {
+  clearAuthenticationTerminalsForSession,
+  runAuthenticationTerminal
+} from "./acpAuthTerminal.js";
 
 function writeAcp(
   child: ChildProcessByStdio<Writable, Readable, Readable>,
@@ -65,20 +74,34 @@ export interface AcpRuntimeInput {
   running: Map<string, Running>;
   capturedSessions: Map<string, string>;
   emit: (e: CliEvent) => void;
+  agentCommand: {
+    bin: string;
+    args: string[];
+    cwd?: string;
+    env: Record<string, string | undefined>;
+  };
+  restartAgent: () => Promise<{
+    child: ChildProcessByStdio<Writable, Readable, Readable>;
+    pid: number;
+  }>;
 }
 
 export async function runAcpAgent({
-  child,
+  child: initialChild,
   webContents,
   args,
-  pid,
+  pid: initialPid,
   logStream,
   toolSessionId,
   toolSessionScope,
   running,
   capturedSessions,
-  emit
+  emit,
+  agentCommand,
+  restartAgent
 }: AcpRuntimeInput): Promise<void> {
+  let child = initialChild;
+  let pid = initialPid;
   let requestId = 0;
   let activeAcpSessionId: string | undefined;
   let finished = false;
@@ -133,6 +156,8 @@ export async function runAcpAgent({
     terminalManager.dispose();
     running.delete(args.sessionId);
     unregisterDraftToolSession(args.sessionId);
+    clearAuthenticationTerminalsForSession(args.sessionId);
+    clearAuthenticationResolversForSession(args.sessionId);
     clearPermissionResolversForSession(args.sessionId);
     if (errorMessage) emit({ type: "error", message: errorMessage });
     emit({ type: "done", exitCode });
@@ -146,10 +171,8 @@ export async function runAcpAgent({
     logStream?.end();
   };
 
-  running.set(args.sessionId, {
-    child,
-    pid,
-    cancel: () => {
+  const cancelRun = () => {
+      clearAuthenticationTerminalsForSession(args.sessionId);
       if (activeAcpSessionId) {
         notify(buildSessionCancelNotification(activeAcpSessionId));
       }
@@ -163,11 +186,13 @@ export async function runAcpAgent({
           }
         }
       }, 500);
-    }
-  });
+  };
+  const updateRunningProcess = () => {
+    running.set(args.sessionId, { child, pid, cancel: cancelRun });
+  };
+  updateRunningProcess();
 
-  const rlOut = readline.createInterface({ input: child.stdout });
-  rlOut.on("line", (line) => {
+  const handleAcpLine = (line: string) => {
     appendLog(logStream, "stdout", line);
     const msg = parseAcpLine(line);
     if (!msg) {
@@ -243,7 +268,7 @@ export async function runAcpAgent({
         });
       }
     }
-  });
+  };
 
   function normalizePermissionOptions(raw: unknown): CliPermissionOption[] {
     if (!Array.isArray(raw)) return [];
@@ -461,11 +486,7 @@ export async function runAcpAgent({
             return;
           }
           const snap = terminalManager.output(terminalId);
-          respond({
-            output: snap.output,
-            truncated: snap.truncated,
-            ...(snap.exited ? { exitCode: snap.exitCode, exited: true } : {})
-          });
+          respond(buildTerminalOutputResponse(snap));
           return;
         }
         case "terminal/wait_for_exit": {
@@ -512,25 +533,84 @@ export async function runAcpAgent({
     }
   }
 
-  const rlErr = readline.createInterface({ input: child.stderr });
-  rlErr.on("line", (line) => {
-    appendLog(logStream, "stderr", line);
-    if (args.showStderr !== false) emit({ type: "stderr", content: line });
-  });
+  let connectionEpoch = 0;
+  let rlOut: readline.Interface | undefined;
+  let rlErr: readline.Interface | undefined;
 
-  child.on("close", (code) => {
-    const exitCode = code ?? -1;
-    for (const waiter of pending.values()) {
-      waiter.reject(new Error(`ACP agent exited with code ${exitCode}`));
-    }
-    pending.clear();
-    if (finished) return;
-    appendLog(logStream, "system", `exit code=${exitCode}`);
-    finish(exitCode === 0 ? "done" : "failed", exitCode);
-  });
+  const attachConnection = () => {
+    const epoch = ++connectionEpoch;
+    rlOut = readline.createInterface({ input: child.stdout });
+    rlOut.on("line", (line) => {
+      if (epoch === connectionEpoch) handleAcpLine(line);
+    });
+    rlErr = readline.createInterface({ input: child.stderr });
+    rlErr.on("line", (line) => {
+      if (epoch !== connectionEpoch) return;
+      appendLog(logStream, "stderr", line);
+      if (args.showStderr !== false) emit({ type: "stderr", content: line });
+    });
+    child.on("close", (code) => {
+      if (epoch !== connectionEpoch) return;
+      const exitCode = code ?? -1;
+      for (const waiter of pending.values()) {
+        waiter.reject(new Error(`ACP agent exited with code ${exitCode}`));
+      }
+      pending.clear();
+      if (finished) return;
+      appendLog(logStream, "system", `exit code=${exitCode}`);
+      finish(exitCode === 0 ? "done" : "failed", exitCode);
+    });
+  };
+  attachConnection();
 
   let agentCaps: any = {};
   let authMethods: AcpAuthMethod[] = [];
+  let authenticationAttempted = false;
+
+  const stopAcpConnectionForAuthentication = async () => {
+    const stoppingChild = child;
+    connectionEpoch += 1;
+    rlOut?.close();
+    rlErr?.close();
+    for (const waiter of pending.values()) {
+      waiter.reject(new Error("ACP connection restarting for authentication."));
+    }
+    pending.clear();
+    await new Promise<void>((resolve) => {
+      let resolved = false;
+      const done = () => {
+        if (resolved) return;
+        resolved = true;
+        resolve();
+      };
+      stoppingChild.once("close", done);
+      setTimeout(done, 2000);
+      try {
+        killProcessTree(stoppingChild, "term");
+      } catch {
+        done();
+      }
+    });
+  };
+
+  const restartAndInitialize = async () => {
+    const restarted = await restartAgent();
+    child = restarted.child;
+    pid = restarted.pid;
+    activeAcpSessionId = undefined;
+    promptStarted = false;
+    promptHadContent = false;
+    updateRunningProcess();
+    attachConnection();
+    const init = await request(buildInitializeRequest(nextId()));
+    if (init?.protocolVersion !== 1) {
+      throw new Error(
+        `Unsupported ACP protocol version ${String(init?.protocolVersion ?? "missing")}; FreeBuddy supports version 1.`
+      );
+    }
+    agentCaps = init?.agentCapabilities ?? {};
+    authMethods = Array.isArray(init?.authMethods) ? init.authMethods : [];
+  };
 
   const establishSession = async () => {
     const emitSetupItems = (result: any) => {
@@ -588,19 +668,96 @@ export async function runAcpAgent({
     );
   };
 
-  /** Build a clear error telling the user the agent needs authentication.
-   *  FreeBuddy does not drive the login flow; the user logs in via the agent's
-   *  own CLI, then retries the task. */
   const authRequiredError = (methods: AcpAuthMethod[]) => {
-    const method = methods[0];
+    const selected = selectAcpAuthMethod(methods);
+    const method = selected ?? methods[0];
     const label = method?.name ? ` (${method.name})` : "";
+    const unsupportedType =
+      method?.type && method.type !== "agent"
+        ? ` The agent requested unsupported ${method.type} authentication.`
+        : "";
     return new Error(
-      `Authentication required${label}. Log in to this agent from your terminal (for example via its login command), then retry the task.`
+      `Authentication required${label}.${unsupportedType} Log in to this agent from your terminal, then retry the task.`
     );
   };
 
-  const isLikelyAuthError = (err: unknown) => {
+  const chooseAuthMethod = async (
+    methods: AcpAuthMethod[]
+  ): Promise<AcpAuthMethod> => {
+    const automatic = selectAcpAuthMethod(methods);
+    if (automatic) return automatic;
+
+    const supported = methods.filter(
+      (method) =>
+        typeof method?.id === "string" &&
+        method.id.length > 0 &&
+        (method.type == null ||
+          method.type === "agent" ||
+          method.type === "terminal")
+    );
+    if (supported.length < 2) throw authRequiredError(methods);
+
+    const requestId = randomUUID();
+    return new Promise<AcpAuthMethod>((resolve, reject) => {
+      registerAuthenticationResolver(args.sessionId, requestId, (decision) => {
+        emit({ type: "authentication-resolved", requestId });
+        if (decision.outcome !== "selected") {
+          reject(new Error("Authentication cancelled."));
+          return;
+        }
+        const selected = supported.find(
+          (method) => method.id === decision.methodId
+        );
+        if (!selected) {
+          reject(new Error("The selected authentication method is unavailable."));
+          return;
+        }
+        resolve(selected);
+      });
+      emit({
+        type: "authentication",
+        request: {
+          requestId,
+          sessionId: args.sessionId,
+          agentName: args.agentName,
+          methods: supported.map((method) => ({
+            methodId: method.id,
+            name: method.name ?? method.id,
+            ...(method.description ? { description: method.description } : {})
+          }))
+        }
+      });
+    });
+  };
+
+  const authenticate = async (methods: AcpAuthMethod[]) => {
+    const method = await chooseAuthMethod(methods);
+    authenticationAttempted = true;
+    appendLog(
+      logStream,
+      "system",
+      `authenticating with ACP method ${method.id}`
+    );
+    if (method.type === "terminal") {
+      await stopAcpConnectionForAuthentication();
+      await runAuthenticationTerminal({
+        sessionId: args.sessionId,
+        agentName: args.agentName,
+        method,
+        command: agentCommand,
+        emit
+      });
+      await restartAndInitialize();
+      await request(buildAuthenticateRequest(nextId(), method.id));
+      return true;
+    }
+    await request(buildAuthenticateRequest(nextId(), method.id));
+    return false;
+  };
+
+  const isAuthenticationRequiredError = (err: unknown) => {
     const e = err as Error & { code?: number };
+    if (e?.code === -32000) return true;
     if (e?.code === 401 || e?.code === 403) return true;
     const message = String(e?.message ?? err).toLowerCase();
     return /\b(auth|unauthorized|unauthenticated|login|credential|api key|subscription)\b/.test(
@@ -622,6 +779,11 @@ export async function runAcpAgent({
 
   try {
     const init = await request(buildInitializeRequest(nextId()));
+    if (init?.protocolVersion !== 1) {
+      throw new Error(
+        `Unsupported ACP protocol version ${String(init?.protocolVersion ?? "missing")}; FreeBuddy supports version 1.`
+      );
+    }
     agentCaps = init?.agentCapabilities ?? {};
     authMethods = Array.isArray(init?.authMethods) ? init.authMethods : [];
 
@@ -639,14 +801,22 @@ export async function runAcpAgent({
     try {
       await establishSession();
     } catch (sessionErr) {
-      // The agent advertised auth methods and rejected session creation.
-      if (!finished && authMethods.length > 0 && isLikelyAuthError(sessionErr)) {
-        throw authRequiredError(authMethods);
-      }
-      if (!finished && toolSessionId && isMissingSavedSessionError(sessionErr)) {
+      if (
+        !finished &&
+        authMethods.length > 0 &&
+        isAuthenticationRequiredError(sessionErr)
+      ) {
+        await authenticate(authMethods);
+        await establishSession();
+      } else if (
+        !finished &&
+        toolSessionId &&
+        isMissingSavedSessionError(sessionErr)
+      ) {
         throw savedSessionUnavailableError(toolSessionId, sessionErr);
+      } else {
+        throw sessionErr;
       }
-      throw sessionErr;
     }
 
     if (!activeAcpSessionId) {
@@ -688,7 +858,22 @@ export async function runAcpAgent({
     };
 
     await applyConfigOptionOverrides();
-    await runPromptOnSession();
+    try {
+      await runPromptOnSession();
+    } catch (promptErr) {
+      if (
+        !finished &&
+        !promptHadContent &&
+        authMethods.length > 0 &&
+        isAuthenticationRequiredError(promptErr)
+      ) {
+        const restarted = await authenticate(authMethods);
+        if (restarted) await establishSession();
+        await runPromptOnSession();
+      } else {
+        throw promptErr;
+      }
+    }
     await syncSessionMetadataFromList();
 
     // Some agents (e.g. kimi when signed out) let session creation succeed but
@@ -696,7 +881,12 @@ export async function runAcpAgent({
     // agent advertised auth methods and produced nothing, treat it as a missing
     // login rather than a silent success.
     if (!promptHadContent && authMethods.length > 0 && !finished) {
-      throw authRequiredError(authMethods);
+      if (!authenticationAttempted) {
+        const restarted = await authenticate(authMethods);
+        if (restarted) await establishSession();
+        await runPromptOnSession();
+      }
+      if (!promptHadContent) throw authRequiredError(authMethods);
     }
 
     if (agentCaps?.sessionCapabilities?.close) {

--- a/electron/cli/acpTerminal.ts
+++ b/electron/cli/acpTerminal.ts
@@ -6,6 +6,7 @@ export interface TerminalSnapshot {
   output: string;
   truncated: boolean;
   exitCode?: number | null;
+  signal?: string | null;
   exited: boolean;
 }
 
@@ -48,6 +49,7 @@ function snapshot(record: TerminalRecord): TerminalSnapshot {
     output: record.chunks.join(""),
     truncated: record.truncated,
     exitCode: record.exitCode,
+    signal: record.signal,
     exited: record.exited
   };
 }
@@ -59,29 +61,25 @@ export function createAcpTerminalManager(options: {
   const terminals = new Map<string, TerminalRecord>();
 
   function appendOutput(record: TerminalRecord, data: Buffer) {
-    if (record.truncated) return;
     const text = data.toString("utf8");
-    const bytes = Buffer.byteLength(text, "utf8");
-    if (record.outputBytes + bytes > record.byteLimit) {
-      const remaining = record.byteLimit - record.outputBytes;
-      if (remaining > 0) {
-        let used = 0;
-        let sliceEnd = 0;
-        for (const char of text) {
-          const charBytes = Buffer.byteLength(char, "utf8");
-          if (used + charBytes > remaining) break;
-          used += charBytes;
-          sliceEnd += char.length;
-        }
-        if (sliceEnd > 0) {
-          record.chunks.push(text.slice(0, sliceEnd));
-          record.outputBytes += used;
-        }
+    const combined = record.chunks.join("") + text;
+    const combinedBytes = Buffer.byteLength(combined, "utf8");
+    if (combinedBytes > record.byteLimit) {
+      let used = 0;
+      const chars = Array.from(combined);
+      let start = chars.length;
+      while (start > 0) {
+        const charBytes = Buffer.byteLength(chars[start - 1], "utf8");
+        if (used + charBytes > record.byteLimit) break;
+        used += charBytes;
+        start -= 1;
       }
+      record.chunks = [chars.slice(start).join("")];
+      record.outputBytes = used;
       record.truncated = true;
     } else {
-      record.chunks.push(text);
-      record.outputBytes += bytes;
+      record.chunks = [combined];
+      record.outputBytes = combinedBytes;
     }
     options.onOutput?.(record.id, snapshot(record));
   }

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -18,7 +18,10 @@ import {
   cliRun,
   type CliRunArgs
 } from "./runtime.js";
-import { takePermissionResolver } from "./runtimeShared.js";
+import {
+  takeAuthenticationResolver,
+  takePermissionResolver
+} from "./runtimeShared.js";
 import {
   getTask,
   listTasks,
@@ -77,6 +80,15 @@ import { registerWorkflowIpc } from "./workflowIpc.js";
 import { readCodexUsage } from "./codexUsage.js";
 import { resolveDraftToolRequest } from "../draftToolService.js";
 import type { DraftToolResolution } from "../shared/draftToolProtocol.js";
+import {
+  logoutAcpAgent,
+  probeAcpAuthentication,
+  type CliAuthControlArgs
+} from "./acpAuth.js";
+import {
+  cancelAuthenticationTerminal,
+  writeAuthenticationTerminal
+} from "./acpAuthTerminal.js";
 
 function senderWindow(event: IpcMainInvokeEvent): BrowserWindow | null {
   return BrowserWindow.fromWebContents(event.sender);
@@ -216,6 +228,12 @@ export function registerCliIpc() {
 
   ipcMain.handle("cli:listRuntimes", () => listRuntimes());
   ipcMain.handle("cli:codexUsage", () => readCodexUsage());
+  ipcMain.handle("cli:probeAuthentication", (_e, args: CliAuthControlArgs) =>
+    probeAcpAuthentication(args)
+  );
+  ipcMain.handle("cli:logout", (_e, args: CliAuthControlArgs) =>
+    logoutAcpAgent(args)
+  );
   ipcMain.handle(
     "cli:check",
     async (
@@ -273,6 +291,39 @@ export function registerCliIpc() {
       }
       return true;
     }
+  );
+
+  ipcMain.handle(
+    "cli:authenticationDecision",
+    (
+      _e,
+      args: {
+        sessionId: string;
+        requestId: string;
+        outcome: "selected" | "cancelled";
+        methodId?: string;
+      }
+    ) => {
+      const resolver = takeAuthenticationResolver(args.sessionId, args.requestId);
+      if (!resolver) return false;
+      if (args.outcome === "selected" && args.methodId) {
+        resolver({ outcome: "selected", methodId: args.methodId });
+      } else {
+        resolver({ outcome: "cancelled" });
+      }
+      return true;
+    }
+  );
+
+  ipcMain.handle(
+    "cli:authenticationTerminalInput",
+    (_e, args: { sessionId: string; requestId: string; data: string }) =>
+      writeAuthenticationTerminal(args.sessionId, args.requestId, args.data)
+  );
+  ipcMain.handle(
+    "cli:authenticationTerminalCancel",
+    (_e, args: { sessionId: string; requestId: string }) =>
+      cancelAuthenticationTerminal(args.sessionId, args.requestId)
   );
 
   ipcMain.handle("cli:listTasks", (_e, args: CliTaskListArgs = {}) =>

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -120,7 +120,7 @@ function mergeJsonEnvValue(current: string | undefined, patch: string) {
   }
 }
 
-function mergeBuiltEnv(
+export function mergeBuiltEnv(
   base: Record<string, string | undefined>,
   patch?: Record<string, string>
 ) {
@@ -255,7 +255,31 @@ export async function cliRun(
       toolSessionScope,
       running,
       capturedSessions,
-      emit
+      emit,
+      agentCommand: {
+        bin: built.bin,
+        args: built.args,
+        cwd: args.cwd,
+        env
+      },
+      restartAgent: async () => {
+        const restarted = spawn(built.bin, built.args, {
+          cwd: args.cwd,
+          env,
+          stdio: ["pipe", "pipe", "pipe"]
+        }) as ChildProcessByStdio<Writable, Readable, Readable>;
+        await new Promise<void>((resolve, reject) => {
+          restarted.once("spawn", resolve);
+          restarted.once("error", reject);
+        });
+        const restartedPid = restarted.pid ?? 0;
+        if (!restartedPid) {
+          throw new Error("Restarted ACP agent did not report a process id.");
+        }
+        setTaskPid(args.sessionId, restartedPid);
+        emit({ type: "started", pid: restartedPid });
+        return { child: restarted, pid: restartedPid };
+      }
     });
     return;
   }

--- a/electron/cli/runtimeShared.ts
+++ b/electron/cli/runtimeShared.ts
@@ -74,6 +74,26 @@ export interface CliPermissionRequest {
   options: CliPermissionOption[];
 }
 
+export interface CliAuthenticationMethod {
+  methodId: string;
+  name: string;
+  description?: string;
+}
+
+export interface CliAuthenticationRequest {
+  requestId: string;
+  sessionId: string;
+  agentName: string;
+  methods: CliAuthenticationMethod[];
+}
+
+export interface CliAuthenticationTerminalRequest {
+  requestId: string;
+  sessionId: string;
+  agentName: string;
+  methodName: string;
+}
+
 export type CliEvent =
   | { type: "started"; pid: number }
   | { type: "stdout"; content: string }
@@ -90,6 +110,21 @@ export type CliEvent =
     }
   | { type: "permission"; request: CliPermissionRequest }
   | { type: "permission-resolved"; requestId: string }
+  | { type: "authentication"; request: CliAuthenticationRequest }
+  | { type: "authentication-resolved"; requestId: string }
+  | {
+      type: "authentication-terminal-started";
+      request: CliAuthenticationTerminalRequest;
+    }
+  | {
+      type: "authentication-terminal-update";
+      requestId: string;
+      output: string;
+      running: boolean;
+      exitCode?: number;
+      signal?: number;
+    }
+  | { type: "authentication-terminal-resolved"; requestId: string }
   | { type: "done"; exitCode: number }
   | { type: "error"; message: string };
 
@@ -307,4 +342,59 @@ export function clearPermissionResolversForSession(sessionId: string) {
     }
   }
   permissionRegistry.delete(sessionId);
+}
+
+// ---- Authentication method registry ------------------------------------
+
+export type CliAuthenticationDecision =
+  | { outcome: "selected"; methodId: string }
+  | { outcome: "cancelled" };
+
+export type CliAuthenticationResolver = (
+  decision: CliAuthenticationDecision
+) => void;
+
+const authenticationRegistry = new Map<
+  string,
+  Map<string, CliAuthenticationResolver>
+>();
+
+export function registerAuthenticationResolver(
+  sessionId: string,
+  requestId: string,
+  resolver: CliAuthenticationResolver
+) {
+  let bucket = authenticationRegistry.get(sessionId);
+  if (!bucket) {
+    bucket = new Map();
+    authenticationRegistry.set(sessionId, bucket);
+  }
+  bucket.set(requestId, resolver);
+}
+
+export function takeAuthenticationResolver(
+  sessionId: string,
+  requestId: string
+): CliAuthenticationResolver | undefined {
+  const bucket = authenticationRegistry.get(sessionId);
+  if (!bucket) return undefined;
+  const resolver = bucket.get(requestId);
+  if (resolver) {
+    bucket.delete(requestId);
+    if (bucket.size === 0) authenticationRegistry.delete(sessionId);
+  }
+  return resolver;
+}
+
+export function clearAuthenticationResolversForSession(sessionId: string) {
+  const bucket = authenticationRegistry.get(sessionId);
+  if (!bucket) return;
+  for (const resolver of bucket.values()) {
+    try {
+      resolver({ outcome: "cancelled" });
+    } catch {
+      /* noop */
+    }
+  }
+  authenticationRegistry.delete(sessionId);
 }

--- a/electron/cli/store.ts
+++ b/electron/cli/store.ts
@@ -559,3 +559,9 @@ export function saveToolSession(
       now
     );
 }
+
+export function clearToolSessionsForAgent(agentId: string): void {
+  getDb()
+    .prepare("DELETE FROM cli_tool_sessions WHERE agent_id = ?")
+    .run(agentId);
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -20,6 +20,9 @@ const cli = {
     return () => ipcRenderer.off(channel, handler);
   },
   codexUsage: () => ipcRenderer.invoke("cli:codexUsage"),
+  probeAuthentication: (args: unknown) =>
+    ipcRenderer.invoke("cli:probeAuthentication", args),
+  logout: (args: unknown) => ipcRenderer.invoke("cli:logout", args),
   check: (
     adapter: string,
     binary?: string,
@@ -47,6 +50,12 @@ const cli = {
   kill: (sessionId: string) => ipcRenderer.invoke("cli:kill", sessionId),
   permissionDecision: (args: unknown) =>
     ipcRenderer.invoke("cli:permissionDecision", args),
+  authenticationDecision: (args: unknown) =>
+    ipcRenderer.invoke("cli:authenticationDecision", args),
+  authenticationTerminalInput: (args: unknown) =>
+    ipcRenderer.invoke("cli:authenticationTerminalInput", args),
+  authenticationTerminalCancel: (args: unknown) =>
+    ipcRenderer.invoke("cli:authenticationTerminalCancel", args),
 
   listTasks: (args: unknown) => ipcRenderer.invoke("cli:listTasks", args),
   getTask: (id: string) => ipcRenderer.invoke("cli:getTask", id),

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "i18next": "^26.3.1",
         "lucide-react": "^0.562.0",
         "nanoid": "^5.1.11",
+        "node-pty": "^1.1.0",
         "posthog-node": "^5.40.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
@@ -27,6 +28,7 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@agentclientprotocol/sdk": "^1.2.1",
         "@electron/rebuild": "^4.0.4",
         "@google/design.md": "^0.3.0",
         "@types/better-sqlite3": "^7.6.13",
@@ -35,10 +37,21 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "ajv": "^8.20.0",
         "electron": "^39.2.7",
         "electron-builder": "^26.15.3",
         "typescript": "^5.9.3",
         "vite": "^7.2.7"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/@agentclientprotocol/sdk/-/sdk-1.2.1.tgz",
+      "integrity": "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@ant-design/colors": {
@@ -11319,6 +11332,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/node-api-version": {
       "version": "0.2.1",
       "resolved": "https://registry.npmmirror.com/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -11412,6 +11431,16 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.48",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "type": "module",
   "scripts": {
     "dev": "node scripts/dev-electron.mjs",
-    "postinstall": "electron-rebuild -f -w better-sqlite3",
-    "rebuild": "electron-rebuild -f -w better-sqlite3",
+    "postinstall": "electron-rebuild -f -w better-sqlite3 -w node-pty && node scripts/fix-node-pty-permissions.mjs",
+    "rebuild": "electron-rebuild -f -w better-sqlite3 -w node-pty && node scripts/fix-node-pty-permissions.mjs",
     "build": "npm run build:renderer && npm run build:electron",
     "build:renderer": "vite build",
     "build:electron": "tsc -p tsconfig.electron.json && tsc -p tsconfig.preload.json && node scripts/write-telemetry-config.mjs",
@@ -36,6 +36,7 @@
     "i18next": "^26.3.1",
     "lucide-react": "^0.562.0",
     "nanoid": "^5.1.11",
+    "node-pty": "^1.1.0",
     "posthog-node": "^5.40.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
@@ -45,6 +46,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@electron/rebuild": "^4.0.4",
     "@google/design.md": "^0.3.0",
     "@types/better-sqlite3": "^7.6.13",
@@ -53,6 +55,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "ajv": "^8.20.0",
     "electron": "^39.2.7",
     "electron-builder": "^26.15.3",
     "typescript": "^5.9.3",

--- a/scripts/fix-node-pty-permissions.mjs
+++ b/scripts/fix-node-pty-permissions.mjs
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const candidates = [
+  path.join(
+    process.cwd(),
+    "node_modules",
+    "node-pty",
+    "prebuilds",
+    `${process.platform}-${process.arch}`,
+    "spawn-helper"
+  ),
+  path.join(
+    process.cwd(),
+    "node_modules",
+    "node-pty",
+    "build",
+    "Release",
+    "spawn-helper"
+  )
+];
+
+for (const candidate of candidates) {
+  if (!fs.existsSync(candidate)) continue;
+  const mode = fs.statSync(candidate).mode & 0o777;
+  if ((mode & 0o111) === 0) {
+    fs.chmodSync(candidate, mode | 0o755);
+    console.log(`Marked node-pty spawn-helper executable: ${candidate}`);
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { ReplayButton } from "./components/CLI/ReplayBar";
 import { ConversationList } from "./components/CLI/ConversationList";
 import { ImageLightboxProvider } from "./components/CLI/ImageLightbox";
 import { PermissionDialog } from "./components/CLI/PermissionDialog";
+import { AuthenticationDialog } from "./components/CLI/AuthenticationDialog";
 import { DetailColumn } from "./components/CLI/DetailColumn";
 import { AgentBridgeListener } from "./components/AgentBridge/AgentBridgeListener";
 import { AgentBridgeToasts } from "./components/AgentBridge/AgentBridgeToasts";
@@ -364,6 +365,7 @@ function App() {
 
       <CliInstallPanelHost />
       <PermissionDialog />
+      <AuthenticationDialog />
       <AgentBridgeListener />
       <AgentBridgeToasts />
     </div>

--- a/src/components/CLI/AuthenticationDialog.tsx
+++ b/src/components/CLI/AuthenticationDialog.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { useAuthenticationStore } from "@/store/authenticationStore";
+
+export function AuthenticationDialog() {
+  const queue = useAuthenticationStore((state) => state.queue);
+  const terminalQueue = useAuthenticationStore((state) => state.terminalQueue);
+  const decide = useAuthenticationStore((state) => state.decide);
+  const writeTerminal = useAuthenticationStore((state) => state.writeTerminal);
+  const cancelTerminal = useAuthenticationStore((state) => state.cancelTerminal);
+  const current = queue[0];
+  const terminal = terminalQueue[0];
+  const [terminalInput, setTerminalInput] = useState("");
+  const outputRef = useRef<HTMLPreElement>(null);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!current) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        void decide(current.requestId, { outcome: "cancelled" });
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [current, decide]);
+
+  useEffect(() => {
+    if (!terminal) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        void cancelTerminal(terminal.requestId);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [cancelTerminal, terminal]);
+
+  useEffect(() => {
+    const output = outputRef.current;
+    if (output) output.scrollTop = output.scrollHeight;
+  }, [terminal?.output]);
+
+  if (terminal) {
+    const readableOutput = terminal.output.replace(
+      // Strip terminal control sequences while keeping the PTY text readable.
+      // eslint-disable-next-line no-control-regex
+      /\u001B(?:[@-_][0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g,
+      ""
+    );
+    return (
+      <div className="permission-backdrop" role="dialog" aria-modal="true">
+        <div className="permission-dialog authentication-dialog">
+          <header className="permission-header">
+            <span className="permission-eyebrow">
+              {t("authentication.terminalEyebrow")}
+            </span>
+            <h2 className="permission-title">
+              {t("authentication.terminalTitle", {
+                agent: terminal.agentName
+              })}
+            </h2>
+            <p className="authentication-description">
+              {t("authentication.terminalDescription", {
+                method: terminal.methodName
+              })}
+            </p>
+          </header>
+
+          <pre ref={outputRef} className="authentication-terminal-output">
+            {readableOutput || t("authentication.terminalStarting")}
+          </pre>
+
+          <form
+            className="authentication-terminal-input-row"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (!terminalInput || !terminal.running) return;
+              void writeTerminal(terminal.requestId, `${terminalInput}\r`);
+              setTerminalInput("");
+            }}
+          >
+            <input
+              type="text"
+              value={terminalInput}
+              autoFocus
+              autoComplete="off"
+              spellCheck={false}
+              disabled={!terminal.running}
+              aria-label={t("authentication.terminalInput")}
+              placeholder={t("authentication.terminalInput")}
+              onChange={(event) => setTerminalInput(event.target.value)}
+              onKeyDown={(event) => {
+                const sequences: Partial<Record<string, string>> = {
+                  ArrowUp: "\u001b[A",
+                  ArrowDown: "\u001b[B",
+                  ArrowRight: "\u001b[C",
+                  ArrowLeft: "\u001b[D",
+                  Tab: "\t"
+                };
+                const sequence = sequences[event.key];
+                if (!sequence || !terminal.running) return;
+                event.preventDefault();
+                void writeTerminal(terminal.requestId, sequence);
+              }}
+            />
+            <button
+              type="submit"
+              className="permission-btn permission-btn-primary"
+              disabled={!terminal.running || terminalInput.length === 0}
+            >
+              {t("authentication.sendInput")}
+            </button>
+          </form>
+
+          <div className="permission-actions">
+            <button
+              type="button"
+              className="permission-btn permission-btn-ghost"
+              disabled={!terminal.running}
+              onClick={() => void cancelTerminal(terminal.requestId)}
+            >
+              {t("common.cancel")}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!current) return null;
+
+  return (
+    <div className="permission-backdrop" role="dialog" aria-modal="true">
+      <div className="permission-dialog authentication-dialog">
+        <header className="permission-header">
+          <span className="permission-eyebrow">
+            {t("authentication.eyebrow")}
+          </span>
+          <h2 className="permission-title">
+            {t("authentication.title", { agent: current.agentName })}
+          </h2>
+          <p className="authentication-description">
+            {t("authentication.description")}
+          </p>
+        </header>
+
+        <div className="authentication-methods">
+          {current.methods.map((method) => (
+            <button
+              key={method.methodId}
+              type="button"
+              className="authentication-method"
+              disabled={current.resolving}
+              aria-label={t("authentication.continueWith", {
+                name: method.name
+              })}
+              onClick={() =>
+                void decide(current.requestId, {
+                  outcome: "selected",
+                  methodId: method.methodId
+                })
+              }
+            >
+              <span className="authentication-method-name">{method.name}</span>
+              {method.description ? (
+                <span className="authentication-method-description">
+                  {method.description}
+                </span>
+              ) : null}
+              <span className="authentication-method-action">
+                {t("authentication.continueWith", { name: method.name })}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="permission-actions">
+          <button
+            type="button"
+            className="permission-btn permission-btn-ghost"
+            disabled={current.resolving}
+            onClick={() =>
+              void decide(current.requestId, { outcome: "cancelled" })
+            }
+          >
+            {t("common.cancel")}
+          </button>
+        </div>
+
+        {queue.length > 1 ? (
+          <div className="permission-queue">
+            {t("authentication.morePending", { count: queue.length - 1 })}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/CLIAdaptersTab.tsx
+++ b/src/components/Settings/CLIAdaptersTab.tsx
@@ -5,7 +5,11 @@ import { nanoid } from "nanoid";
 import { useCliExecutorStore, type ResolvedExecutor } from "@/store/cliExecutorStore";
 import { useConversationStore } from "@/store/conversationStore";
 import { cliClient } from "@/services/cli/client";
-import type { CLIExecutorOverride, CliRuntime } from "@/services/cli/types";
+import type {
+  CliAuthProbeResult,
+  CLIExecutorOverride,
+  CliRuntime
+} from "@/services/cli/types";
 import { AgentAvatar } from "@/components/CLI/AgentAvatar";
 import { AvatarPicker } from "./AvatarPicker";
 import { useCliInstallStore } from "@/store/cliInstallStore";
@@ -128,6 +132,13 @@ export function CLIAdaptersTab() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [checkingIds, setCheckingIds] = useState<Set<string>>(() => new Set());
   const [checkingAll, setCheckingAll] = useState(false);
+  const [authProbes, setAuthProbes] = useState<
+    Record<string, CliAuthProbeResult>
+  >({});
+  const [authBusyIds, setAuthBusyIds] = useState<Set<string>>(
+    () => new Set()
+  );
+  const [authMessages, setAuthMessages] = useState<Record<string, string>>({});
   const autoCheckedRef = useRef(false);
   const autoInstallAttemptedRef = useRef<Set<string>>(new Set());
   const selectedExecutor = useMemo(
@@ -212,6 +223,67 @@ export function CLIAdaptersTab() {
     [list, refreshMembers, upsertOverride]
   );
 
+  const authControlArgs = useCallback((ex: ResolvedExecutor) => ({
+    agentId: `cli-${ex.id}`,
+    adapter: ex.baseAdapter ?? ex.id,
+    binary: ex.binary,
+    extraArgs: ex.extraArgs,
+    env: ex.env
+  }), []);
+
+  const handleAuthProbe = useCallback(async (ex: ResolvedExecutor) => {
+    setAuthBusyIds((current) => new Set(current).add(ex.id));
+    setAuthMessages((current) => ({ ...current, [ex.id]: "" }));
+    try {
+      const result = await cliClient.probeAuthentication(authControlArgs(ex));
+      setAuthProbes((current) => ({ ...current, [ex.id]: result }));
+      setAuthMessages((current) => ({
+        ...current,
+        [ex.id]: t("settings.cli.authMethodsFound", {
+          count: result.authMethods.length
+        })
+      }));
+    } catch (error) {
+      setAuthMessages((current) => ({
+        ...current,
+        [ex.id]: t("settings.cli.authProbeFailed", {
+          error: (error as Error)?.message || String(error)
+        })
+      }));
+    } finally {
+      setAuthBusyIds((current) => {
+        const next = new Set(current);
+        next.delete(ex.id);
+        return next;
+      });
+    }
+  }, [authControlArgs, t]);
+
+  const handleLogout = useCallback(async (ex: ResolvedExecutor) => {
+    setAuthBusyIds((current) => new Set(current).add(ex.id));
+    setAuthMessages((current) => ({ ...current, [ex.id]: "" }));
+    try {
+      await cliClient.logout(authControlArgs(ex));
+      setAuthMessages((current) => ({
+        ...current,
+        [ex.id]: t("settings.cli.logoutSuccess")
+      }));
+    } catch (error) {
+      setAuthMessages((current) => ({
+        ...current,
+        [ex.id]: t("settings.cli.logoutFailed", {
+          error: (error as Error)?.message || String(error)
+        })
+      }));
+    } finally {
+      setAuthBusyIds((current) => {
+        const next = new Set(current);
+        next.delete(ex.id);
+        return next;
+      });
+    }
+  }, [authControlArgs, t]);
+
   useEffect(() => {
     if (!loaded) void load();
   }, [loaded, load]);
@@ -262,6 +334,11 @@ export function CLIAdaptersTab() {
           command: ex.installHint
         });
       }}
+      authProbe={authProbes[ex.id]}
+      authBusy={authBusyIds.has(ex.id)}
+      authMessage={authMessages[ex.id]}
+      onAuthProbe={() => void handleAuthProbe(ex)}
+      onLogout={() => void handleLogout(ex)}
       installing={installingIdSet.has(ex.id)}
     />
   );
@@ -354,6 +431,11 @@ function AdapterRow({
   onClone,
   onEdit,
   onInstall,
+  authProbe,
+  authBusy,
+  authMessage,
+  onAuthProbe,
+  onLogout,
   installing
 }: {
   ex: ResolvedExecutor;
@@ -363,6 +445,11 @@ function AdapterRow({
   onClone: () => void;
   onEdit: () => void;
   onInstall: () => void;
+  authProbe?: CliAuthProbeResult;
+  authBusy: boolean;
+  authMessage?: string;
+  onAuthProbe: () => void;
+  onLogout: () => void;
   installing: boolean;
 }) {
   const { t } = useTranslation();
@@ -437,6 +524,11 @@ function AdapterRow({
               {t("settings.cli.modelLabel")}: <code>{model}</code>
             </span>
           )}
+          {authMessage && (
+            <span className="adapter-status muted" title={authMessage}>
+              {authMessage}
+            </span>
+          )}
         </div>
       </button>
       <div className="adapter-row-actions">
@@ -453,6 +545,23 @@ function AdapterRow({
         <button type="button" onClick={onCheck} disabled={checking || installing}>
           {checking ? t("settings.cli.checking") : t("common.check")}
         </button>
+        {rt?.installed && !authProbe && (
+          <button type="button" onClick={onAuthProbe} disabled={authBusy}>
+            {authBusy
+              ? t("settings.cli.authChecking")
+              : t("settings.cli.checkAuthentication")}
+          </button>
+        )}
+        {rt?.installed && authProbe?.logoutSupported && (
+          <button
+            type="button"
+            className="danger"
+            onClick={onLogout}
+            disabled={authBusy}
+          >
+            {authBusy ? t("settings.cli.loggingOut") : t("settings.cli.logout")}
+          </button>
+        )}
         <button type="button" onClick={onClone} disabled={checking || installing}>
           {t("common.clone")}
         </button>
@@ -945,4 +1054,3 @@ function EditOverridePanel({
     </section>
   );
 }
-

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -324,6 +324,20 @@
     "morePending_one": "+{{count}} more pending request",
     "morePending_other": "+{{count}} more pending requests"
   },
+  "authentication": {
+    "eyebrow": "Sign in required",
+    "title": "Choose how to sign in to {{agent}}",
+    "description": "This agent supports multiple authentication methods. Select one to continue the current task after sign-in.",
+    "continueWith": "Continue with {{name}}",
+    "terminalEyebrow": "Interactive sign-in",
+    "terminalTitle": "Sign in to {{agent}}",
+    "terminalDescription": "Complete {{method}} in the terminal below. The agent will restart automatically after sign-in.",
+    "terminalStarting": "Starting authentication terminal…",
+    "terminalInput": "Type terminal input",
+    "sendInput": "Send",
+    "morePending_one": "+{{count}} more sign-in request",
+    "morePending_other": "+{{count}} more sign-in requests"
+  },
   "lightbox": {
     "preview": "Image preview",
     "close": "Close preview"
@@ -344,6 +358,15 @@
       "commandOverride": "Command override",
       "model": "Model",
       "saveSuccess": "Saved",
+      "checkAuthentication": "Check sign-in",
+      "authChecking": "Checking…",
+      "authMethodsFound_one": "{{count}} sign-in method",
+      "authMethodsFound_other": "{{count}} sign-in methods",
+      "authProbeFailed": "Sign-in check failed: {{error}}",
+      "logout": "Sign out",
+      "loggingOut": "Signing out…",
+      "logoutSuccess": "Signed out",
+      "logoutFailed": "Sign-out failed: {{error}}",
       "saveFailed": "Save failed: {{err}}",
       "byok": {
         "title": "API Key",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -312,6 +312,19 @@
     },
     "morePending_other": "还有 {{count}} 个待处理请求"
   },
+  "authentication": {
+    "eyebrow": "需要登录",
+    "title": "选择 {{agent}} 的登录方式",
+    "description": "该 Agent 支持多种认证方式。请选择一种，登录后当前任务会自动继续。",
+    "continueWith": "使用 {{name}} 登录",
+    "terminalEyebrow": "交互式登录",
+    "terminalTitle": "登录 {{agent}}",
+    "terminalDescription": "请在下方终端完成 {{method}}。登录完成后 Agent 会自动重启。",
+    "terminalStarting": "正在启动认证终端…",
+    "terminalInput": "输入终端内容",
+    "sendInput": "发送",
+    "morePending_other": "还有 {{count}} 个登录请求"
+  },
   "lightbox": {
     "preview": "图片预览",
     "close": "关闭预览"
@@ -332,6 +345,14 @@
       "commandOverride": "命令覆盖",
       "model": "模型",
       "saveSuccess": "已保存",
+      "checkAuthentication": "检查登录",
+      "authChecking": "检查中…",
+      "authMethodsFound_other": "发现 {{count}} 种登录方式",
+      "authProbeFailed": "登录检查失败：{{error}}",
+      "logout": "退出登录",
+      "loggingOut": "退出中…",
+      "logoutSuccess": "已退出登录",
+      "logoutFailed": "退出登录失败：{{error}}",
       "saveFailed": "保存失败：{{err}}",
       "byok": {
         "title": "API Key",

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -4,6 +4,8 @@ import type {
   CliCheckResult,
   CliEvent,
   CliInstallResult,
+  CliAuthControlArgs,
+  CliAuthProbeResult,
   CliRunArgs,
   CliRuntime,
   CliTaskListArgs,
@@ -56,6 +58,12 @@ export const cliClient = {
   codexUsage(): Promise<CodexUsageResult> {
     return api().codexUsage();
   },
+  probeAuthentication(args: CliAuthControlArgs): Promise<CliAuthProbeResult> {
+    return api().probeAuthentication(args);
+  },
+  logout(args: CliAuthControlArgs): Promise<void> {
+    return api().logout(args);
+  },
   check(
     adapter: string,
     binary?: string,
@@ -88,6 +96,27 @@ export const cliClient = {
     optionId?: string;
   }): Promise<boolean> {
     return api().permissionDecision(args);
+  },
+  authenticationDecision(args: {
+    sessionId: string;
+    requestId: string;
+    outcome: "selected" | "cancelled";
+    methodId?: string;
+  }): Promise<boolean> {
+    return api().authenticationDecision(args);
+  },
+  authenticationTerminalInput(args: {
+    sessionId: string;
+    requestId: string;
+    data: string;
+  }): Promise<boolean> {
+    return api().authenticationTerminalInput(args);
+  },
+  authenticationTerminalCancel(args: {
+    sessionId: string;
+    requestId: string;
+  }): Promise<boolean> {
+    return api().authenticationTerminalCancel(args);
   },
 
   listTasks(args?: CliTaskListArgs): Promise<CliTaskRow[]> {

--- a/src/services/cli/types.ts
+++ b/src/services/cli/types.ts
@@ -145,6 +145,45 @@ export interface CliPermissionRequest {
   options: CliPermissionOption[];
 }
 
+export interface CliAuthenticationMethod {
+  methodId: string;
+  name: string;
+  description?: string;
+}
+
+export interface CliAuthenticationRequest {
+  requestId: string;
+  sessionId: string;
+  agentName: string;
+  methods: CliAuthenticationMethod[];
+}
+
+export interface CliAuthenticationTerminalRequest {
+  requestId: string;
+  sessionId: string;
+  agentName: string;
+  methodName: string;
+}
+
+export interface CliAuthControlArgs {
+  agentId: string;
+  adapter: CLIAdapterId;
+  binary?: string;
+  extraArgs?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface CliAuthProbeResult {
+  authMethods: Array<{
+    methodId: string;
+    name: string;
+    description?: string;
+    type: "agent" | "terminal" | "env_var";
+  }>;
+  logoutSupported: boolean;
+}
+
 export type CliEvent =
   | { type: "started"; pid: number }
   | { type: "stdout"; content: string }
@@ -161,6 +200,21 @@ export type CliEvent =
     }
   | { type: "permission"; request: CliPermissionRequest }
   | { type: "permission-resolved"; requestId: string }
+  | { type: "authentication"; request: CliAuthenticationRequest }
+  | { type: "authentication-resolved"; requestId: string }
+  | {
+      type: "authentication-terminal-started";
+      request: CliAuthenticationTerminalRequest;
+    }
+  | {
+      type: "authentication-terminal-update";
+      requestId: string;
+      output: string;
+      running: boolean;
+      exitCode?: number;
+      signal?: number;
+    }
+  | { type: "authentication-terminal-resolved"; requestId: string }
   | { type: "done"; exitCode: number }
   | { type: "error"; message: string };
 

--- a/src/store/authenticationStore.ts
+++ b/src/store/authenticationStore.ts
@@ -1,0 +1,155 @@
+import { create } from "zustand";
+
+import type {
+  CliAuthenticationRequest,
+  CliAuthenticationTerminalRequest
+} from "@/services/cli/types";
+import { cliClient } from "@/services/cli/client";
+
+interface QueuedAuthentication extends CliAuthenticationRequest {
+  conversationId: string;
+  resolving?: boolean;
+}
+
+interface AuthenticationState {
+  queue: QueuedAuthentication[];
+  terminalQueue: Array<
+    CliAuthenticationTerminalRequest & {
+      conversationId: string;
+      output: string;
+      running: boolean;
+      exitCode?: number;
+    }
+  >;
+  enqueue: (
+    conversationId: string,
+    request: CliAuthenticationRequest
+  ) => void;
+  remove: (requestId: string) => void;
+  removeForSession: (sessionId: string) => void;
+  removeForConversation: (conversationId: string) => void;
+  startTerminal: (
+    conversationId: string,
+    request: CliAuthenticationTerminalRequest
+  ) => void;
+  updateTerminal: (
+    requestId: string,
+    update: { output: string; running: boolean; exitCode?: number }
+  ) => void;
+  removeTerminal: (requestId: string) => void;
+  writeTerminal: (requestId: string, data: string) => Promise<void>;
+  cancelTerminal: (requestId: string) => Promise<void>;
+  decide: (
+    requestId: string,
+    decision:
+      | { outcome: "selected"; methodId: string }
+      | { outcome: "cancelled" }
+  ) => Promise<void>;
+}
+
+export const useAuthenticationStore = create<AuthenticationState>((set, get) => ({
+  queue: [],
+  terminalQueue: [],
+  enqueue(conversationId, request) {
+    set((state) => {
+      if (state.queue.some((entry) => entry.requestId === request.requestId)) {
+        return state;
+      }
+      return {
+        queue: [...state.queue, { ...request, conversationId }]
+      };
+    });
+  },
+  remove(requestId) {
+    set((state) => ({
+      queue: state.queue.filter((entry) => entry.requestId !== requestId)
+    }));
+  },
+  removeForSession(sessionId) {
+    set((state) => ({
+      queue: state.queue.filter((entry) => entry.sessionId !== sessionId),
+      terminalQueue: state.terminalQueue.filter(
+        (entry) => entry.sessionId !== sessionId
+      )
+    }));
+  },
+  removeForConversation(conversationId) {
+    set((state) => ({
+      queue: state.queue.filter(
+        (entry) => entry.conversationId !== conversationId
+      ),
+      terminalQueue: state.terminalQueue.filter(
+        (entry) => entry.conversationId !== conversationId
+      )
+    }));
+  },
+  startTerminal(conversationId, request) {
+    set((state) => ({
+      terminalQueue: state.terminalQueue.some(
+        (entry) => entry.requestId === request.requestId
+      )
+        ? state.terminalQueue
+        : [
+            ...state.terminalQueue,
+            { ...request, conversationId, output: "", running: true }
+          ]
+    }));
+  },
+  updateTerminal(requestId, update) {
+    set((state) => ({
+      terminalQueue: state.terminalQueue.map((entry) =>
+        entry.requestId === requestId ? { ...entry, ...update } : entry
+      )
+    }));
+  },
+  removeTerminal(requestId) {
+    set((state) => ({
+      terminalQueue: state.terminalQueue.filter(
+        (entry) => entry.requestId !== requestId
+      )
+    }));
+  },
+  async writeTerminal(requestId, data) {
+    const entry = get().terminalQueue.find(
+      (item) => item.requestId === requestId
+    );
+    if (!entry || !entry.running) return;
+    await cliClient.authenticationTerminalInput({
+      sessionId: entry.sessionId,
+      requestId,
+      data
+    });
+  },
+  async cancelTerminal(requestId) {
+    const entry = get().terminalQueue.find(
+      (item) => item.requestId === requestId
+    );
+    if (!entry) return;
+    await cliClient.authenticationTerminalCancel({
+      sessionId: entry.sessionId,
+      requestId
+    });
+  },
+  async decide(requestId, decision) {
+    const entry = get().queue.find((item) => item.requestId === requestId);
+    if (!entry || entry.resolving) return;
+    set((state) => ({
+      queue: state.queue.map((item) =>
+        item.requestId === requestId ? { ...item, resolving: true } : item
+      )
+    }));
+    try {
+      await cliClient.authenticationDecision({
+        sessionId: entry.sessionId,
+        requestId,
+        outcome: decision.outcome,
+        methodId:
+          decision.outcome === "selected" ? decision.methodId : undefined
+      });
+    } finally {
+      set((state) => ({
+        queue: state.queue.filter((item) => item.requestId !== requestId)
+      }));
+    }
+  }
+}));

--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -10,6 +10,7 @@ import { cliClient } from "@/services/cli/client";
 import type { ConversationState } from "./conversationStore";
 import { runCtxMap } from "./conversationStore";
 import { usePermissionStore } from "./permissionStore";
+import { useAuthenticationStore } from "./authenticationStore";
 import { appendItems, shouldApplyAgentSessionTitle } from "./conversationUtils";
 import { latestSessionInfoFromMessages } from "./sessionMetaUtils";
 import { useImagePreviewStore } from "./imagePreviewStore";
@@ -128,6 +129,30 @@ export function handleStreamEvent(
   }
   if (e.type === "permission-resolved") {
     usePermissionStore.getState().remove(e.requestId);
+    return;
+  }
+  if (e.type === "authentication") {
+    useAuthenticationStore.getState().enqueue(conversationId, e.request);
+    return;
+  }
+  if (e.type === "authentication-resolved") {
+    useAuthenticationStore.getState().remove(e.requestId);
+    return;
+  }
+  if (e.type === "authentication-terminal-started") {
+    useAuthenticationStore.getState().startTerminal(conversationId, e.request);
+    return;
+  }
+  if (e.type === "authentication-terminal-update") {
+    useAuthenticationStore.getState().updateTerminal(e.requestId, {
+      output: e.output,
+      running: e.running,
+      exitCode: e.exitCode
+    });
+    return;
+  }
+  if (e.type === "authentication-terminal-resolved") {
+    useAuthenticationStore.getState().removeTerminal(e.requestId);
     return;
   }
 
@@ -297,6 +322,7 @@ export function handleStreamEvent(
 
   if (e.type === "done") {
     usePermissionStore.getState().removeForConversation(conversationId);
+    useAuthenticationStore.getState().removeForConversation(conversationId);
     const live = get().live[conversationId];
     const reason = live?.status === "killed" ? "killed" : "done";
     void finalizeRun(set, get, conversationId, reason);

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -13,6 +13,8 @@ import type {
   CliTaskLogPage,
   CliTaskListArgs,
   CodexUsageResult,
+  CliAuthControlArgs,
+  CliAuthProbeResult,
   ToolSessionRecord,
   Conversation,
   ConversationMessage,
@@ -60,6 +62,8 @@ declare global {
     listRuntimes(): Promise<CliRuntime[]>;
     onRuntimeUpdated(cb: (runtime: CliRuntime) => void): () => void;
     codexUsage(): Promise<CodexUsageResult>;
+    probeAuthentication(args: CliAuthControlArgs): Promise<CliAuthProbeResult>;
+    logout(args: CliAuthControlArgs): Promise<void>;
     check(
       adapter: string,
       binary?: string,
@@ -80,6 +84,21 @@ declare global {
       requestId: string;
       outcome: "selected" | "cancelled";
       optionId?: string;
+    }): Promise<boolean>;
+    authenticationDecision(args: {
+      sessionId: string;
+      requestId: string;
+      outcome: "selected" | "cancelled";
+      methodId?: string;
+    }): Promise<boolean>;
+    authenticationTerminalInput(args: {
+      sessionId: string;
+      requestId: string;
+      data: string;
+    }): Promise<boolean>;
+    authenticationTerminalCancel(args: {
+      sessionId: string;
+      requestId: string;
     }): Promise<boolean>;
 
     listTasks(args?: CliTaskListArgs): Promise<CliTaskRow[]>;

--- a/styles.css
+++ b/styles.css
@@ -7838,6 +7838,113 @@ button.ghost:focus-visible,
   background: rgba(148, 163, 184, 0.16);
 }
 
+.authentication-description {
+  margin: 4px 0 0;
+  color: var(--fb-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.authentication-methods {
+  display: grid;
+  gap: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.authentication-method {
+  appearance: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--fb-border);
+  border-radius: 10px;
+  background: var(--fb-panel-soft);
+  color: var(--fb-text-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
+}
+
+.authentication-method:hover:not(:disabled) {
+  border-color: var(--fb-brand);
+  background: var(--fb-panel-bg);
+  transform: translateY(-1px);
+}
+
+.authentication-method:focus-visible {
+  outline: 2px solid var(--fb-brand);
+  outline-offset: 2px;
+}
+
+.authentication-method:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+
+.authentication-method-name {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.authentication-method-description {
+  color: var(--fb-text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.authentication-method-action {
+  margin-top: 4px;
+  color: var(--fb-brand);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+[data-theme="dark"] .authentication-method {
+  background: rgba(148, 163, 184, 0.08);
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+[data-theme="dark"] .authentication-method:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.authentication-terminal-output {
+  min-height: 220px;
+  max-height: 380px;
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 10px;
+  background: #08101f;
+  color: #dbeafe;
+  font-family: var(--fb-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.authentication-terminal-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.authentication-terminal-input-row input {
+  min-width: 0;
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--fb-border);
+  border-radius: 8px;
+  background: var(--fb-panel-bg);
+  color: var(--fb-text-primary);
+  font-family: var(--fb-mono);
+}
+
 .settings-section { padding: 12px 0; border-bottom: 1px solid var(--border, #e5e7eb); }
 .settings-section h3 { margin: 0 0 8px; font-size: 13px; }
 .settings-section select { padding: 6px 8px; border-radius: 6px; }

--- a/tests/acp-auth-selection.test.mjs
+++ b/tests/acp-auth-selection.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) =>
+  fs.readFileSync(new URL(path, import.meta.url), "utf8");
+
+const runtime = read("../electron/cli/acpRuntime.ts");
+const runtimeShared = read("../electron/cli/runtimeShared.ts");
+const ipc = read("../electron/cli/ipc.ts");
+const preload = read("../electron/preload.ts");
+const app = read("../src/App.tsx");
+const handlers = read("../src/store/conversationHandlers.ts");
+const store = read("../src/store/authenticationStore.ts");
+const dialog = read("../src/components/CLI/AuthenticationDialog.tsx");
+
+test("ACP runtime asks the renderer to select among multiple agent auth methods", () => {
+  assert.match(runtime, /const automatic = selectAcpAuthMethod\(methods\)/);
+  assert.match(runtime, /supported\.length < 2/);
+  assert.match(runtime, /type: "authentication"/);
+  assert.match(runtime, /registerAuthenticationResolver/);
+  assert.match(runtime, /buildAuthenticateRequest\(nextId\(\), method\.id\)/);
+});
+
+test("authentication decisions cross the preload and IPC boundary", () => {
+  assert.match(runtimeShared, /registerAuthenticationResolver/);
+  assert.match(runtimeShared, /takeAuthenticationResolver/);
+  assert.match(runtimeShared, /resolver\(\{ outcome: "cancelled" \}\)/);
+  assert.match(ipc, /"cli:authenticationDecision"/);
+  assert.match(ipc, /takeAuthenticationResolver/);
+  assert.match(preload, /authenticationDecision/);
+});
+
+test("renderer queues, displays, resolves, and cleans up authentication requests", () => {
+  assert.match(app, /<AuthenticationDialog \/>/);
+  assert.match(handlers, /e\.type === "authentication"/);
+  assert.match(handlers, /e\.type === "authentication-resolved"/);
+  assert.match(handlers, /useAuthenticationStore\.getState\(\)\.removeForConversation/);
+  assert.match(store, /cliClient\.authenticationDecision/);
+  assert.match(dialog, /current\.methods\.map/);
+  assert.match(dialog, /event\.key === "Escape"/);
+  assert.match(dialog, /outcome: "cancelled"/);
+  assert.match(dialog, /ArrowUp: "\\u001b\[A"/);
+});
+
+test("terminal auth restarts ACP and repeats initialize before authenticate", () => {
+  assert.match(runtime, /runAuthenticationTerminal/);
+  assert.match(runtime, /await restartAndInitialize\(\)/);
+  const restartIndex = runtime.indexOf("await restartAndInitialize();");
+  const authenticateIndex = runtime.indexOf(
+    "buildAuthenticateRequest(nextId(), method.id)",
+    restartIndex
+  );
+  assert.ok(restartIndex >= 0);
+  assert.ok(authenticateIndex > restartIndex);
+});

--- a/tests/acp-auth-terminal.test.mjs
+++ b/tests/acp-auth-terminal.test.mjs
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import {
+  runAuthenticationTerminal,
+  writeAuthenticationTerminal
+} from "../dist-electron/cli/acpAuthTerminal.js";
+
+test("terminal authentication uses a PTY, accepts input, and reports completion", async () => {
+  const sessionId = "auth-terminal-test";
+  const events = [];
+  let requestId;
+  let startedResolve;
+  const started = new Promise((resolve) => {
+    startedResolve = resolve;
+  });
+
+  const completed = runAuthenticationTerminal({
+    sessionId,
+    agentName: "Mock Agent",
+    method: { id: "terminal-login", name: "Terminal Login", type: "terminal" },
+    command: {
+      bin: process.execPath,
+      args: [
+        "-e",
+        "process.stdin.setEncoding('utf8'); process.stdout.write('LOGIN> '); process.stdin.on('data', data => { if (data.includes('secret')) { process.stdout.write('AUTH_OK'); process.exit(0); } }); setTimeout(() => process.exit(2), 5000);"
+      ],
+      env: process.env
+    },
+    emit(event) {
+      events.push(event);
+      if (event.type === "authentication-terminal-started") {
+        requestId = event.request.requestId;
+        startedResolve();
+      }
+    }
+  });
+
+  await started;
+  assert.ok(requestId);
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (writeAuthenticationTerminal(sessionId, requestId, "secret\r")) break;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  await completed;
+
+  assert.ok(
+    events.some(
+      (event) =>
+        event.type === "authentication-terminal-update" &&
+        event.output.includes("AUTH_OK")
+    )
+  );
+  assert.ok(
+    events.some(
+      (event) =>
+        event.type === "authentication-terminal-update" &&
+        event.running === false &&
+        event.exitCode === 0
+    )
+  );
+  assert.ok(
+    events.some((event) => event.type === "authentication-terminal-resolved")
+  );
+});
+
+test("terminal authentication preserves the agent's failure reason", async () => {
+  const events = [];
+
+  await assert.rejects(
+    runAuthenticationTerminal({
+      sessionId: "auth-terminal-failure-test",
+      agentName: "Mock Agent",
+      method: {
+        id: "terminal-login",
+        name: "Terminal Login",
+        type: "terminal"
+      },
+      command: {
+        bin: process.execPath,
+        args: [
+          "-e",
+          "process.stdout.write('Opening login...\\r\\n\\u001b[31mLogin failed: membership is inactive.\\u001b[0m\\r\\n'); process.exit(1);"
+        ],
+        env: process.env
+      },
+      emit(event) {
+        events.push(event);
+      }
+    }),
+    /Authentication terminal exited with code 1\. Login failed: membership is inactive\./
+  );
+
+  assert.ok(
+    events.some(
+      (event) =>
+        event.type === "authentication-terminal-update" &&
+        event.running === false &&
+        event.exitCode === 1
+    )
+  );
+});
+
+test("packaging keeps node-pty and its spawn helper outside asar", () => {
+  const builder = fs.readFileSync(
+    new URL("../electron-builder.yml", import.meta.url),
+    "utf8"
+  );
+  const scripts = fs.readFileSync(
+    new URL("../package.json", import.meta.url),
+    "utf8"
+  );
+  assert.match(builder, /node_modules\/node-pty\/\*\*\/\*/);
+  assert.match(scripts, /fix-node-pty-permissions\.mjs/);
+});

--- a/tests/acp-logout-contract.test.mjs
+++ b/tests/acp-logout-contract.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(new URL(path, import.meta.url), "utf8");
+
+const auth = read("../electron/cli/acpAuth.ts");
+const ipc = read("../electron/cli/ipc.ts");
+const preload = read("../electron/preload.ts");
+const settings = read("../src/components/Settings/CLIAdaptersTab.tsx");
+
+test("logout is gated by the official agent auth capability", () => {
+  assert.match(auth, /agentCapabilities\?\.auth\?\.logout == null/);
+  assert.match(auth, /buildLogoutRequest\(2\)/);
+});
+
+test("renderer exposes authentication probing and logout only when supported", () => {
+  assert.match(ipc, /"cli:probeAuthentication"/);
+  assert.match(ipc, /"cli:logout"/);
+  assert.match(preload, /probeAuthentication/);
+  assert.match(preload, /logout/);
+  assert.match(settings, /authProbe\?\.logoutSupported/);
+  assert.match(settings, /cliClient\.logout/);
+});

--- a/tests/acp-official-schema.test.mjs
+++ b/tests/acp-official-schema.test.mjs
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import Ajv2020 from "ajv/dist/2020.js";
+
+import {
+  buildAuthenticateRequest,
+  buildInitializeRequest,
+  buildLogoutRequest,
+  buildSessionCancelNotification,
+  buildSessionCloseRequest,
+  buildSessionListRequest,
+  buildSessionLoadRequest,
+  buildSessionNewRequest,
+  buildSessionPromptRequest,
+  buildSessionResumeRequest,
+  buildSessionSetConfigOptionRequest,
+  buildTerminalOutputResponse
+} from "../dist-electron/cli/acp.js";
+
+const schema = JSON.parse(
+  fs.readFileSync(
+    new URL(
+      "../node_modules/@agentclientprotocol/sdk/schema/schema.json",
+      import.meta.url
+    ),
+    "utf8"
+  )
+);
+
+const ajv = new Ajv2020({ strict: false, validateFormats: false });
+ajv.addSchema(schema, "acp-official");
+
+function officialDefinition(name) {
+  return ajv.compile({ $ref: `acp-official#/$defs/${name}` });
+}
+
+function assertValid(validate, value) {
+  assert.equal(validate(value), true, JSON.stringify(validate.errors, null, 2));
+}
+
+test("FreeBuddy ACP requests validate against the official SDK schema", () => {
+  const validateMessage = ajv.getSchema("acp-official");
+  assert.ok(validateMessage);
+  const messages = [
+    buildInitializeRequest(1, "0.4.9-test"),
+    buildAuthenticateRequest(2, "browser-login"),
+    buildLogoutRequest(3),
+    buildSessionNewRequest(4, "/tmp/project"),
+    buildSessionLoadRequest(5, "session-1", "/tmp/project"),
+    buildSessionResumeRequest(6, "session-1", "/tmp/project"),
+    buildSessionPromptRequest(7, "session-1", "hello"),
+    buildSessionCancelNotification("session-1"),
+    buildSessionCloseRequest(8, "session-1"),
+    buildSessionSetConfigOptionRequest(9, "session-1", "model", "fast"),
+    buildSessionListRequest(10, "/tmp/project")
+  ];
+  for (const message of messages) assertValid(validateMessage, message);
+});
+
+test("initialize opts into terminal auth only with the implemented PTY flow", () => {
+  const request = buildInitializeRequest(1, "0.4.9-test");
+  assertValid(officialDefinition("InitializeRequest"), request.params);
+  assert.equal(request.params.clientCapabilities?.auth?.terminal, true);
+});
+
+test("terminal/output response validates against the official SDK schema", () => {
+  const response = buildTerminalOutputResponse({
+    output: "tail",
+    truncated: true,
+    exited: true,
+    exitCode: 0,
+    signal: null
+  });
+  assertValid(officialDefinition("TerminalOutputResponse"), response);
+});

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -32,3 +32,7 @@ test("ACP runtime still treats process close as a fallback finish signal", () =>
     /finish\(exitCode === 0 \? "done" : "failed", exitCode\)/
   );
 });
+
+test("ACP terminal output uses the stable exitStatus response shape", () => {
+  assert.match(acpRuntimeSource, /buildTerminalOutputResponse\(snap\)/);
+});

--- a/tests/acp-terminal.test.mjs
+++ b/tests/acp-terminal.test.mjs
@@ -36,7 +36,7 @@ test("terminal manager enforces output byte limits", async () => {
   const { terminalId } = manager.create({
     sessionId: "sess-2",
     command: process.execPath,
-    args: ["-e", "process.stdout.write('x'.repeat(200))"],
+    args: ["-e", "process.stdout.write('prefix-' + 'x'.repeat(200) + '-tail')"],
     outputByteLimit: 32
   });
 
@@ -45,6 +45,28 @@ test("terminal manager enforces output byte limits", async () => {
 
   assert.equal(snap.truncated, true);
   assert.ok(Buffer.byteLength(snap.output, "utf8") <= 32);
+  assert.match(snap.output, /-tail$/);
+  assert.doesNotMatch(snap.output, /^prefix-/);
+
+  manager.release(terminalId);
+});
+
+test("terminal manager truncates UTF-8 output at character boundaries", async () => {
+  const manager = createAcpTerminalManager({});
+  const { terminalId } = manager.create({
+    sessionId: "sess-3",
+    command: process.execPath,
+    args: ["-e", "process.stdout.write('前缀内容🙂最终')"],
+    outputByteLimit: 10
+  });
+
+  await manager.waitForExit(terminalId);
+  const snap = manager.output(terminalId);
+
+  assert.equal(snap.truncated, true);
+  assert.ok(Buffer.byteLength(snap.output, "utf8") <= 10);
+  assert.match(snap.output, /最终$/);
+  assert.doesNotMatch(snap.output, /�/);
 
   manager.release(terminalId);
 });

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -7,15 +7,19 @@ import {
   acpSessionListToItems,
   acpSessionSetupToItems,
   acpUpdateToItems,
+  buildAuthenticateRequest,
   buildInitializeRequest,
+  buildLogoutRequest,
   buildPromptContentBlocks,
   buildSessionLoadRequest,
   buildSessionNewRequest,
   buildSessionPromptRequest,
   buildSessionResumeRequest,
   buildSessionSetConfigOptionRequest,
+  buildTerminalOutputResponse,
   contentBlockToItems,
   parseAcpLine,
+  selectAcpAuthMethod,
   shouldEmitAcpUpdate,
   shouldSkipUserMessageChunk
 } from "../dist-electron/cli/acp.js";
@@ -271,24 +275,102 @@ test("buildCommand keeps Grok global flags before the ACP subcommand", () => {
   assert.equal(built.protocol, "acp");
 });
 
-test("buildInitializeRequest advertises conservative client capabilities", () => {
-  assert.deepEqual(buildInitializeRequest(7), {
+test("buildInitializeRequest advertises only implemented stable capabilities", () => {
+  assert.deepEqual(buildInitializeRequest(7, "0.4.9-test"), {
     jsonrpc: "2.0",
     id: 7,
     method: "initialize",
     params: {
       protocolVersion: 1,
       clientCapabilities: {
-        auth: { terminal: true },
-        terminal: true
+        terminal: true,
+        auth: { terminal: true }
       },
       clientInfo: {
         name: "freebuddy",
         title: "FreeBuddy",
-        version: "0.1.0"
+        version: "0.4.9-test"
       }
     }
   });
+});
+
+test("ACP auth request builders use stable v1 method shapes", () => {
+  assert.deepEqual(buildAuthenticateRequest(8, "agent-login"), {
+    jsonrpc: "2.0",
+    id: 8,
+    method: "authenticate",
+    params: { methodId: "agent-login" }
+  });
+  assert.deepEqual(buildLogoutRequest(9), {
+    jsonrpc: "2.0",
+    id: 9,
+    method: "logout",
+    params: {}
+  });
+});
+
+test("ACP auth selection prefers available API keys, otherwise interactive login", () => {
+  const methods = [
+    {
+      id: "api-key",
+      name: "API Key",
+      _meta: { "api-key": { provider: "openai" } }
+    },
+    { id: "chat-gpt", name: "ChatGPT" }
+  ];
+
+  assert.equal(selectAcpAuthMethod(methods, {})?.id, "chat-gpt");
+  assert.equal(
+    selectAcpAuthMethod(methods, { ANTHROPIC_API_KEY: "unrelated-key" })?.id,
+    "chat-gpt"
+  );
+  assert.equal(
+    selectAcpAuthMethod(methods, { OPENAI_API_KEY: "test-key" })?.id,
+    "api-key"
+  );
+  assert.equal(
+    selectAcpAuthMethod(
+      [{ id: "login", type: "terminal", name: "Login" }],
+      {}
+    )?.id,
+    "login"
+  );
+  assert.equal(
+    selectAcpAuthMethod(
+      [
+        { id: "ioa", name: "Login with iOA" },
+        { id: "external", name: "Login with Google/GitHub" }
+      ],
+      {}
+    ),
+    undefined
+  );
+});
+
+test("terminal/output uses the stable ACP exitStatus shape", () => {
+  assert.deepEqual(
+    buildTerminalOutputResponse({
+      output: "done",
+      truncated: false,
+      exited: true,
+      exitCode: 0,
+      signal: null
+    }),
+    {
+      output: "done",
+      truncated: false,
+      exitStatus: { exitCode: 0, signal: null }
+    }
+  );
+  assert.deepEqual(
+    buildTerminalOutputResponse({
+      output: "running",
+      truncated: false,
+      exited: false
+    }),
+    { output: "running", truncated: false }
+  );
 });
 
 test("buildSessionPromptRequest sends a text content block", () => {
@@ -368,18 +450,19 @@ test("ACP session lifecycle injects FreeBuddy stdio MCP servers", () => {
   );
 });
 
-test("ACP runtime reports missing saved sessions separately from auth failures", () => {
+test("ACP runtime authenticates standard auth-required errors and separates missing sessions", () => {
   assert.match(acpRuntimeSource, /Saved agent session is no longer available/);
-  assert.match(acpRuntimeSource, /function isLikelyAuthError|const isLikelyAuthError/);
+  assert.match(acpRuntimeSource, /isAuthenticationRequiredError/);
+  assert.match(acpRuntimeSource, /e\?\.code === -32000/);
   assert.match(
     acpRuntimeSource,
-    /authMethods\.length > 0 && isLikelyAuthError\(sessionErr\)/
+    /buildAuthenticateRequest\(nextId\(\), method\.id\)/
   );
   assert.match(
     acpRuntimeSource,
-    /toolSessionId && isMissingSavedSessionError\(sessionErr\)/
+    /toolSessionId\s*&&\s*isMissingSavedSessionError\(sessionErr\)/
   );
-  assert.doesNotMatch(acpRuntimeSource, /authMethods\.length > 0\) throw authRequiredError/);
+  assert.match(acpRuntimeSource, /Unsupported ACP protocol version/);
 });
 
 test("parseAcpLine parses JSON-RPC messages and ignores blank lines", () => {

--- a/tests/i18n-strings.test.mjs
+++ b/tests/i18n-strings.test.mjs
@@ -24,6 +24,7 @@ const migratedFiles = [
   "../src/components/CLI/MessageBubble.tsx",
   "../src/components/CLI/StreamItem.tsx",
   "../src/components/CLI/PermissionDialog.tsx",
+  "../src/components/CLI/AuthenticationDialog.tsx",
   "../src/components/CLI/ImageLightbox.tsx",
   "../src/components/Settings/SettingsModal.tsx",
   "../src/components/Settings/CLIAdaptersTab.tsx",


### PR DESCRIPTION
## What changed

- Align ACP initialize, authenticate, and logout requests with the stable protocol shapes.
- Prefer the standard `-32000` authentication-required error and expose advertised auth methods to the renderer.
- Add auth method selection, login, and capability-gated logout controls.
- Implement terminal authentication with a visible interactive PTY, then restart the ACP agent and repeat `initialize → authenticate` before resuming the session.
- Fix terminal `exitStatus` responses and retain-tail UTF-8 output truncation.
- Preserve terminal authentication failure details instead of reporting only exit code 1.
- Package and rebuild `node-pty` correctly for Electron.
- Add contract tests driven by the official ACP SDK schemas.

## Why

FreeBuddy's earlier ACP authentication support relied mainly on project-owned object shapes. It could advertise terminal auth without a complete interactive flow, miss stable schema differences, and hide the agent's actual terminal login failure reason.

## Impact

Agents that advertise stable ACP authentication can now present their available login methods, complete interactive terminal login inside FreeBuddy, restart cleanly after login, and expose logout when supported.

## Validation

- `npm test` — 465 tests passed
- `git diff --check`
- Manual ChatGPT/Codex login flow
- Manual Kimi terminal-auth/device-login path
