### PR TITLE
fix: make Codex BYOK work on Windows

### DIFF
--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -748,7 +748,7 @@ export async function runAcpAgent({
   };
 
   const authRequiredError = (methods: AcpAuthMethod[]) => {
-    const selected = selectAcpAuthMethod(methods);
+    const selected = selectAcpAuthMethod(methods, agentCommand.env);
     const method = selected ?? methods[0];
     const label = method?.name ? ` (${method.name})` : "";
     const unsupportedType =
@@ -763,7 +763,7 @@ export async function runAcpAgent({
   const chooseAuthMethod = async (
     methods: AcpAuthMethod[]
   ): Promise<AcpAuthMethod> => {
-    const automatic = selectAcpAuthMethod(methods);
+    const automatic = selectAcpAuthMethod(methods, agentCommand.env);
     if (automatic) return automatic;
 
     const supported = methods.filter(

--- a/electron/cli/codexByokWrapper.ts
+++ b/electron/cli/codexByokWrapper.ts
@@ -1,0 +1,62 @@
+/**
+ * Platform-specific Codex BYOK wrappers that inject model_catalog_json via `-c`
+ * when codex-acp spawns the real Codex binary through CODEX_PATH.
+ */
+
+export function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildCodexAppServerWrapperContent(
+  modelCatalogPath: string,
+  platform: NodeJS.Platform = process.platform
+): { extension: ".cmd" | ".sh"; script: string } {
+  if (platform === "win32") {
+    // codex-acp on Windows spawns: `"${CODEX_PATH}" app-server` with shell:true,
+    // so a .cmd launcher is required (.sh is not executable under cmd.exe).
+    // Keep the catalog path in its own variable so nested quotes from
+    // JSON.stringify do not break `set "VAR=..."`.
+    const catalogPathCmd = modelCatalogPath
+      .replace(/\//g, "\\")
+      .replace(/%/g, "%%");
+    const script = `@echo off
+setlocal EnableExtensions
+set "FREEBUDDY_CATALOG_PATH=${catalogPathCmd}"
+if defined FREEBUDDY_CODEX_BIN if exist "%FREEBUDDY_CODEX_BIN%" (
+  "%FREEBUDDY_CODEX_BIN%" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+  exit /b %ERRORLEVEL%
+)
+where codex >nul 2>nul
+if not errorlevel 1 (
+  for /f "delims=" %%I in ('where codex 2^>nul') do (
+    "%%I" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+    exit /b %ERRORLEVEL%
+  )
+)
+if defined APPDATA if exist "%APPDATA%\\npm\\codex.cmd" (
+  call "%APPDATA%\\npm\\codex.cmd" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+  exit /b %ERRORLEVEL%
+)
+if defined LOCALAPPDATA if exist "%LOCALAPPDATA%\\Yarn\\bin\\codex.cmd" (
+  call "%LOCALAPPDATA%\\Yarn\\bin\\codex.cmd" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+  exit /b %ERRORLEVEL%
+)
+echo FreeBuddy Codex BYOK wrapper could not find the codex binary. 1>&2
+exit /b 127
+`;
+    return { extension: ".cmd", script };
+  }
+
+  const catalogArg = `model_catalog_json=${JSON.stringify(modelCatalogPath)}`;
+  const script = `#!/bin/sh
+catalog_arg=${shellSingleQuote(catalogArg)}
+for candidate in "$FREEBUDDY_CODEX_BIN" "$(command -v codex 2>/dev/null)" "/opt/homebrew/bin/codex" "/usr/local/bin/codex"; do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    exec "$candidate" "$@" -c "$catalog_arg"
+  fi
+done
+echo "FreeBuddy Codex BYOK wrapper could not find the codex binary." >&2
+exit 127
+`;
+  return { extension: ".sh", script };
+}

--- a/electron/cli/store.ts
+++ b/electron/cli/store.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { CLIAdapterId } from "./adapters.js";
+import { buildCodexAppServerWrapperContent } from "./codexByokWrapper.js";
 import { getDataDir, getDb } from "./db.js";
 
 export interface CLICodexByokConfig {
@@ -246,8 +247,48 @@ function createCodexByokModelCatalog(
   return file;
 }
 
-function shellSingleQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
+function isExecutableFile(candidate: string): boolean {
+  try {
+    const stat = fs.statSync(candidate);
+    if (!stat.isFile()) return false;
+    if (process.platform === "win32") return true;
+    return (stat.mode & 0o111) !== 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Best-effort sync lookup for the real Codex CLI (not the BYOK wrapper). */
+function resolveCodexBinaryHint(): string | undefined {
+  const fromEnv = process.env.FREEBUDDY_CODEX_BIN?.trim();
+  if (fromEnv && isExecutableFile(fromEnv)) return fromEnv;
+
+  if (process.platform === "win32") {
+    const candidates: string[] = [];
+    if (process.env.APPDATA) {
+      candidates.push(path.join(process.env.APPDATA, "npm", "codex.cmd"));
+      candidates.push(path.join(process.env.APPDATA, "npm", "codex.exe"));
+    }
+    if (process.env.LOCALAPPDATA) {
+      candidates.push(
+        path.join(process.env.LOCALAPPDATA, "Yarn", "bin", "codex.cmd")
+      );
+    }
+    for (const candidate of candidates) {
+      if (isExecutableFile(candidate)) return candidate;
+    }
+    return undefined;
+  }
+
+  for (const candidate of [
+    "/opt/homebrew/bin/codex",
+    "/usr/local/bin/codex",
+    path.join(os.homedir(), ".local", "bin", "codex"),
+    path.join(os.homedir(), ".npm-global", "bin", "codex")
+  ]) {
+    if (isExecutableFile(candidate)) return candidate;
+  }
+  return undefined;
 }
 
 function createCodexAppServerWrapper(
@@ -255,20 +296,16 @@ function createCodexAppServerWrapper(
 ): string | undefined {
   const dir = path.join(getDataDir(), "codex-wrappers");
   fs.mkdirSync(dir, { recursive: true });
-  const file = path.join(dir, `${safeCatalogFilePart(modelCatalogPath)}.sh`);
-  const catalogArg = `model_catalog_json=${JSON.stringify(modelCatalogPath)}`;
-  const script = `#!/bin/sh
-catalog_arg=${shellSingleQuote(catalogArg)}
-for candidate in "$FREEBUDDY_CODEX_BIN" "$(command -v codex 2>/dev/null)" "/opt/homebrew/bin/codex" "/usr/local/bin/codex"; do
-  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
-    exec "$candidate" "$@" -c "$catalog_arg"
-  fi
-done
-echo "FreeBuddy Codex BYOK wrapper could not find the codex binary." >&2
-exit 127
-`;
+  const { extension, script } =
+    buildCodexAppServerWrapperContent(modelCatalogPath);
+  const file = path.join(
+    dir,
+    `${safeCatalogFilePart(modelCatalogPath)}${extension}`
+  );
   fs.writeFileSync(file, script, { encoding: "utf8", mode: 0o755 });
-  fs.chmodSync(file, 0o755);
+  if (process.platform !== "win32") {
+    fs.chmodSync(file, 0o755);
+  }
   return file;
 }
 
@@ -487,6 +524,8 @@ export function resolveCodexByokEnv(
     MODEL_PROVIDER: providerId
   };
   if (codexPath) env.CODEX_PATH = codexPath;
+  const codexBin = resolveCodexBinaryHint();
+  if (codexBin) env.FREEBUDDY_CODEX_BIN = codexBin;
   if (apiKey) env[envKey] = apiKey;
   return env;
 }

--- a/tests/acp-auth-selection.test.mjs
+++ b/tests/acp-auth-selection.test.mjs
@@ -15,13 +15,15 @@ const store = read("../src/store/authenticationStore.ts");
 const dialog = read("../src/components/CLI/AuthenticationDialog.tsx");
 
 test("ACP runtime asks the renderer to select among multiple agent auth methods", () => {
-  assert.match(runtime, /const automatic = selectAcpAuthMethod\(methods\)/);
+  assert.match(
+    runtime,
+    /const automatic = selectAcpAuthMethod\(\s*methods\s*,\s*agentCommand\.env\s*\)/
+  );
   assert.match(runtime, /supported\.length < 2/);
   assert.match(runtime, /type: "authentication"/);
   assert.match(runtime, /registerAuthenticationResolver/);
   assert.match(runtime, /buildAuthenticateRequest\(nextId\(\), method\.id\)/);
 });
-
 test("authentication decisions cross the preload and IPC boundary", () => {
   assert.match(runtimeShared, /registerAuthenticationResolver/);
   assert.match(runtimeShared, /takeAuthenticationResolver/);

--- a/tests/codex-byok-windows.test.mjs
+++ b/tests/codex-byok-windows.test.mjs
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const storeSource = fs.readFileSync(
+  new URL("../electron/cli/store.ts", import.meta.url),
+  "utf8"
+);
+const runtimeSource = fs.readFileSync(
+  new URL("../electron/cli/acpRuntime.ts", import.meta.url),
+  "utf8"
+);
+const wrapperSource = fs.readFileSync(
+  new URL("../electron/cli/codexByokWrapper.ts", import.meta.url),
+  "utf8"
+);
+
+test("Codex BYOK wrapper module is platform-aware for Windows .cmd and Unix .sh", () => {
+  assert.match(wrapperSource, /export function buildCodexAppServerWrapperContent/);
+  assert.match(wrapperSource, /platform\s*===\s*["']win32["']/);
+  assert.match(wrapperSource, /\.cmd/);
+  assert.match(wrapperSource, /codex\.cmd/);
+  assert.match(wrapperSource, /FREEBUDDY_CODEX_BIN/);
+  assert.match(storeSource, /from ["'].\/codexByokWrapper/);
+  assert.match(storeSource, /buildCodexAppServerWrapperContent/);
+});
+
+test("resolveCodexByokEnv sets FREEBUDDY_CODEX_BIN for the wrapper", () => {
+  assert.match(
+    storeSource,
+    /env\.FREEBUDDY_CODEX_BIN\s*=/,
+    "BYOK env must set FREEBUDDY_CODEX_BIN so the wrapper can find the real binary"
+  );
+});
+
+test("ACP auth selection uses the agent child env so BYOK keys win over ChatGPT login", () => {
+  assert.match(
+    runtimeSource,
+    /selectAcpAuthMethod\(\s*methods\s*,\s*agentCommand\.env\s*\)/,
+    "auth method selection must see BYOK OPENAI_API_KEY from the agent env"
+  );
+  assert.equal(
+    /selectAcpAuthMethod\(\s*methods\s*\)/.test(runtimeSource),
+    false,
+    "must not call selectAcpAuthMethod(methods) without the agent env"
+  );
+});
+
+test("buildCodexAppServerWrapperContent emits Windows cmd and Unix sh scripts", async (t) => {
+  let buildCodexAppServerWrapperContent;
+  try {
+    ({ buildCodexAppServerWrapperContent } = await import(
+      "../dist-electron/cli/codexByokWrapper.js"
+    ));
+  } catch {
+    t.skip("dist-electron wrapper not built yet");
+    return;
+  }
+
+  const catalogPath = path.win32.join(
+    "C:",
+    "Users",
+    "demo",
+    "AppData",
+    "Roaming",
+    "FreeBuddy",
+    "freebuddy",
+    "codex-model-catalogs",
+    "demo.json"
+  );
+  const win = buildCodexAppServerWrapperContent(catalogPath, "win32");
+  assert.equal(win.extension, ".cmd");
+  assert.match(win.script, /@echo off/i);
+  assert.match(win.script, /model_catalog_json=/);
+  assert.match(win.script, /%\*/);
+  assert.match(win.script, /-c /);
+  assert.match(win.script, /FREEBUDDY_CODEX_BIN/);
+  assert.match(win.script, /codex\.cmd/);
+  assert.match(
+    win.script,
+    /set "FREEBUDDY_CATALOG_PATH=C:\\Users\\demo\\/,
+    "catalog path must be set without nested JSON quotes that break cmd.exe"
+  );
+  assert.doesNotMatch(win.script, /#!\/bin\/sh/);
+
+  const unix = buildCodexAppServerWrapperContent(catalogPath, "darwin");
+  assert.equal(unix.extension, ".sh");
+  assert.match(unix.script, /^#!\/bin\/sh/);
+  assert.match(unix.script, /command -v codex/);
+  assert.match(unix.script, /\/opt\/homebrew\/bin\/codex/);
+});


### PR DESCRIPTION
## Summary
- Windows 上 Codex BYOK 改为生成 `.cmd` wrapper（不再用无法执行的 `.sh`），并查找常见 Windows `codex` 路径
- ACP 认证选择改为读取 agent 子进程 env，使 BYOK 的 `OPENAI_API_KEY` 优先于官方 ChatGPT 登录
- 注入 `FREEBUDDY_CODEX_BIN`，方便 wrapper 找到真实 Codex 二进制

## Test plan
- [ ] Windows：启用 Codex BYOK，填写 Base URL / API Key，并保留自定义模型列表（如 `gpt-5.6-luna`），保存后能正常发消息
- [ ] Windows：确认不会再误跳转官方 ChatGPT 登录
- [ ] macOS：原有 Codex BYOK 路径仍可用
- [ ] `node --test --test-force-exit tests/codex-byok-windows.test.mjs tests/acp-auth-selection.test.mjs`


Made with [Cursor](https://cursor.com)