### PR TITLE
test(handoff): fix Windows transcript mode assertion

### DIFF
--- a/tests/handoff-transcript.test.mjs
+++ b/tests/handoff-transcript.test.mjs
@@ -47,7 +47,9 @@ test("snapshot sanitizes secrets, inline media, private reasoning, and attachmen
       })
     ]);
     assert.equal(path.basename(transcript.path), "brief_1.jsonl");
-    assert.equal(fs.statSync(transcript.path).mode & 0o777, 0o600);
+    if (process.platform !== "win32") {
+      assert.equal(fs.statSync(transcript.path).mode & 0o777, 0o600);
+    }
     const loaded = readHandoffTranscriptSnapshot(dir, transcript);
     const serialized = JSON.stringify(loaded);
     assert.equal(serialized.includes("QUJDRA"), false);


### PR DESCRIPTION
## Summary

- skip the POSIX-only 0600 file-mode assertion on Windows
- keep the permission assertion active on POSIX platforms
- retain all cross-platform transcript sanitization and path-hiding assertions

## Root cause

Release v0.5.11 failed only on the Windows x64 job because Node reports mode 0666 on Windows, where POSIX permission bits do not have the same semantics. The implementation still creates the snapshot with mode 0600 where the platform supports it.

Failed run: https://github.com/maojindao55/freebuddy/actions/runs/29644736336

## Verification

- node --test tests/handoff-transcript.test.mjs (4 passed)
- npm test (640 tests: 635 passed, 5 skipped, 0 failed; handoff DB 5 passed)
- git diff --check
- npm run github:preflight