### PR TITLE
fix: isolate concurrent agent install events

### DIFF
--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -807,12 +807,13 @@ export function cliInstall(command: string, adapter = "custom"): Promise<CliInst
 export function cliInstallStream(
   command: string,
   webContents?: Electron.WebContents | null,
-  adapter = "custom"
+  adapter = "custom",
+  requestId = adapter
 ): Promise<CliInstallResult> {
   return new Promise((resolve, reject) => {
     const channel = "cli://install";
-    const send = (payload: unknown) => {
-      safeSendToWebContents(webContents, channel, payload);
+    const send = (payload: Record<string, unknown>) => {
+      safeSendToWebContents(webContents, channel, { ...payload, requestId });
     };
     void (async () => {
       const trimmed = command.trim();

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -269,11 +269,16 @@ export function registerCliIpc() {
   ipcMain.handle("cli:install", async (_e, args: { adapter: string; command: string }) =>
     cliInstall(args.command, args.adapter)
   );
-  ipcMain.handle("cli:installStream", async (_e, args: { adapter: string; command: string }) =>
+  ipcMain.handle("cli:installStream", async (event, args: {
+    adapter: string;
+    command: string;
+    requestId: string;
+  }) =>
     cliInstallStream(
       args.command,
-      BrowserWindow.getFocusedWindow()?.webContents,
-      args.adapter
+      event.sender,
+      args.adapter,
+      args.requestId
     )
   );
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,6 +19,15 @@ type CliInstallEvent =
       failureDetail?: string;
     };
 
+type CliInstallWireEvent = CliInstallEvent & { requestId: string };
+
+let cliInstallRequestSequence = 0;
+
+function nextCliInstallRequestId(): string {
+  cliInstallRequestSequence += 1;
+  return `cli-install-${Date.now()}-${cliInstallRequestSequence}`;
+}
+
 const cli = {
   listAdapters: () => ipcRenderer.invoke("cli:listAdapters"),
   listOverrides: () => ipcRenderer.invoke("cli:listOverrides"),
@@ -50,9 +59,15 @@ const cli = {
     cb: (event: CliInstallEvent) => void
   ): (() => void) => {
     const channel = "cli://install";
-    const handler = (_e: IpcRendererEvent, payload: unknown) => cb(payload as any);
+    const requestId = nextCliInstallRequestId();
+    const handler = (_e: IpcRendererEvent, payload: unknown) => {
+      if (!payload || typeof payload !== "object") return;
+      const event = payload as CliInstallWireEvent;
+      if (event.requestId !== requestId) return;
+      cb(event);
+    };
     ipcRenderer.on(channel, handler);
-    ipcRenderer.invoke("cli:installStream", { adapter, command }).catch((err) => {
+    ipcRenderer.invoke("cli:installStream", { adapter, command, requestId }).catch((err) => {
       cb({ type: "stderr", content: String(err) });
       cb({ type: "done", exitCode: 1 });
     });

--- a/tests/cli-install-ui.test.mjs
+++ b/tests/cli-install-ui.test.mjs
@@ -26,6 +26,14 @@ const checkSource = fs.readFileSync(
   new URL("../electron/cli/check.ts", import.meta.url),
   "utf8"
 );
+const preloadSource = fs.readFileSync(
+  new URL("../electron/preload.ts", import.meta.url),
+  "utf8"
+);
+const ipcSource = fs.readFileSync(
+  new URL("../electron/cli/ipc.ts", import.meta.url),
+  "utf8"
+);
 const zhLocale = JSON.parse(
   fs.readFileSync(new URL("../src/locales/zh-CN.json", import.meta.url), "utf8")
 );
@@ -72,6 +80,15 @@ test("successful package install is verified before the UI reports success", () 
   assert.match(hostSource, /settings\.cli\.installVerifying/);
   assert.match(hostSource, /settings\.cli\.installVerifiedSuccess/);
   assert.match(hostSource, /settings\.cli\.installVerificationFailed/);
+});
+
+test("concurrent agent installs keep stream events scoped to their request", () => {
+  assert.match(preloadSource, /nextCliInstallRequestId/);
+  assert.match(preloadSource, /event\.requestId !== requestId/);
+  assert.match(preloadSource, /\{ adapter, command, requestId \}/);
+  assert.match(checkSource, /\{ \.\.\.payload, requestId \}/);
+  assert.match(ipcSource, /event\.sender,[\s\S]*args\.adapter,[\s\S]*args\.requestId/);
+  assert.equal(ipcSource.includes("BrowserWindow.getFocusedWindow()?.webContents"), false);
 });
 
 test("agent version probes preserve actionable failure categories", () => {


### PR DESCRIPTION
## What changed

- Assign a unique request ID to every streamed Agent installation.
- Filter installation output and completion events in the preload bridge so each panel only receives its own events.
- Send stream updates back to the web contents that initiated the installation instead of whichever window is currently focused.
- Add regression coverage for concurrent installation event isolation.

## Why

All installations shared the same `cli://install` broadcast channel without a task identifier. When users installed multiple Agents concurrently, the first process to finish broadcast its output and `done` event to every open installation panel. Other jobs then stopped listening and ran verification before their own installers had completed, producing duplicated output and false `binary not found` results.

## User impact

OpenCode, Codex, ClaudeCode, and other Agents can now be installed concurrently without their output, completion state, or post-install verification affecting one another.

## Validation

- `npm run typecheck`
- Focused install and telemetry tests — 12 tests passed
- `npm test` — 505 tests passed
- `git diff --check`

Fixes #53
