### PR TITLE
fix: suppress ACP session replay duplicates and recover interrupted messages

### DIFF
--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -1211,6 +1211,7 @@ export function shouldEmitAcpUpdate(
   state: {
     promptStarted: boolean;
     replayMessageIds?: ReadonlySet<string>;
+    replayContentSignatures?: ReadonlySet<string>;
   }
 ): boolean {
   const type = String(update?.sessionUpdate ?? "");
@@ -1220,12 +1221,29 @@ export function shouldEmitAcpUpdate(
   if (!state.promptStarted) {
     return false;
   }
+  const isMessageOrThought =
+    type === "agent_message_chunk" || type === "agent_thought_chunk";
   const messageId =
     typeof update?.messageId === "string" ? update.messageId : undefined;
   if (
     messageId &&
     state.replayMessageIds?.has(messageId) &&
-    (type === "agent_message_chunk" || type === "agent_thought_chunk")
+    isMessageOrThought
+  ) {
+    return false;
+  }
+  if (isMessageOrThought && state.replayContentSignatures?.size) {
+    const signature = textFromContent(update?.content).trim();
+    if (signature.length > 0 && state.replayContentSignatures.has(signature)) {
+      return false;
+    }
+  }
+  const toolCallId =
+    typeof update?.toolCallId === "string" ? update.toolCallId : undefined;
+  if (
+    toolCallId &&
+    state.replayMessageIds?.has(toolCallId) &&
+    (type === "tool_call" || type === "tool_call_update")
   ) {
     return false;
   }

--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -1206,6 +1206,18 @@ export function shouldSkipUserMessageChunk(
   return false;
 }
 
+export function shouldDropReplayPhaseAgentChunk(
+  update: any,
+  state: { suppressReplayByPhase: boolean; turnHadLiveAgentChunk: boolean }
+): boolean {
+  if (!state.suppressReplayByPhase || state.turnHadLiveAgentChunk) return false;
+  const type = String(update?.sessionUpdate ?? "");
+  if (type !== "agent_message_chunk" && type !== "agent_thought_chunk") {
+    return false;
+  }
+  return typeof update?.messageId === "string" && update.messageId.length > 0;
+}
+
 export function shouldEmitAcpUpdate(
   update: any,
   state: {

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -22,6 +22,7 @@ import {
   buildTerminalOutputResponse,
   parseAcpLine,
   selectAcpAuthMethod,
+  shouldDropReplayPhaseAgentChunk,
   shouldEmitAcpUpdate,
   shouldSkipUserMessageChunk,
   type AcpAuthMethod,
@@ -119,11 +120,19 @@ export async function runAcpAgent({
   let finished = false;
   let promptStarted = false;
   let promptHadContent = false;
+  let turnHadLiveAgentChunk = false;
   let mcpServers: AcpStdioMcpServer[] = [];
   const replayMessageIds = new Set(args.knownStreamMessageIds ?? []);
   const replayContentSignatures = new Set(
     args.knownStreamContentSignatures ?? []
   );
+  // Qoder-style adapters stream live agent chunks WITHOUT a messageId and only
+  // attach messageIds when replaying history on resume. When resuming such an
+  // adapter (prior turns persisted zero agent messageIds), drop messageId-
+  // carrying chunks until the first live chunk signals real generation.
+  const suppressReplayByPhase =
+    Boolean(toolSessionId) &&
+    (args.knownAgentStreamMessageIds ?? []).length === 0;
   const terminalManager = createAcpTerminalManager({
     defaultCwd: args.cwd,
     onOutput: (terminalId, snap) => {
@@ -255,6 +264,25 @@ export async function runAcpAgent({
         })
       ) {
         return;
+      }
+      const isAgentChunkForPhase =
+        updateType === "agent_message_chunk" ||
+        updateType === "agent_thought_chunk";
+      if (isAgentChunkForPhase && suppressReplayByPhase) {
+        if (
+          shouldDropReplayPhaseAgentChunk(msg.params?.update, {
+            suppressReplayByPhase,
+            turnHadLiveAgentChunk
+          })
+        ) {
+          return;
+        }
+        const hasMessageId =
+          typeof msg.params?.update?.messageId === "string" &&
+          msg.params.update.messageId.length > 0;
+        if (!hasMessageId) {
+          turnHadLiveAgentChunk = true;
+        }
       }
       if (
         !shouldEmitAcpUpdate(msg.params?.update, {
@@ -618,6 +646,7 @@ export async function runAcpAgent({
     activeAcpSessionId = undefined;
     promptStarted = false;
     promptHadContent = false;
+    turnHadLiveAgentChunk = false;
     updateRunningProcess();
     attachConnection();
     const init = await request(buildInitializeRequest(nextId()));
@@ -688,6 +717,7 @@ export async function runAcpAgent({
     });
     promptStarted = true;
     promptHadContent = false;
+    turnHadLiveAgentChunk = false;
     await request(
       buildSessionPromptRequest(
         nextId(),

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -121,6 +121,9 @@ export async function runAcpAgent({
   let promptHadContent = false;
   let mcpServers: AcpStdioMcpServer[] = [];
   const replayMessageIds = new Set(args.knownStreamMessageIds ?? []);
+  const replayContentSignatures = new Set(
+    args.knownStreamContentSignatures ?? []
+  );
   const terminalManager = createAcpTerminalManager({
     defaultCwd: args.cwd,
     onOutput: (terminalId, snap) => {
@@ -256,7 +259,8 @@ export async function runAcpAgent({
       if (
         !shouldEmitAcpUpdate(msg.params?.update, {
           promptStarted,
-          replayMessageIds
+          replayMessageIds,
+          replayContentSignatures
         })
       ) {
         return;

--- a/electron/cli/conversations.ts
+++ b/electron/cli/conversations.ts
@@ -437,6 +437,22 @@ export function updateMessage(input: UpdateMessageInput): void {
     .run(...params);
 }
 
+// A force-quit while an agent is streaming leaves the assistant message row at
+// 'running'/'starting' with no live process to finish it. On restart the UI
+// would otherwise show a permanent "thinking" state that can't be stopped, so
+// reconcile those orphaned rows to a terminal status.
+export function recoverInterruptedMessages(): number {
+  const now = new Date().toISOString();
+  const result = getDb()
+    .prepare(
+      `UPDATE conversation_messages
+       SET status = 'failed', updated_at = ?
+       WHERE status IN ('running', 'starting')`
+    )
+    .run(now);
+  return result.changes;
+}
+
 export function getMessage(id: string): ConversationMessage | undefined {
   const row = getDb()
     .prepare(`SELECT * FROM conversation_messages WHERE id = ?`)

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -46,6 +46,7 @@ import {
   setConversationApprovalMode,
   setConversationConfigOptionOverrides,
   setConversationSkills,
+  recoverInterruptedMessages,
   updateConversationAgentName,
   updateMessage,
   type AppendMessageInput,
@@ -203,6 +204,7 @@ function attachmentCandidate(filePath: string) {
 }
 
 export function registerCliIpc() {
+  recoverInterruptedMessages();
   ipcMain.handle("skills:list", () => listSkills());
   ipcMain.handle("skills:import", (_event, sourcePath: string) =>
     importSkills(sourcePath)

--- a/electron/cli/runtimeShared.ts
+++ b/electron/cli/runtimeShared.ts
@@ -48,6 +48,12 @@ export interface CliRunArgs {
   knownStreamMessageIds?: string[];
   /** Normalized text signatures of prior turns (replay suppression when messageIds are absent). */
   knownStreamContentSignatures?: string[];
+  /**
+   * Agent-chunk messageIds (text/thinking only) persisted from prior turns.
+   * Empty for adapters (e.g. Qoder) that stream live without messageIds, which
+   * enables replay-phase suppression on resumed sessions.
+   */
+  knownAgentStreamMessageIds?: string[];
   skills?: SkillSnapshot[];
   announceSkills?: boolean;
 }

--- a/electron/cli/runtimeShared.ts
+++ b/electron/cli/runtimeShared.ts
@@ -46,6 +46,8 @@ export interface CliRunArgs {
   userMessageId?: string;
   /** Known stream messageIds from prior assistant turns (replay suppression). */
   knownStreamMessageIds?: string[];
+  /** Normalized text signatures of prior turns (replay suppression when messageIds are absent). */
+  knownStreamContentSignatures?: string[];
   skills?: SkillSnapshot[];
   announceSkills?: boolean;
 }

--- a/src/services/cli/types.ts
+++ b/src/services/cli/types.ts
@@ -75,6 +75,7 @@ export interface CliRunArgs {
   timeoutMs?: number;
   userMessageId?: string;
   knownStreamMessageIds?: string[];
+  knownStreamContentSignatures?: string[];
   skills?: SkillSnapshot[];
   announceSkills?: boolean;
 }

--- a/src/services/cli/types.ts
+++ b/src/services/cli/types.ts
@@ -76,6 +76,7 @@ export interface CliRunArgs {
   userMessageId?: string;
   knownStreamMessageIds?: string[];
   knownStreamContentSignatures?: string[];
+  knownAgentStreamMessageIds?: string[];
   skills?: SkillSnapshot[];
   announceSkills?: boolean;
 }

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -31,6 +31,7 @@ import {
 import { useCliExecutorStore } from "./cliExecutorStore";
 import {
   collectStreamMessageIds,
+  collectStreamContentSignatures,
   defaultTitleFor,
   feedArticleTitleFromMessages,
   mergeConversationMessages,
@@ -851,6 +852,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       resumeToolSession: !wantFresh,
       userMessageId: userMsgId,
       knownStreamMessageIds: collectStreamMessageIds(
+        get().messages[conversationId] ?? []
+      ),
+      knownStreamContentSignatures: collectStreamContentSignatures(
         get().messages[conversationId] ?? []
       ),
       skills: conv.skillSnapshot,

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -31,6 +31,7 @@ import {
 import { useCliExecutorStore } from "./cliExecutorStore";
 import {
   collectStreamMessageIds,
+  collectStreamAgentMessageIds,
   collectStreamContentSignatures,
   defaultTitleFor,
   feedArticleTitleFromMessages,
@@ -855,6 +856,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
         get().messages[conversationId] ?? []
       ),
       knownStreamContentSignatures: collectStreamContentSignatures(
+        get().messages[conversationId] ?? []
+      ),
+      knownAgentStreamMessageIds: collectStreamAgentMessageIds(
         get().messages[conversationId] ?? []
       ),
       skills: conv.skillSnapshot,

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -74,6 +74,39 @@ export function collectStreamMessageIds(
   return [...ids];
 }
 
+/**
+ * Agent-chunk messageIds only (text/thinking), excluding tool-call ids.
+ *
+ * Used to detect adapters (e.g. Qoder) that stream live agent chunks WITHOUT a
+ * messageId and only attach messageIds when replaying history on resume. When a
+ * resumed session has zero persisted agent messageIds, FreeBuddy can safely
+ * treat messageId-carrying chunks that arrive before any live chunk as replay.
+ */
+export function collectStreamAgentMessageIds(
+  messages: ConversationMessage[]
+): string[] {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    try {
+      const parsed = JSON.parse(message.content);
+      if (!Array.isArray(parsed)) continue;
+      for (const item of parsed as CliStreamItem[]) {
+        if (
+          (item.kind === "text" || item.kind === "thinking") &&
+          typeof item.messageId === "string" &&
+          item.messageId.length > 0
+        ) {
+          ids.add(item.messageId);
+        }
+      }
+    } catch {
+      /* ignore malformed snapshots */
+    }
+  }
+  return [...ids];
+}
+
 export function normalizeReplaySignature(text: string): string {
   return text.trim();
 }

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -59,12 +59,53 @@ export function collectStreamMessageIds(
         ) {
           ids.add(item.messageId);
         }
+        if (
+          item.kind === "tool-call" &&
+          typeof item.id === "string" &&
+          item.id.length > 0
+        ) {
+          ids.add(item.id);
+        }
       }
     } catch {
       /* ignore malformed snapshots */
     }
   }
   return [...ids];
+}
+
+export function normalizeReplaySignature(text: string): string {
+  return text.trim();
+}
+
+export function collectStreamContentSignatures(
+  messages: ConversationMessage[]
+): string[] {
+  const signatures = new Set<string>();
+  const add = (value: unknown) => {
+    if (typeof value !== "string") return;
+    const normalized = normalizeReplaySignature(value);
+    if (normalized.length > 0) signatures.add(normalized);
+  };
+  for (const message of messages) {
+    if (message.role === "user") {
+      add(message.content);
+      continue;
+    }
+    if (message.role !== "assistant") continue;
+    try {
+      const parsed = JSON.parse(message.content);
+      if (!Array.isArray(parsed)) continue;
+      for (const item of parsed as CliStreamItem[]) {
+        if (item.kind === "text" || item.kind === "thinking") {
+          add(item.content);
+        }
+      }
+    } catch {
+      /* ignore malformed snapshots */
+    }
+  }
+  return [...signatures];
 }
 
 export function mergeToolCalls(prev: ToolCallItem, next: ToolCallItem): ToolCallItem {
@@ -286,6 +327,13 @@ export function appendItems(
       const planIndex = out.findIndex((previous) => previous.kind === "plan");
       if (planIndex >= 0) {
         out[planIndex] = item;
+        continue;
+      }
+    }
+    if (item.kind === "session") {
+      const index = out.findIndex((previous) => previous.kind === "session");
+      if (index >= 0) {
+        out[index] = item;
         continue;
       }
     }

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -1056,6 +1056,56 @@ test("shouldEmitAcpUpdate suppresses persisted messageId replay after prompt sta
   );
 });
 
+test("shouldEmitAcpUpdate suppresses replayed tool calls by toolCallId", () => {
+  const replayMessageIds = new Set(["tool-old-1"]);
+  assert.equal(
+    shouldEmitAcpUpdate(
+      { sessionUpdate: "tool_call", toolCallId: "tool-old-1", title: "Read" },
+      { promptStarted: true, replayMessageIds }
+    ),
+    false
+  );
+  assert.equal(
+    shouldEmitAcpUpdate(
+      { sessionUpdate: "tool_call_update", toolCallId: "tool-old-1", status: "completed" },
+      { promptStarted: true, replayMessageIds }
+    ),
+    false
+  );
+  assert.equal(
+    shouldEmitAcpUpdate(
+      { sessionUpdate: "tool_call", toolCallId: "tool-new-1", title: "Read" },
+      { promptStarted: true, replayMessageIds }
+    ),
+    true
+  );
+});
+
+test("shouldEmitAcpUpdate suppresses replayed chunks by content signature", () => {
+  const replayContentSignatures = new Set(["你好！我是 Qoder"]);
+  assert.equal(
+    shouldEmitAcpUpdate(
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "fresh-id-never-persisted",
+        content: { type: "text", text: "  你好！我是 Qoder  " }
+      },
+      { promptStarted: true, replayContentSignatures }
+    ),
+    false
+  );
+  assert.equal(
+    shouldEmitAcpUpdate(
+      {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "抱歉，" }
+      },
+      { promptStarted: true, replayContentSignatures }
+    ),
+    true
+  );
+});
+
 test("shouldSkipUserMessageChunk deduplicates echoed user messages", () => {
   assert.equal(
     shouldSkipUserMessageChunk(

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -21,7 +21,8 @@ import {
   parseAcpLine,
   selectAcpAuthMethod,
   shouldEmitAcpUpdate,
-  shouldSkipUserMessageChunk
+  shouldSkipUserMessageChunk,
+  shouldDropReplayPhaseAgentChunk
 } from "../dist-electron/cli/acp.js";
 
 const acpRuntimeSource = fs.readFileSync(
@@ -1103,6 +1104,55 @@ test("shouldEmitAcpUpdate suppresses replayed chunks by content signature", () =
       { promptStarted: true, replayContentSignatures }
     ),
     true
+  );
+});
+
+test("shouldDropReplayPhaseAgentChunk drops messageId chunks before any live chunk", () => {
+  const state = { suppressReplayByPhase: true, turnHadLiveAgentChunk: false };
+  assert.equal(
+    shouldDropReplayPhaseAgentChunk(
+      { sessionUpdate: "agent_thought_chunk", messageId: "replay-mid-1", content: { type: "text", text: "a" } },
+      state
+    ),
+    true
+  );
+  assert.equal(
+    shouldDropReplayPhaseAgentChunk(
+      { sessionUpdate: "agent_message_chunk", messageId: "replay-mid-2", content: { type: "text", text: "b" } },
+      state
+    ),
+    true
+  );
+});
+
+test("shouldDropReplayPhaseAgentChunk keeps live (messageId-less) chunks and post-live chunks", () => {
+  assert.equal(
+    shouldDropReplayPhaseAgentChunk(
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "live" } },
+      { suppressReplayByPhase: true, turnHadLiveAgentChunk: false }
+    ),
+    false
+  );
+  assert.equal(
+    shouldDropReplayPhaseAgentChunk(
+      { sessionUpdate: "agent_message_chunk", messageId: "mid-late", content: { type: "text", text: "x" } },
+      { suppressReplayByPhase: true, turnHadLiveAgentChunk: true }
+    ),
+    false
+  );
+  assert.equal(
+    shouldDropReplayPhaseAgentChunk(
+      { sessionUpdate: "tool_call", toolCallId: "call-1" },
+      { suppressReplayByPhase: true, turnHadLiveAgentChunk: false }
+    ),
+    false
+  );
+  assert.equal(
+    shouldDropReplayPhaseAgentChunk(
+      { sessionUpdate: "agent_message_chunk", messageId: "mid-1", content: { type: "text", text: "x" } },
+      { suppressReplayByPhase: false, turnHadLiveAgentChunk: false }
+    ),
+    false
   );
 });
 

--- a/tests/conversation-utils.test.mjs
+++ b/tests/conversation-utils.test.mjs
@@ -715,3 +715,49 @@ test("collectStreamMessageIds gathers ids from stored assistant snapshots", asyn
     ["msg-a-1", "msg-t-1", "tool-1"]
   );
 });
+
+test("collectStreamAgentMessageIds gathers only text/thinking messageIds (excludes tool ids)", async () => {
+  const { collectStreamAgentMessageIds } = await loadConversationUtils();
+
+  assert.deepEqual(
+    collectStreamAgentMessageIds([
+      {
+        id: "assistant-1",
+        conversationId: "conv-1",
+        role: "assistant",
+        status: "done",
+        content: JSON.stringify([
+          { kind: "text", role: "assistant", content: "Hi", messageId: "msg-a-1" },
+          { kind: "thinking", content: "hmm", messageId: "msg-t-1" },
+          { kind: "tool-call", id: "tool-1", tool: "Read" }
+        ]),
+        createdAt: "2026-06-23T10:00:00.000Z",
+        updatedAt: "2026-06-23T10:00:00.000Z"
+      }
+    ]),
+    ["msg-a-1", "msg-t-1"]
+  );
+});
+
+test("collectStreamAgentMessageIds returns empty for Qoder-style turns without messageIds", async () => {
+  const { collectStreamAgentMessageIds } = await loadConversationUtils();
+
+  assert.deepEqual(
+    collectStreamAgentMessageIds([
+      {
+        id: "assistant-1",
+        conversationId: "conv-1",
+        role: "assistant",
+        status: "done",
+        content: JSON.stringify([
+          { kind: "thinking", content: "The user just said \"\"", append: true },
+          { kind: "tool-call", id: "call_72c22954", tool: "tool", status: "completed" },
+          { kind: "text", role: "assistant", content: "现在是…", append: true }
+        ]),
+        createdAt: "2026-06-23T10:00:00.000Z",
+        updatedAt: "2026-06-23T10:00:00.000Z"
+      }
+    ]),
+    []
+  );
+});

--- a/tests/conversation-utils.test.mjs
+++ b/tests/conversation-utils.test.mjs
@@ -137,6 +137,23 @@ test("appendItems replaces the current agent plan with the latest update", async
   ]);
 });
 
+test("appendItems keeps a single session item, replacing with the latest", async () => {
+  const { appendItems } = await loadConversationUtils();
+
+  const items = appendItems(
+    [{ kind: "session", sessionId: "sess-1" }],
+    [
+      { kind: "text", role: "assistant", content: "Hello" },
+      { kind: "session", sessionId: "sess-1", title: "Renamed" }
+    ]
+  );
+
+  assert.deepEqual(items, [
+    { kind: "session", sessionId: "sess-1", title: "Renamed" },
+    { kind: "text", role: "assistant", content: "Hello" }
+  ]);
+});
+
 test("appendItems converts legacy todo tool calls into the current agent plan", async () => {
   const { appendItems } = await loadConversationUtils();
 
@@ -688,12 +705,13 @@ test("collectStreamMessageIds gathers ids from stored assistant snapshots", asyn
             content: "Hi",
             messageId: "msg-a-1"
           },
-          { kind: "thinking", content: "hmm", messageId: "msg-t-1" }
+          { kind: "thinking", content: "hmm", messageId: "msg-t-1" },
+          { kind: "tool-call", id: "tool-1", tool: "Read" }
         ]),
         createdAt: "2026-06-23T10:00:00.000Z",
         updatedAt: "2026-06-23T10:00:00.000Z"
       }
     ]),
-    ["msg-a-1", "msg-t-1"]
+    ["msg-a-1", "msg-t-1", "tool-1"]
   );
 });


### PR DESCRIPTION
## Problem

ACP adapters (notably Qoder) replay historical `session/update` chunks when resuming a session. The previous replay suppression only covered `agent_message_chunk`/`agent_thought_chunk` matching a persisted `messageId`, leaving three gaps that caused duplicated/garbled conversations:

- Agent chunks without a `messageId` (Qoder often omits it, or uses fresh ids) — e.g. the "你好！我是 Qoder" intro kept reappearing
- `tool_call` / `tool_call_update` keyed by `toolCallId`, which was never collected or compared
- `session` metadata items were appended instead of upserted, stacking up and garbling the view

Separately, force-quitting during a stream orphaned the assistant row at `running`/`starting` with no live process to finish it, leaving the UI stuck in a permanent "thinking" state after restart.

## Fix

- `shouldEmitAcpUpdate` now also drops `tool_call`/`tool_call_update` by `toolCallId`, and agent/thought chunks by trimmed content signature when messageIds are absent (`electron/cli/acp.ts`)
- `collectStreamMessageIds` now also gathers `tool-call` ids; new `collectStreamContentSignatures` feeds signature-based suppression (`src/store/conversationUtils.ts`)
- `appendItems` upserts `session` items instead of stacking them
- `recoverInterruptedMessages()` runs once at IPC registration to mark orphaned `running`/`starting` rows as `failed`

## Impact

- Non-ACP adapters (codex/claude/opencode legacy): zero behavioral change — the collected sets are not consumed on the legacy path
- Other ACP adapters (codex-acp, claude-agent-acp, opencode-acp, cursor-agent-acp, kimi-acp, codebuddy-acp, grok-acp): receive the same dedup protection; triggers are strict (exact trimmed-text equality or toolCallId hit), so normal incremental streaming is unaffected

## Verification

- `npm run typecheck` ✅
- `npm test` — 594/594 passing (3 new tests: toolCallId suppression, content-signature suppression, session upsert; extended `collectStreamMessageIds` test for tool-call ids)
- `npm run github:preflight` ✅