### PR TITLE
fix: preserve matching live ACP response chunks

### DIFF
--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -261,6 +261,24 @@ export function buildTerminalOutputResponse(snapshot: {
   };
 }
 
+export type AcpSessionStartMode = "new" | "load" | "resume";
+
+export function selectAcpSessionStartMode(
+  toolSessionId: string | undefined,
+  agentCapabilities:
+    | {
+        loadSession?: unknown;
+        sessionCapabilities?: { resume?: unknown };
+      }
+    | undefined
+): AcpSessionStartMode {
+  if (toolSessionId && agentCapabilities?.loadSession) return "load";
+  if (toolSessionId && agentCapabilities?.sessionCapabilities?.resume) {
+    return "resume";
+  }
+  return "new";
+}
+
 export function buildSessionNewRequest(
   id: AcpRequestId,
   cwd?: string,
@@ -1224,6 +1242,7 @@ export function shouldEmitAcpUpdate(
   update: any,
   state: {
     promptStarted: boolean;
+    replaySuppressionEnabled: boolean;
     replayMessageIds?: ReadonlySet<string>;
     replayContentSignatures?: ReadonlySet<string>;
   }
@@ -1234,6 +1253,9 @@ export function shouldEmitAcpUpdate(
   }
   if (!state.promptStarted) {
     return false;
+  }
+  if (!state.replaySuppressionEnabled) {
+    return true;
   }
   const isMessageOrThought =
     type === "agent_message_chunk" || type === "agent_thought_chunk";

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -21,6 +21,7 @@ import {
   buildSessionSetConfigOptionRequest,
   buildTerminalOutputResponse,
   parseAcpLine,
+  selectAcpSessionStartMode,
   selectAcpAuthMethod,
   shouldDropReplayPhaseAgentChunk,
   shouldEmitAcpUpdate,
@@ -129,6 +130,7 @@ export async function runAcpAgent({
   let promptStarted = false;
   let promptHadContent = false;
   let turnHadLiveAgentChunk = false;
+  let sessionWasResumed = false;
   let mcpServers: AcpStdioMcpServer[] = [];
   const replayMessageIds = new Set(args.knownStreamMessageIds ?? []);
   const replayContentSignatures = new Set(
@@ -138,8 +140,8 @@ export async function runAcpAgent({
   // attach messageIds when replaying history on resume. When resuming such an
   // adapter (prior turns persisted zero agent messageIds), drop messageId-
   // carrying chunks until the first live chunk signals real generation.
-  const suppressReplayByPhase =
-    Boolean(toolSessionId) &&
+  const suppressReplayByPhase = () =>
+    sessionWasResumed &&
     (args.knownAgentStreamMessageIds ?? []).length === 0;
   const terminalManager = createAcpTerminalManager({
     defaultCwd: args.cwd,
@@ -278,10 +280,11 @@ export async function runAcpAgent({
       const isAgentChunkForPhase =
         updateType === "agent_message_chunk" ||
         updateType === "agent_thought_chunk";
-      if (isAgentChunkForPhase && suppressReplayByPhase) {
+      const replayPhaseSuppressionEnabled = suppressReplayByPhase();
+      if (isAgentChunkForPhase && replayPhaseSuppressionEnabled) {
         if (
           shouldDropReplayPhaseAgentChunk(msg.params?.update, {
-            suppressReplayByPhase,
+            suppressReplayByPhase: replayPhaseSuppressionEnabled,
             turnHadLiveAgentChunk
           })
         ) {
@@ -297,6 +300,7 @@ export async function runAcpAgent({
       if (
         !shouldEmitAcpUpdate(msg.params?.update, {
           promptStarted,
+          replaySuppressionEnabled: sessionWasResumed,
           replayMessageIds,
           replayContentSignatures
         })
@@ -657,6 +661,7 @@ export async function runAcpAgent({
     promptStarted = false;
     promptHadContent = false;
     turnHadLiveAgentChunk = false;
+    sessionWasResumed = false;
     updateRunningProcess();
     attachConnection();
     const init = await request(buildInitializeRequest(nextId()));
@@ -688,17 +693,21 @@ export async function runAcpAgent({
       if (items.length) emit({ type: "items", items });
     };
 
-    if (toolSessionId && agentCaps?.loadSession) {
+    sessionWasResumed = false;
+    const sessionStartMode = selectAcpSessionStartMode(toolSessionId, agentCaps);
+    if (sessionStartMode === "load") {
       const loaded = await request(
-        buildSessionLoadRequest(nextId(), toolSessionId, args.cwd, mcpServers)
+        buildSessionLoadRequest(nextId(), toolSessionId!, args.cwd, mcpServers)
       );
-      activeAcpSessionId = toolSessionId;
+      activeAcpSessionId = toolSessionId!;
+      sessionWasResumed = true;
       emitSetupItems(loaded);
-    } else if (toolSessionId && agentCaps?.sessionCapabilities?.resume) {
+    } else if (sessionStartMode === "resume") {
       const resumed = await request(
-        buildSessionResumeRequest(nextId(), toolSessionId, args.cwd, mcpServers)
+        buildSessionResumeRequest(nextId(), toolSessionId!, args.cwd, mcpServers)
       );
-      activeAcpSessionId = toolSessionId;
+      activeAcpSessionId = toolSessionId!;
+      sessionWasResumed = true;
       emitSetupItems(resumed);
     } else {
       const created = await request(

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -968,9 +968,13 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       knownStreamMessageIds: collectStreamMessageIds(
         get().messages[conversationId] ?? []
       ),
-      knownStreamContentSignatures: collectStreamContentSignatures(
-        get().messages[conversationId] ?? []
-      ),
+      // Content signatures suppress history replay from resumed ACP sessions.
+      // A fresh session cannot replay history, so every live chunk must pass.
+      ...(resumedFromSessionId
+        ? {
+            knownStreamContentSignatures: collectStreamContentSignatures(msgs)
+          }
+        : {}),
       knownAgentStreamMessageIds: collectStreamAgentMessageIds(
         get().messages[conversationId] ?? []
       ),

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -121,10 +121,8 @@ export function collectStreamContentSignatures(
     if (normalized.length > 0) signatures.add(normalized);
   };
   for (const message of messages) {
-    if (message.role === "user") {
-      add(message.content);
-      continue;
-    }
+    // Replay suppression is applied only to agent message/thought chunks.
+    // User text must not cross-match and hide a live assistant chunk.
     if (message.role !== "assistant") continue;
     try {
       const parsed = JSON.parse(message.content);

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -20,6 +20,7 @@ import {
   contentBlockToItems,
   parseAcpLine,
   selectAcpAuthMethod,
+  selectAcpSessionStartMode,
   shouldEmitAcpUpdate,
   shouldSkipUserMessageChunk,
   shouldDropReplayPhaseAgentChunk
@@ -1040,7 +1041,7 @@ test("shouldEmitAcpUpdate suppresses replay updates before the current prompt st
         sessionUpdate: "agent_message_chunk",
         content: { type: "text", text: "previous answer" }
       },
-      { promptStarted: false }
+      { promptStarted: false, replaySuppressionEnabled: false }
     ),
     false
   );
@@ -1050,7 +1051,7 @@ test("shouldEmitAcpUpdate suppresses replay updates before the current prompt st
         sessionUpdate: "agent_message_chunk",
         content: { type: "text", text: "current answer" }
       },
-      { promptStarted: true }
+      { promptStarted: true, replaySuppressionEnabled: false }
     ),
     true
   );
@@ -1063,7 +1064,7 @@ test("shouldEmitAcpUpdate always emits session metadata updates", () => {
         sessionUpdate: "session_info_update",
         title: "Renamed session"
       },
-      { promptStarted: false }
+      { promptStarted: false, replaySuppressionEnabled: false }
     ),
     true
   );
@@ -1073,7 +1074,30 @@ test("shouldEmitAcpUpdate always emits session metadata updates", () => {
         sessionUpdate: "config_option_update",
         configOptions: [{ id: "model", name: "Model", type: "select" }]
       },
-      { promptStarted: false }
+      { promptStarted: false, replaySuppressionEnabled: false }
+    ),
+    true
+  );
+});
+
+test("saved ACP sessions that fall back to session/new keep matching live chunks", () => {
+  const sessionStartMode = selectAcpSessionStartMode("saved-session", {
+    sessionCapabilities: {}
+  });
+  const replayContentSignatures = new Set(["same as a previous answer"]);
+
+  assert.equal(sessionStartMode, "new");
+  assert.equal(
+    shouldEmitAcpUpdate(
+      {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "same as a previous answer" }
+      },
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: sessionStartMode !== "new",
+        replayContentSignatures
+      }
     ),
     true
   );
@@ -1088,7 +1112,11 @@ test("shouldEmitAcpUpdate suppresses persisted messageId replay after prompt sta
         messageId: "msg-old-1",
         content: { type: "text", text: "previous answer" }
       },
-      { promptStarted: true, replayMessageIds }
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: true,
+        replayMessageIds
+      }
     ),
     false
   );
@@ -1099,7 +1127,11 @@ test("shouldEmitAcpUpdate suppresses persisted messageId replay after prompt sta
         messageId: "msg-new-1",
         content: { type: "text", text: "fresh answer" }
       },
-      { promptStarted: true, replayMessageIds }
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: true,
+        replayMessageIds
+      }
     ),
     true
   );
@@ -1110,21 +1142,33 @@ test("shouldEmitAcpUpdate suppresses replayed tool calls by toolCallId", () => {
   assert.equal(
     shouldEmitAcpUpdate(
       { sessionUpdate: "tool_call", toolCallId: "tool-old-1", title: "Read" },
-      { promptStarted: true, replayMessageIds }
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: true,
+        replayMessageIds
+      }
     ),
     false
   );
   assert.equal(
     shouldEmitAcpUpdate(
       { sessionUpdate: "tool_call_update", toolCallId: "tool-old-1", status: "completed" },
-      { promptStarted: true, replayMessageIds }
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: true,
+        replayMessageIds
+      }
     ),
     false
   );
   assert.equal(
     shouldEmitAcpUpdate(
       { sessionUpdate: "tool_call", toolCallId: "tool-new-1", title: "Read" },
-      { promptStarted: true, replayMessageIds }
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: true,
+        replayMessageIds
+      }
     ),
     true
   );
@@ -1139,7 +1183,11 @@ test("shouldEmitAcpUpdate suppresses replayed chunks by content signature", () =
         messageId: "fresh-id-never-persisted",
         content: { type: "text", text: "  你好！我是 Qoder  " }
       },
-      { promptStarted: true, replayContentSignatures }
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: true,
+        replayContentSignatures
+      }
     ),
     false
   );
@@ -1149,7 +1197,11 @@ test("shouldEmitAcpUpdate suppresses replayed chunks by content signature", () =
         sessionUpdate: "agent_message_chunk",
         content: { type: "text", text: "抱歉，" }
       },
-      { promptStarted: true, replayContentSignatures }
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: true,
+        replayContentSignatures
+      }
     ),
     true
   );

--- a/tests/conversation-send-replay.test.mjs
+++ b/tests/conversation-send-replay.test.mjs
@@ -1,0 +1,266 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+import {
+  selectAcpSessionStartMode,
+  shouldEmitAcpUpdate
+} from "../dist-electron/cli/acp.js";
+
+function toDataUrl(source) {
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+async function loadConversationStoreHarness() {
+  const mockSource = `
+    let nextId = 0;
+    let savedToolSession = {
+      adapter: "mock-acp",
+      sessionId: "saved-session"
+    };
+
+    export let capturedRunArgs;
+
+    export function setSavedToolSession(value) {
+      savedToolSession = value;
+    }
+
+    export function create(initializer) {
+      let state;
+      const getState = () => state;
+      const setState = (update, replace = false) => {
+        const next = typeof update === "function" ? update(state) : update;
+        state = replace ? next : { ...state, ...next };
+      };
+      state = initializer(setState, getState);
+      const store = (selector = (value) => value) => selector(state);
+      store.getState = getState;
+      store.setState = setState;
+      store.subscribe = () => () => {};
+      return store;
+    }
+
+    export function nanoid() {
+      nextId += 1;
+      return \`generated-\${nextId}\`;
+    }
+
+    export const builtinCliMembers = [
+      {
+        id: "agent-1",
+        kind: "cli",
+        name: "Mock ACP",
+        enabled: true,
+        cli: {
+          adapter: "mock-acp",
+          approvalMode: "auto",
+          showStderr: false
+        }
+      }
+    ];
+
+    export const cliClient = {
+      appendMessage: async (message) => message,
+      getToolSession: async () => savedToolSession,
+      updateMessage: async () => undefined,
+      onEvent: () => () => {},
+      run: async (args) => {
+        capturedRunArgs = args;
+      }
+    };
+
+    export function getParser() {
+      return () => [];
+    }
+
+    export const workflowFollowupAgentId = () => undefined;
+    export const workflowClient = {
+      isAvailable: () => false,
+      listRuns: async () => [],
+      getSteps: async () => []
+    };
+
+    export const composeMessageWithAttachments = (prompt) => prompt;
+    export const filterSessionConfigPickerOptions = () => [];
+    export const resolveConfigOptionOverrides = () => undefined;
+
+    export const useCliExecutorStore = {
+      getState: () => ({
+        resolve: () => ({
+          enabled: true,
+          binary: "mock-agent",
+          extraArgs: [],
+          env: {},
+          protocol: "acp",
+          streamMode: "raw"
+        }),
+        listResolved: () => []
+      })
+    };
+
+    export const useProjectStore = {
+      getState: () => ({ projects: [] })
+    };
+
+    export const buildOrphanFollowupContext = () => undefined;
+    export const composeOrphanFollowupPrompt = (prompt) => prompt;
+    export const defaultTitleFor = () => "Mock ACP";
+    export const feedArticleTitleFromMessages = () => undefined;
+    export const mergeConversationMessages = (_, messages) => messages;
+    export const shouldApplyAgentSessionTitle = () => false;
+    export const handleStreamEvent = () => undefined;
+    export const killConversation = async () => undefined;
+    export const latestConfigOptionsFromItems = () => [];
+    export const latestConfigOptionsFromMessages = () => [];
+    export const latestSessionInfoFromMessages = () => undefined;
+    export const loadUnreadConversations = () => ({});
+    export const persistUnreadConversations = () => undefined;
+  `;
+  const mockUrl = toDataUrl(mockSource);
+  const conversationUtilsSource = fs.readFileSync(
+    new URL("../src/store/conversationUtils.ts", import.meta.url),
+    "utf8"
+  );
+  const conversationUtilsUrl = toDataUrl(
+    ts.transpileModule(conversationUtilsSource, {
+      compilerOptions: {
+        module: ts.ModuleKind.ES2022,
+        target: ts.ScriptTarget.ES2022
+      }
+    }).outputText
+  );
+  const source = fs.readFileSync(
+    new URL("../src/store/conversationStore.ts", import.meta.url),
+    "utf8"
+  );
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  const mockedStoreSource = transpiled.replace(
+    /from\s+["']([^"']+)["']/g,
+    (_, specifier) =>
+      `from "${
+        specifier === "./conversationUtils"
+          ? conversationUtilsUrl
+          : mockUrl
+      }"`
+  );
+
+  const [storeModule, mocks] = await Promise.all([
+    import(toDataUrl(mockedStoreSource)),
+    import(mockUrl)
+  ]);
+  return { ...storeModule, mocks };
+}
+
+test("sendMessage keeps matching live chunks when a saved ACP session falls back to session/new", async () => {
+  const { useConversationStore, mocks } =
+    await loadConversationStoreHarness();
+  const timestamp = "2026-07-29T10:00:00.000Z";
+  const previousAnswer = "same as a previous answer";
+  const conversation = {
+    id: "conv-1",
+    title: "Replay test",
+    agentId: "agent-1",
+    agentName: "Mock ACP",
+    adapter: "mock-acp",
+    cwd: "C:\\work\\sample",
+    approvalMode: "auto",
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+  const previousMessage = {
+    id: "assistant-old",
+    conversationId: conversation.id,
+    role: "assistant",
+    status: "done",
+    content: JSON.stringify([
+      { kind: "session", sessionId: "saved-session" },
+      { kind: "text", role: "assistant", content: previousAnswer }
+    ]),
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+
+  useConversationStore.setState({
+    conversations: [conversation],
+    messages: { [conversation.id]: [previousMessage] },
+    live: {},
+    pendingFreshContext: {}
+  });
+
+  await useConversationStore.getState().sendMessage({
+    conversationId: conversation.id,
+    prompt: "continue",
+    userMessageId: "user-current",
+    assistantMessageId: "assistant-current"
+  });
+
+  const runArgs = mocks.capturedRunArgs;
+  assert.equal(runArgs.toolSessionId, "saved-session");
+  assert.deepEqual(runArgs.knownStreamContentSignatures, [previousAnswer]);
+
+  const sessionStartMode = selectAcpSessionStartMode(runArgs.toolSessionId, {
+    sessionCapabilities: {}
+  });
+  assert.equal(sessionStartMode, "new");
+  assert.equal(
+    shouldEmitAcpUpdate(
+      {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: previousAnswer }
+      },
+      {
+        promptStarted: true,
+        replaySuppressionEnabled: sessionStartMode !== "new",
+        replayContentSignatures: new Set(
+          runArgs.knownStreamContentSignatures
+        )
+      }
+    ),
+    true
+  );
+
+  mocks.setSavedToolSession(undefined);
+  const freshConversation = {
+    ...conversation,
+    id: "conv-2",
+    title: "Fresh test"
+  };
+  useConversationStore.setState({
+    conversations: [freshConversation],
+    messages: {
+      [freshConversation.id]: [
+        {
+          ...previousMessage,
+          id: "assistant-fresh-old",
+          conversationId: freshConversation.id,
+          content: JSON.stringify([
+            { kind: "text", role: "assistant", content: previousAnswer }
+          ])
+        }
+      ]
+    },
+    live: {},
+    pendingFreshContext: {}
+  });
+
+  await useConversationStore.getState().sendMessage({
+    conversationId: freshConversation.id,
+    prompt: "fresh prompt",
+    userMessageId: "user-fresh",
+    assistantMessageId: "assistant-fresh"
+  });
+
+  assert.equal(
+    Object.hasOwn(
+      mocks.capturedRunArgs,
+      "knownStreamContentSignatures"
+    ),
+    false
+  );
+});

--- a/tests/conversation-utils.test.mjs
+++ b/tests/conversation-utils.test.mjs
@@ -716,6 +716,50 @@ test("collectStreamMessageIds gathers ids from stored assistant snapshots", asyn
   );
 });
 
+test("collectStreamContentSignatures gathers assistant content only", async () => {
+  const { collectStreamContentSignatures } = await loadConversationUtils();
+  const timestamp = "2026-06-23T10:00:00.000Z";
+
+  assert.deepEqual(
+    collectStreamContentSignatures([
+      {
+        id: "user-1",
+        conversationId: "conv-1",
+        role: "user",
+        status: "sent",
+        content: "你好",
+        createdAt: timestamp,
+        updatedAt: timestamp
+      },
+      {
+        id: "assistant-1",
+        conversationId: "conv-1",
+        role: "assistant",
+        status: "done",
+        content: JSON.stringify([
+          { kind: "text", role: "assistant", content: "你好" },
+          { kind: "thinking", content: "准备回复" }
+        ]),
+        createdAt: timestamp,
+        updatedAt: timestamp
+      }
+    ]),
+    ["你好", "准备回复"]
+  );
+});
+
+test("fresh ACP sessions do not enable content-signature replay suppression", () => {
+  const source = fs.readFileSync(
+    new URL("../src/store/conversationStore.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(
+    source,
+    /resumedFromSessionId\s*\?\s*\{\s*knownStreamContentSignatures:\s*collectStreamContentSignatures\(msgs\)/
+  );
+});
+
 test("collectStreamAgentMessageIds gathers only text/thinking messageIds (excludes tool ids)", async () => {
   const { collectStreamAgentMessageIds } = await loadConversationUtils();
 

--- a/tests/conversation-utils.test.mjs
+++ b/tests/conversation-utils.test.mjs
@@ -748,15 +748,32 @@ test("collectStreamContentSignatures gathers assistant content only", async () =
   );
 });
 
-test("fresh ACP sessions do not enable content-signature replay suppression", () => {
-  const source = fs.readFileSync(
-    new URL("../src/store/conversationStore.ts", import.meta.url),
-    "utf8"
-  );
+test("fresh ACP turns do not derive replay signatures from the current user prompt", async () => {
+  const { collectStreamContentSignatures } = await loadConversationUtils();
+  const timestamp = "2026-07-29T10:00:00.000Z";
 
-  assert.match(
-    source,
-    /resumedFromSessionId\s*\?\s*\{\s*knownStreamContentSignatures:\s*collectStreamContentSignatures\(msgs\)/
+  assert.deepEqual(
+    collectStreamContentSignatures([
+      {
+        id: "user-1",
+        conversationId: "conv-1",
+        role: "user",
+        status: "sent",
+        content: "你好",
+        createdAt: timestamp,
+        updatedAt: timestamp
+      },
+      {
+        id: "assistant-1",
+        conversationId: "conv-1",
+        role: "assistant",
+        status: "running",
+        content: "[]",
+        createdAt: timestamp,
+        updatedAt: timestamp
+      }
+    ]),
+    []
   );
 });
 


### PR DESCRIPTION
## Summary

- collect replay content signatures from assistant text/thought history only
- enable content-signature suppression only when an ACP session is actually resumed
- add regression coverage for a fresh turn where the user prompt matches the first live assistant chunk

## Root cause

FreeBuddy persisted the current user message before collecting replay signatures. On a fresh conversation with user text `你好`, an agent response streamed as `你好` followed by `！...`; the first live chunk matched the user-derived signature and was incorrectly dropped. Fresh ACP sessions also received replay signatures even though no history could be replayed.

This keeps the existing resumed-session protection for adapters such as Qoder while preventing cross-role and fresh-session false positives.

## Validation

- `npm run typecheck`
- `npm test` (797 regular tests: 766 passed, 31 skipped; 28 Electron database tests passed)