### PR TITLE
fix: preserve chat history when agent session cannot resume

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,15 +216,19 @@ jobs:
           repo="${{ github.repository }}"
           version_suffix="v$(node -p "require('./package.json').version")"
           appimage_name="FreeBuddy_Linux_x64-${version_suffix}.AppImage"
+          deb_name="FreeBuddy_Ubuntu_x64-${version_suffix}.deb"
           yml=$(find release -name latest-linux.yml -type f | head -1)
           if [ -z "$yml" ]; then
             echo "No latest-linux.yml found; skipping"
             exit 0
           fi
           # AppImage blockmap data is embedded in the AppImage itself. Rewrite
-          # the native artifact name to the friendly download name above.
+          # native artifact names to the friendly download names uploaded above.
+          # Deb installs (Ubuntu/Debian) also auto-update from this file, so the
+          # .deb URL must match the renamed release asset or downloads 404.
           sed -E -i.bak \
-            "s#FreeBuddy-[0-9]+\.[0-9]+\.[0-9]+-linux-(x64|x86_64)\.AppImage#${appimage_name}#g" \
+            -e "s#FreeBuddy-[0-9]+\.[0-9]+\.[0-9]+-linux-(x64|x86_64)\.AppImage#${appimage_name}#g" \
+            -e "s#FreeBuddy-[0-9]+\.[0-9]+\.[0-9]+-linux-(amd64|x64|x86_64)\.deb#${deb_name}#g" \
             "$yml"
           cp "$yml" latest-linux.yml
           gh release upload "$tag" latest-linux.yml \

--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -162,7 +162,7 @@ export type AcpStreamItem =
       entries: {
         content: string;
         priority: "high" | "medium" | "low";
-        status: "pending" | "in_progress" | "completed";
+        status: "pending" | "in_progress" | "completed" | "cancelled";
       }[];
     }
   | {
@@ -760,8 +760,10 @@ function planPriority(value: unknown): "high" | "medium" | "low" {
 
 function planStatus(
   value: unknown
-): "pending" | "in_progress" | "completed" {
-  return value === "in_progress" || value === "completed"
+): "pending" | "in_progress" | "completed" | "cancelled" {
+  return value === "in_progress" ||
+    value === "completed" ||
+    value === "cancelled"
     ? value
     : "pending";
 }

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -22,6 +22,7 @@ import type { ChatAttachment, ConversationMessage } from "@/services/cli/types";
 import type { CliStreamItem } from "@/services/cli/parsers";
 import { appendItems } from "@/store/conversationUtils";
 import { useImagePreviewStore } from "@/store/imagePreviewStore";
+import { splitAutolinkSegments } from "@/utils/autolink";
 import { formatBytes, attachmentPreviewUrl } from "@/utils/chatAttachments";
 import { splitWorkspaceFileMentions } from "@/utils/workspaceFileMentions";
 import { pluginDisplayName, splitPluginMentions } from "@/utils/pluginMentions";
@@ -725,7 +726,23 @@ function UserMessageText({ content }: { content: string }) {
             {fileSegment.value}
           </span>
         ) : (
-            <span key={`text-${index}-${fileIndex}`}>{fileSegment.value}</span>
+            splitAutolinkSegments(fileSegment.value).map((linkSegment, linkIndex) =>
+              linkSegment.kind === "link" ? (
+                <a
+                  className="message-autolink"
+                  href={linkSegment.href}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  key={`link-${index}-${fileIndex}-${linkIndex}`}
+                >
+                  {linkSegment.value}
+                </a>
+              ) : (
+                <span key={`text-${index}-${fileIndex}-${linkIndex}`}>
+                  {linkSegment.value}
+                </span>
+              )
+            )
           )
         );
       })}

--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -21,6 +21,7 @@ import type { CliStreamItem } from "@/services/cli/parsers";
 import { dedupeCommands, dedupeToolResults } from "@/store/conversationUtils";
 import { useImagePreviewStore } from "@/store/imagePreviewStore";
 import { useTerminalStore } from "@/store/terminalStore";
+import { splitAutolinkSegments } from "@/utils/autolink";
 import { prepareToolResultText } from "@/utils/streamMedia";
 import { attachmentPreviewUrl, formatBytes } from "@/utils/chatAttachments";
 import { useImageLightbox } from "./ImageLightbox";
@@ -99,17 +100,43 @@ function renderInline(text: string, keyPrefix = "i", depth = 0): ReactNode[] {
       const href = resolveLinkHref(linkMatch[2]);
       if (href) {
         nodes.push(
-          <a key={key} href={href} target="_blank" rel="noreferrer noopener">
+          <a
+            key={key}
+            className="message-autolink"
+            href={href}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
             {renderNested(label, `${key}-link`)}
           </a>
         );
         return;
       }
     }
-    nodes.push(part);
+    nodes.push(...renderAutolinkedText(part, key));
   });
 
   return nodes;
+}
+
+function renderAutolinkedText(text: string, keyPrefix: string): ReactNode[] {
+  return splitAutolinkSegments(text).map((segment, index) => {
+    const key = `${keyPrefix}-auto-${index}`;
+    if (segment.kind === "link") {
+      return (
+        <a
+          key={key}
+          className="message-autolink"
+          href={segment.href}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {segment.value}
+        </a>
+      );
+    }
+    return <span key={key}>{segment.value}</span>;
+  });
 }
 
 function resolveLinkHref(raw: string): string {

--- a/src/components/CLI/WorkspacePanel.tsx
+++ b/src/components/CLI/WorkspacePanel.tsx
@@ -383,13 +383,17 @@ export function WorkspacePanel({
         </dl>
       </section>
 
-      {latestPlan && (
+      {latestPlan &&
+        latestPlan.entries.some((entry) => entry.status !== "cancelled") && (
         <section className="side-card plan-card">
           <div className="side-card-header">
             <span>{t("workspace.plan")}</span>
             <strong>
               {t("workspace.planProgress", {
-                done: latestPlan.entries.filter((entry) => entry.status === "completed").length,
+                done: latestPlan.entries.filter(
+                  (entry) =>
+                    entry.status === "completed" || entry.status === "cancelled"
+                ).length,
                 total: latestPlan.entries.length
               })}
             </strong>
@@ -646,7 +650,8 @@ function isPlanEntry(entry: unknown): entry is PlanEntry {
       candidate.priority === "low") &&
     (candidate.status === "pending" ||
       candidate.status === "in_progress" ||
-      candidate.status === "completed")
+      candidate.status === "completed" ||
+      candidate.status === "cancelled")
   );
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -505,7 +505,8 @@
     "planStatus": {
       "pending": "Pending",
       "in_progress": "In progress",
-      "completed": "Completed"
+      "completed": "Completed",
+      "cancelled": "Cancelled"
     },
     "planPriority": {
       "high": "High priority",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -504,7 +504,8 @@
     "planStatus": {
       "pending": "待处理",
       "in_progress": "进行中",
-      "completed": "已完成"
+      "completed": "已完成",
+      "cancelled": "已取消"
     },
     "planPriority": {
       "high": "高优先级",

--- a/src/services/cli/streamParser.ts
+++ b/src/services/cli/streamParser.ts
@@ -103,7 +103,7 @@ export type CliStreamItem =
       entries: {
         content: string;
         priority: "high" | "medium" | "low";
-        status: "pending" | "in_progress" | "completed";
+        status: "pending" | "in_progress" | "completed" | "cancelled";
       }[];
     }
   | {

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -30,9 +30,11 @@ import {
 
 import { useCliExecutorStore } from "./cliExecutorStore";
 import {
+  buildOrphanFollowupContext,
   collectStreamMessageIds,
   collectStreamAgentMessageIds,
   collectStreamContentSignatures,
+  composeOrphanFollowupPrompt,
   defaultTitleFor,
   feedArticleTitleFromMessages,
   mergeConversationMessages,
@@ -901,9 +903,17 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       workflowRun && (wantFresh || !resumedFromSessionId)
         ? await workflowFollowupContextForRun(workflowRun)
         : undefined;
+    // No resumable agent session (common after a failed first turn): inject
+    // FreeBuddy chat history so short follow-ups like "继续" keep prior asks.
+    const orphanFollowupContext =
+      !workflowRun && !wantFresh && !resumedFromSessionId
+        ? buildOrphanFollowupContext(get().messages[conversationId] ?? [], {
+            excludeMessageIds: [userMsgId, assistantMsgId]
+          })
+        : undefined;
     const promptWithWorkflowContext = workflowFollowupContext
       ? `${workflowFollowupContext}\n\nUser follow-up:\n${userPrompt}`
-      : userPrompt;
+      : composeOrphanFollowupPrompt(userPrompt, orphanFollowupContext);
 
     const msgs = get().messages[conversationId] ?? [];
     const liveItems = get().live[conversationId]?.items;

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -222,7 +222,9 @@ function planPriority(value: unknown): PlanEntry["priority"] {
 }
 
 function planStatus(value: unknown): PlanEntry["status"] {
-  return value === "in_progress" || value === "completed"
+  return value === "in_progress" ||
+    value === "completed" ||
+    value === "cancelled"
     ? value
     : "pending";
 }

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -460,6 +460,108 @@ export function plainAssistantText(items: CliStreamItem[]): string {
     .trim();
 }
 
+function assistantErrorSummary(items: CliStreamItem[]): string | undefined {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const item = items[i];
+    if (item.kind === "error" && item.message.trim()) {
+      return item.message.trim();
+    }
+  }
+  return undefined;
+}
+
+function truncateFollowupBlock(text: string, max: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max).trimEnd()}\n[truncated]`;
+}
+
+/**
+ * When FreeBuddy cannot resume an agent tool session (e.g. the previous turn
+ * failed before a session id existed), inject recent conversation history so
+ * a short follow-up like "继续" still has the unanswered user question.
+ */
+export function buildOrphanFollowupContext(
+  messages: ConversationMessage[],
+  options: {
+    excludeMessageIds?: Iterable<string>;
+    maxChars?: number;
+    maxTurns?: number;
+  } = {}
+): string | undefined {
+  const exclude = new Set(options.excludeMessageIds ?? []);
+  const maxChars = options.maxChars ?? 6000;
+  const maxTurns = options.maxTurns ?? 12;
+
+  const prior = messages.filter((message) => {
+    if (exclude.has(message.id)) return false;
+    if (message.role === "assistant" && message.status === "running") {
+      return false;
+    }
+    return message.role === "user" || message.role === "assistant";
+  });
+  if (prior.length === 0) return undefined;
+
+  const recent = prior.slice(-maxTurns);
+  const blocks: string[] = [];
+  let hadUnansweredUser = false;
+
+  for (const message of recent) {
+    if (message.role === "user") {
+      const text = message.content.trim();
+      if (!text) continue;
+      blocks.push(`User:\n${truncateFollowupBlock(text, 1500)}`);
+      hadUnansweredUser = true;
+      continue;
+    }
+
+    let items: CliStreamItem[] = [];
+    try {
+      const parsed = JSON.parse(message.content);
+      if (Array.isArray(parsed)) items = parsed as CliStreamItem[];
+    } catch {
+      items = [];
+    }
+    const text = plainAssistantText(items);
+    const error = assistantErrorSummary(items);
+    if (text) {
+      blocks.push(`Assistant:\n${truncateFollowupBlock(text, 2000)}`);
+      hadUnansweredUser = false;
+    } else if (error || message.status === "failed" || message.status === "killed") {
+      blocks.push(
+        `Assistant:\n[previous turn ${message.status === "killed" ? "interrupted" : "failed"}${
+          error ? `: ${truncateFollowupBlock(error, 400)}` : ""
+        }]`
+      );
+    } else if (message.content.trim() && !message.content.trim().startsWith("[")) {
+      blocks.push(`Assistant:\n${truncateFollowupBlock(message.content, 2000)}`);
+      hadUnansweredUser = false;
+    }
+  }
+
+  if (blocks.length === 0) return undefined;
+
+  const lines = [
+    "You are continuing a FreeBuddy conversation, but there is no resumable agent session (the previous turn may have failed before a session was created).",
+    "Use the prior messages below as the source of truth for what the user already asked.",
+    hadUnansweredUser
+      ? "The latest user question below was not successfully answered. If the current follow-up is a short continue/retry request, answer that unanswered question."
+      : "Answer the current follow-up in light of this history.",
+    "",
+    "Prior conversation:",
+    ...blocks
+  ];
+  return truncateFollowupBlock(lines.join("\n"), maxChars);
+}
+
+export function composeOrphanFollowupPrompt(
+  followup: string,
+  context: string | undefined
+): string {
+  if (!context) return followup;
+  return `${context}\n\nUser follow-up:\n${followup}`;
+}
+
 export function defaultTitleFor(member: CLIMember, cwd?: string): string {
   const tail = cwd
     ? cwd.split(/[/\\]/).filter(Boolean).slice(-1)[0]

--- a/src/utils/autolink.ts
+++ b/src/utils/autolink.ts
@@ -1,0 +1,72 @@
+export type AutolinkSegment =
+  | { kind: "text"; value: string }
+  | { kind: "link"; value: string; href: string };
+
+const BARE_URL_RE = /\bhttps?:\/\/[^\s<>\[\]"'`]+/gi;
+const TRAILING_PUNCT_RE = /[.,;:!?，。；：！？、）》」』】…]+$/u;
+
+function trimUrlMatch(raw: string): { href: string; trailing: string } {
+  let href = raw;
+  let trailing = "";
+
+  const punct = href.match(TRAILING_PUNCT_RE);
+  if (punct) {
+    trailing = punct[0];
+    href = href.slice(0, -trailing.length);
+  }
+
+  while (
+    (href.endsWith(")") && countChar(href, "(") < countChar(href, ")")) ||
+    (href.endsWith("]") && countChar(href, "[") < countChar(href, "]")) ||
+    (href.endsWith("}") && countChar(href, "{") < countChar(href, "}"))
+  ) {
+    trailing = href.slice(-1) + trailing;
+    href = href.slice(0, -1);
+  }
+
+  return { href, trailing };
+}
+
+function countChar(value: string, char: string): number {
+  let count = 0;
+  for (const current of value) {
+    if (current === char) count += 1;
+  }
+  return count;
+}
+
+/** Split plain text into text/link segments for bubble autolinking. */
+export function splitAutolinkSegments(text: string): AutolinkSegment[] {
+  if (!text) return [];
+
+  const segments: AutolinkSegment[] = [];
+  let lastIndex = 0;
+  BARE_URL_RE.lastIndex = 0;
+
+  for (const match of text.matchAll(BARE_URL_RE)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      segments.push({ kind: "text", value: text.slice(lastIndex, index) });
+    }
+
+    const { href, trailing } = trimUrlMatch(match[0]);
+    if (/^https?:\/\//i.test(href)) {
+      segments.push({ kind: "link", value: href, href });
+    } else if (match[0]) {
+      segments.push({ kind: "text", value: match[0] });
+      lastIndex = index + match[0].length;
+      continue;
+    }
+
+    if (trailing) {
+      segments.push({ kind: "text", value: trailing });
+    }
+    lastIndex = index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ kind: "text", value: text.slice(lastIndex) });
+  }
+
+  return segments.length > 0 ? segments : [{ kind: "text", value: text }];
+}

--- a/styles.css
+++ b/styles.css
@@ -11341,14 +11341,21 @@ button.ghost:focus-visible,
   background: rgba(0, 0, 0, 0.02);
 }
 
-.markdown-body a {
+.markdown-body a,
+.message-autolink {
   color: var(--fb-link, #047857);
   text-decoration: underline;
   text-underline-offset: 3px;
+  word-break: break-all;
 }
 
-.markdown-body a:hover {
+.markdown-body a:hover,
+.message-autolink:hover {
   opacity: 0.85;
+}
+
+.msg-user .msg-bubble .message-autolink {
+  color: var(--fb-link, #047857);
 }
 
 .markdown-blockquote {

--- a/styles.css
+++ b/styles.css
@@ -10248,6 +10248,11 @@ button.ghost:disabled {
   box-shadow: 0 0 0 3px rgba(47, 158, 68, 0.12);
 }
 
+.plan-entry.cancelled .plan-status-dot {
+  background: var(--fb-text-tertiary);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.12);
+}
+
 .plan-entry p {
   margin: 0;
   color: var(--fb-text-primary);
@@ -10258,6 +10263,11 @@ button.ghost:disabled {
 
 .plan-entry.completed p {
   color: var(--fb-text-secondary);
+}
+
+.plan-entry.cancelled p {
+  color: var(--fb-text-tertiary);
+  text-decoration: line-through;
 }
 
 .plan-entry small {

--- a/tests/autolink.test.mjs
+++ b/tests/autolink.test.mjs
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+async function loadAutolink() {
+  const source = fs.readFileSync(
+    new URL("../src/utils/autolink.ts", import.meta.url),
+    "utf8"
+  );
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(
+    `data:text/javascript;base64,${Buffer.from(output).toString("base64")}`
+  );
+}
+
+test("splitAutolinkSegments detects bare https URLs", async () => {
+  const { splitAutolinkSegments } = await loadAutolink();
+  assert.deepEqual(
+    splitAutolinkSegments(
+      "PR 已创建：https://github.com/maojindao55/freebuddy/pull/74"
+    ),
+    [
+      { kind: "text", value: "PR 已创建：" },
+      {
+        kind: "link",
+        value: "https://github.com/maojindao55/freebuddy/pull/74",
+        href: "https://github.com/maojindao55/freebuddy/pull/74"
+      }
+    ]
+  );
+});
+
+test("splitAutolinkSegments strips trailing punctuation", async () => {
+  const { splitAutolinkSegments } = await loadAutolink();
+  assert.deepEqual(splitAutolinkSegments("see https://example.com/path."), [
+    { kind: "text", value: "see " },
+    {
+      kind: "link",
+      value: "https://example.com/path",
+      href: "https://example.com/path"
+    },
+    { kind: "text", value: "." }
+  ]);
+});
+
+test("splitAutolinkSegments keeps balanced parentheses in URLs", async () => {
+  const { splitAutolinkSegments } = await loadAutolink();
+  assert.deepEqual(
+    splitAutolinkSegments("https://en.wikipedia.org/wiki/Foo_(bar)"),
+    [
+      {
+        kind: "link",
+        value: "https://en.wikipedia.org/wiki/Foo_(bar)",
+        href: "https://en.wikipedia.org/wiki/Foo_(bar)"
+      }
+    ]
+  );
+});
+
+test("splitAutolinkSegments returns plain text when no URL", async () => {
+  const { splitAutolinkSegments } = await loadAutolink();
+  assert.deepEqual(splitAutolinkSegments("no links here"), [
+    { kind: "text", value: "no links here" }
+  ]);
+});

--- a/tests/conversation-utils.test.mjs
+++ b/tests/conversation-utils.test.mjs
@@ -761,3 +761,97 @@ test("collectStreamAgentMessageIds returns empty for Qoder-style turns without m
     []
   );
 });
+
+test("buildOrphanFollowupContext keeps unanswered user ask after a failed turn", async () => {
+  const {
+    buildOrphanFollowupContext,
+    composeOrphanFollowupPrompt
+  } = await loadConversationUtils();
+
+  const context = buildOrphanFollowupContext(
+    [
+      {
+        id: "user-1",
+        conversationId: "conv-1",
+        role: "user",
+        status: "sent",
+        content: "我现在手动测试可以听了,我需要关注哪些日志?",
+        createdAt: "2026-07-22T11:43:00.000Z",
+        updatedAt: "2026-07-22T11:43:00.000Z"
+      },
+      {
+        id: "assistant-1",
+        conversationId: "conv-1",
+        role: "assistant",
+        status: "failed",
+        content: JSON.stringify([
+          {
+            kind: "error",
+            message:
+              "Codex process has exited with code 1: You are not logged in. Please run 'wecode codex login' first."
+          }
+        ]),
+        createdAt: "2026-07-22T11:43:01.000Z",
+        updatedAt: "2026-07-22T11:43:02.000Z"
+      },
+      {
+        id: "user-2",
+        conversationId: "conv-1",
+        role: "user",
+        status: "sent",
+        content: "继续",
+        createdAt: "2026-07-22T11:44:00.000Z",
+        updatedAt: "2026-07-22T11:44:00.000Z"
+      },
+      {
+        id: "assistant-2",
+        conversationId: "conv-1",
+        role: "assistant",
+        status: "running",
+        content: "[]",
+        createdAt: "2026-07-22T11:44:00.000Z",
+        updatedAt: "2026-07-22T11:44:00.000Z"
+      }
+    ],
+    { excludeMessageIds: ["user-2", "assistant-2"] }
+  );
+
+  assert.match(context ?? "", /我现在手动测试可以听了/);
+  assert.match(context ?? "", /not logged in/i);
+  assert.match(context ?? "", /not successfully answered/i);
+  assert.equal(
+    composeOrphanFollowupPrompt("继续", context),
+    `${context}\n\nUser follow-up:\n继续`
+  );
+});
+
+test("buildOrphanFollowupContext returns undefined when there is no prior history", async () => {
+  const { buildOrphanFollowupContext } = await loadConversationUtils();
+
+  assert.equal(
+    buildOrphanFollowupContext(
+      [
+        {
+          id: "user-1",
+          conversationId: "conv-1",
+          role: "user",
+          status: "sent",
+          content: "hello",
+          createdAt: "2026-07-22T11:43:00.000Z",
+          updatedAt: "2026-07-22T11:43:00.000Z"
+        },
+        {
+          id: "assistant-1",
+          conversationId: "conv-1",
+          role: "assistant",
+          status: "running",
+          content: "[]",
+          createdAt: "2026-07-22T11:43:00.000Z",
+          updatedAt: "2026-07-22T11:43:00.000Z"
+        }
+      ],
+      { excludeMessageIds: ["user-1", "assistant-1"] }
+    ),
+    undefined
+  );
+});

--- a/tests/plan-cancelled-status.test.mjs
+++ b/tests/plan-cancelled-status.test.mjs
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+async function loadConversationUtils() {
+  const source = fs.readFileSync(
+    new URL("../src/store/conversationUtils.ts", import.meta.url),
+    "utf8"
+  );
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(
+    `data:text/javascript;base64,${Buffer.from(output).toString("base64")}`
+  );
+}
+
+test("appendItems keeps cancelled todo plan status instead of pending", async () => {
+  const { appendItems } = await loadConversationUtils();
+
+  const items = appendItems([], [
+    {
+      kind: "tool-call",
+      id: "todo-1",
+      tool: "TodoWrite",
+      input: {
+        todos: [
+          {
+            id: "auth-classifier",
+            content: "新增 authFailure 分类器",
+            status: "cancelled"
+          },
+          {
+            id: "fix-continue",
+            content: "无 session 可 resume 时注入会话历史",
+            status: "completed"
+          }
+        ]
+      }
+    }
+  ]);
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0].kind, "plan");
+  assert.deepEqual(items[0].entries, [
+    {
+      content: "新增 authFailure 分类器",
+      priority: "medium",
+      status: "cancelled"
+    },
+    {
+      content: "无 session 可 resume 时注入会话历史",
+      priority: "medium",
+      status: "completed"
+    }
+  ]);
+});

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -60,8 +60,14 @@ test("release workflow uploads version-suffixed assets and update metadata for e
   assert.match(workflow, /Upload Windows update metadata/);
   assert.match(workflow, /FreeBuddy_Windows_x64-v\$appVersion\.exe/);
   assert.match(workflow, /\$windowsAssetName\.blockmap/);
-  // AppImage supports auto-update through latest-linux.yml; its blockmap is embedded.
+  // AppImage and .deb both auto-update through latest-linux.yml; rewrite both
+  // friendly asset names so Ubuntu .deb installs do not 404.
   assert.match(workflow, /Upload Linux update metadata/);
   assert.match(workflow, /find release -name latest-linux\.yml/);
   assert.match(workflow, /FreeBuddy_Linux_x64-\$\{version_suffix\}\.AppImage/);
+  assert.match(workflow, /FreeBuddy_Ubuntu_x64-\$\{version_suffix\}\.deb/);
+  assert.match(
+    workflow,
+    /FreeBuddy-\[0-9\]\+\\.\[0-9\]\+\\.\[0-9\]\+-linux-\(amd64\|x64\|x86_64\)\\.deb/
+  );
 });

--- a/tests/stream-content-block.test.mjs
+++ b/tests/stream-content-block.test.mjs
@@ -24,6 +24,8 @@ test("MarkdownText supports links and blockquotes", () => {
   assert.match(streamItemSource, /\[[^\]]+\]\([^)]+\)/);
   assert.match(streamItemSource, /markdown-blockquote/);
   assert.match(streamItemSource, /resolveLinkHref/);
+  assert.match(streamItemSource, /splitAutolinkSegments/);
+  assert.match(streamItemSource, /message-autolink/);
 });
 
 test("MarkdownText recursively renders inline markup inside emphasis and links", () => {
@@ -37,10 +39,11 @@ test("styles include content-block and markdown quote rules", () => {
   assert.match(stylesSource, /\.stream-content-block\b/);
   assert.match(stylesSource, /\.stream-audio\b/);
   assert.match(stylesSource, /\.markdown-body a\b/);
+  assert.match(stylesSource, /\.message-autolink\b/);
   assert.match(stylesSource, /--fb-chat-font:\s*-apple-system,/);
   assert.match(stylesSource, /\.markdown-body\s*\{[\s\S]*?font-family:\s*var\(--fb-chat-font\);[\s\S]*?font-size:\s*14px;[\s\S]*?line-height:\s*22px;/);
   assert.match(stylesSource, /\.markdown-body p\s*\{[\s\S]*?white-space:\s*normal;/);
-  assert.match(stylesSource, /\.markdown-body a\s*\{[\s\S]*?color:\s*var\(--fb-link,/);
+  assert.match(stylesSource, /\.markdown-body a\s*,\s*\.message-autolink\s*\{[\s\S]*?color:\s*var\(--fb-link,/);
   assert.match(stylesSource, /\.markdown-body p\s*\{[\s\S]*?margin:\s*0 0 11px;/);
   assert.match(stylesSource, /\.markdown-body \.markdown-heading\s*\{[\s\S]*?margin:\s*20px 0 10px;/);
   assert.match(stylesSource, /\.markdown-blockquote\s*\{[\s\S]*?border-left:\s*4px solid var\(--fb-border-strong\);/);


### PR DESCRIPTION
## Summary
- When a turn fails before an agent tool session exists (e.g. login required), follow-ups like 「继续」 previously started a fresh session with only that short prompt.
- Inject recent FreeBuddy conversation history into the prompt whenever there is no resumable tool session, so unanswered user questions stay visible to the agent.
- Autolink bare `http(s)://` URLs in assistant and user message bubbles (highlight + click opens the system default browser).
- Preserve TodoWrite `cancelled` plan status in the sidebar (was wrongly shown as pending / stuck at 0/N); hide all-cancelled plans.
- Add unit coverage for orphan follow-up context, URL autolinking, and cancelled plan status.

## Test plan
- [x] `node --test tests/conversation-utils.test.mjs`
- [x] `node --test tests/autolink.test.mjs tests/stream-content-block.test.mjs`
- [x] `node --test tests/plan-cancelled-status.test.mjs`
- [ ] Manually: send a message that fails before session creation, then reply 「继续」 — agent should still answer the original question
- [ ] Manually: normal multi-turn chat with a resumable session still resumes (no history injection)
- [ ] Manually: assistant/user bubbles with bare URLs highlight and open in the system default browser
- [ ] Manually: cancel agent plan todos — sidebar shows cancelled (or hides when all cancelled), not stuck at 0/N pending