### PR TITLE
feat: 聊天消息排版对标 Codex/ChatGPT 标准

### DIFF
--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -1,6 +1,8 @@
 import type { TFunction } from "i18next";
 import {
   Brain,
+  Check,
+  Copy,
   Download,
   FileText,
   MoveRight,
@@ -12,7 +14,7 @@ import {
   Wrench,
   type LucideIcon
 } from "lucide-react";
-import type { ReactNode } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { CliStreamItem } from "@/services/cli/parsers";
@@ -65,7 +67,7 @@ function renderInline(text: string, keyPrefix = "i"): ReactNode[] {
   const nodes: ReactNode[] = [];
   // Strip markdown image syntax: image previews are rendered as separate figure blocks.
   const cleaned = text.replace(MARKDOWN_IMAGE_REGEX, "").replace(/[ \t]{2,}/g, " ");
-  const parts = cleaned.split(/(`[^`]+`|\*\*[^*]+\*\*|\[[^\]]+\]\([^)]+\))/g);
+  const parts = cleaned.split(/(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*|~~[^~]+~~|\[[^\]]+\]\([^)]+\))/g);
 
   parts.forEach((part, index) => {
     if (!part) return;
@@ -76,6 +78,14 @@ function renderInline(text: string, keyPrefix = "i"): ReactNode[] {
     }
     if (part.startsWith("**") && part.endsWith("**")) {
       nodes.push(<strong key={key}>{part.slice(2, -2)}</strong>);
+      return;
+    }
+    if (part.startsWith("*") && part.endsWith("*") && part.length > 2) {
+      nodes.push(<em key={key}>{part.slice(1, -1)}</em>);
+      return;
+    }
+    if (part.startsWith("~~") && part.endsWith("~~") && part.length > 4) {
+      nodes.push(<del key={key}>{part.slice(2, -2)}</del>);
       return;
     }
     const linkMatch = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
@@ -197,6 +207,45 @@ function tableCells(line: string) {
     .map((cell) => cell.trim());
 }
 
+function CodeBlockCard({ lang, code }: { lang?: string; code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [code]);
+
+  return (
+    <div className="markdown-code-card">
+      <div className="markdown-code-header">
+        <span className="markdown-code-lang">{lang || "code"}</span>
+        <button
+          type="button"
+          className="markdown-code-copy-btn"
+          onClick={handleCopy}
+          title="Copy code"
+        >
+          {copied ? (
+            <>
+              <Check className="code-copy-icon" />
+              <span>Copied</span>
+            </>
+          ) : (
+            <>
+              <Copy className="code-copy-icon" />
+              <span>Copy</span>
+            </>
+          )}
+        </button>
+      </div>
+      <pre className="markdown-code">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
 export function MarkdownText({ content }: { content: string }) {
   const blocks: ReactNode[] = [];
   const lines = content.replace(/\r\n/g, "\n").split("\n");
@@ -239,6 +288,7 @@ export function MarkdownText({ content }: { content: string }) {
     }
 
     if (line.trim().startsWith("```")) {
+      const lang = line.trim().slice(3).trim();
       const code: string[] = [];
       i += 1;
       while (i < lines.length && !lines[i].trim().startsWith("```")) {
@@ -247,9 +297,7 @@ export function MarkdownText({ content }: { content: string }) {
       }
       if (i < lines.length) i += 1;
       blocks.push(
-        <pre className="markdown-code" key={`code-${i}`}>
-          <code>{code.join("\n")}</code>
-        </pre>
+        <CodeBlockCard key={`code-${i}`} lang={lang} code={code.join("\n")} />
       );
       continue;
     }

--- a/styles.css
+++ b/styles.css
@@ -5553,23 +5553,26 @@ button {
 }
 
 .msg-user .msg-bubble {
-  border-color: transparent;
-  background: var(--fb-brand-gradient);
-  box-shadow: 0 3px 12px rgba(16, 185, 129, 0.18);
-  border-radius: var(--fb-rounded-lg) 2px var(--fb-rounded-lg) var(--fb-rounded-lg);
+  border: 1px solid var(--fb-border-strong, rgba(0, 0, 0, 0.08));
+  border-radius: 18px 18px 5px 18px;
+  background: var(--fb-panel-soft, #f4f4f5);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+  transition: all 0.15s ease;
 }
 
 .msg-user:hover .msg-bubble {
-  box-shadow: 0 6px 20px rgba(16, 185, 129, 0.25);
+  border-color: rgba(0, 0, 0, 0.14);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 .msg-user .msg-bubble pre {
-  padding: 11px 16px;
+  padding: 10px 16px;
   margin: 0;
-  color: #ffffff;
+  color: var(--fb-text-primary, #18181b);
   font-size: 15px;
-  line-height: 1.72;
-  font-family: var(--fb-font);
+  line-height: 1.6;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  letter-spacing: -0.003em;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -5812,9 +5815,9 @@ button {
 }
 
 .stream-text {
-  padding: 4px 0;
-  font-size: 14px;
-  line-height: 1.6;
+  padding: 0;
+  font-size: 15px;
+  line-height: 1.62;
   color: var(--fb-text-primary);
 }
 
@@ -10252,25 +10255,29 @@ button.ghost:focus-visible,
 }
 
 .msg-user .msg-content-wrapper {
-  max-width: min(420px, 64%);
+  max-width: min(680px, 78%);
 }
 
 .msg-user .msg-bubble {
-  border: 0;
-  border-radius: 18px 18px 4px 18px;
-  background: #f3f3f3;
-  box-shadow: none;
+  border: 1px solid var(--fb-border-strong, rgba(0, 0, 0, 0.08));
+  border-radius: 18px 18px 5px 18px;
+  background: var(--fb-panel-soft, #f4f4f5);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+  transition: all 0.15s ease;
 }
 
 .msg-user:hover .msg-bubble {
-  box-shadow: none;
+  border-color: rgba(0, 0, 0, 0.14);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 .msg-user .msg-bubble pre {
-  padding: 8px 14px;
-  color: #202124;
+  padding: 10px 16px;
+  color: var(--fb-text-primary, #18181b);
   font-size: 15px;
-  line-height: 1.72;
+  line-height: 1.6;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  letter-spacing: -0.003em;
 }
 
 .msg-user .message-attachment {
@@ -10310,14 +10317,20 @@ button.ghost:focus-visible,
 
 .stream-text {
   padding: 0;
-  color: #242424;
+  color: var(--fb-text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
   font-size: 15px;
-  line-height: 1.72;
+  line-height: 1.62;
+  letter-spacing: -0.005em;
 }
 
 .markdown-body {
   display: block;
   min-width: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  font-size: 15px;
+  line-height: 1.62;
+  color: var(--fb-text-primary);
 }
 
 .markdown-body p {
@@ -10326,19 +10339,21 @@ button.ghost:focus-visible,
 }
 
 .markdown-body .markdown-heading {
-  margin: 14px 0 6px;
+  margin: 18px 0 8px;
   font-weight: 700;
-  line-height: 1.3;
+  line-height: 1.35;
+  color: var(--fb-text-primary);
+  letter-spacing: -0.01em;
 }
 .markdown-body .markdown-heading:first-child {
   margin-top: 0;
 }
-.markdown-body h1.markdown-heading { font-size: 18px; }
-.markdown-body h2.markdown-heading { font-size: 16px; }
-.markdown-body h3.markdown-heading { font-size: 15px; }
-.markdown-body h4.markdown-heading { font-size: 14px; }
-.markdown-body h5.markdown-heading { font-size: 13px; }
-.markdown-body h6.markdown-heading { font-size: 12px; color: var(--muted, #6b7280); }
+.markdown-body h1.markdown-heading { font-size: 20px; font-weight: 700; }
+.markdown-body h2.markdown-heading { font-size: 18px; font-weight: 700; }
+.markdown-body h3.markdown-heading { font-size: 16.5px; font-weight: 650; }
+.markdown-body h4.markdown-heading { font-size: 15px; font-weight: 600; color: var(--fb-text-primary); }
+.markdown-body h5.markdown-heading { font-size: 14px; font-weight: 600; color: var(--fb-text-secondary); }
+.markdown-body h6.markdown-heading { font-size: 14px; font-weight: 500; color: var(--fb-text-tertiary); }
 
 .markdown-body p:last-child,
 .markdown-body ul:last-child,
@@ -10348,73 +10363,124 @@ button.ghost:focus-visible,
   margin-bottom: 0;
 }
 
-.markdown-body .markdown-heading {
-  margin: 14px 0 6px;
-  font-weight: 700;
-  line-height: 1.3;
-}
-.markdown-body .markdown-heading:first-child {
-  margin-top: 0;
-}
-.markdown-body h1.markdown-heading { font-size: 18px; }
-.markdown-body h2.markdown-heading { font-size: 16px; }
-.markdown-body h3.markdown-heading { font-size: 15px; }
-.markdown-body h4.markdown-heading { font-size: 14px; }
-.markdown-body h5.markdown-heading { font-size: 13px; }
-.markdown-body h6.markdown-heading { font-size: 12px; color: var(--muted, #6b7280); }
-
-.markdown-body .markdown-heading {
-  margin: 14px 0 6px;
-  font-weight: 700;
-  line-height: 1.3;
-}
-.markdown-body .markdown-heading:first-child {
-  margin-top: 0;
-}
-.markdown-body h1.markdown-heading { font-size: 18px; }
-.markdown-body h2.markdown-heading { font-size: 16px; }
-.markdown-body h3.markdown-heading { font-size: 15px; }
-.markdown-body h4.markdown-heading { font-size: 14px; }
-.markdown-body h5.markdown-heading { font-size: 13px; }
-.markdown-body h6.markdown-heading { font-size: 12px; color: var(--muted, #6b7280); }
-
 .markdown-body ul,
 .markdown-body ol {
-  margin: 0 0 12px 20px;
+  margin: 0 0 12px 22px;
   padding: 0;
 }
 
 .markdown-body li {
   margin: 4px 0;
   padding-left: 2px;
+  line-height: 1.6;
 }
 
 .markdown-body strong {
-  font-weight: 700;
+  font-weight: 650;
 }
 
 .markdown-body code,
 .stream-command code,
 .stream-meta code {
-  padding: 1px 5px;
-  border-radius: 4px;
-  background: #f1f1f1;
-  color: #3f3f46;
+  padding: 2px 6px;
+  border-radius: 5px;
+  background: var(--fb-hover, rgba(148, 163, 184, 0.12));
+  color: var(--fb-text-primary);
   font-family: var(--fb-mono);
-  font-size: 0.92em;
+  font-size: 0.88em;
+  border: 1px solid var(--fb-border);
+}
+
+.markdown-code-card {
+  margin: 14px 0 16px;
+  border: 1px solid var(--fb-border-strong);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--fb-panel-soft);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.markdown-code-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 14px;
+  background: rgba(0, 0, 0, 0.04);
+  border-bottom: 1px solid var(--fb-border);
+  font-family: var(--fb-mono);
+  font-size: 12px;
+  color: var(--fb-text-tertiary);
+  user-select: none;
+}
+
+[data-theme="dark"] .markdown-code-header {
+  background: rgba(0, 0, 0, 0.25);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.markdown-code-lang {
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+
+.markdown-code-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  color: var(--fb-text-tertiary);
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 2px 6px;
+  transition: all 0.15s ease;
+}
+
+.markdown-code-copy-btn:hover {
+  color: var(--fb-text-primary);
+  background: var(--fb-hover);
+}
+
+.code-copy-icon {
+  width: 13px;
+  height: 13px;
 }
 
 .markdown-code {
-  margin: 10px 0 12px;
+  margin: 0;
   padding: 12px 14px;
   overflow-x: auto;
-  border: 1px solid #e6e6e6;
-  border-radius: 8px;
-  background: #fafafa;
-  color: #2b2b2b;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--fb-text-primary);
   font-family: var(--fb-mono);
-  font-size: 13px;
-  line-height: 1.6;
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+
+.markdown-code::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+.markdown-code::-webkit-scrollbar-track {
+  background: transparent;
+}
+.markdown-code::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+}
+.markdown-code::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 184, 0.45);
+}
+
+.markdown-body ::selection,
+.stream-text ::selection {
+  background: rgba(16, 185, 129, 0.2);
+  color: inherit;
 }
 
 .markdown-code code {
@@ -10458,9 +10524,9 @@ button.ghost:focus-visible,
 }
 
 .markdown-body a {
-  color: var(--fb-brand, #2563eb);
+  color: var(--fb-brand, #10b981);
   text-decoration: underline;
-  text-underline-offset: 2px;
+  text-underline-offset: 3px;
 }
 
 .markdown-body a:hover {
@@ -10468,11 +10534,11 @@ button.ghost:focus-visible,
 }
 
 .markdown-blockquote {
-  margin: 10px 0 12px;
-  padding: 8px 12px;
-  border-left: 3px solid rgba(0, 0, 0, 0.12);
-  color: var(--muted, #6b7280);
-  background: rgba(0, 0, 0, 0.02);
+  margin: 14px 0 16px;
+  padding: 8px 16px;
+  border-left: 3px solid var(--fb-brand, #10b981);
+  color: var(--fb-text-secondary);
+  background: var(--fb-brand-glow, rgba(16, 185, 129, 0.06));
   border-radius: 0 8px 8px 0;
 }
 
@@ -11072,11 +11138,18 @@ button.ghost:focus-visible,
 }
 
 [data-theme="dark"] .msg-user .msg-bubble {
-  background: #1f2937;
+  background: #27272a;
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .msg-user:hover .msg-bubble {
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 [data-theme="dark"] .msg-user .msg-bubble pre {
-  color: #f8fafc;
+  color: #f4f4f5;
 }
 
 [data-theme="dark"] .workspace-file-mention {
@@ -11105,7 +11178,7 @@ button.ghost:focus-visible,
 }
 
 [data-theme="dark"] .stream-text {
-  color: #e5e7eb;
+  color: var(--fb-text-primary);
 }
 
 [data-theme="dark"] .stream-process {


### PR DESCRIPTION
## 概述

对标 Codex / ChatGPT Web 的排版标准，全面优化聊天主窗口的消息流字体、字号、标题层级、代码块与用户气泡样式。

## 改动内容

### 🔤 字阶系统 (Typographic Scale)
- **修正 Markdown 标题层级**：H1:20px → H2:18px → H3:16.5px → H4:15px → H5/H6:14px
- 原先 H3(15px) 与正文同号、H4(14px) 比正文还小的倒置问题已彻底解决

### 🅰️ 字体族 (Font Family)
- 消息流 `.stream-text` 和 `.markdown-body` 切换为系统无衬线字体栈
- UI 控件（侧边栏、按钮等）继续保留 Outfit / Plus Jakarta Sans

### 📦 代码块卡片 (Code Block Card)
- 新增 `CodeBlockCard` 组件，包含语言标识 Header 和一键复制按钮（含 Copied 状态反馈）
- 代码块字号调整为 13.5px，行高 1.55
- 定制超薄半透明滚动条

### 💬 用户消息气泡 (User Bubble)
- 最大宽度从 `min(420px, 64%)` 放宽至 `min(680px, 78%)`
- 背景从绿色渐变改为中性石墨灰 `panel-soft`
- 添加细边框与悬浮提升微交互

### 📝 行内 Markdown 增强
- 新增斜体 (`*text*`) 和删除线 (`~~text~~`) 解析支持

### 🎨 其他视觉优化
- 品牌色 `::selection` 文本选中高亮
- Blockquote 引用块使用品牌色左竖线 + 柔和辉光底色
- 暗色模式修复：stream-text 颜色改用 CSS 变量

### 🧹 CSS 清理
- 解决 styles.css 中多处重复声明导致的级联冲突
- 统一早期与后期的 `.msg-user .msg-bubble` 和 `.stream-text` 规则

## 测试
- `npm run build:renderer` 编译通过（0 报错）
- 浅色 / 暗色模式均已验证