### PR TITLE
Add search to skill selectors

### DIFF
--- a/src/components/CLI/ComposerAddMenu.tsx
+++ b/src/components/CLI/ComposerAddMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Plus, Sparkles, UploadCloud } from "lucide-react";
+import { ChevronRight, Plus, Search, Sparkles, UploadCloud } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -23,10 +23,17 @@ export function ComposerAddMenu({
   const rootRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [skillsOpen, setSkillsOpen] = useState(false);
+  const [skillQuery, setSkillQuery] = useState("");
   const available = useMemo(
     () => skills.filter((skill) => skill.enabled && skill.trusted),
     [skills]
   );
+  const filteredAvailable = useMemo(() => {
+    const needle = skillQuery.trim().toLocaleLowerCase();
+    return available.filter((skill) =>
+      !needle || `${skill.name} ${skill.description}`.toLocaleLowerCase().includes(needle)
+    );
+  }, [available, skillQuery]);
   const selected = useMemo(() => new Set(selectedIds), [selectedIds]);
   const selectedAvailableCount = available.reduce(
     (count, skill) => count + (selected.has(skill.id) ? 1 : 0),
@@ -63,6 +70,10 @@ export function ComposerAddMenu({
     setOpen(false);
     setSkillsOpen(false);
   }, [disabled]);
+
+  useEffect(() => {
+    if (!skillsOpen) setSkillQuery("");
+  }, [skillsOpen]);
 
   const toggleSkill = (skillId: string, checked: boolean) => {
     const next = new Set(selectedIds);
@@ -140,21 +151,31 @@ export function ComposerAddMenu({
                 <strong>{t("skills.activeForTask")}</strong>
                 <span>{selectedAvailableCount}/{available.length}</span>
               </div>
+              <label className="composer-add-skills-search">
+                <Search size={14} aria-hidden="true" />
+                <input
+                  type="search"
+                  value={skillQuery}
+                  onChange={(event) => setSkillQuery(event.currentTarget.value)}
+                  placeholder={t("skills.search")}
+                  aria-label={t("skills.search")}
+                />
+              </label>
               <div className="composer-add-skills-list">
-                {available.length ? (
-                  available.map((skill) => (
-                    <label key={skill.id} title={skill.description}>
-                      <input
-                        type="checkbox"
-                        checked={selected.has(skill.id)}
-                        onChange={(event) => toggleSkill(skill.id, event.currentTarget.checked)}
-                      />
-                      <span>{skill.name}</span>
-                    </label>
-                  ))
-                ) : (
-                  <p>{t("skills.none")}</p>
-                )}
+                {!available.length ? <p>{t("skills.none")}</p> : null}
+                {available.length && !filteredAvailable.length ? (
+                  <p>{t("skills.noResults")}</p>
+                ) : null}
+                {filteredAvailable.map((skill) => (
+                  <label key={skill.id} title={skill.description}>
+                    <input
+                      type="checkbox"
+                      checked={selected.has(skill.id)}
+                      onChange={(event) => toggleSkill(skill.id, event.currentTarget.checked)}
+                    />
+                    <span>{skill.name}</span>
+                  </label>
+                ))}
               </div>
             </div>
           ) : null}

--- a/src/components/CLI/SkillPicker.tsx
+++ b/src/components/CLI/SkillPicker.tsx
@@ -1,4 +1,5 @@
-import { Sparkles } from "lucide-react";
+import { useState } from "react";
+import { Search, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { SkillRecord } from "@/services/skills/types";
@@ -15,7 +16,12 @@ export function SkillPicker({
   disabled?: boolean;
 }) {
   const { t } = useTranslation();
+  const [query, setQuery] = useState("");
   const available = skills.filter((skill) => skill.enabled && skill.trusted);
+  const needle = query.trim().toLocaleLowerCase();
+  const filtered = available.filter((skill) =>
+    !needle || `${skill.name} ${skill.description}`.toLocaleLowerCase().includes(needle)
+  );
   const selected = new Set(selectedIds);
   return (
     <details className="skill-picker">
@@ -27,21 +33,35 @@ export function SkillPicker({
       </summary>
       <div className="skill-picker-menu">
         <strong>{t("skills.activeForTask")}</strong>
-        {available.length ? available.map((skill) => (
-          <label key={skill.id}>
-            <input
-              type="checkbox"
-              checked={selected.has(skill.id)}
-              onChange={(event) => {
-                const next = new Set(selected);
-                if (event.currentTarget.checked) next.add(skill.id);
-                else next.delete(skill.id);
-                onChange([...next]);
-              }}
-            />
-            <span><b>{skill.name}</b><small>{skill.description}</small></span>
-          </label>
-        )) : <p>{t("skills.none")}</p>}
+        <label className="skill-picker-search">
+          <Search size={14} aria-hidden="true" />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder={t("skills.search")}
+            aria-label={t("skills.search")}
+          />
+        </label>
+        <div className="skill-picker-list">
+          {!available.length ? <p>{t("skills.none")}</p> : null}
+          {available.length && !filtered.length ? <p>{t("skills.noResults")}</p> : null}
+          {filtered.map((skill) => (
+            <label key={skill.id}>
+              <input
+                type="checkbox"
+                checked={selected.has(skill.id)}
+                onChange={(event) => {
+                  const next = new Set(selected);
+                  if (event.currentTarget.checked) next.add(skill.id);
+                  else next.delete(skill.id);
+                  onChange([...next]);
+                }}
+              />
+              <span><b>{skill.name}</b><small>{skill.description}</small></span>
+            </label>
+          ))}
+        </div>
       </div>
     </details>
   );

--- a/styles.css
+++ b/styles.css
@@ -2495,7 +2495,8 @@ button {
 
 .skills-manager {
   display: grid;
-  min-height: min(620px, calc(100vh - 330px));
+  height: min(620px, calc(100vh - 330px));
+  min-height: 420px;
   flex: 1;
   grid-template-columns: minmax(270px, 34%) minmax(0, 1fr);
   overflow: hidden;
@@ -2875,13 +2876,18 @@ button {
 .skill-picker { position: relative; }
 .skill-picker > summary { list-style: none; }
 .skill-picker > summary::-webkit-details-marker { display: none; }
-.skill-picker-menu { position: absolute; z-index: 80; bottom: calc(100% + 8px); left: 0; width: 300px; max-height: 320px; overflow: auto; padding: 10px; border: 1px solid var(--fb-border); border-radius: 12px; background: var(--fb-panel-bg); box-shadow: var(--fb-shadow); }
+.skill-picker-menu { position: absolute; z-index: 80; bottom: calc(100% + 8px); left: 0; display: grid; width: 300px; max-height: 320px; grid-template-rows: auto auto minmax(0, 1fr); overflow: hidden; padding: 10px; border: 1px solid var(--fb-border); border-radius: 12px; background: var(--fb-panel-bg); box-shadow: var(--fb-shadow); }
 .skill-picker-menu > strong { display: block; padding: 3px 5px 8px; font-size: 12px; }
-.skill-picker-menu label { display: flex; gap: 8px; padding: 7px 5px; border-radius: 8px; cursor: pointer; }
-.skill-picker-menu label:hover { background: var(--fb-panel-soft); }
-.skill-picker-menu label span { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
-.skill-picker-menu label b { font-size: 12px; }
-.skill-picker-menu label small, .skill-picker-menu p { margin: 0; color: var(--fb-text-secondary); font-size: 10px; line-height: 1.4; }
+.skill-picker-search { display: flex; min-height: 32px; align-items: center; gap: 7px; margin-bottom: 5px; padding: 0 8px; border: 1px solid var(--fb-border-strong); border-radius: 8px; color: var(--fb-text-tertiary); }
+.skill-picker-search:focus-within { border-color: color-mix(in srgb, var(--fb-brand) 45%, var(--fb-border-strong)); box-shadow: 0 0 0 3px var(--fb-brand-glow); }
+.skill-picker-search input { width: 100%; min-width: 0; padding: 0; border: 0; outline: 0; background: transparent; color: var(--fb-text-primary); font: inherit; font-size: 11px; }
+.skill-picker-search input::-webkit-search-cancel-button { cursor: pointer; }
+.skill-picker-list { min-height: 0; overflow-y: auto; }
+.skill-picker-list label { display: flex; gap: 8px; padding: 7px 5px; border-radius: 8px; cursor: pointer; }
+.skill-picker-list label:hover { background: var(--fb-panel-soft); }
+.skill-picker-list label span { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
+.skill-picker-list label b { font-size: 12px; }
+.skill-picker-list label small, .skill-picker-list p { margin: 0; color: var(--fb-text-secondary); font-size: 10px; line-height: 1.4; }
 
 .composer-add-menu-root {
   position: relative;
@@ -3004,8 +3010,10 @@ button {
 }
 
 .composer-add-skills-panel {
+  display: flex;
   width: 292px;
   max-height: min(420px, 52vh);
+  flex-direction: column;
 }
 
 .composer-add-skills-heading {
@@ -3024,7 +3032,42 @@ button {
   font-variant-numeric: tabular-nums;
 }
 
+.composer-add-skills-search {
+  display: flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 7px;
+  margin: 8px 8px 2px;
+  padding: 0 9px;
+  border: 1px solid var(--fb-border-strong);
+  border-radius: 8px;
+  color: var(--fb-text-tertiary);
+}
+
+.composer-add-skills-search:focus-within {
+  border-color: color-mix(in srgb, var(--fb-brand) 45%, var(--fb-border-strong));
+  box-shadow: 0 0 0 3px var(--fb-brand-glow);
+}
+
+.composer-add-skills-search input {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--fb-text-primary);
+  font: inherit;
+  font-size: 11px;
+}
+
+.composer-add-skills-search input::-webkit-search-cancel-button {
+  cursor: pointer;
+}
+
 .composer-add-skills-list {
+  min-height: 0;
+  flex: 1;
   max-height: min(360px, 44vh);
   overflow-y: auto;
   padding: 6px;


### PR DESCRIPTION
## Summary

- add name and description search to the shared Skill picker used by Agent defaults and team roles
- add the same search experience to new-task and active-conversation Skill menus
- keep search controls fixed while only the result lists scroll
- constrain the installed Skills manager height so its list scrolls independently

## Why

Large Skill collections were difficult to navigate because several selectors only supported scrolling. The installed Skills pane could also expand with its contents instead of creating an internal scroll area.

## Impact

Users can now search every Skill selection surface without losing existing selections, and long installed-Skill lists remain usable in the settings view.

## Validation

- `npm run typecheck`
- `npm run build:renderer`
- `git diff --check`
- `npm run github:preflight`

Closes #67
