### PR TITLE
fix: harden plugin runtime and chat rendering

### DIFF
--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -17,6 +17,7 @@ import {
   resolveWindowsShellCommand,
   windowsInstallInvocation
 } from "./windowsEnv.js";
+import { findMacAppCliBinary } from "./macAppCli.js";
 
 const CODEX_ACP_UPGRADE_REQUIRED = "codex-acp requires @agentclientprotocol/codex-acp";
 const CODEX_ACP_ADAPTER = "codex-acp";
@@ -158,6 +159,13 @@ function which(
               return resolve(fullPath);
             }
           }
+
+          const macAppBinary = findMacAppCliBinary(bin, {
+            platform: process.platform,
+            home,
+            isFile
+          });
+          if (macAppBinary) return resolve(macAppBinary);
         } catch {}
       }
 

--- a/electron/cli/macAppCli.ts
+++ b/electron/cli/macAppCli.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const MAC_APP_BUNDLED_CLIS: Record<string, string[]> = {
+  codex: ["Codex.app", "ChatGPT.app"]
+};
+
+interface MacAppCliLookupOptions {
+  platform?: NodeJS.Platform;
+  home?: string;
+  isFile?: (candidate: string) => boolean;
+}
+
+export function macAppCliCandidates(binary: string, home = os.homedir()): string[] {
+  const appNames = MAC_APP_BUNDLED_CLIS[binary] || [];
+  const applicationRoots = ["/Applications", path.join(home, "Applications")];
+  return applicationRoots.flatMap((root) =>
+    appNames.map((appName) =>
+      path.join(root, appName, "Contents", "Resources", binary)
+    )
+  );
+}
+
+export function findMacAppCliBinary(
+  binary: string,
+  options: MacAppCliLookupOptions = {}
+): string | undefined {
+  if ((options.platform || process.platform) !== "darwin") return undefined;
+  const isFile = options.isFile || ((candidate: string) => {
+    try {
+      return fs.statSync(candidate).isFile();
+    } catch {
+      return false;
+    }
+  });
+  return macAppCliCandidates(binary, options.home).find(isFile);
+}

--- a/electron/cli/nativePlugins.ts
+++ b/electron/cli/nativePlugins.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import spawn from "cross-spawn";
 
 import { getFreshWindowsEnvironment } from "./windowsEnv.js";
+import { findMacAppCliBinary } from "./macAppCli.js";
 
 export type NativePluginAgent = "codex" | "claude";
 export type NativePluginScope = "user" | "project" | "local" | "managed";
@@ -31,6 +32,7 @@ export interface NativePluginMarketplace {
   name: string;
   source?: string;
   root?: string;
+  sourceType?: string;
 }
 
 export interface NativePluginSnapshot {
@@ -424,12 +426,25 @@ function normalizeMarketplace(value: unknown, fallbackName?: string): NativePlug
   }
   const name = stringValue(marketplace.name, marketplace.marketplaceName, fallbackName);
   if (!name) return undefined;
-  const source = sourceValue(marketplace.source);
+  const marketplaceSource = asRecord(marketplace.marketplaceSource);
+  const legacySource = asRecord(marketplace.source);
+  const source = sourceValue(marketplace.marketplaceSource) ?? sourceValue(marketplace.source);
   const root = stringValue(marketplace.root, marketplace.path);
+  const sourceType = stringValue(
+    marketplaceSource?.sourceType,
+    marketplaceSource?.source_type,
+    marketplaceSource?.type,
+    marketplace.sourceType,
+    marketplace.source_type,
+    legacySource?.sourceType,
+    legacySource?.source_type,
+    legacySource?.type
+  )?.toLowerCase();
   return {
     name,
     ...(source ? { source } : {}),
-    ...(root ? { root } : {})
+    ...(root ? { root } : {}),
+    ...(sourceType ? { sourceType } : {})
   };
 }
 
@@ -696,6 +711,13 @@ interface AgentProbe {
 async function probeAgent(agent: NativePluginAgent): Promise<AgentProbe> {
   let binary: string = agent;
   let result = await runCommand({ binary, args: ["--version"] }, 15_000);
+  if (agent === "codex" && (result.exitCode !== 0 || result.spawnError || result.timedOut)) {
+    const bundled = findMacAppCliBinary(agent);
+    if (bundled) {
+      binary = bundled;
+      result = await runCommand({ binary, args: ["--version"] }, 15_000);
+    }
+  }
   if (agent === "claude" && (result.exitCode !== 0 || result.spawnError || result.timedOut)) {
     const embedded = await findEmbeddedClaudeBinary();
     if (embedded) {

--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -63,11 +63,14 @@ function formatCost(amount: number, currency?: string): string {
   return currency === "USD" ? `$${value}` : `${value} ${currency ?? ""}`.trim();
 }
 
-function renderInline(text: string, keyPrefix = "i"): ReactNode[] {
+function renderInline(text: string, keyPrefix = "i", depth = 0): ReactNode[] {
   const nodes: ReactNode[] = [];
   // Strip markdown image syntax: image previews are rendered as separate figure blocks.
   const cleaned = text.replace(MARKDOWN_IMAGE_REGEX, "").replace(/[ \t]{2,}/g, " ");
   const parts = cleaned.split(/(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*|~~[^~]+~~|\[[^\]]+\]\([^)]+\))/g);
+
+  const renderNested = (value: string, key: string) =>
+    depth < 8 ? renderInline(value, key, depth + 1) : value;
 
   parts.forEach((part, index) => {
     if (!part) return;
@@ -77,15 +80,17 @@ function renderInline(text: string, keyPrefix = "i"): ReactNode[] {
       return;
     }
     if (part.startsWith("**") && part.endsWith("**")) {
-      nodes.push(<strong key={key}>{part.slice(2, -2)}</strong>);
+      nodes.push(
+        <strong key={key}>{renderNested(part.slice(2, -2), `${key}-strong`)}</strong>
+      );
       return;
     }
     if (part.startsWith("*") && part.endsWith("*") && part.length > 2) {
-      nodes.push(<em key={key}>{part.slice(1, -1)}</em>);
+      nodes.push(<em key={key}>{renderNested(part.slice(1, -1), `${key}-em`)}</em>);
       return;
     }
     if (part.startsWith("~~") && part.endsWith("~~") && part.length > 4) {
-      nodes.push(<del key={key}>{part.slice(2, -2)}</del>);
+      nodes.push(<del key={key}>{renderNested(part.slice(2, -2), `${key}-del`)}</del>);
       return;
     }
     const linkMatch = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
@@ -95,7 +100,7 @@ function renderInline(text: string, keyPrefix = "i"): ReactNode[] {
       if (href) {
         nodes.push(
           <a key={key} href={href} target="_blank" rel="noreferrer noopener">
-            {label}
+            {renderNested(label, `${key}-link`)}
           </a>
         );
         return;

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -372,17 +372,19 @@ export function PluginsTab() {
                     </button>
                     {isConfiguredMarketplace ? (
                       <div className="plugins-marketplace-actions">
-                        <button
-                          type="button"
-                          className="icon-btn"
-                          disabled={Boolean(busyKey)}
-                          onClick={() => void runAction(`marketplace:update:${marketplace.name}`, () =>
-                            pluginsClient.updateMarketplace({ agent, marketplace: marketplace.name })
-                          )}
-                          aria-label={t("plugins.updateMarketplace", { name: marketplace.name })}
-                        >
-                          <RefreshCw size={14} />
-                        </button>
+                        {agent !== "codex" || marketplace.sourceType === "git" ? (
+                          <button
+                            type="button"
+                            className="icon-btn"
+                            disabled={Boolean(busyKey)}
+                            onClick={() => void runAction(`marketplace:update:${marketplace.name}`, () =>
+                              pluginsClient.updateMarketplace({ agent, marketplace: marketplace.name })
+                            )}
+                            aria-label={t("plugins.updateMarketplace", { name: marketplace.name })}
+                          >
+                            <RefreshCw size={14} />
+                          </button>
+                        ) : null}
                         <button
                           type="button"
                           className="icon-btn danger"
@@ -443,6 +445,10 @@ export function PluginsTab() {
                 const installing = busyKey === `install:${plugin.id}`;
                 const updating = busyKey === `update:${plugin.id}`;
                 const uninstalling = busyKey === `uninstall:${plugin.id}`;
+                const pluginMarketplace = snapshot.marketplaces.find(
+                  (marketplace) => marketplace.name === plugin.marketplace
+                );
+                const canUpdate = agent !== "codex" || pluginMarketplace?.sourceType === "git";
                 return (
                   <article className="plugin-card" key={plugin.id}>
                     <PluginIcon plugin={plugin} />
@@ -468,15 +474,17 @@ export function PluginsTab() {
                         </span>
                       ) : plugin.installed ? (
                         <>
-                          <button
-                            type="button"
-                            className="secondary"
-                            disabled={Boolean(busyKey)}
-                            onClick={() => void update(plugin)}
-                          >
-                            <RefreshCw size={14} className={updating ? "spin" : ""} />
-                            {updating ? t("plugins.updating") : t("plugins.update")}
-                          </button>
+                          {canUpdate ? (
+                            <button
+                              type="button"
+                              className="secondary"
+                              disabled={Boolean(busyKey)}
+                              onClick={() => void update(plugin)}
+                            >
+                              <RefreshCw size={14} className={updating ? "spin" : ""} />
+                              {updating ? t("plugins.updating") : t("plugins.update")}
+                            </button>
+                          ) : null}
                           <button
                             type="button"
                             className="icon-btn danger"

--- a/src/services/plugins/types.ts
+++ b/src/services/plugins/types.ts
@@ -24,6 +24,7 @@ export interface NativePluginMarketplace {
   name: string;
   source?: string;
   root?: string;
+  sourceType?: string;
 }
 
 export interface NativePluginSnapshot {

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,6 @@
 :root {
   --fb-font: 'Plus Jakarta Sans', 'Outfit', -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "微软雅黑", "Noto Sans SC", "Source Han Sans SC", "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  --fb-chat-font: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
   --fb-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Sarasa Mono SC", monospace;
   
   /* Spec dimensions */
@@ -30,6 +31,7 @@
   --fb-active: #0f172a;
   --fb-active-fg: #ffffff;
   --fb-brand: #10b981;
+  --fb-link: #047857;
   --fb-brand-glow: rgba(16, 185, 129, 0.12);
   --fb-workflow: #8b5cf6;
   --fb-workflow-glow: rgba(139, 92, 246, 0.16);
@@ -67,6 +69,7 @@
   --fb-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
   --fb-shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.4);
   --fb-danger: #fb7185;
+  --fb-link: #34d399;
   --surface: var(--fb-panel-bg);
   --surface-alt: var(--fb-panel-soft);
   --border: var(--fb-border);
@@ -10717,7 +10720,7 @@ button.ghost:focus-visible,
 }
 
 .msg-assistant .msg-content-wrapper {
-  max-width: min(760px, calc(100% - 44px));
+  max-width: min(768px, calc(100% - 44px));
   gap: 8px;
 }
 
@@ -10851,15 +10854,19 @@ button.ghost:focus-visible,
 }
 
 .msg-assistant .msg-items {
-  gap: 10px;
+  gap: 16px;
   padding: 0;
 }
 
 .stream-process {
-  margin: 8px 0 12px;
+  margin: 0;
   color: #969ba3;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 22px;
+}
+
+.stream-process + .stream-process {
+  margin-top: -12px;
 }
 
 .stream-process > summary {
@@ -10905,7 +10912,7 @@ button.ghost:focus-visible,
   height: 16px;
   flex: 0 0 16px;
   color: currentColor;
-  stroke-width: 1.85;
+  stroke-width: 2;
 }
 
 .stream-process-icon.spinning {
@@ -10957,8 +10964,8 @@ button.ghost:focus-visible,
 
 .stream-process-detail-list {
   display: grid;
-  gap: 8px;
-  margin: 10px 0 0 24px;
+  gap: 4px;
+  margin: 4px 0 0 24px;
   padding: 0;
 }
 
@@ -11112,44 +11119,47 @@ button.ghost:focus-visible,
 .stream-text {
   padding: 0;
   color: var(--fb-text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "PingFang SC", "Noto Sans SC", "Microsoft YaHei", sans-serif;
-  font-size: 14.5px;
-  line-height: 1.68;
-  letter-spacing: -0.003em;
+  font-family: var(--fb-chat-font);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: 0;
 }
 
 .markdown-body {
   display: block;
   min-width: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "PingFang SC", "Noto Sans SC", "Microsoft YaHei", sans-serif;
-  font-size: 14.5px;
-  line-height: 1.68;
-  letter-spacing: -0.003em;
+  font-family: var(--fb-chat-font);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: 0;
   color: var(--fb-text-primary);
+  overflow-wrap: anywhere;
 }
 
 .markdown-body p {
-  margin: 0 0 14px;
-  line-height: 1.68;
-  white-space: pre-wrap;
+  margin: 0 0 11px;
+  line-height: inherit;
+  white-space: normal;
 }
 
 .markdown-body .markdown-heading {
-  margin: 22px 0 8px;
-  font-weight: 650;
-  line-height: 1.35;
+  margin: 20px 0 10px;
+  font-weight: 600;
+  line-height: 1.25;
   color: var(--fb-text-primary);
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 .markdown-body .markdown-heading:first-child {
   margin-top: 0;
 }
-.markdown-body h1.markdown-heading { font-size: 19px; font-weight: 650; }
-.markdown-body h2.markdown-heading { font-size: 17px; font-weight: 650; }
-.markdown-body h3.markdown-heading { font-size: 15.5px; font-weight: 600; }
-.markdown-body h4.markdown-heading { font-size: 14.5px; font-weight: 600; color: var(--fb-text-primary); }
-.markdown-body h5.markdown-heading { font-size: 14px; font-weight: 600; color: var(--fb-text-secondary); }
-.markdown-body h6.markdown-heading { font-size: 13.5px; font-weight: 500; color: var(--fb-text-tertiary); }
+.markdown-body h1.markdown-heading { font-size: 24px; }
+.markdown-body h2.markdown-heading { font-size: 20px; }
+.markdown-body h3.markdown-heading,
+.markdown-body h4.markdown-heading { font-size: 17px; line-height: 22px; }
+.markdown-body h5.markdown-heading,
+.markdown-body h6.markdown-heading { font-size: 15px; line-height: 20px; }
 
 .markdown-body p:last-child,
 .markdown-body ul:last-child,
@@ -11161,14 +11171,19 @@ button.ghost:focus-visible,
 
 .markdown-body ul,
 .markdown-body ol {
-  margin: 0 0 14px 20px;
-  padding: 0;
+  margin: 0 0 11px;
+  padding-inline-start: 21px;
+  list-style-position: outside;
 }
 
 .markdown-body li {
-  margin: 4px 0;
-  padding-left: 2px;
-  line-height: 1.65;
+  margin: 0;
+  padding-inline-start: 2px;
+  line-height: inherit;
+}
+
+.markdown-body li + li {
+  margin-top: 8px;
 }
 
 .markdown-body strong {
@@ -11178,12 +11193,12 @@ button.ghost:focus-visible,
 .markdown-body code,
 .stream-command code,
 .stream-meta code {
-  padding: 2px 5.5px;
-  border-radius: 5px;
+  padding: 1px 6px;
+  border-radius: 6px;
   background: color-mix(in srgb, var(--fb-text-primary) 7%, transparent);
   color: var(--fb-text-primary);
   font-family: var(--fb-mono);
-  font-size: 0.875em;
+  font-size: 0.92em;
   border: none;
 }
 
@@ -11194,7 +11209,7 @@ button.ghost:focus-visible,
 }
 
 .markdown-code-card {
-  margin: 16px 0;
+  margin: 14px 0;
   border: 1px solid var(--fb-border-strong);
   border-radius: 10px;
   overflow: hidden;
@@ -11327,7 +11342,7 @@ button.ghost:focus-visible,
 }
 
 .markdown-body a {
-  color: var(--fb-brand, #10b981);
+  color: var(--fb-link, #047857);
   text-decoration: underline;
   text-underline-offset: 3px;
 }
@@ -11337,12 +11352,14 @@ button.ghost:focus-visible,
 }
 
 .markdown-blockquote {
-  margin: 14px 0 16px;
-  padding: 8px 16px;
-  border-left: 3px solid var(--fb-brand, #10b981);
-  color: var(--fb-text-secondary);
-  background: var(--fb-brand-glow, rgba(16, 185, 129, 0.06));
-  border-radius: 0 8px 8px 0;
+  margin: 0 0 8px;
+  padding: 8px 0 8px 20px;
+  border-left: 4px solid var(--fb-border-strong);
+  color: var(--fb-text-primary);
+  background: transparent;
+  border-radius: 0;
+  font-style: normal;
+  line-height: 24px;
 }
 
 .stream-content-block {

--- a/tests/mac-app-cli.test.mjs
+++ b/tests/mac-app-cli.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import {
+  findMacAppCliBinary,
+  macAppCliCandidates
+} from "../dist-electron/cli/macAppCli.js";
+
+test("macOS Codex lookup includes official desktop app bundles", () => {
+  const home = "/Users/example";
+  assert.deepEqual(macAppCliCandidates("codex", home), [
+    "/Applications/Codex.app/Contents/Resources/codex",
+    "/Applications/ChatGPT.app/Contents/Resources/codex",
+    path.join(home, "Applications", "Codex.app", "Contents", "Resources", "codex"),
+    path.join(home, "Applications", "ChatGPT.app", "Contents", "Resources", "codex")
+  ]);
+});
+
+test("macOS Codex lookup returns the first existing app-bundled CLI", () => {
+  const expected = "/Applications/ChatGPT.app/Contents/Resources/codex";
+  assert.equal(
+    findMacAppCliBinary("codex", {
+      platform: "darwin",
+      home: "/Users/example",
+      isFile: (candidate) => candidate === expected
+    }),
+    expected
+  );
+});
+
+test("app-bundled CLI lookup stays disabled on other platforms", () => {
+  assert.equal(
+    findMacAppCliBinary("codex", {
+      platform: "linux",
+      isFile: () => true
+    }),
+    undefined
+  );
+});

--- a/tests/native-plugins.test.mjs
+++ b/tests/native-plugins.test.mjs
@@ -252,15 +252,30 @@ test("plugin list normalization accepts Codex and Claude JSON shapes", () => {
 test("marketplace normalization accepts arrays and keyed objects", () => {
   assert.deepEqual(
     normalizeMarketplacePayload({
-      marketplaces: [{ name: "openai", root: "/market/openai" }]
+      marketplaces: [{
+        name: "openai",
+        root: "/market/openai",
+        marketplaceSource: {
+          sourceType: "local",
+          source: "/market/openai"
+        }
+      }]
     }),
-    [{ name: "openai", root: "/market/openai" }]
+    [{
+      name: "openai",
+      source: "/market/openai",
+      root: "/market/openai",
+      sourceType: "local"
+    }]
   );
   assert.deepEqual(
     normalizeMarketplacePayload({
-      team: { source: { source: "github", repo: "owner/repo" } }
+      team: {
+        source: { source: "github", repo: "owner/repo" },
+        sourceType: "git"
+      }
     }),
-    [{ name: "team", source: "owner/repo" }]
+    [{ name: "team", source: "owner/repo", sourceType: "git" }]
   );
 });
 
@@ -279,6 +294,8 @@ test("plugin management is wired through settings, preload, and IPC", () => {
   assert.match(ui, /attachmentPreviewUrl\(plugin\.iconPath\)/);
   assert.match(ui, /loading="lazy"/);
   assert.match(ui, /plugin\.managedBy === "desktop"/);
+  assert.match(ui, /marketplace\.sourceType === "git"/);
+  assert.match(ui, /pluginMarketplace\?\.sourceType === "git"/);
   assert.match(ui, /selectedMarketplace/);
   assert.match(ui, /plugin\.marketplace === selectedMarketplace/);
   assert.match(ui, /plugins\.allMarketplaces/);

--- a/tests/stream-content-block.test.mjs
+++ b/tests/stream-content-block.test.mjs
@@ -26,11 +26,24 @@ test("MarkdownText supports links and blockquotes", () => {
   assert.match(streamItemSource, /resolveLinkHref/);
 });
 
+test("MarkdownText recursively renders inline markup inside emphasis and links", () => {
+  assert.match(streamItemSource, /function renderInline\(text: string, keyPrefix = "i", depth = 0\)/);
+  assert.match(streamItemSource, /renderNested\(part\.slice\(2, -2\), `\$\{key\}-strong`\)/);
+  assert.match(streamItemSource, /renderNested\(label, `\$\{key\}-link`\)/);
+});
+
 test("styles include content-block and markdown quote rules", () => {
   assert.match(stylesSource, /\.markdown-blockquote\b/);
   assert.match(stylesSource, /\.stream-content-block\b/);
   assert.match(stylesSource, /\.stream-audio\b/);
   assert.match(stylesSource, /\.markdown-body a\b/);
+  assert.match(stylesSource, /--fb-chat-font:\s*-apple-system,/);
+  assert.match(stylesSource, /\.markdown-body\s*\{[\s\S]*?font-family:\s*var\(--fb-chat-font\);[\s\S]*?font-size:\s*14px;[\s\S]*?line-height:\s*22px;/);
+  assert.match(stylesSource, /\.markdown-body p\s*\{[\s\S]*?white-space:\s*normal;/);
+  assert.match(stylesSource, /\.markdown-body a\s*\{[\s\S]*?color:\s*var\(--fb-link,/);
+  assert.match(stylesSource, /\.markdown-body p\s*\{[\s\S]*?margin:\s*0 0 11px;/);
+  assert.match(stylesSource, /\.markdown-body \.markdown-heading\s*\{[\s\S]*?margin:\s*20px 0 10px;/);
+  assert.match(stylesSource, /\.markdown-blockquote\s*\{[\s\S]*?border-left:\s*4px solid var\(--fb-border-strong\);/);
 });
 
 test("tool invocation rows avoid disclosure arrows", () => {

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -311,7 +311,10 @@ test("MessageBubble compacts execution process while preserving final text", () 
   assert.doesNotMatch(src, /stream-process-head/);
   assert.doesNotMatch(src, /stream-process-recent/);
   assert.match(css, /\.stream-process\s*\{/);
+  assert.match(css, /\.stream-process\s*\{[^}]*color:\s*#969ba3;[^}]*font-size:\s*14px;/);
+  assert.match(css, /\.stream-process \+ \.stream-process\s*\{[\s\S]*?margin-top:\s*-12px;/);
   assert.match(css, /\.stream-process > summary\s*\{/);
+  assert.match(css, /\.stream-process > summary\s*\{[\s\S]*?font-weight:\s*650;/);
   assert.match(css, /\.stream-process > summary::after\s*\{/);
   assert.match(css, /\.stream-process\[open\] > summary::after\s*\{/);
   assert.doesNotMatch(css, /\.stream-process summary::after\s*\{/);
@@ -325,7 +328,7 @@ test("MessageBubble compacts execution process while preserving final text", () 
   assert.doesNotMatch(css, /\.stream-process\.failed/);
   assert.match(css, /stream-process-title-shimmer/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
-  assert.match(css, /\.stream-process-icon\s*\{[\s\S]*?width:\s*16px;[\s\S]*?height:\s*16px;[\s\S]*?flex:\s*0 0 16px;/);
+  assert.match(css, /\.stream-process-icon\s*\{[\s\S]*?width:\s*16px;[\s\S]*?height:\s*16px;[\s\S]*?flex:\s*0 0 16px;[\s\S]*?stroke-width:\s*2;/);
   assert.equal(en.stream.activityEditedFiles_one, "Edited {{count}} file");
   assert.equal(en.stream.activitySucceeded_one, "{{count}} succeeded");
   assert.equal(en.stream.activityFailed_one, "{{count}} failed");


### PR DESCRIPTION
## Summary

- discover the bundled Codex CLI from macOS Codex and ChatGPT app installations when it is not on `PATH`
- normalize marketplace source types and hide unsupported update actions for managed or local Codex sources
- recursively render inline Markdown inside emphasis and links
- refine chat typography, spacing, links, blockquotes, and execution-process presentation

## Why

This is a follow-up to #71 and #72. The first PR established native plugin management and marketplace filtering; these commits cover macOS app-bundled CLI discovery, safer source-aware update controls, and the remaining chat rendering refinements that were already present in the shared worktree.

## Validation

- `npm run typecheck`
- `npm run build:renderer`
- `npm run build:electron && node --test --test-force-exit tests/native-plugins.test.mjs tests/mac-app-cli.test.mjs` — 11 passed
- `node --test --test-force-exit tests/stream-content-block.test.mjs tests/workflow-ui.test.mjs` — 33 passed
- `npm run github:preflight`

Follow-up to #71 and #72.
