### PR TITLE
feat: reorganize sidebar conversations by project

### DIFF
--- a/docs/sidebar-layout-proposal.html
+++ b/docs/sidebar-layout-proposal.html
@@ -1,0 +1,721 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>FreeBuddy 侧栏改版草案</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --fb-font: "Plus Jakarta Sans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+      --fb-display: "Outfit", var(--fb-font);
+      --fb-sidebar-bg: #f8fafc;
+      --fb-panel-soft: #f1f5f9;
+      --fb-border: rgba(148, 163, 184, 0.16);
+      --fb-text-primary: #0f172a;
+      --fb-text-secondary: #475569;
+      --fb-text-tertiary: #94a3b8;
+      --fb-hover: rgba(148, 163, 184, 0.1);
+      --fb-brand: #10b981;
+      --fb-brand-soft: rgba(16, 185, 129, 0.12);
+      --rail: 268px;
+    }
+
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      font-family: var(--fb-font);
+      color: var(--fb-text-primary);
+      background:
+        radial-gradient(900px 420px at 12% -10%, rgba(16, 185, 129, 0.12), transparent 55%),
+        radial-gradient(700px 380px at 88% 0%, rgba(6, 182, 212, 0.1), transparent 50%),
+        #eef2f7;
+    }
+
+    .page {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 36px 28px 56px;
+    }
+
+    .hero {
+      max-width: 760px;
+      margin-bottom: 28px;
+    }
+    .hero .eyebrow {
+      margin: 0 0 8px;
+      color: var(--fb-brand);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .hero h1 {
+      margin: 0 0 10px;
+      font-family: var(--fb-display);
+      font-size: 34px;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      line-height: 1.15;
+    }
+    .hero p {
+      margin: 0;
+      color: var(--fb-text-secondary);
+      font-size: 15px;
+      line-height: 1.55;
+    }
+
+    .compare {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 22px;
+      align-items: start;
+    }
+
+    .panel {
+      border: 1px solid var(--fb-border);
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.72);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.06);
+      overflow: hidden;
+    }
+    .panel-label {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--fb-border);
+      background: rgba(255, 255, 255, 0.85);
+    }
+    .panel-label strong { font-size: 13px; font-weight: 700; }
+    .panel-label span { color: var(--fb-text-tertiary); font-size: 12px; }
+    .panel.proposed .panel-label strong { color: #047857; }
+
+    .shell {
+      display: grid;
+      grid-template-columns: var(--rail) 1fr;
+      min-height: 640px;
+      background: #fff;
+      position: relative;
+    }
+
+    .main-fake {
+      padding: 28px 24px;
+      background: linear-gradient(180deg, #fff, #f8fafc 70%);
+      border-left: 1px solid var(--fb-border);
+    }
+    .main-fake h2 {
+      margin: 0 0 8px;
+      font-family: var(--fb-display);
+      font-size: 22px;
+      letter-spacing: -0.02em;
+    }
+    .main-fake p {
+      margin: 0;
+      color: var(--fb-text-secondary);
+      font-size: 13px;
+      line-height: 1.5;
+      max-width: 34ch;
+    }
+
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      min-height: 640px;
+      background: var(--fb-sidebar-bg);
+    }
+    .sidebar-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 16px 12px 12px 14px;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      min-width: 0;
+    }
+    .brand-mark {
+      width: 28px;
+      height: 28px;
+      border-radius: 8px;
+      background: linear-gradient(135deg, #10b981, #06b6d4);
+      flex: 0 0 auto;
+    }
+    .brand h3 {
+      margin: 0;
+      font-family: var(--fb-display);
+      font-size: 16px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      flex: 0 0 auto;
+    }
+    .icon-btn {
+      width: 28px;
+      height: 28px;
+      display: grid;
+      place-items: center;
+      border: 0;
+      border-radius: 7px;
+      background: transparent;
+      color: var(--fb-text-tertiary);
+      cursor: pointer;
+    }
+    .icon-btn:hover { background: var(--fb-hover); color: var(--fb-text-primary); }
+    .icon-btn svg { width: 16px; height: 16px; }
+
+    .primary-nav {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      margin: 2px 10px 10px;
+    }
+    .primary-item {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      height: 40px;
+      padding: 0 10px;
+      border-radius: 10px;
+      color: var(--fb-text-secondary);
+      font-size: 13.5px;
+      font-weight: 500;
+    }
+    .primary-item.active { background: var(--fb-panel-soft); }
+    .primary-item .ico {
+      width: 18px;
+      height: 18px;
+      opacity: 0.85;
+      flex: 0 0 auto;
+    }
+
+    .scroll {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+      padding: 0 8px 12px;
+    }
+
+    .section-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 8px 6px;
+      color: var(--fb-text-tertiary);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .date-header {
+      padding: 10px 8px 4px;
+      color: var(--fb-text-tertiary);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .conv {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 44px;
+      padding: 7px 8px;
+      border-radius: 8px;
+    }
+    .conv.active { background: var(--fb-hover); }
+    .avatar {
+      width: 22px;
+      height: 22px;
+      border-radius: 6px;
+      background: #e2e8f0;
+      flex: 0 0 auto;
+    }
+    .conv strong {
+      display: block;
+      font-size: 13px;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .conv em {
+      display: block;
+      margin-top: 1px;
+      color: var(--fb-text-tertiary);
+      font-size: 11px;
+      font-style: normal;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .footer {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px 12px;
+      border-top: 1px solid var(--fb-border);
+      background: var(--fb-sidebar-bg);
+    }
+    .footer .settings {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      height: 28px;
+      padding: 0 8px;
+      border-radius: 7px;
+      color: var(--fb-text-secondary);
+      font-size: 12.5px;
+      font-weight: 500;
+    }
+    .footer .ver {
+      margin-left: auto;
+      color: var(--fb-text-tertiary);
+      font-size: 11px;
+    }
+
+    .project { margin-bottom: 4px; }
+    .project-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 34px;
+      padding: 4px 8px;
+      border-radius: 8px;
+      color: var(--fb-text-primary);
+      font-size: 13px;
+      font-weight: 650;
+    }
+    .project-row.selected { background: rgba(15, 23, 42, 0.05); }
+    .project-row .folder {
+      width: 15px;
+      height: 15px;
+      color: var(--fb-text-tertiary);
+      flex: 0 0 auto;
+    }
+    .project-row .count {
+      margin-left: auto;
+      color: var(--fb-text-tertiary);
+      font-size: 11px;
+      font-weight: 500;
+    }
+    .project-tasks {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      padding: 0 0 4px 10px;
+    }
+    .task {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 30px;
+      padding: 3px 8px 3px 18px;
+      border-radius: 7px;
+      color: var(--fb-text-secondary);
+      font-size: 12.5px;
+      font-weight: 500;
+      position: relative;
+    }
+    .task::before {
+      content: "";
+      position: absolute;
+      left: 6px;
+      top: 50%;
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: #cbd5e1;
+      transform: translateY(-50%);
+    }
+    .task.active {
+      background: var(--fb-brand-soft);
+      color: #065f46;
+      font-weight: 600;
+    }
+    .task.active::before { background: var(--fb-brand); }
+    .task .dot-run {
+      margin-left: auto;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--fb-brand);
+      box-shadow: 0 0 0 3px var(--fb-brand-soft);
+    }
+    .expand {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      margin-left: 18px;
+      padding: 0 8px;
+      border: 0;
+      border-radius: 6px;
+      background: transparent;
+      color: var(--fb-text-tertiary);
+      font-size: 12px;
+      font-weight: 500;
+      cursor: pointer;
+    }
+    .empty-note {
+      padding: 2px 8px 8px 34px;
+      color: var(--fb-text-tertiary);
+      font-size: 12px;
+    }
+    .recent-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 32px;
+      padding: 4px 8px;
+      border-radius: 8px;
+      color: var(--fb-text-secondary);
+      font-size: 12.5px;
+      font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* Command palette — Codex pattern */
+    .palette-layer {
+      position: absolute;
+      inset: 0;
+      z-index: 5;
+      display: grid;
+      place-items: start center;
+      padding: 72px 18px 24px;
+      background: rgba(15, 23, 42, 0.18);
+      backdrop-filter: blur(2px);
+    }
+    .palette {
+      width: min(520px, 100%);
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      border-radius: 14px;
+      background: #fff;
+      box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+      overflow: hidden;
+    }
+    .palette-head {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 16px 10px;
+      border-bottom: 1px solid var(--fb-border);
+    }
+    .palette-head strong {
+      font-size: 14px;
+      font-weight: 700;
+    }
+    .palette-tag {
+      margin-left: auto;
+      padding: 3px 8px;
+      border-radius: 999px;
+      background: var(--fb-panel-soft);
+      color: var(--fb-text-secondary);
+      font-size: 11px;
+      font-weight: 600;
+    }
+    .palette-input {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 10px 12px 6px;
+      padding: 10px 12px;
+      border: 1px solid var(--fb-border);
+      border-radius: 10px;
+      background: #f8fafc;
+      color: var(--fb-text-tertiary);
+      font-size: 13px;
+    }
+    .palette-input svg { width: 15px; height: 15px; flex: 0 0 auto; }
+    .palette-section {
+      padding: 6px 8px 10px;
+    }
+    .palette-section h5 {
+      margin: 0;
+      padding: 6px 8px;
+      color: var(--fb-text-tertiary);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .palette-row {
+      display: grid;
+      grid-template-columns: 1fr auto auto;
+      align-items: center;
+      gap: 10px;
+      min-height: 36px;
+      padding: 6px 10px;
+      border-radius: 8px;
+      font-size: 13px;
+      color: var(--fb-text-primary);
+    }
+    .palette-row.active { background: var(--fb-panel-soft); }
+    .palette-row .proj {
+      color: var(--fb-text-tertiary);
+      font-size: 12px;
+    }
+    .palette-row kbd {
+      color: var(--fb-text-tertiary);
+      font-size: 12px;
+      font-family: inherit;
+    }
+    .palette-action {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 34px;
+      padding: 4px 10px;
+      border-radius: 8px;
+      color: var(--fb-text-secondary);
+      font-size: 13px;
+    }
+    .palette-action:hover { background: var(--fb-hover); }
+    .palette-action kbd {
+      color: var(--fb-text-tertiary);
+      font-size: 12px;
+      font-family: inherit;
+    }
+
+    .notes {
+      margin-top: 22px;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+    }
+    .note {
+      padding: 14px 14px 16px;
+      border: 1px solid var(--fb-border);
+      border-radius: 14px;
+      background: rgba(255,255,255,0.78);
+    }
+    .note h4 {
+      margin: 0 0 6px;
+      font-size: 13px;
+      font-weight: 700;
+    }
+    .note p {
+      margin: 0;
+      color: var(--fb-text-secondary);
+      font-size: 12.5px;
+      line-height: 1.5;
+    }
+
+    @media (max-width: 980px) {
+      .compare, .notes { grid-template-columns: 1fr; }
+      .main-fake { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <p class="eyebrow">Sidebar IA Draft · v2</p>
+      <h1>搜索跟 Codex：图标触发，居中命令面板</h1>
+      <p>
+        侧栏<strong>不放搜索输入框</strong>。顶栏右侧只留放大镜图标（与折叠并列）；
+        点击或 ⌘K 打开居中「搜索对话」命令面板。侧栏主体仍是「项目 + 最近」。
+      </p>
+    </header>
+
+    <div class="compare">
+      <!-- CURRENT -->
+      <section class="panel">
+        <div class="panel-label">
+          <strong>现状</strong>
+          <span>列表内嵌搜索开关</span>
+        </div>
+        <div class="shell">
+          <aside class="sidebar">
+            <div class="sidebar-header">
+              <div class="brand">
+                <div class="brand-mark" aria-hidden="true"></div>
+                <h3>FreeBuddy</h3>
+              </div>
+              <div class="header-actions">
+                <button class="icon-btn" aria-label="折叠">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 6h16M4 12h10M4 18h16"/></svg>
+                </button>
+              </div>
+            </div>
+            <nav class="primary-nav">
+              <div class="primary-item active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 5v14M5 12h14"/><rect x="3" y="4" width="18" height="16" rx="3"/></svg>新建对话</div>
+              <div class="primary-item"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="8"/><path d="M12 8v4l2.5 1.5"/></svg>已安排</div>
+              <div class="primary-item"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M16 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2"/><circle cx="9.5" cy="7" r="3"/><path d="M22 21v-2a3.5 3.5 0 0 0-2.5-3.35M16.5 4.2a3 3 0 0 1 0 5.6"/></svg>团队</div>
+              <div class="primary-item"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 19V5M8 19V9M12 19v-6M16 19V8M20 19V3"/></svg>用量</div>
+            </nav>
+            <div class="scroll">
+              <div class="section-title">
+                <span>对话</span>
+                <button class="icon-btn" aria-label="搜索"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg></button>
+              </div>
+              <div class="date-header">今天</div>
+              <div class="conv active"><div class="avatar"></div><div><strong>解释插件市场概念</strong><em>Claude · freebuddy · 17:20</em></div></div>
+              <div class="conv"><div class="avatar"></div><div><strong>优化运行中状态UI</strong><em>Codex · freebuddy · 15:02</em></div></div>
+              <div class="date-header">昨天</div>
+              <div class="conv"><div class="avatar"></div><div><strong>对比推荐三匹方柜空调</strong><em>Claude · Documents · 昨天</em></div></div>
+              <div class="conv"><div class="avatar"></div><div><strong>执行中心设计方案</strong><em>Claude · freebuddy · 昨天</em></div></div>
+            </div>
+            <div class="footer"><div class="settings">设置</div><span class="ver">v0.x.x</span></div>
+          </aside>
+          <div class="main-fake">
+            <h2>搜索挤在列表头</h2>
+            <p>放大镜开合输入框，占侧栏纵向空间；也不是全局命令入口。</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- PROPOSED -->
+      <section class="panel proposed">
+        <div class="panel-label">
+          <strong>提案 v2</strong>
+          <span>顶栏图标 → 命令面板</span>
+        </div>
+        <div class="shell">
+          <aside class="sidebar">
+            <div class="sidebar-header">
+              <div class="brand">
+                <div class="brand-mark" aria-hidden="true"></div>
+                <h3>FreeBuddy</h3>
+              </div>
+              <div class="header-actions">
+                <button class="icon-btn" aria-label="搜索对话" title="搜索对话 ⌘K">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+                </button>
+                <button class="icon-btn" aria-label="折叠">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 6h16M4 12h10M4 18h16"/></svg>
+                </button>
+              </div>
+            </div>
+
+            <nav class="primary-nav">
+              <div class="primary-item active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 5v14M5 12h14"/><rect x="3" y="4" width="18" height="16" rx="3"/></svg>新建对话</div>
+              <div class="primary-item"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="8"/><path d="M12 8v4l2.5 1.5"/></svg>已安排</div>
+              <div class="primary-item"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M16 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2"/><circle cx="9.5" cy="7" r="3"/><path d="M22 21v-2a3.5 3.5 0 0 0-2.5-3.35M16.5 4.2a3 3 0 0 1 0 5.6"/></svg>团队</div>
+              <div class="primary-item"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 19V5M8 19V9M12 19v-6M16 19V8M20 19V3"/></svg>用量</div>
+            </nav>
+
+            <div class="scroll">
+              <div class="section-title"><span>项目</span></div>
+              <div class="project">
+                <div class="project-row selected">
+                  <svg class="folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5v-9Z"/></svg>
+                  freebuddy
+                  <span class="count">8</span>
+                </div>
+                <div class="project-tasks">
+                  <div class="task active">解释插件市场概念</div>
+                  <div class="task">配置 Mac 电脑 <span class="dot-run" title="运行中"></span></div>
+                  <div class="task">优化运行中状态UI</div>
+                  <div class="task">撤销关闭改动</div>
+                  <div class="task">检查导入 skill zip</div>
+                  <button class="expand" type="button">展开显示 · 3</button>
+                </div>
+              </div>
+              <div class="project">
+                <div class="project-row">
+                  <svg class="folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5v-9Z"/></svg>
+                  themes
+                  <span class="count">1</span>
+                </div>
+                <div class="project-tasks">
+                  <div class="task">AI应用场景优化建议</div>
+                </div>
+              </div>
+              <div class="project">
+                <div class="project-row">
+                  <svg class="folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5v-9Z"/></svg>
+                  badcase
+                </div>
+                <div class="empty-note">无任务</div>
+              </div>
+              <div class="section-title" style="margin-top:10px"><span>最近</span></div>
+              <div class="recent-item">对比推荐三匹方柜空调</div>
+              <div class="recent-item">执行中心设计方案</div>
+              <div class="recent-item">AI辅助开发场景建议</div>
+            </div>
+            <div class="footer"><div class="settings">设置</div><span class="ver">v0.x.x</span></div>
+          </aside>
+
+          <div class="main-fake">
+            <h2>侧栏保持干净</h2>
+            <p>搜索不占侧栏行高；真正交互在中间命令面板完成。</p>
+          </div>
+
+          <div class="palette-layer" aria-label="搜索对话命令面板示意">
+            <div class="palette" role="dialog" aria-modal="true" aria-labelledby="palette-title">
+              <div class="palette-head">
+                <strong id="palette-title">搜索对话</strong>
+                <span class="palette-tag">命令菜单</span>
+              </div>
+              <div class="palette-input">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+                输入标题、项目或 Agent…
+              </div>
+              <div class="palette-section">
+                <h5>对话</h5>
+                <div class="palette-row active">
+                  <span>对比推荐三匹方柜空调</span>
+                  <span class="proj"></span>
+                  <kbd>⌘1</kbd>
+                </div>
+                <div class="palette-row">
+                  <span>解释插件市场概念</span>
+                  <span class="proj">freebuddy</span>
+                  <kbd>⌘2</kbd>
+                </div>
+                <div class="palette-row">
+                  <span>优化运行中状态UI</span>
+                  <span class="proj">freebuddy</span>
+                  <kbd>⌘3</kbd>
+                </div>
+                <div class="palette-row">
+                  <span>执行中心设计方案</span>
+                  <span class="proj">freebuddy</span>
+                  <kbd>⌘4</kbd>
+                </div>
+              </div>
+              <div class="palette-section" style="border-top:1px solid var(--fb-border)">
+                <h5>推荐</h5>
+                <div class="palette-action"><span>新建对话</span><kbd>⌘N</kbd></div>
+                <div class="palette-action"><span>已安排</span><kbd>⌘S</kbd></div>
+                <div class="palette-action"><span>打开设置</span><kbd>⌘,</kbd></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="notes">
+      <article class="note">
+        <h4>搜索入口</h4>
+        <p>侧栏顶栏右侧：放大镜图标（对齐 Codex）。不铺输入条。快捷键 ⌘K / Ctrl+K 同开面板。</p>
+      </article>
+      <article class="note">
+        <h4>命令面板</h4>
+        <p>居中浮层：搜对话（带项目名）+ 底部推荐动作（新建 / 已安排 / 设置）。替代现有列表内嵌搜索。</p>
+      </article>
+      <article class="note">
+        <h4>侧栏列表</h4>
+        <p>仍按项目分组 + 最近；去掉「对话」标题旁的搜索按钮，列表区只负责浏览切换。</p>
+      </article>
+    </section>
+  </div>
+</body>
+</html>

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -346,6 +346,14 @@ export function registerCliIpc() {
     shell.showItemInFolder(path.join(skill.rootPath, "SKILL.md"));
     return true;
   });
+  ipcMain.handle("shell:showItemInFolder", (_event, targetPath: unknown) => {
+    if (typeof targetPath !== "string" || !targetPath.trim()) return false;
+    const resolved = path.resolve(targetPath.trim());
+    if (!path.isAbsolute(resolved)) return false;
+    if (!fs.existsSync(resolved)) return false;
+    shell.showItemInFolder(resolved);
+    return true;
+  });
   ipcMain.handle("skills:marketProviders", () => listSkillMarketProviders());
   ipcMain.handle("skills:getMarketProvider", () => getSkillMarketProvider());
   ipcMain.handle(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -441,6 +441,11 @@ const updater = {
   }
 };
 
+const shellApi = {
+  showItemInFolder: (targetPath: string) =>
+    ipcRenderer.invoke("shell:showItemInFolder", targetPath) as Promise<boolean>
+};
+
 contextBridge.exposeInMainWorld("freebuddy", {
   platform: process.platform,
   arch: process.arch,
@@ -460,5 +465,6 @@ contextBridge.exposeInMainWorld("freebuddy", {
   feed,
   infoCards,
   window,
-  updater
+  updater,
+  shell: shellApi
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import { ConfigProvider, theme as antdTheme } from "antd";
-import { ArrowLeftRight, Menu, Monitor, Moon, PanelLeft, PanelRight, Sun } from "lucide-react";
+import { ArrowLeftRight, Menu, Monitor, Moon, PanelLeft, PanelRight, Search, Sun } from "lucide-react";
 
 import sidebarLogoUrl from "../assets/sidebar-logo.png";
 import { ChatView } from "./components/CLI/ChatView";
 import { ReplayButton } from "./components/CLI/ReplayBar";
 import { ConversationList } from "./components/CLI/ConversationList";
+import { ConversationCommandPalette } from "./components/CLI/ConversationCommandPalette";
 import { TransferDialog } from "./components/CLI/TransferDialog";
 import {
   SidebarNavigation,
@@ -79,6 +80,7 @@ function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [chromeVisible, setChromeVisible] = useState(true);
   const [workspaceView, setWorkspaceView] = useState<WorkspaceView>("chat");
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [transferSourceId, setTransferSourceId] = useState<string>();
   const [teamPageRequest, setTeamPageRequest] = useState<{
     key: number;
@@ -116,6 +118,17 @@ function App() {
     return () => {
       off?.();
     };
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
+      if (event.key.toLowerCase() !== "k") return;
+      event.preventDefault();
+      setCommandPaletteOpen((open) => !open);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
 
   const { t } = useTranslation();
@@ -250,9 +263,11 @@ function App() {
   const isNewTask = !activeConversation;
   const setNewTaskMode = useNewTaskUiStore((s) => s.setTaskMode);
   const setRequestedTeamId = useNewTaskUiStore((s) => s.setRequestedTeamId);
-  const startNewTask = () => {
+  const requestNewTaskCwd = useNewTaskUiStore((s) => s.requestNewTaskCwd);
+  const startNewTask = (options?: { cwd?: string }) => {
     setRequestedTeamId(undefined);
     setNewTaskMode("normal");
+    requestNewTaskCwd(options?.cwd);
     setSettingsOpen(false);
     setWorkspaceView("chat");
     void setActive(undefined);
@@ -371,6 +386,15 @@ function App() {
                   <h1>{t("app.brand")}</h1>
                 </div>
               </div>
+              <button
+                type="button"
+                className="sidebar-search-button"
+                title={t("commandPalette.openShortcut")}
+                aria-label={t("commandPalette.open")}
+                onClick={() => setCommandPaletteOpen(true)}
+              >
+                <Search aria-hidden="true" size={16} strokeWidth={1.8} />
+              </button>
               {renderToggleButton()}
             </div>
 
@@ -382,7 +406,7 @@ function App() {
               onOpenTeams={() => openWorkflowTeams()}
               onOpenUsage={openUsage}
             />
-            <ConversationList />
+            <ConversationList onNewTaskInProject={(cwd) => startNewTask({ cwd })} />
 
             <div className="sidebar-footer">
               <button
@@ -538,6 +562,17 @@ function App() {
       <CliInstallPanelHost />
       <PermissionDialog />
       <AuthenticationDialog />
+      <ConversationCommandPalette
+        open={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
+        onNewTask={startNewTask}
+        onOpenScheduledTasks={openScheduledTasks}
+        onOpenSettings={() => openSettings("cli")}
+        onSelectConversation={() => {
+          setSettingsOpen(false);
+          setWorkspaceView("chat");
+        }}
+      />
       {transferSource && (
         <TransferDialog
           source={transferSource}

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -415,6 +415,8 @@ export function ChatView({
   const setTaskMode = useNewTaskUiStore((s) => s.setTaskMode);
   const requestedTeamId = useNewTaskUiStore((s) => s.requestedTeamId);
   const setRequestedTeamId = useNewTaskUiStore((s) => s.setRequestedTeamId);
+  const requestedCwd = useNewTaskUiStore((s) => s.requestedCwd);
+  const cwdRequestToken = useNewTaskUiStore((s) => s.cwdRequestToken);
   const teamMode = taskMode === "team";
   const workflowMode = false;
   const createAndStartTeam = useWorkflowStore((s) => s.createAndStartTeam);
@@ -877,6 +879,12 @@ export function ChatView({
       setSelectedTeamId(requestedTeamId);
     }
   }, [requestedTeamId, selectedTeamId, teams]);
+
+  useEffect(() => {
+    if (activeId) return;
+    if (cwdRequestToken === 0) return;
+    setNewTaskCwd(requestedCwd ?? "");
+  }, [activeId, cwdRequestToken, requestedCwd]);
 
   useEffect(() => {
     const resolved = conv?.approvalMode ?? member?.cli.approvalMode;

--- a/src/components/CLI/ConversationCommandPalette.tsx
+++ b/src/components/CLI/ConversationCommandPalette.tsx
@@ -1,0 +1,332 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent
+} from "react";
+import { Search } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { displayAgentName } from "@/config/agentDisplay";
+import { useConversationStore } from "@/store/conversationStore";
+import type { Conversation } from "@/services/cli/types";
+import {
+  projectLabelFromCwd,
+  conversationActivityTime
+} from "./conversationProjectGrouping";
+
+const RESULT_LIMIT = 9;
+
+type PaletteAction = {
+  id: string;
+  label: string;
+  meta?: string;
+  shortcut?: string;
+  run: () => void;
+};
+
+export function ConversationCommandPalette({
+  open,
+  onClose,
+  onNewTask,
+  onOpenScheduledTasks,
+  onOpenSettings,
+  onSelectConversation
+}: {
+  open: boolean;
+  onClose: () => void;
+  onNewTask: (options?: { cwd?: string }) => void;
+  onOpenScheduledTasks: () => void;
+  onOpenSettings: () => void;
+  onSelectConversation?: () => void;
+}) {
+  const { t } = useTranslation();
+  const titleId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const conversations = useConversationStore((s) => s.conversations);
+  const activeId = useConversationStore((s) => s.activeId);
+  const setActive = useConversationStore((s) => s.setActive);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const currentProjectCwd = useMemo(() => {
+    const active = conversations.find((conversation) => conversation.id === activeId);
+    const cwd = active?.cwd?.trim();
+    return cwd || undefined;
+  }, [activeId, conversations]);
+
+  const actions = useMemo<PaletteAction[]>(() => {
+    const items: PaletteAction[] = [
+      {
+        id: "new-task",
+        label: t("sidebar.newConversation"),
+        shortcut: "⌘N",
+        run: () => {
+          onNewTask();
+          onClose();
+        }
+      }
+    ];
+    if (currentProjectCwd) {
+      items.push({
+        id: "new-task-in-project",
+        label: t("conversations.newInCurrentProject"),
+        meta: projectLabelFromCwd(currentProjectCwd),
+        run: () => {
+          onNewTask({ cwd: currentProjectCwd });
+          onClose();
+        }
+      });
+    }
+    items.push(
+      {
+        id: "scheduled",
+        label: t("sidebar.scheduledTasks"),
+        run: () => {
+          onOpenScheduledTasks();
+          onClose();
+        }
+      },
+      {
+        id: "settings",
+        label: t("common.settings"),
+        shortcut: "⌘,",
+        run: () => {
+          onOpenSettings();
+          onClose();
+        }
+      }
+    );
+    return items;
+  }, [
+    currentProjectCwd,
+    onClose,
+    onNewTask,
+    onOpenScheduledTasks,
+    onOpenSettings,
+    t
+  ]);
+
+  const results = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const filtered = normalized
+      ? conversations.filter((conversation) => {
+          if (conversation.title.toLowerCase().includes(normalized)) return true;
+          if (conversation.cwd?.toLowerCase().includes(normalized)) return true;
+          return displayAgentName(conversation.agentName, conversation.adapter)
+            .toLowerCase()
+            .includes(normalized);
+        })
+      : conversations;
+    return [...filtered]
+      .sort((a, b) => conversationActivityTime(b) - conversationActivityTime(a))
+      .slice(0, RESULT_LIMIT);
+  }, [conversations, query]);
+
+  const selectableCount = results.length + actions.length;
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setActiveIndex(0);
+      return;
+    }
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const frame = window.requestAnimationFrame(() => inputRef.current?.focus());
+    return () => {
+      window.cancelAnimationFrame(frame);
+      previousFocusRef.current?.focus();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (selectableCount === 0) {
+      setActiveIndex(0);
+      return;
+    }
+    setActiveIndex((current) => Math.min(current, selectableCount - 1));
+  }, [open, selectableCount]);
+
+  if (!open) return null;
+
+  const selectConversation = (conversation: Conversation) => {
+    void setActive(conversation.id);
+    onSelectConversation?.();
+    onClose();
+  };
+
+  const activateIndex = (index: number) => {
+    if (index < results.length) {
+      const conversation = results[index];
+      if (conversation) selectConversation(conversation);
+      return;
+    }
+    const action = actions[index - results.length];
+    action?.run();
+  };
+
+  const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (selectableCount === 0) return;
+      setActiveIndex((current) => (current + 1) % selectableCount);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (selectableCount === 0) return;
+      setActiveIndex((current) => (current - 1 + selectableCount) % selectableCount);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      activateIndex(activeIndex);
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && /^[1-9]$/.test(event.key)) {
+      const index = Number(event.key) - 1;
+      if (index < results.length) {
+        event.preventDefault();
+        activateIndex(index);
+      }
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])'
+      ) ?? []
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <div
+      className="modal-backdrop command-palette-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="command-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onKeyDown={handleDialogKeyDown}
+      >
+        <div className="command-palette-head">
+          <strong id={titleId}>{t("commandPalette.title")}</strong>
+          <span className="command-palette-tag">{t("commandPalette.commandMenu")}</span>
+        </div>
+        <div className="command-palette-input-wrap">
+          <Search aria-hidden="true" size={15} strokeWidth={1.8} />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            enterKeyHint="search"
+            placeholder={t("commandPalette.placeholder")}
+            aria-label={t("commandPalette.placeholder")}
+            aria-controls="command-palette-results"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
+        <div id="command-palette-results" className="command-palette-body">
+          <section className="command-palette-section" aria-label={t("conversations.title")}>
+            <h5>{t("conversations.title")}</h5>
+            {results.length === 0 ? (
+              <p className="command-palette-empty">
+                {query.trim()
+                  ? t("conversations.noResults")
+                  : t("conversations.empty")}
+              </p>
+            ) : (
+              <ul role="listbox" aria-label={t("conversations.title")}>
+                {results.map((conversation, index) => {
+                  const project = conversation.cwd
+                    ? projectLabelFromCwd(conversation.cwd)
+                    : "";
+                  const shortcut =
+                    index < 9 ? `⌘${index + 1}` : undefined;
+                  return (
+                    <li key={conversation.id} role="none">
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={activeIndex === index}
+                        className={`command-palette-row${activeIndex === index ? " active" : ""}`}
+                        onMouseEnter={() => setActiveIndex(index)}
+                        onClick={() => selectConversation(conversation)}
+                      >
+                        <span className="command-palette-row-title">
+                          {conversation.title}
+                        </span>
+                        {project ? (
+                          <span className="command-palette-row-meta">{project}</span>
+                        ) : (
+                          <span className="command-palette-row-meta" />
+                        )}
+                        {shortcut ? <kbd>{shortcut}</kbd> : <span />}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+          <section
+            className="command-palette-section command-palette-actions"
+            aria-label={t("commandPalette.recommended")}
+          >
+            <h5>{t("commandPalette.recommended")}</h5>
+            <ul>
+              {actions.map((action, actionIndex) => {
+                const index = results.length + actionIndex;
+                return (
+                  <li key={action.id}>
+                    <button
+                      type="button"
+                      className={`command-palette-row action${activeIndex === index ? " active" : ""}`}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      onClick={action.run}
+                    >
+                      <span className="command-palette-row-title">{action.label}</span>
+                      <span className="command-palette-row-meta">
+                        {action.meta ?? ""}
+                      </span>
+                      {action.shortcut ? <kbd>{action.shortcut}</kbd> : <span />}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CLI/ConversationList.tsx
+++ b/src/components/CLI/ConversationList.tsx
@@ -1,114 +1,37 @@
-import { Fragment, memo, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { useConversationStore } from "@/store/conversationStore";
+import { usePinnedProjectsStore } from "@/store/pinnedProjectsStore";
 import { useWorkflowStore } from "@/store/workflowStore";
 import type { Conversation } from "@/services/cli/types";
-import { displayAgentName } from "@/config/agentDisplay";
 import i18next from "i18next";
 import { useTranslation } from "react-i18next";
-import { LoaderCircle, MessageSquare, Search, X } from "lucide-react";
+import {
+  Folder,
+  FolderOpen,
+  LoaderCircle,
+  MessageSquare,
+  MoreHorizontal,
+  Pin,
+  PinOff,
+  Plus,
+  Trash2,
+  X
+} from "lucide-react";
 import { AgentAvatar } from "./AgentAvatar";
-
-function conversationTimeValue(conversation: Conversation) {
-  return conversation.lastMessageAt ?? conversation.updatedAt ?? conversation.createdAt;
-}
-
-type TimeFormatVariant = "time" | "md" | "ymd" | "full";
-
-// Intl.DateTimeFormat construction is expensive; cache one formatter per
-// (language, variant). Previously the list rebuilt up to 4*N formatter
-// objects on every render of the sidebar.
-const formatterCache = new Map<string, Intl.DateTimeFormat>();
-function dateTimeFormatter(lang: string, variant: TimeFormatVariant): Intl.DateTimeFormat {
-  const key = `${lang}|${variant}`;
-  const cached = formatterCache.get(key);
-  if (cached) return cached;
-  const options: Intl.DateTimeFormatOptions =
-    variant === "time"
-      ? { hour: "2-digit", minute: "2-digit" }
-      : variant === "md"
-        ? { month: "2-digit", day: "2-digit" }
-        : variant === "ymd"
-          ? { year: "numeric", month: "2-digit", day: "2-digit" }
-          : {
-              year: "numeric",
-              month: "2-digit",
-              day: "2-digit",
-              hour: "2-digit",
-              minute: "2-digit"
-            };
-  const formatter = new Intl.DateTimeFormat(lang, options);
-  formatterCache.set(key, formatter);
-  return formatter;
-}
-
-function formatConversationTime(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  const lang = i18next.language || "en";
-  const now = new Date();
-  const sameDay =
-    date.getFullYear() === now.getFullYear() &&
-    date.getMonth() === now.getMonth() &&
-    date.getDate() === now.getDate();
-  if (sameDay) return dateTimeFormatter(lang, "time").format(date);
-  if (date.getFullYear() === now.getFullYear())
-    return dateTimeFormatter(lang, "md").format(date);
-  return dateTimeFormatter(lang, "ymd").format(date);
-}
-
-function shortCwd(cwd: string) {
-  return cwd.split(/[/\\]/).slice(-2).join("/");
-}
-
-interface ConvSection {
-  key: string;
-  label: string;
-  items: Conversation[];
-}
-
-const SECTION_ORDER = ["today", "yesterday", "last7", "last30", "earlier"] as const;
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/**
- * Bucket conversations into ordered recency sections. Items arrive pre-sorted
- * by recency (DESC) from the DB, so each bucket preserves that order.
- */
-function groupConversationsByDate(
-  items: Conversation[],
-  labels: Record<string, string>
-): ConvSection[] {
-  const now = new Date();
-  const startToday = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate()
-  ).getTime();
-  const buckets: Record<string, Conversation[]> = {
-    today: [],
-    yesterday: [],
-    last7: [],
-    last30: [],
-    earlier: []
-  };
-  for (const c of items) {
-    const ts = Date.parse(conversationTimeValue(c));
-    let key: string;
-    if (!Number.isFinite(ts)) key = "earlier";
-    else if (ts >= startToday) key = "today";
-    else if (ts >= startToday - DAY_MS) key = "yesterday";
-    else if (ts >= startToday - 7 * DAY_MS) key = "last7";
-    else if (ts >= startToday - 30 * DAY_MS) key = "last30";
-    else key = "earlier";
-    buckets[key].push(c);
-  }
-  const sections: ConvSection[] = [];
-  for (const key of SECTION_ORDER) {
-    if (buckets[key].length > 0) {
-      sections.push({ key, label: labels[key], items: buckets[key] });
-    }
-  }
-  return sections;
-}
+import {
+  PROJECT_PREVIEW_LIMIT,
+  groupConversationsByProject,
+  recentConversations,
+  type ConversationProjectGroup
+} from "./conversationProjectGrouping";
 
 const ConversationRow = memo(function ConversationRow({
   conversation,
@@ -116,6 +39,7 @@ const ConversationRow = memo(function ConversationRow({
   isRunning,
   isWorkflowRunning,
   isUnread,
+  compact,
   onSelect,
   onDelete
 }: {
@@ -124,27 +48,20 @@ const ConversationRow = memo(function ConversationRow({
   isRunning: boolean;
   isWorkflowRunning: boolean;
   isUnread: boolean;
+  compact?: boolean;
   onSelect: (id: string) => void;
   onDelete: (id: string, title: string) => void;
 }) {
   const { t } = useTranslation();
-  const timeValue = conversationTimeValue(conversation);
-  const timeLabel = formatConversationTime(timeValue);
-  const agentName = displayAgentName(conversation.agentName, conversation.adapter);
-  const metadata = [
-    agentName,
-    conversation.cwd ? shortCwd(conversation.cwd) : "",
-    timeLabel
-  ].filter(Boolean).join(" · ");
   const isBusy = isRunning || isWorkflowRunning;
 
   return (
     <li
-      className={`conv-item${isActive ? " active" : ""}${!isBusy && isUnread ? " unread" : ""}`}
+      className={`conv-item${compact ? " compact" : ""}${isActive ? " active" : ""}${!isBusy && isUnread ? " unread" : ""}`}
       role="button"
       tabIndex={0}
       aria-current={isActive ? "true" : undefined}
-      title={metadata}
+      title={conversation.title}
       onClick={() => onSelect(conversation.id)}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
@@ -201,14 +118,127 @@ const ConversationRow = memo(function ConversationRow({
   );
 });
 
-export function ConversationList() {
+function ProjectOverflowMenu({
+  pinned,
+  open,
+  canReveal,
+  onOpenChange,
+  onTogglePin,
+  onReveal,
+  onDeleteAll
+}: {
+  pinned: boolean;
+  open: boolean;
+  canReveal: boolean;
+  onOpenChange: (open: boolean) => void;
+  onTogglePin: () => void;
+  onReveal: () => void;
+  onDeleteAll: () => void;
+}) {
+  const { t } = useTranslation();
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        onOpenChange(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onOpenChange(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, onOpenChange]);
+
+  return (
+    <div className={`conv-project-more${open ? " open" : ""}`} ref={rootRef}>
+      <button
+        type="button"
+        className="conv-project-action-btn"
+        aria-label={t("conversations.projectMenu")}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={t("conversations.projectMenu")}
+        onClick={(event) => {
+          event.stopPropagation();
+          onOpenChange(!open);
+        }}
+      >
+        <MoreHorizontal aria-hidden="true" size={14} strokeWidth={1.8} />
+      </button>
+      {open && (
+        <div className="conv-project-menu" role="menu">
+          <button
+            type="button"
+            role="menuitem"
+            className="conv-project-menu-item"
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenChange(false);
+              onTogglePin();
+            }}
+          >
+            {pinned ? (
+              <PinOff aria-hidden="true" size={14} strokeWidth={1.8} />
+            ) : (
+              <Pin aria-hidden="true" size={14} strokeWidth={1.8} />
+            )}
+            <span>
+              {pinned
+                ? t("conversations.unpinProject")
+                : t("conversations.pinProject")}
+            </span>
+          </button>
+          {canReveal && (
+            <button
+              type="button"
+              role="menuitem"
+              className="conv-project-menu-item"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenChange(false);
+                onReveal();
+              }}
+            >
+              <FolderOpen aria-hidden="true" size={14} strokeWidth={1.8} />
+              <span>{t("conversations.revealProject")}</span>
+            </button>
+          )}
+          <button
+            type="button"
+            role="menuitem"
+            className="conv-project-menu-item danger"
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenChange(false);
+              onDeleteAll();
+            }}
+          >
+            <Trash2 aria-hidden="true" size={14} strokeWidth={1.8} />
+            <span>{t("conversations.deleteProjectConversations")}</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ConversationList({
+  onNewTaskInProject
+}: {
+  onNewTaskInProject?: (cwd: string) => void;
+}) {
   const conversations = useConversationStore((s) => s.conversations);
   const activeId = useConversationStore((s) => s.activeId);
   const unreadConversations = useConversationStore((s) => s.unreadConversations);
   const setActive = useConversationStore((s) => s.setActive);
-  // Subscribe to a stable signature of the running set instead of the whole
-  // live map: this list re-renders only when a conversation starts or stops,
-  // not on every streaming chunk emitted by an already-running agent.
+  const deleteConversation = useConversationStore((s) => s.deleteConversation);
   const runningSignature = useConversationStore((s) => {
     const ids: string[] = [];
     for (const c of s.conversations) {
@@ -219,10 +249,13 @@ export function ConversationList() {
   });
   const workflowActiveRuns = useWorkflowStore((s) => s.activeRuns);
   const loadWorkflowActiveRuns = useWorkflowStore((s) => s.loadActiveRuns);
-  const remove = useConversationStore((s) => s.deleteConversation);
+  const pinnedKeys = usePinnedProjectsStore((s) => s.pinnedKeys);
+  const togglePin = usePinnedProjectsStore((s) => s.toggle);
+  const unpin = usePinnedProjectsStore((s) => s.unpin);
   const { t } = useTranslation();
-  const [query, setQuery] = useState("");
-  const [searchOpen, setSearchOpen] = useState(false);
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => new Set());
+  const [expandedFully, setExpandedFully] = useState<Set<string>>(() => new Set());
+  const [menuProjectKey, setMenuProjectKey] = useState<string | null>(null);
 
   const runningSet = new Set(runningSignature ? runningSignature.split("\n") : []);
   const workflowRunningSet = new Set(
@@ -231,7 +264,6 @@ export function ConversationList() {
       .filter((id): id is string => Boolean(id))
   );
 
-  // Stable callbacks so memoized rows don't all re-render on every parent render.
   const handleSelect = useCallback(
     (id: string) => {
       void setActive(id);
@@ -241,104 +273,245 @@ export function ConversationList() {
   const handleDelete = useCallback(
     (id: string, title: string) => {
       if (window.confirm(i18next.t("conversations.deleteConfirm", { title }))) {
-        void remove(id);
+        void deleteConversation(id);
       }
     },
-    [remove]
+    [deleteConversation]
   );
-
-  const normalizedQuery = query.trim().toLowerCase();
 
   useEffect(() => {
     void loadWorkflowActiveRuns();
   }, [loadWorkflowActiveRuns]);
 
-  const filtered = useMemo(() => {
-    if (!normalizedQuery) return conversations;
-    return conversations.filter((c) => {
-      if (c.title.toLowerCase().includes(normalizedQuery)) return true;
-      return displayAgentName(c.agentName, c.adapter)
-        .toLowerCase()
-        .includes(normalizedQuery);
+  const projects = useMemo(() => {
+    const groups = groupConversationsByProject(conversations);
+    return [...groups].sort((a, b) => {
+      const aPin = pinnedKeys.indexOf(a.key);
+      const bPin = pinnedKeys.indexOf(b.key);
+      const aPinned = aPin >= 0;
+      const bPinned = bPin >= 0;
+      if (aPinned !== bPinned) return aPinned ? -1 : 1;
+      if (aPinned && bPinned && aPin !== bPin) return aPin - bPin;
+      return b.latestAt - a.latestAt || a.label.localeCompare(b.label);
     });
-  }, [conversations, normalizedQuery]);
+  }, [conversations, pinnedKeys]);
+  const recent = useMemo(() => recentConversations(conversations), [conversations]);
 
-  const sections = useMemo(() => {
-    const labels: Record<string, string> = {
-      today: t("conversations.group.today"),
-      yesterday: t("conversations.group.yesterday"),
-      last7: t("conversations.group.last7Days"),
-      last30: t("conversations.group.last30Days"),
-      earlier: t("conversations.group.earlier")
-    };
-    return groupConversationsByDate(filtered, labels);
-  }, [filtered, t]);
+  const activeProjectKey = useMemo(() => {
+    const active = conversations.find((c) => c.id === activeId);
+    const cwd = active?.cwd?.trim();
+    if (!cwd) return undefined;
+    return cwd.replace(/[\\/]+$/, "").toLowerCase();
+  }, [activeId, conversations]);
+
+  useEffect(() => {
+    if (!activeProjectKey) return;
+    setExpandedProjects((current) => {
+      if (current.has(activeProjectKey)) return current;
+      const next = new Set(current);
+      next.add(activeProjectKey);
+      return next;
+    });
+  }, [activeProjectKey]);
+
+  useEffect(() => {
+    if (projects.length === 0) return;
+    setExpandedProjects((current) => {
+      if (current.size > 0) return current;
+      const next = new Set<string>();
+      next.add(projects[0].key);
+      return next;
+    });
+  }, [projects]);
+
+  const toggleProject = (key: string) => {
+    setExpandedProjects((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const showAllInProject = (key: string) => {
+    setExpandedFully((current) => {
+      const next = new Set(current);
+      next.add(key);
+      return next;
+    });
+  };
+
+  const handleDeleteProject = async (project: ConversationProjectGroup) => {
+    const confirmed = window.confirm(
+      i18next.t("conversations.deleteProjectConfirm", {
+        name: project.label,
+        count: project.items.length
+      })
+    );
+    if (!confirmed) return;
+    for (const conversation of project.items) {
+      await deleteConversation(conversation.id);
+    }
+    unpin(project.key);
+    setMenuProjectKey(null);
+  };
+
+  const renderRow = (conversation: Conversation, compact?: boolean) => (
+    <ConversationRow
+      key={conversation.id}
+      conversation={conversation}
+      isActive={activeId === conversation.id}
+      isRunning={runningSet.has(conversation.id)}
+      isWorkflowRunning={workflowRunningSet.has(conversation.id)}
+      isUnread={Boolean(unreadConversations[conversation.id])}
+      compact={compact}
+      onSelect={handleSelect}
+      onDelete={handleDelete}
+    />
+  );
 
   return (
     <div className="conv-list">
-      <div className="conv-list-header">
-        <h2>{t("conversations.title")}</h2>
-        <button
-          type="button"
-          className={`conv-list-search-toggle${searchOpen || query ? " active" : ""}`}
-          title={t("conversations.searchPlaceholder")}
-          aria-label={t("conversations.searchPlaceholder")}
-          aria-expanded={searchOpen || Boolean(query)}
-          onClick={() => {
-            if (searchOpen && query) setQuery("");
-            setSearchOpen((open) => !open);
-          }}
-        >
-          {searchOpen || query ? <X aria-hidden="true" /> : <Search aria-hidden="true" />}
-        </button>
-      </div>
-      {(searchOpen || query) && (
-        <div className="conv-search">
-          <input
-            type="text"
-            autoFocus
-            value={query}
-            enterKeyHint="search"
-            placeholder={t("conversations.searchPlaceholder")}
-            aria-label={t("conversations.searchPlaceholder")}
-            onChange={(event) => setQuery(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Escape") {
-                event.preventDefault();
-                setQuery("");
-                setSearchOpen(false);
-              }
-            }}
-          />
-        </div>
-      )}
       <ul>
-        {sections.length === 0 ? (
-          <li className="conv-empty muted">
-            {normalizedQuery
-              ? t("conversations.noResults")
-              : t("conversations.empty")}
-          </li>
+        {conversations.length === 0 ? (
+          <li className="conv-empty muted">{t("conversations.empty")}</li>
         ) : (
-          sections.map((section) => (
-            <Fragment key={section.key}>
-              <li className="conv-group-header">
-                <span>{section.label}</span>
+          <>
+            {projects.length > 0 && (
+              <li className="conv-group-header" aria-hidden="true">
+                <span>{t("conversations.projects")}</span>
               </li>
-              {section.items.map((c) => (
-                <ConversationRow
-                  key={c.id}
-                  conversation={c}
-                  isActive={activeId === c.id}
-                  isRunning={runningSet.has(c.id)}
-                  isWorkflowRunning={workflowRunningSet.has(c.id)}
-                  isUnread={Boolean(unreadConversations[c.id])}
-                  onSelect={handleSelect}
-                  onDelete={handleDelete}
-                />
-              ))}
-            </Fragment>
-          ))
+            )}
+            {projects.map((project) => {
+              const expanded = expandedProjects.has(project.key);
+              const showAll = expandedFully.has(project.key);
+              const visibleItems = expanded
+                ? showAll
+                  ? project.items
+                  : project.items.slice(0, PROJECT_PREVIEW_LIMIT)
+                : [];
+              const hiddenCount = expanded
+                ? Math.max(0, project.items.length - visibleItems.length)
+                : 0;
+              const selected = activeProjectKey === project.key;
+              const pinned = pinnedKeys.includes(project.key);
+              const menuOpen = menuProjectKey === project.key;
+
+              return (
+                <Fragment key={project.key}>
+                  <li
+                    className={`conv-project-row${selected ? " selected" : ""}${menuOpen ? " menu-open" : ""}${pinned ? " pinned" : ""}`}
+                  >
+                    <div className="conv-project-row-inner">
+                      <button
+                        type="button"
+                        className="conv-project-toggle"
+                        aria-expanded={expanded}
+                        onClick={() => toggleProject(project.key)}
+                      >
+                        {expanded ? (
+                          <FolderOpen
+                            className="conv-project-folder"
+                            aria-hidden="true"
+                            size={15}
+                            strokeWidth={1.8}
+                          />
+                        ) : (
+                          <Folder
+                            className="conv-project-folder"
+                            aria-hidden="true"
+                            size={15}
+                            strokeWidth={1.8}
+                          />
+                        )}
+                        <span className="conv-project-name">{project.label}</span>
+                      </button>
+                      <div className="conv-project-trailing">
+                        {pinned && (
+                          <span className="conv-project-pin-slot" aria-hidden="true">
+                            <Pin
+                              className="conv-project-pin"
+                              size={12}
+                              strokeWidth={2}
+                            />
+                          </span>
+                        )}
+                        <div className="conv-project-actions">
+                          <button
+                            type="button"
+                            className="conv-project-action-btn new"
+                            title={t("conversations.newInProject")}
+                            aria-label={t("conversations.newInProject")}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              if (!project.cwd || !onNewTaskInProject) return;
+                              setExpandedProjects((current) => {
+                                const next = new Set(current);
+                                next.add(project.key);
+                                return next;
+                              });
+                              onNewTaskInProject(project.cwd);
+                            }}
+                          >
+                            <Plus aria-hidden="true" size={14} strokeWidth={2} />
+                          </button>
+                          <ProjectOverflowMenu
+                            pinned={pinned}
+                            open={menuOpen}
+                            canReveal={Boolean(
+                              project.cwd && window.freebuddy?.shell?.showItemInFolder
+                            )}
+                            onOpenChange={(open) =>
+                              setMenuProjectKey(open ? project.key : null)
+                            }
+                            onTogglePin={() => togglePin(project.key)}
+                            onReveal={() => {
+                              if (!project.cwd) return;
+                              void window.freebuddy?.shell?.showItemInFolder(project.cwd);
+                            }}
+                            onDeleteAll={() => {
+                              void handleDeleteProject(project);
+                            }}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  {expanded && (
+                    <li className="conv-project-tasks" aria-label={project.label}>
+                      <ul>
+                        {visibleItems.length === 0 ? (
+                          <li className="conv-project-empty">{t("conversations.noTasks")}</li>
+                        ) : (
+                          visibleItems.map((conversation) => renderRow(conversation, true))
+                        )}
+                        {hiddenCount > 0 && (
+                          <li>
+                            <button
+                              type="button"
+                              className="conv-project-expand"
+                              onClick={() => showAllInProject(project.key)}
+                            >
+                              {t("conversations.showMore", { count: hiddenCount })}
+                            </button>
+                          </li>
+                        )}
+                      </ul>
+                    </li>
+                  )}
+                </Fragment>
+              );
+            })}
+
+            {recent.length > 0 && (
+              <>
+                <li className="conv-group-header recent" aria-hidden="true">
+                  <span>{t("conversations.recent")}</span>
+                </li>
+                {recent.map((conversation) => renderRow(conversation))}
+              </>
+            )}
+          </>
         )}
       </ul>
     </div>

--- a/src/components/CLI/conversationProjectGrouping.ts
+++ b/src/components/CLI/conversationProjectGrouping.ts
@@ -1,0 +1,78 @@
+import type { Conversation } from "@/services/cli/types";
+
+export const PROJECT_PREVIEW_LIMIT = 5;
+export const RECENT_LIMIT = 8;
+
+export type ConversationProjectGroup = {
+  key: string;
+  label: string;
+  cwd?: string;
+  items: Conversation[];
+  latestAt: number;
+};
+
+function conversationTimeValue(conversation: Conversation) {
+  return conversation.lastMessageAt ?? conversation.updatedAt ?? conversation.createdAt;
+}
+
+export function conversationActivityTime(conversation: Conversation): number {
+  const ts = Date.parse(conversationTimeValue(conversation));
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+/** Last path segment for sidebar project label. */
+export function projectLabelFromCwd(cwd: string): string {
+  const normalized = cwd.replace(/[\\/]+$/, "");
+  const parts = normalized.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] || cwd;
+}
+
+export function projectKeyFromCwd(cwd: string): string {
+  return cwd.replace(/[\\/]+$/, "").toLowerCase();
+}
+
+/**
+ * Group conversations that have a cwd into project folders, newest activity first.
+ * Conversations without cwd are omitted (they belong in Recent).
+ */
+export function groupConversationsByProject(
+  items: Conversation[]
+): ConversationProjectGroup[] {
+  const map = new Map<string, ConversationProjectGroup>();
+  for (const conversation of items) {
+    const cwd = conversation.cwd?.trim();
+    if (!cwd) continue;
+    const key = projectKeyFromCwd(cwd);
+    const existing = map.get(key);
+    const at = conversationActivityTime(conversation);
+    if (existing) {
+      existing.items.push(conversation);
+      if (at > existing.latestAt) existing.latestAt = at;
+      continue;
+    }
+    map.set(key, {
+      key,
+      label: projectLabelFromCwd(cwd),
+      cwd,
+      items: [conversation],
+      latestAt: at
+    });
+  }
+  const groups = Array.from(map.values());
+  for (const group of groups) {
+    group.items.sort((a, b) => conversationActivityTime(b) - conversationActivityTime(a));
+  }
+  groups.sort((a, b) => b.latestAt - a.latestAt || a.label.localeCompare(b.label));
+  return groups;
+}
+
+/** Flat recent list for conversations without a project cwd. */
+export function recentConversations(
+  items: Conversation[],
+  limit = RECENT_LIMIT
+): Conversation[] {
+  return items
+    .filter((conversation) => !conversation.cwd?.trim())
+    .sort((a, b) => conversationActivityTime(b) - conversationActivityTime(a))
+    .slice(0, limit);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -174,6 +174,14 @@
     "usage": "Usage",
     "allTeams": "All teams"
   },
+  "commandPalette": {
+    "open": "Search conversations",
+    "openShortcut": "Search conversations ⌘K",
+    "title": "Search conversations",
+    "commandMenu": "Command menu",
+    "placeholder": "Search by title, project, or agent…",
+    "recommended": "Recommended"
+  },
   "detail": {
     "expand": "Expand right panel",
     "collapse": "Collapse right panel"
@@ -329,6 +337,19 @@
   },
   "conversations": {
     "title": "Conversations",
+    "projects": "Projects",
+    "recent": "Recent",
+    "noTasks": "No tasks",
+    "showMore": "Show more · {{count}}",
+    "projectMenu": "Project actions",
+    "newInProject": "New task",
+    "pinProject": "Pin project",
+    "unpinProject": "Unpin project",
+    "pinned": "Pinned",
+    "revealProject": "Show in folder",
+    "deleteProjectConversations": "Delete all conversations",
+    "deleteProjectConfirm": "Delete {{count}} conversations in \"{{name}}\"? This cannot be undone.",
+    "newInCurrentProject": "New task in current project",
     "new": "+ New",
     "empty": "No conversations yet.",
     "deleteConfirm": "Delete \"{{title}}\"?",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -174,6 +174,14 @@
     "usage": "用量",
     "allTeams": "全部团队"
   },
+  "commandPalette": {
+    "open": "搜索对话",
+    "openShortcut": "搜索对话 ⌘K",
+    "title": "搜索对话",
+    "commandMenu": "命令菜单",
+    "placeholder": "输入标题、项目或 Agent…",
+    "recommended": "推荐"
+  },
   "detail": {
     "expand": "展开右侧栏",
     "collapse": "收起右侧栏"
@@ -329,6 +337,19 @@
   },
   "conversations": {
     "title": "对话",
+    "projects": "项目",
+    "recent": "最近",
+    "noTasks": "无任务",
+    "showMore": "展开显示 · {{count}}",
+    "projectMenu": "项目操作",
+    "newInProject": "新建任务",
+    "pinProject": "置顶项目",
+    "unpinProject": "取消置顶",
+    "pinned": "已置顶",
+    "revealProject": "打开所在文件夹",
+    "deleteProjectConversations": "删除全部会话",
+    "deleteProjectConfirm": "删除项目「{{name}}」下的 {{count}} 个会话？此操作不可撤销。",
+    "newInCurrentProject": "在当前项目新建",
     "new": "+ 新建",
     "empty": "暂无会话。",
     "deleteConfirm": "删除“{{title}}”?",

--- a/src/store/newTaskUiStore.ts
+++ b/src/store/newTaskUiStore.ts
@@ -5,17 +5,29 @@ export type NewTaskMode = "normal" | "team";
 interface NewTaskUiState {
   taskMode: NewTaskMode;
   requestedTeamId?: string;
+  /** Bumped whenever a new-task cwd should be applied (including clear). */
+  cwdRequestToken: number;
+  /** Absolute project cwd to prefill; undefined clears the field. */
+  requestedCwd?: string;
   setTaskMode(mode: NewTaskMode): void;
   setRequestedTeamId(teamId?: string): void;
+  requestNewTaskCwd(cwd?: string): void;
 }
 
 export const useNewTaskUiStore = create<NewTaskUiState>((set) => ({
   taskMode: "normal",
   requestedTeamId: undefined,
+  cwdRequestToken: 0,
+  requestedCwd: undefined,
   setTaskMode: (taskMode) =>
     set((state) => ({
       taskMode,
       requestedTeamId: taskMode === "normal" ? undefined : state.requestedTeamId
     })),
-  setRequestedTeamId: (requestedTeamId) => set({ requestedTeamId })
+  setRequestedTeamId: (requestedTeamId) => set({ requestedTeamId }),
+  requestNewTaskCwd: (cwd) =>
+    set((state) => ({
+      requestedCwd: cwd,
+      cwdRequestToken: state.cwdRequestToken + 1
+    }))
 }));

--- a/src/store/pinnedProjectsStore.ts
+++ b/src/store/pinnedProjectsStore.ts
@@ -1,0 +1,62 @@
+import { create } from "zustand";
+
+const STORAGE_KEY = "freebuddy.projects.pinned.v1";
+
+function loadPinnedKeys(): string[] {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((key): key is string => typeof key === "string" && key.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function persistPinnedKeys(keys: string[]) {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(keys));
+  } catch {
+    // Pin state is progressive enhancement.
+  }
+}
+
+interface PinnedProjectsState {
+  pinnedKeys: string[];
+  isPinned(key: string): boolean;
+  pin(key: string): void;
+  unpin(key: string): void;
+  toggle(key: string): void;
+}
+
+export const usePinnedProjectsStore = create<PinnedProjectsState>((set, get) => ({
+  pinnedKeys: loadPinnedKeys(),
+
+  isPinned(key) {
+    return get().pinnedKeys.includes(key);
+  },
+
+  pin(key) {
+    set((state) => {
+      if (state.pinnedKeys.includes(key)) return state;
+      const pinnedKeys = [key, ...state.pinnedKeys];
+      persistPinnedKeys(pinnedKeys);
+      return { pinnedKeys };
+    });
+  },
+
+  unpin(key) {
+    set((state) => {
+      if (!state.pinnedKeys.includes(key)) return state;
+      const pinnedKeys = state.pinnedKeys.filter((entry) => entry !== key);
+      persistPinnedKeys(pinnedKeys);
+      return { pinnedKeys };
+    });
+  },
+
+  toggle(key) {
+    if (get().isPinned(key)) get().unpin(key);
+    else get().pin(key);
+  }
+}));

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -467,6 +467,10 @@ declare global {
     onEvent(cb: (event: UpdaterEvent) => void): () => void;
   }
 
+  interface FreebuddyShell {
+    showItemInFolder(targetPath: string): Promise<boolean>;
+  }
+
   interface FreebuddyApi {
     platform: string;
     arch: string;
@@ -487,6 +491,7 @@ declare global {
     infoCards: FreebuddyInfoCards;
     window: FreebuddyWindow;
     updater: FreebuddyUpdater;
+    shell: FreebuddyShell;
   }
 
   interface Window {

--- a/styles.css
+++ b/styles.css
@@ -273,9 +273,8 @@ button {
 .sidebar-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 18px 16px 14px;
+  gap: 4px;
+  padding: 18px 12px 14px 16px;
   position: relative;
 }
 .electron-shell .sidebar-header {
@@ -363,6 +362,30 @@ button {
   align-items: center;
   gap: 10px;
   min-width: 0;
+  flex: 1;
+}
+
+.sidebar-search-button {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  color: var(--fb-text-secondary);
+  background: transparent;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.sidebar-search-button:hover {
+  background: var(--fb-hover);
+  color: var(--fb-text-primary);
+}
+
+.sidebar-search-button svg {
+  width: 16px;
+  height: 16px;
 }
 
 .sidebar-logo {
@@ -8970,7 +8993,7 @@ button {
   flex-direction: column;
   gap: 4px;
   min-height: 0;
-  padding: 6px 16px 12px;
+  padding: 2px 10px 12px;
 }
 
 .conv-list-header {
@@ -9073,11 +9096,282 @@ button {
 .conv-group-header {
   padding: 10px 6px 4px;
   color: var(--fb-text-tertiary);
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   user-select: none;
+}
+
+.conv-group-header.recent {
+  margin-top: 8px;
+}
+
+.conv-project-row {
+  list-style: none;
+  position: relative;
+}
+
+.conv-project-row-inner {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  min-width: 0;
+  border-radius: 8px;
+  transition: background-color 0.12s ease;
+}
+
+.conv-project-row-inner:hover,
+.conv-project-row.menu-open .conv-project-row-inner {
+  background: var(--fb-hover);
+}
+
+.conv-project-row.selected .conv-project-row-inner {
+  background: rgba(15, 23, 42, 0.05);
+}
+
+.conv-project-row.selected .conv-project-row-inner:hover,
+.conv-project-row.selected.menu-open .conv-project-row-inner {
+  background: rgba(15, 23, 42, 0.07);
+}
+
+[data-theme="dark"] .conv-project-row.selected .conv-project-row-inner {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+[data-theme="dark"] .conv-project-row.selected .conv-project-row-inner:hover,
+[data-theme="dark"] .conv-project-row.selected.menu-open .conv-project-row-inner {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.conv-project-toggle {
+  display: flex;
+  flex: 1;
+  width: auto;
+  min-width: 0;
+  min-height: 34px;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 6px 4px 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--fb-text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.conv-project-toggle:hover {
+  background: transparent;
+}
+
+.conv-project-folder {
+  flex: 0 0 auto;
+  color: var(--fb-text-tertiary);
+}
+
+.conv-project-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conv-project-trailing {
+  position: relative;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  align-self: stretch;
+  width: 0;
+  min-width: 0;
+  margin-right: 6px;
+  overflow: hidden;
+  transition: width 0.12s ease;
+}
+
+.conv-project-row.pinned:not(:hover):not(.menu-open) .conv-project-trailing {
+  width: 22px;
+  overflow: visible;
+}
+
+.conv-project-row:hover .conv-project-trailing,
+.conv-project-row.menu-open .conv-project-trailing {
+  width: 46px;
+  overflow: visible;
+}
+
+.conv-project-pin-slot {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 2px;
+  color: var(--fb-text-tertiary);
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.conv-project-pin {
+  flex: 0 0 auto;
+}
+
+.conv-project-actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.conv-project-row:hover .conv-project-pin-slot,
+.conv-project-row.menu-open .conv-project-pin-slot {
+  opacity: 0;
+}
+
+.conv-project-row:hover .conv-project-actions,
+.conv-project-row.menu-open .conv-project-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.conv-project-action-btn,
+.conv-project-more {
+  flex: 0 0 auto;
+}
+
+.conv-project-more {
+  position: relative;
+}
+
+.conv-project-action-btn {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fb-text-tertiary);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.conv-project-action-btn:hover,
+.conv-project-more.open > .conv-project-action-btn {
+  background: color-mix(in srgb, var(--fb-text-tertiary) 14%, transparent);
+  color: var(--fb-text-primary);
+}
+
+.conv-project-action-btn.new:hover {
+  color: var(--fb-brand);
+}
+
+.conv-project-count {
+  flex: 0 0 auto;
+  min-width: 1.1em;
+  margin-left: 2px;
+  padding: 0 4px;
+  color: var(--fb-text-tertiary);
+  font-size: 11px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.conv-project-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 30;
+  display: flex;
+  min-width: 168px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--fb-border-strong);
+  border-radius: 10px;
+  background: var(--fb-panel-bg);
+  box-shadow: var(--fb-shadow);
+}
+
+.conv-project-menu-item {
+  display: flex;
+  width: 100%;
+  min-height: 32px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--fb-text-primary);
+  font-size: 12.5px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+
+.conv-project-menu-item:hover {
+  background: var(--fb-hover);
+}
+
+.conv-project-menu-item.danger {
+  color: var(--fb-danger);
+}
+
+.conv-project-menu-item.danger:hover {
+  background: color-mix(in srgb, var(--fb-danger) 10%, transparent);
+}
+
+.conv-project-tasks {
+  list-style: none;
+  padding: 0 0 4px 4px;
+}
+
+.conv-project-tasks > ul {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow: visible;
+}
+
+.conv-project-empty {
+  padding: 2px 8px 8px 34px;
+  color: var(--fb-text-tertiary);
+  font-size: 12px;
+}
+
+.conv-project-expand {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  margin: 0 0 2px 18px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fb-text-tertiary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.conv-project-expand:hover {
+  background: var(--fb-hover);
+  color: var(--fb-text-secondary);
 }
 
 .conv-item {
@@ -9095,6 +9389,21 @@ button {
   transition: background-color 0.15s ease, box-shadow 0.15s ease,
     border-color 0.15s ease;
   margin-bottom: 0;
+}
+
+.conv-item.compact {
+  min-height: 34px;
+  gap: 9px;
+  padding: 4px 8px;
+}
+
+.conv-item.compact.active {
+  background: var(--fb-hover);
+}
+
+.conv-item.compact.active .conv-item-main strong {
+  color: var(--fb-text-primary);
+  font-weight: 600;
 }
 
 .conv-item-avatar {
@@ -9156,6 +9465,16 @@ button {
   line-height: 18px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.conv-item.compact .conv-item-title-row strong {
+  font-size: 13px;
+  color: var(--fb-text-primary);
+  font-weight: 400;
+}
+
+.conv-item.compact.active .conv-item-title-row strong {
+  font-weight: 600;
 }
 
 
@@ -9228,6 +9547,158 @@ button {
   .conv-item-running svg {
     animation: none;
   }
+}
+
+.command-palette-backdrop {
+  align-items: flex-start;
+  padding-top: min(18vh, 140px);
+  background: rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(4px) saturate(1.05);
+}
+
+.command-palette {
+  display: flex;
+  width: min(520px, calc(100vw - 32px));
+  max-height: min(72vh, 560px);
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--fb-border-strong);
+  border-radius: 14px;
+  background: var(--fb-panel-bg);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.2);
+  animation: slideUp 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.command-palette-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--fb-border);
+}
+
+.command-palette-head strong {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.command-palette-tag {
+  margin-left: auto;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--fb-panel-soft);
+  color: var(--fb-text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.command-palette-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 12px 6px;
+  padding: 0 12px;
+  border: 1px solid var(--fb-border);
+  border-radius: 10px;
+  background: var(--fb-sidebar-bg);
+  color: var(--fb-text-tertiary);
+}
+
+.command-palette-input-wrap input {
+  flex: 1;
+  min-width: 0;
+  height: 40px;
+  border: 0;
+  background: transparent;
+  color: var(--fb-text-primary);
+  font-size: 13px;
+  outline: none;
+}
+
+.command-palette-input-wrap input::placeholder {
+  color: var(--fb-text-tertiary);
+}
+
+.command-palette-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: 8px;
+}
+
+.command-palette-section {
+  padding: 4px 8px 8px;
+}
+
+.command-palette-section h5 {
+  margin: 0;
+  padding: 6px 8px;
+  color: var(--fb-text-tertiary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.command-palette-section ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.command-palette-actions {
+  border-top: 1px solid var(--fb-border);
+  margin-top: 2px;
+  padding-top: 8px;
+}
+
+.command-palette-empty {
+  margin: 0;
+  padding: 8px 10px 12px;
+  color: var(--fb-text-tertiary);
+  font-size: 13px;
+}
+
+.command-palette-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 36px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--fb-text-primary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.command-palette-row:hover,
+.command-palette-row.active {
+  background: var(--fb-panel-soft);
+}
+
+.command-palette-row-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-palette-row-meta {
+  color: var(--fb-text-tertiary);
+  font-size: 12px;
+}
+
+.command-palette-row kbd {
+  color: var(--fb-text-tertiary);
+  font-size: 12px;
+  font-family: inherit;
 }
 
 .icon-btn {

--- a/tests/conversation-project-grouping.test.mjs
+++ b/tests/conversation-project-grouping.test.mjs
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+async function loadGrouping() {
+  const source = fs.readFileSync(
+    new URL("../src/components/CLI/conversationProjectGrouping.ts", import.meta.url),
+    "utf8"
+  );
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(`data:text/javascript;base64,${Buffer.from(output).toString("base64")}`);
+}
+
+function conversation(partial) {
+  return {
+    id: partial.id,
+    title: partial.title ?? partial.id,
+    agentId: "agent",
+    agentName: "Agent",
+    adapter: "cli",
+    skillSnapshot: [],
+    archived: false,
+    createdAt: partial.createdAt ?? "2026-07-01T00:00:00.000Z",
+    updatedAt: partial.updatedAt ?? partial.lastMessageAt ?? "2026-07-01T00:00:00.000Z",
+    lastMessageAt: partial.lastMessageAt,
+    cwd: partial.cwd
+  };
+}
+
+test("groupConversationsByProject buckets by cwd basename and sorts by activity", async () => {
+  const {
+    groupConversationsByProject,
+    projectLabelFromCwd,
+    recentConversations
+  } = await loadGrouping();
+
+  assert.equal(projectLabelFromCwd("/Users/me/Documents/freebuddy/"), "freebuddy");
+  assert.equal(projectLabelFromCwd("C:\\\\work\\\\themes"), "themes");
+
+  const groups = groupConversationsByProject([
+    conversation({
+      id: "a",
+      title: "older freebuddy",
+      cwd: "/Users/me/Documents/freebuddy",
+      lastMessageAt: "2026-07-20T10:00:00.000Z"
+    }),
+    conversation({
+      id: "b",
+      title: "newer freebuddy",
+      cwd: "/Users/me/Documents/freebuddy/",
+      lastMessageAt: "2026-07-22T10:00:00.000Z"
+    }),
+    conversation({
+      id: "c",
+      title: "themes task",
+      cwd: "/Users/me/work/themes",
+      lastMessageAt: "2026-07-21T10:00:00.000Z"
+    }),
+    conversation({
+      id: "d",
+      title: "no cwd",
+      lastMessageAt: "2026-07-23T10:00:00.000Z"
+    })
+  ]);
+
+  assert.equal(groups.length, 2);
+  assert.equal(groups[0].label, "freebuddy");
+  assert.deepEqual(
+    groups[0].items.map((item) => item.id),
+    ["b", "a"]
+  );
+  assert.equal(groups[1].label, "themes");
+
+  const recent = recentConversations(
+    [
+      conversation({
+        id: "d",
+        lastMessageAt: "2026-07-23T10:00:00.000Z"
+      }),
+      conversation({
+        id: "b",
+        cwd: "/Users/me/Documents/freebuddy",
+        lastMessageAt: "2026-07-22T10:00:00.000Z"
+      }),
+      conversation({
+        id: "e",
+        lastMessageAt: "2026-07-21T12:00:00.000Z"
+      }),
+      conversation({
+        id: "c",
+        cwd: "/Users/me/work/themes",
+        lastMessageAt: "2026-07-21T10:00:00.000Z"
+      })
+    ],
+    2
+  );
+  assert.deepEqual(
+    recent.map((item) => item.id),
+    ["d", "e"]
+  );
+});

--- a/tests/sidebar-navigation.test.mjs
+++ b/tests/sidebar-navigation.test.mjs
@@ -65,10 +65,29 @@ test("sidebar navigation matches the flat primary reference hierarchy", () => {
   assert.match(css, /\.app-shell\.tool-page-mode\s*\{/);
 });
 
-test("conversation list keeps search available behind a compact section action", () => {
+test("sidebar search opens a command palette instead of an inline list filter", () => {
+  const app = read("../src/App.tsx");
   const conversations = read("../src/components/CLI/ConversationList.tsx");
-  assert.match(conversations, /conv-list-search-toggle/);
-  assert.match(conversations, /setSearchOpen/);
-  assert.match(conversations, /<AgentAvatar/);
-  assert.match(conversations, /className="conv-item-avatar"/);
+  const palette = read("../src/components/CLI/ConversationCommandPalette.tsx");
+  const css = read("../styles.css");
+  const en = JSON.parse(read("../src/locales/en.json"));
+  const zh = JSON.parse(read("../src/locales/zh-CN.json"));
+
+  assert.match(app, /sidebar-search-button/);
+  assert.match(app, /<ConversationCommandPalette/);
+  assert.match(app, /setCommandPaletteOpen/);
+  assert.match(app, /onNewTaskInProject=/);
+  assert.match(conversations, /conv-project-trailing/);
+  assert.match(conversations, /conv-project-action-btn/);
+  assert.match(conversations, /newInProject/);
+  assert.match(conversations, /conv-project-menu/);
+  assert.doesNotMatch(conversations, /conv-list-search-toggle/);
+  assert.match(css, /\.command-palette\s*\{/);
+  assert.match(css, /\.conv-project-toggle\s*\{/);
+  assert.match(css, /\.conv-project-trailing\s*\{/);
+  assert.ok(en.commandPalette?.title);
+  assert.ok(zh.commandPalette?.title);
+  assert.equal(zh.conversations.projects, "项目");
+  assert.equal(zh.conversations.recent, "最近");
+  assert.equal(zh.conversations.newInProject, "新建任务");
 });


### PR DESCRIPTION
## Summary
- 侧栏会话按项目（cwd）分组，支持置顶、项目内新建、打开文件夹与批量删除
- 「最近」仅展示未绑定项目的会话；项目内会话显示 Agent 图标
- 搜索改为顶栏图标 / ⌘K 打开命令面板

## Test plan
- [ ] 侧栏按项目折叠/展开正常，悬停出现 `+` / `⋯`
- [ ] 项目内新建会预填对应 cwd
- [ ] 「最近」不含已有 cwd 的会话
- [ ] ⌘K / 搜索图标可打开命令面板并跳转会话
- [ ] 置顶后项目排序靠前，刷新后仍保留


Made with [Cursor](https://cursor.com)