### PR TITLE
fix: unblock CI CJK and GeoIP test failures

### DIFF
--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -904,7 +904,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
         ? await workflowFollowupContextForRun(workflowRun)
         : undefined;
     // No resumable agent session (common after a failed first turn): inject
-    // FreeBuddy chat history so short follow-ups like "继续" keep prior asks.
+    // FreeBuddy chat history so short follow-ups like "continue" keep prior asks.
     const orphanFollowupContext =
       !workflowRun && !wantFresh && !resumedFromSessionId
         ? buildOrphanFollowupContext(get().messages[conversationId] ?? [], {

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -481,7 +481,7 @@ function truncateFollowupBlock(text: string, max: number): string {
 /**
  * When FreeBuddy cannot resume an agent tool session (e.g. the previous turn
  * failed before a session id existed), inject recent conversation history so
- * a short follow-up like "继续" still has the unanswered user question.
+ * a short follow-up like "continue" still has the unanswered user question.
  */
 export function buildOrphanFollowupContext(
   messages: ConversationMessage[],

--- a/tests/telemetry.test.mjs
+++ b/tests/telemetry.test.mjs
@@ -19,7 +19,7 @@ test("PostHog telemetry is owned by the Electron main process", () => {
   assert.match(telemetry, /app_first_launch/);
   assert.match(telemetry, /app_launched/);
   assert.match(telemetry, /app_updated/);
-  assert.match(telemetry, /disableGeoip:\s*true/);
+  assert.match(telemetry, /disableGeoip:\s*false/);
   assert.match(telemetry, /\$process_person_profile:\s*false/);
   assert.match(telemetry, /flushAt:\s*20/);
   assert.match(telemetry, /flushInterval:\s*1000/);


### PR DESCRIPTION
## Summary
- Remove CJK literals from `src/` comments that broke `i18n-strings` CI.
- Update telemetry test to expect `disableGeoip: false`, matching the GeoIP enablement already on main.

## Test plan
- [x] `node --test tests/i18n-strings.test.mjs tests/telemetry.test.mjs`

Made with [Cursor](https://cursor.com)