### PR TITLE
fix(opencode): 多文件夹项目放行 external_directory

### DIFF
--- a/docs/superpowers/plans/2026-07-28-opencode-workspace-roots-permission.md
+++ b/docs/superpowers/plans/2026-07-28-opencode-workspace-roots-permission.md
@@ -1,0 +1,380 @@
+# OpenCode Workspace Roots Permission Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When FreeBuddy starts OpenCode ACP for a multi-folder project, inject `OPENCODE_CONFIG_CONTENT.permission.external_directory` allows for every `workspaceRoots` path so OpenCode native tools no longer hang on silent internal `ask`.
+
+**Architecture:** Extend `buildCommand` for `opencode-acp` to merge a session-scoped permission block into the existing `OPENCODE_CONFIG_CONTENT` env (already used for model). Pass `CliRunArgs.workspaceRoots` from `runtime.ts` into `buildCommand`. No disk writes; other adapters unchanged.
+
+**Tech Stack:** TypeScript (Electron main), Node `path`, existing `buildCommand` / `node --test` suite (`tests/acp.test.mjs` imports `dist-electron`).
+
+**Spec:** `docs/superpowers/specs/2026-07-28-opencode-workspace-roots-permission-design.zh-CN.md`
+
+## Global Constraints
+
+- Only adapter `opencode-acp`.
+- Full allow (read + write + bash): `"${root}/**": "allow"` — no `edit: deny`.
+- Inject `permission` only when `workspaceRoots.length > 1` after filtering empties.
+- Do not write project `opencode.json`.
+- Do not change MCP registration; keep `freebuddy-workspace-fs` as-is.
+- Paths outside project folders stay on OpenCode defaults.
+- Merge with existing `model` in the same `OPENCODE_CONFIG_CONTENT` JSON object.
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `electron/cli/adapters.ts` | `BuildCommandInput.workspaceRoots`; helper to build OpenCode config content; `opencode-acp` case |
+| `electron/cli/runtime.ts` | Pass `args.workspaceRoots` into `buildCommand` |
+| `tests/acp.test.mjs` | Unit tests for single-root / multi-root / model+permission merge / trailing slash |
+
+Out of scope for this plan: `sessionConfigProbe.ts` / `acpAuth.ts` (no conversation `workspaceRoots` today; config probe and auth login do not need multi-root allow).
+
+---
+
+### Task 1: buildCommand injects external_directory allows
+
+**Files:**
+- Modify: `electron/cli/adapters.ts`
+- Test: `tests/acp.test.mjs`
+
+**Interfaces:**
+- Consumes: `BuildCommandInput` (extend with `workspaceRoots?: string[]`)
+- Produces:
+  - `export function buildOpenCodeConfigContent(input: { model?: string; workspaceRoots?: string[] }): Record<string, unknown> | undefined`
+  - `buildCommand` for `opencode-acp` sets `env.OPENCODE_CONFIG_CONTENT` when the helper returns a non-empty object
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/acp.test.mjs` (keep existing OpenCode model tests unchanged):
+
+```js
+test("buildCommand omits OpenCode permission for single workspace root", () => {
+  const built = buildCommand({
+    adapter: "opencode-acp",
+    prompt: "hello",
+    cwd: "/tmp/primary",
+    workspaceRoots: ["/tmp/primary"]
+  });
+  assert.equal(built.env, undefined);
+});
+
+test("buildCommand injects OpenCode external_directory allows for multi-root projects", () => {
+  const built = buildCommand({
+    adapter: "opencode-acp",
+    prompt: "hello",
+    cwd: "/tmp/primary",
+    workspaceRoots: ["/tmp/primary/", "/tmp/secondary", ""]
+  });
+  const content = JSON.parse(built.env.OPENCODE_CONFIG_CONTENT);
+  assert.deepEqual(content.permission.external_directory, {
+    "/tmp/primary/**": "allow",
+    "/tmp/secondary/**": "allow"
+  });
+  assert.equal(content.model, undefined);
+});
+
+test("buildCommand merges OpenCode model with multi-root permission", () => {
+  const built = buildCommand({
+    adapter: "opencode-acp",
+    prompt: "hello",
+    cwd: "/tmp/primary",
+    extraArgs: ["-m", "openai/gpt-4.1"],
+    workspaceRoots: ["/tmp/primary", "/tmp/secondary"]
+  });
+  assert.deepEqual(JSON.parse(built.env.OPENCODE_CONFIG_CONTENT), {
+    model: "openai/gpt-4.1",
+    permission: {
+      external_directory: {
+        "/tmp/primary/**": "allow",
+        "/tmp/secondary/**": "allow"
+      }
+    }
+  });
+});
+```
+
+Note: on Windows CI, `path.resolve` may change separators. Prefer asserting with `path.resolve` in the test expected keys so Darwin/Linux/Windows agree:
+
+```js
+import path from "node:path";
+
+function allowPattern(root) {
+  return `${path.resolve(root).replace(/[/\\]+$/, "")}${path.sep === "\\" ? "\\\\**" : "/**"}`;
+}
+```
+
+Prefer generating expected keys the same way as production: export `buildOpenCodeConfigContent` and assert on its output using `path.resolve` + `/**` with forward slashes if the helper always emits POSIX-style patterns (OpenCode docs use `/`). **Implementation choice (lock in code):** normalize with `path.resolve`, strip trailing separators, then always emit `"${abs}/**"` using forward slashes by replacing `\` → `/` on the absolute path before appending `/**`. That matches OpenCode docs and keeps tests OS-stable when written with forward-slash expectations after resolving on the current OS — actually on Windows resolve yields `C:\...`. Safer: in tests, build expected via the same exported helper for path list only, or compare `Object.keys(content.permission.external_directory).length === 2` and every value `"allow"` and every key endsWith `/**`.
+
+Use this assertion style (OS-stable):
+
+```js
+test("buildCommand injects OpenCode external_directory allows for multi-root projects", () => {
+  const built = buildCommand({
+    adapter: "opencode-acp",
+    prompt: "hello",
+    cwd: "/tmp/primary",
+    workspaceRoots: ["/tmp/primary/", "/tmp/secondary", ""]
+  });
+  const content = JSON.parse(built.env.OPENCODE_CONFIG_CONTENT);
+  const rules = content.permission.external_directory;
+  assert.equal(Object.keys(rules).length, 2);
+  for (const [pattern, action] of Object.entries(rules)) {
+    assert.equal(action, "allow");
+    assert.match(pattern, /\/\*\*$/);
+  }
+  assert.ok(Object.keys(rules).some((k) => k.includes("primary")));
+  assert.ok(Object.keys(rules).some((k) => k.includes("secondary")));
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run build:electron && node --test --test-force-exit tests/acp.test.mjs
+```
+
+Expected: new tests FAIL (e.g. `built.env` undefined, or `workspaceRoots` ignored).
+
+- [ ] **Step 3: Implement helpers + opencode-acp branch**
+
+In `electron/cli/adapters.ts`:
+
+1. Add at top: `import path from "node:path";` (if not already present).
+
+2. Extend interface:
+
+```ts
+export interface BuildCommandInput {
+  adapter: string;
+  binary?: string;
+  prompt: string;
+  extraArgs?: string[];
+  cwd?: string;
+  toolSessionId?: string;
+  /** Absolute multi-folder project roots; OpenCode gets external_directory allows when length > 1. */
+  workspaceRoots?: string[];
+}
+```
+
+3. Add exported helper (place near `buildCommand`):
+
+```ts
+/** Build OpenCode OPENCODE_CONFIG_CONTENT object (model + multi-root permission). */
+export function buildOpenCodeConfigContent(input: {
+  model?: string;
+  workspaceRoots?: string[];
+}): Record<string, unknown> | undefined {
+  const content: Record<string, unknown> = {};
+  if (input.model) {
+    content.model = input.model;
+  }
+
+  const roots = (input.workspaceRoots ?? [])
+    .map((raw) => {
+      if (typeof raw !== "string") return "";
+      const trimmed = raw.trim();
+      if (!trimmed) return "";
+      try {
+        return path.resolve(trimmed).replace(/[/\\]+$/, "");
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+
+  const uniqueRoots = [...new Set(roots)];
+  if (uniqueRoots.length > 1) {
+    const externalDirectory: Record<string, "allow"> = {};
+    for (const root of uniqueRoots) {
+      const pattern = `${root.replace(/\\/g, "/")}/**`;
+      externalDirectory[pattern] = "allow";
+    }
+    content.permission = { external_directory: externalDirectory };
+  }
+
+  return Object.keys(content).length > 0 ? content : undefined;
+}
+```
+
+4. Replace the `opencode-acp` case body env construction:
+
+```ts
+case "opencode-acp": {
+  const { model, args: acpArgs } = splitModelArg(extra);
+  const args: string[] = ["acp"];
+  if (input.cwd) args.push("--cwd", input.cwd);
+  args.push(...acpArgs);
+  const configContent = buildOpenCodeConfigContent({
+    model,
+    workspaceRoots: input.workspaceRoots
+  });
+  return {
+    bin,
+    args,
+    ...(configContent
+      ? { env: { OPENCODE_CONFIG_CONTENT: JSON.stringify(configContent) } }
+      : {}),
+    promptViaStdin: false,
+    protocol: "acp"
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npm run build:electron && node --test --test-force-exit tests/acp.test.mjs
+```
+
+Expected: all tests in the file PASS, including the three new ones and existing OpenCode model tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/cli/adapters.ts tests/acp.test.mjs
+git commit -m "$(cat <<'EOF'
+feat(opencode): allow multi-folder workspace roots via config inject
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Pass workspaceRoots from cliRun into buildCommand
+
+**Files:**
+- Modify: `electron/cli/runtime.ts` (the `buildCommand({...})` call ~lines 207–214)
+- Test: reuse `tests/acp.test.mjs` (already covers buildCommand); add a thin wiring assertion only if an existing runtime test harness mocks `buildCommand` — otherwise verify by reading the call site and running full electron test build. Prefer a small unit test that imports nothing heavy: grep-based contract test is already used elsewhere (`tests/acp-runtime-contract.test.mjs` style).
+
+**Interfaces:**
+- Consumes: `CliRunArgs.workspaceRoots` (already on `runtimeShared.ts`)
+- Produces: `buildCommand` receives `workspaceRoots: args.workspaceRoots`
+
+- [ ] **Step 1: Write the failing contract test**
+
+Create or extend a lightweight test. Prefer adding to `tests/acp.test.mjs` is not enough for wiring — add to `tests/acp-runtime-contract.test.mjs` if it already greps `runtime.ts`, or create assertion in an existing file that reads source:
+
+Check whether `tests/acp-runtime-contract.test.mjs` exists and pattern-matches. If yes, add:
+
+```js
+test("cliRun passes workspaceRoots into buildCommand", () => {
+  const src = fs.readFileSync(
+    new URL("../electron/cli/runtime.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(src, /workspaceRoots:\s*args\.workspaceRoots/);
+});
+```
+
+If that file is unsuitable, add the same test at the bottom of `tests/acp.test.mjs` with `fs` + `assert.match` on `runtime.ts` source (same pattern as other contract tests in the repo).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm run build:electron && node --test --test-force-exit tests/acp.test.mjs
+```
+
+(or the contract file you edited)
+
+Expected: FAIL — `workspaceRoots: args.workspaceRoots` not present.
+
+- [ ] **Step 3: Wire runtime.ts**
+
+Change the `buildCommand` call in `electron/cli/runtime.ts` to:
+
+```ts
+    built = buildCommand({
+      adapter: args.adapter,
+      binary: args.binary,
+      prompt: effectiveArgs.prompt,
+      extraArgs: args.extraArgs,
+      cwd: args.cwd,
+      toolSessionId,
+      workspaceRoots: args.workspaceRoots
+    });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm run build:electron && node --test --test-force-exit tests/acp.test.mjs
+```
+
+Expected: PASS (including contract test). Optionally also run:
+
+```bash
+node --test --test-force-exit tests/acp-runtime-contract.test.mjs
+```
+
+if that file was modified.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/cli/runtime.ts tests/acp.test.mjs tests/acp-runtime-contract.test.mjs
+git commit -m "$(cat <<'EOF'
+fix(runtime): pass workspaceRoots into OpenCode buildCommand
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Spec amendment note + manual checklist
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-27-multi-folder-projects-design.zh-CN.md` (short amendment pointer only)
+
+- [ ] **Step 1: Add a one-paragraph amendment**
+
+Near the product decision that said「不按 CLI Adapter 做原生 multi-root 特例」, append:
+
+```markdown
+> **修订（2026-07-28）：** OpenCode 例外 — 见 `2026-07-28-opencode-workspace-roots-permission-design.zh-CN.md`。多根项目启动 `opencode-acp` 时通过 `OPENCODE_CONFIG_CONTENT` 注入 `permission.external_directory` allow；其它 adapter 仍仅依赖 MCP。
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-27-multi-folder-projects-design.zh-CN.md
+git commit -m "$(cat <<'EOF'
+docs: note OpenCode multi-root permission exception in projects spec
+
+EOF
+)"
+```
+
+- [ ] **Step 3: Manual verification checklist (do not automate)**
+
+1. Open FreeBuddy project `51caiji` (folders: primary + `exadmin` + WeChat mini program).
+2. Start a new OpenCode turn that explores a secondary root (e.g. list files under `exadmin`).
+3. Confirm `~/.local/share/opencode/log/opencode.log` shows `external_directory` with `action=allow` for that path (not `asking`).
+4. Confirm the session does not leave task tools stuck in「等待中」for mounted roots.
+5. Confirm a path **outside** folders (if tested) still asks / is not auto-allowed by FreeBuddy injection.
+
+---
+
+## Spec coverage self-review
+
+| Spec requirement | Task |
+|------------------|------|
+| Inject via `OPENCODE_CONFIG_CONTENT` | Task 1 |
+| Full allow `root/**` | Task 1 |
+| Only `opencode-acp` | Task 1 |
+| Multi-root only (`length > 1`) | Task 1 |
+| Merge with model | Task 1 |
+| Pass `workspaceRoots` from run path | Task 2 |
+| No disk `opencode.json` | (no task writes disk) |
+| Amend multi-folder design note | Task 3 |
+| Manual acceptance | Task 3 Step 3 |
+
+No TBD placeholders. Helper and `buildCommand` signatures are consistent across tasks.

--- a/docs/superpowers/plans/2026-07-28-project-form-delete-button-style.md
+++ b/docs/superpowers/plans/2026-07-28-project-form-delete-button-style.md
@@ -1,0 +1,108 @@
+# Project Form Delete Button Style Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Soften the Edit Project modal’s “Delete project” control into a muted text link so it no longer competes with Save.
+
+**Architecture:** Keep footer layout. Remove the shared `.danger` class from the delete button and restyle `.project-form-delete` as a borderless muted link that turns danger-colored on hover/focus.
+
+**Tech Stack:** React (`ProjectFormModal.tsx`), global `styles.css`, existing CSS variables (`--fb-text-secondary`, `--fb-danger`).
+
+## Global Constraints
+
+- Layout unchanged: delete left, cancel/save right.
+- No i18n / copy changes.
+- Keep `window.confirm` delete flow.
+- Do not change source-folder UI or create-mode footer.
+- Do not commit unless the user explicitly asks.
+
+---
+
+### Task 1: Soften delete button styles
+
+**Files:**
+- Modify: `src/components/CLI/ProjectFormModal.tsx` (delete button `className`)
+- Modify: `styles.css` (`.project-form-delete` rules near existing `project-form-actions`)
+
+**Interfaces:**
+- Consumes: existing `handleDelete`, `saving`, `t("conversations.deleteProject")`
+- Produces: visual-only change; no new props/APIs
+
+- [x] **Step 1: Remove `danger` from the delete button classList**
+
+In `src/components/CLI/ProjectFormModal.tsx`, change:
+
+```tsx
+<button
+  type="button"
+  className="project-form-delete"
+  onClick={() => void handleDelete()}
+  disabled={saving}
+>
+  {t("conversations.deleteProject")}
+</button>
+```
+
+(Previously `className="danger project-form-delete"`.)
+
+- [x] **Step 2: Restyle `.project-form-delete` as a muted text link**
+
+Replace/extend the existing block in `styles.css`:
+
+```css
+.project-form-delete {
+  margin-right: auto;
+  padding: 8px 4px;
+  border: none;
+  background: transparent;
+  color: var(--fb-text-secondary);
+  font-size: 13px;
+  font-weight: 550;
+  cursor: pointer;
+  box-shadow: none;
+}
+
+.project-form-delete:hover:not(:disabled),
+.project-form-delete:focus-visible:not(:disabled) {
+  color: var(--fb-danger);
+  background: transparent;
+}
+
+.project-form-delete:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+```
+
+- [x] **Step 3: Manual verify**
+
+1. Open Edit Project on a multi-folder project.
+2. Confirm delete is muted text (no red border/fill at rest).
+3. Hover/focus → text turns danger red.
+4. Click → confirm dialog still appears; Cancel leaves modal open.
+5. Cancel/Save look unchanged; create-project modal has no delete control.
+
+- [ ] **Step 4: Commit only if user requests**
+
+Do not commit by default. If asked:
+
+```bash
+git add src/components/CLI/ProjectFormModal.tsx styles.css
+git commit -m "$(cat <<'EOF'
+style(projects): soften delete project control as text link
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage
+
+| Spec requirement | Task |
+|------------------|------|
+| Remove danger chrome / muted default | Task 1 Steps 1–2 |
+| Hover danger color | Task 1 Step 2 |
+| Cancel/Save unchanged | Task 1 (no edits to those controls) |
+| Layout + confirm unchanged | Task 1 (DOM/handlers untouched) |
+| Dark theme readable | Uses `--fb-text-secondary` / `--fb-danger` |

--- a/docs/superpowers/specs/2026-07-27-multi-folder-projects-design.zh-CN.md
+++ b/docs/superpowers/specs/2026-07-27-multi-folder-projects-design.zh-CN.md
@@ -15,6 +15,9 @@
 - 不与 `remote.workspaceRoots` 双向同步（远程沙箱白名单与侧栏项目隔离）。
 - 不向 prompt / 系统上下文注入文件夹列表来「告知」Agent。
 - 不按 CLI Adapter 做原生 multi-root 特例配置。
+
+> **修订（2026-07-28）：** OpenCode 例外 — 见 `2026-07-28-opencode-workspace-roots-permission-design.zh-CN.md`。多根项目启动 `opencode-acp` 时通过 `OPENCODE_CONFIG_CONTENT` 注入 `permission.external_directory` allow；其它 adapter 仍仅依赖 MCP。
+
 - 不在第一版改 Draft / Browser 等现有单 cwd MCP 的多根语义。
 
 ## 背景与现状

--- a/docs/superpowers/specs/2026-07-28-opencode-workspace-roots-permission-design.zh-CN.md
+++ b/docs/superpowers/specs/2026-07-28-opencode-workspace-roots-permission-design.zh-CN.md
@@ -1,0 +1,122 @@
+# OpenCode 多挂载目录权限放行设计
+
+## 目标
+
+当 FreeBuddy 多文件夹项目挂载了多个本地目录时，启动 **OpenCode ACP** 后，OpenCode 原生工具（`read` / `edit` / `glob` / `grep` / `bash` 等）访问这些挂载目录 **不再触发** `external_directory` 的 `ask`，从而避免子 agent 在内部等待审批、ACP 又不透出请求导致的会话永久卡住。
+
+用户心智：
+
+> 项目里挂上的目录，对 OpenCode 就是工作区的一部分（可读可写），不该再弹「外部目录」审批，更不该静默挂死。
+
+## 非目标
+
+- 不改 Qoder / Cursor / CodeBuddy / Codex 等其它 adapter（它们 ACP `session/request_permission` 链路已可用）。
+- 不写入用户仓库的 `opencode.json` / `.opencode/`（避免污染 git）。
+- 不做「卡住看门狗 / 假权限弹窗」止血方案（可另开 B 方案）。
+- 不放行 **项目 folders 以外** 的路径（例如未挂载的 `ex-mfe` 仍按 OpenCode 默认 `ask`）。
+- 不把多根变成 ACP 协议级多 `cwd`（协议仍只传 Primary）。
+
+## 背景与根因
+
+多文件夹项目（见 `2026-07-27-multi-folder-projects-design.zh-CN.md`）已实现：
+
+- SQLite `projects.folders` + `primaryPath`
+- 运行时 `CliRunArgs.workspaceRoots`
+- 多根时注册 `freebuddy-workspace-fs` MCP
+
+但 ACP `session/new|resume|load` 只能传 **单个** `cwd`（Primary）。OpenCode 以该 cwd 为工作区边界；访问其它绝对路径会走 `external_directory`（默认 `ask`）。
+
+实测（2026-07-27 过夜卡住会话 `FUL4VeoBTh7AKEZeyngkB`）：
+
+1. 主 agent 并行派 5 个 explore 子任务；2 个在 Primary 内完成，3 个访问挂载仓后进入内部 `asking`。
+2. OpenCode 进程日志有 `external_directory` ask，但 **ACP stdout 从未出现** `session/request_permission`。
+3. FreeBuddy 对 stdout **先 `appendLog` 再解析**；同机其它 OpenCode 会话若发出 `request_permission` 可正常 auto-approve。故结论是 **OpenCode 子 agent 路径未桥接 ACP**，不是 FreeBuddy 漏识别。
+4. 第一版「仅靠 MCP 文件桥」无法约束 OpenCode 原生工具，因此需要 **Adapter 特例**：启动时向 OpenCode 注入挂载目录放行规则。
+
+这修正了多文件夹设计中「不按 CLI Adapter 做原生 multi-root 特例」的决策，**仅针对 OpenCode**。
+
+## 产品决策（已确认）
+
+| 决策点 | 选择 |
+|--------|------|
+| 修法 | 根因：挂载目录对 OpenCode 不再算外部 |
+| 注入方式 | 启动时 `OPENCODE_CONFIG_CONTENT`（会话级，不写盘） |
+| 权限强度 | **完全放行**（读 + 写 + bash，与 Primary 同权） |
+| 作用范围 | 仅 `opencode-acp` |
+| 单根项目 | 不注入 `permission`（行为与今日一致） |
+| 未挂载路径 | 仍走 OpenCode 默认（通常 `ask`） |
+
+## 架构
+
+### 配置注入
+
+OpenCode 配置优先级中，`OPENCODE_CONFIG_CONTENT` 为运行时覆盖层（见 [OpenCode Config](https://opencode.ai/docs/config/)）。FreeBuddy 已用该 env 注入 `model`；本设计在同一 JSON 上合并 `permission`。
+
+```
+Project.folders
+  → resolveWorkspaceRootsForConversation
+  → CliRunArgs.workspaceRoots
+  → buildCommand({ adapter: "opencode-acp", cwd, workspaceRoots, … })
+  → env.OPENCODE_CONFIG_CONTENT = {
+      ...(model ? { model } : {}),
+      ...(multiRoot ? {
+        permission: {
+          external_directory: {
+            "<absRoot1>/**": "allow",
+            "<absRoot2>/**": "allow",
+            …
+          }
+        }
+      } : {})
+    }
+```
+
+OpenCode 文档约定：`permission.external_directory` 可用路径 glob；允许后该目录继承工作区默认工具策略（读默认可、编辑默认可，除非另有 deny）。本设计 **不** 额外加 `edit: deny`。
+
+### 路径规则
+
+1. 对 `workspaceRoots` 中每个非空字符串：`path.resolve` 后规范化。
+2. 生成 pattern：`"${resolvedRoot}/**"`（去掉尾部多余 `/` 再拼 `/**`）。
+3. Primary / 非 Primary **全部**写入（含 Primary 幂等，简化逻辑）。
+4. `workspaceRoots.length <= 1`：**不**写入 `permission` 键。
+5. 与已有 `model` 字段浅合并：同一 `OPENCODE_CONFIG_CONTENT` 对象内同时可有 `model` 与 `permission`。
+
+### 调用链改动
+
+| 位置 | 改动 |
+|------|------|
+| `BuildCommandInput` | 增加可选 `workspaceRoots?: string[]` |
+| `adapters.ts` → `opencode-acp` | 按上表构建 / 合并 `OPENCODE_CONFIG_CONTENT` |
+| `runtime.ts`（及凡调用 `buildCommand` 且已有 `CliRunArgs.workspaceRoots` 处） | 传入 `workspaceRoots` |
+| `sessionConfigProbe.ts` 等探测路径 | 若探测也 spawn OpenCode，同样传入，避免探测与真跑不一致 |
+
+不改 UI；不改 `projects` 表结构；不改 MCP 注册策略（多根仍注册 `freebuddy-workspace-fs`，作为补充而非本修复依赖）。
+
+## 错误处理与边界
+
+- `workspaceRoots` 缺省或空：等同单 cwd 行为。
+- 非法 / 无法 resolve 的条目：跳过该条，不让整个 spawn 失败。
+- 用户全局 `~/.config/opencode/opencode.json` 若已有更严的 `external_directory`：按 OpenCode 合并规则，后加载的 `OPENCODE_CONFIG_CONTENT` 应能覆盖冲突键；实现后用实测确认「Content 层 allow」优先生效。若实测相反，改为 `OPENCODE_CONFIG` 临时文件或调整合并策略（实现计划里验证）。
+- 子 agent 继承同一 OpenCode 进程配置：一次注入覆盖主会话与 task 子会话。
+
+## 测试
+
+- 单元：`buildCommand("opencode-acp")`
+  - 单根 / 无 roots → env 无 `permission`
+  - 多根 → `external_directory` 含每个 `root/**` 且为 `"allow"`
+  - 同时有 model → JSON 同时含 `model` 与 `permission`
+  - 路径带尾斜杠 → 规范化后 pattern 正确
+- 回归：现有 opencode-acp model 注入测试仍通过。
+- 手工：`51caiji` 项目（folders 含 `exadmin` + 微信小程序目录）再跑跨仓探索；OpenCode 日志对挂载路径应为 `action=allow`，会话不应因 `external_directory` 永久 `等待中`。
+
+## 验收标准
+
+1. 多文件夹项目启动 OpenCode 时，进程环境含合并后的 `OPENCODE_CONFIG_CONTENT.permission.external_directory`。
+2. 访问任一项目 folder 下路径不再因 `external_directory` 进入无 ACP 透出的内部 ask。
+3. 单文件夹项目行为与改前一致。
+4. 未挂载目录仍可被 OpenCode 按默认策略拦截（不扩大到整个家目录）。
+
+## 与既有设计的关系
+
+- **补充** `2026-07-27-multi-folder-projects-design.zh-CN.md`：MCP 文件桥保留；OpenCode 额外需要原生权限注入才能让「项目内多根可读写」在 OpenCode 上成立。
+- **不替代** 未来若 OpenCode / ACP 支持真正多 root workspace 的上游修复；届时可删除或收窄本特例。

--- a/docs/superpowers/specs/2026-07-28-project-form-delete-button-style-design.zh-CN.md
+++ b/docs/superpowers/specs/2026-07-28-project-form-delete-button-style-design.zh-CN.md
@@ -1,0 +1,41 @@
+# 编辑项目弹窗：底部按钮统一样式
+
+日期：2026-07-28  
+状态：已定稿（实现中修订）
+
+## 背景
+
+`ProjectFormModal` 底部「删除 / 取消 / 保存」布局正确，但视觉不齐：删除偏抢眼，取消与保存尺寸/圆角不统一。初版曾尝试把删除改成文字链，已否决——**须保持按钮外形**。
+
+## 目标
+
+- 三个底部控件保持**同高、同圆角、同字号**的按钮形状。
+- 删除仍为 danger 语义（浅红底 + 淡红边），但不做成文字链。
+- 取消为次要描边按钮；保存保持现有 primary 青绿。
+- 布局、文案、confirm 流程不变。
+
+## 非目标
+
+- 不改源文件夹列表与「设为 Primary」。
+- 不改其它 modal 的全局 `.modal-actions`（仅作用域 `.project-form-actions`）。
+
+## 设计
+
+### 结构
+
+DOM 不变：删除保留 `className="danger project-form-delete"`；取消无额外语义 class；保存 `primary`。
+
+### 样式（作用域 `.project-form-actions`）
+
+| 控件 | 外形 | 颜色 |
+|------|------|------|
+| 共用 | `min-height: 34px`、`padding: 0 14px`、`border-radius: 8px`、`font-size: 13px` | — |
+| 取消 | 描边按钮 | `border-strong` + `panel-soft` / hover `fb-hover` |
+| 删除 | 同尺寸描边按钮 | `fb-danger` 淡底淡边（`color-mix`） |
+| 保存 | 同尺寸实心 | 现有 `primary` 渐变，对齐高度与 padding |
+
+## 验收
+
+- 删除仍是圆角矩形按钮，不是文字链。
+- 三钮高度/圆角视觉一致。
+- confirm 与创建模式行为不变。

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 export type CLIAdapterId =
   | "codex"
   | "codex-acp"
@@ -262,6 +264,8 @@ export interface BuildCommandInput {
   extraArgs?: string[];
   cwd?: string;
   toolSessionId?: string;
+  /** Absolute multi-folder project roots; OpenCode gets external_directory allows when length > 1. */
+  workspaceRoots?: string[];
 }
 
 export interface BuiltCommand {
@@ -392,6 +396,42 @@ function splitModelArg(args: string[]): {
   return { model, args: rest };
 }
 
+/** Build OpenCode OPENCODE_CONFIG_CONTENT object (model + multi-root permission). */
+export function buildOpenCodeConfigContent(input: {
+  model?: string;
+  workspaceRoots?: string[];
+}): Record<string, unknown> | undefined {
+  const content: Record<string, unknown> = {};
+  if (input.model) {
+    content.model = input.model;
+  }
+
+  const roots = (input.workspaceRoots ?? [])
+    .map((raw) => {
+      if (typeof raw !== "string") return "";
+      const trimmed = raw.trim();
+      if (!trimmed) return "";
+      try {
+        return path.resolve(trimmed).replace(/[/\\]+$/, "");
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+
+  const uniqueRoots = [...new Set(roots)];
+  if (uniqueRoots.length > 1) {
+    const externalDirectory: Record<string, "allow"> = {};
+    for (const root of uniqueRoots) {
+      const pattern = `${root.replace(/\\/g, "/")}/**`;
+      externalDirectory[pattern] = "allow";
+    }
+    content.permission = { external_directory: externalDirectory };
+  }
+
+  return Object.keys(content).length > 0 ? content : undefined;
+}
+
 /**
  * Per-adapter command construction. The result is fed straight to spawn().
  * Stream parsing happens in the renderer; here we only assemble argv that
@@ -440,11 +480,15 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
       const args: string[] = ["acp"];
       if (input.cwd) args.push("--cwd", input.cwd);
       args.push(...acpArgs);
+      const configContent = buildOpenCodeConfigContent({
+        model,
+        workspaceRoots: input.workspaceRoots
+      });
       return {
         bin,
         args,
-        ...(model
-          ? { env: { OPENCODE_CONFIG_CONTENT: JSON.stringify({ model }) } }
+        ...(configContent
+          ? { env: { OPENCODE_CONFIG_CONTENT: JSON.stringify(configContent) } }
           : {}),
         promptViaStdin: false,
         protocol: "acp"

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -210,7 +210,8 @@ export async function cliRun(
       prompt: effectiveArgs.prompt,
       extraArgs: args.extraArgs,
       cwd: args.cwd,
-      toolSessionId
+      toolSessionId,
+      workspaceRoots: args.workspaceRoots
     });
   } catch (e) {
     const msg = `build command failed: ${(e as Error)?.message || e}`;

--- a/styles.css
+++ b/styles.css
@@ -10322,8 +10322,55 @@ button {
   margin-left: auto;
 }
 
-.project-form-delete {
+.project-form-actions button {
+  min-height: 34px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.project-form-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.project-form-actions button:not(.primary):not(.danger) {
+  border: 1px solid var(--fb-border-strong);
+  background: var(--fb-panel-soft);
+  color: var(--fb-text-secondary);
+}
+
+.project-form-actions button:not(.primary):not(.danger):hover:not(:disabled) {
+  color: var(--fb-text-primary);
+  background: var(--fb-hover);
+}
+
+.project-form-actions .danger {
   margin-right: auto;
+  border: 1px solid color-mix(in srgb, var(--fb-danger) 30%, var(--fb-border));
+  background: color-mix(in srgb, var(--fb-danger) 8%, var(--fb-panel-bg));
+  color: var(--fb-danger);
+  box-shadow: none;
+}
+
+.project-form-actions .danger:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--fb-danger) 48%, var(--fb-border));
+  background: color-mix(in srgb, var(--fb-danger) 12%, var(--fb-panel-bg));
+}
+
+.project-form-actions .primary {
+  min-height: 34px;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .conv-item {

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -10,6 +10,10 @@ const ipcSource = fs.readFileSync(
   new URL("../electron/cli/ipc.ts", import.meta.url),
   "utf8"
 );
+const runtimeSource = fs.readFileSync(
+  new URL("../electron/cli/runtime.ts", import.meta.url),
+  "utf8"
+);
 
 test("ACP runtime finalizes successful prompt turns without waiting for process exit", () => {
   const promptIndex = acpRuntimeSource.indexOf("await runPromptOnSession();");
@@ -46,6 +50,10 @@ test("acpRuntime registers workspace FS MCP only for multi-root", () => {
   assert.match(acpRuntimeSource, /unregisterWorkspaceFsToolSession/);
   assert.match(acpRuntimeSource, /workspaceRoots/);
   assert.match(acpRuntimeSource, /roots\.length\s*>\s*1/);
+});
+
+test("cliRun passes workspaceRoots into buildCommand", () => {
+  assert.match(runtimeSource, /workspaceRoots:\s*args\.workspaceRoots/);
 });
 
 test("cli:run always overwrites renderer workspaceRoots with authoritative resolution", () => {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -43,6 +43,53 @@ test("buildCommand starts OpenCode through its ACP server", () => {
   assert.equal(built.protocol, "acp");
 });
 
+test("buildCommand omits OpenCode permission for single workspace root", () => {
+  const built = buildCommand({
+    adapter: "opencode-acp",
+    prompt: "hello",
+    cwd: "/tmp/primary",
+    workspaceRoots: ["/tmp/primary"]
+  });
+  assert.equal(built.env, undefined);
+});
+
+test("buildCommand injects OpenCode external_directory allows for multi-root projects", () => {
+  const built = buildCommand({
+    adapter: "opencode-acp",
+    prompt: "hello",
+    cwd: "/tmp/primary",
+    workspaceRoots: ["/tmp/primary/", "/tmp/secondary", ""]
+  });
+  const content = JSON.parse(built.env.OPENCODE_CONFIG_CONTENT);
+  const rules = content.permission.external_directory;
+  assert.equal(Object.keys(rules).length, 2);
+  for (const [pattern, action] of Object.entries(rules)) {
+    assert.equal(action, "allow");
+    assert.match(pattern, /\/\*\*$/);
+  }
+  assert.ok(Object.keys(rules).some((k) => k.includes("primary")));
+  assert.ok(Object.keys(rules).some((k) => k.includes("secondary")));
+});
+
+test("buildCommand merges OpenCode model with multi-root permission", () => {
+  const built = buildCommand({
+    adapter: "opencode-acp",
+    prompt: "hello",
+    cwd: "/tmp/primary",
+    extraArgs: ["-m", "openai/gpt-4.1"],
+    workspaceRoots: ["/tmp/primary", "/tmp/secondary"]
+  });
+  assert.deepEqual(JSON.parse(built.env.OPENCODE_CONFIG_CONTENT), {
+    model: "openai/gpt-4.1",
+    permission: {
+      external_directory: {
+        "/tmp/primary/**": "allow",
+        "/tmp/secondary/**": "allow"
+      }
+    }
+  });
+});
+
 test("buildCommand applies OpenCode ACP model through config env", () => {
   const built = buildCommand({
     adapter: "opencode-acp",

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -79,15 +79,16 @@ test("buildCommand merges OpenCode model with multi-root permission", () => {
     extraArgs: ["-m", "openai/gpt-4.1"],
     workspaceRoots: ["/tmp/primary", "/tmp/secondary"]
   });
-  assert.deepEqual(JSON.parse(built.env.OPENCODE_CONFIG_CONTENT), {
-    model: "openai/gpt-4.1",
-    permission: {
-      external_directory: {
-        "/tmp/primary/**": "allow",
-        "/tmp/secondary/**": "allow"
-      }
-    }
-  });
+  const content = JSON.parse(built.env.OPENCODE_CONFIG_CONTENT);
+  assert.equal(content.model, "openai/gpt-4.1");
+  const rules = content.permission.external_directory;
+  assert.equal(Object.keys(rules).length, 2);
+  for (const [pattern, action] of Object.entries(rules)) {
+    assert.equal(action, "allow");
+    assert.match(pattern, /\/\*\*$/);
+  }
+  assert.ok(Object.keys(rules).some((k) => k.includes("primary")));
+  assert.ok(Object.keys(rules).some((k) => k.includes("secondary")));
 });
 
 test("buildCommand applies OpenCode ACP model through config env", () => {


### PR DESCRIPTION
## Summary
- 多根工作区启动 OpenCode 时注入 `OPENCODE_CONFIG_CONTENT.permission.external_directory`，对挂载根目录 `allow`，避免原生 read/glob/bash 卡在 `ask`
- runtime 把 `workspaceRoots` 传入 OpenCode `buildCommand`
- 顺带统一「编辑项目」弹窗底部删除/取消/保存按钮的高度与圆角样式（保持按钮外形）

## Test plan
- [ ] 多文件夹项目（如 51caiji + exadmin + collection）用 OpenCode 原生 `read`/`glob` 读挂载仓，`opencode.log` 中 `external_directory` 为 `action=allow`，无 ACP 权限卡死
- [ ] 单根项目行为不变（不注入多余 external_directory）
- [ ] `node --test tests/acp.test.mjs tests/acp-runtime-contract.test.mjs tests/project-form-modal.test.mjs`
- [ ] 打开编辑项目弹窗：三钮同高；删除仍为 danger 矩形按钮，非文字链


Made with [Cursor](https://cursor.com)