### PR TITLE
test: align release checks with current UI

### DIFF
--- a/tests/star-history.test.mjs
+++ b/tests/star-history.test.mjs
@@ -34,9 +34,13 @@ test("rendered chart includes an accessible title and curve", () => {
   assert.match(svg, /2 stars · Updated 2026-01-03/);
 });
 
-test("readmes embed the generated star history curve", () => {
+test("readmes embed the hosted star history chart", () => {
   const readme = fs.readFileSync(new URL("../README.md", import.meta.url), "utf8");
   const readmeZh = fs.readFileSync(new URL("../README.zh-CN.md", import.meta.url), "utf8");
-  assert.match(readme, /assets\/star-history\.svg/);
-  assert.match(readmeZh, /assets\/star-history\.svg/);
+  const chartUrl = /https:\/\/api\.star-history\.com\/chart\?repos=maojindao55\/freebuddy&/;
+  const detailsUrl = /https:\/\/www\.star-history\.com\/\?repos=maojindao55%2Ffreebuddy&/;
+  assert.match(readme, chartUrl);
+  assert.match(readmeZh, chartUrl);
+  assert.match(readme, detailsUrl);
+  assert.match(readmeZh, detailsUrl);
 });

--- a/tests/workflow-teams.test.mjs
+++ b/tests/workflow-teams.test.mjs
@@ -305,7 +305,7 @@ test("team i18n keys exist in both locales", () => {
 test("workflow team settings editor localizes builtin role and node labels", () => {
   const src = read("../src/components/Settings/WorkflowTeamEditor.tsx");
   assert.match(src, /workflowTeamRoleLabel\(draft, role, t\)/);
-  assert.match(src, /workflowTeamRoleKind\(role\.kind, t\)/);
+  assert.match(src, /workflow\.roleDescriptions\.\$\{role\.kind\}/);
   assert.match(src, /workflowTeamNodeTitle\(draft, n, t\)/);
   assert.match(src, /workflowTeamNodeMode\(n\.mode, t\)/);
   assert.doesNotMatch(src, /<strong>\{role\.label\}<\/strong>/);


### PR DESCRIPTION
## Summary

- update the README Star History test to recognize the hosted chart and detail links in both languages
- update the workflow team localization assertion to match the current localized role-description UI

## Root cause

The release test suite still asserted the previous local `assets/star-history.svg` embed after the README switched to the hosted chart. A second assertion still expected the role-kind badge removed by the compact team-role UI, even though role descriptions remain localized through `workflow.roleDescriptions.${role.kind}`.

## Impact

This restores the GitHub packaging and release test gate without changing runtime behavior or weakening the intended localization and README coverage.

## Validation

- `node --test tests/star-history.test.mjs tests/workflow-teams.test.mjs` — 39/39 passed
- `npm test` — 528/528 passed
- `npm run build` — passed