### PR TITLE
fix: classify Linux app as development

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -51,7 +51,7 @@ nsis:
 
 linux:
   icon: assets/app-icon.png
-  category: Utility
+  category: Development
   maintainer: FreeBuddy <noreply@freebuddy.dev>
   target:
     - target: AppImage

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -26,6 +26,7 @@ test("electron-builder config packages FreeBuddy for desktop platforms", () => {
   assert.match(builderConfig, /mac:[\s\S]*target:[\s\S]*- target:\s+dmg[\s\S]*- target:\s+zip/m);
   assert.match(builderConfig, /win:[\s\S]*target:[\s\S]*- target:\s+nsis/m);
   assert.match(builderConfig, /linux:[\s\S]*target:[\s\S]*- target:\s+AppImage[\s\S]*- target:\s+deb/m);
+  assert.match(builderConfig, /linux:[\s\S]*category:\s+Development/m);
   assert.match(builderConfig, /linux:[\s\S]*maintainer:\s+FreeBuddy <noreply@freebuddy\.dev>/m);
   assert.match(builderConfig, /toolsets:[\s\S]*appimage:\s+"1\.0\.3"/m);
   assert.match(builderConfig, /extraResources:[\s\S]*from:\s+assets\/app-icon\.png[\s\S]*to:\s+app-icon\.png/m);


### PR DESCRIPTION
## What changed

- Change the Linux desktop category from `Utility` to `Development`.
- Add a release configuration regression test for the expected Linux category.

## Why

The generated desktop entry currently places FreeBuddy in Ubuntu's utility/accessories area. FreeBuddy is a developer workspace and should appear in the Development application category.

## User impact

New Linux packages will place FreeBuddy under Ubuntu's development applications. Existing installations need to update or reinstall a package built with this change.

## Validation

- `node --test tests/release-workflow.test.mjs` — 3 tests passed
- `npm test` — 504 tests passed
- `git diff --check`

Fixes #49
