### PR TITLE
fix: task completion sound in packaged app + local-timezone debug logs

### DIFF
--- a/electron/cli/runtimeShared.ts
+++ b/electron/cli/runtimeShared.ts
@@ -17,6 +17,7 @@ import {
 import { scheduleAgentUsageReconciliation } from "./usageReconciler.js";
 import { linkAgentUsageSessionForTask } from "./usageStore.js";
 import { redactsecrets } from "../shared/logSanitize.js";
+import { formatLocalTimestamp } from "../shared/debugLogCore.js";
 
 export interface CliPromptAttachment {
   path: string;
@@ -275,7 +276,7 @@ export function appendLog(
     safeContent = `${safeContent.slice(0, MAX_LOG_LINE_CHARS)}\n… [log truncated]`;
   }
   const entry = JSON.stringify({
-    ts: new Date().toISOString(),
+    ts: formatLocalTimestamp(new Date()),
     type: kind,
     content: safeContent
   });

--- a/electron/debugLogExport.ts
+++ b/electron/debugLogExport.ts
@@ -25,6 +25,32 @@ const SESSION_TAIL_BYTES = 2 * 1024 * 1024;
 const MAX_SESSION_FILES = 20;
 const PREVIEW_LINES = 200;
 
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** ISO 8601 timestamp in the machine's local timezone, e.g. 2026-07-31T07:18:13.481+08:00. */
+function formatLocalTimestamp(date: Date): string {
+  const offsetMin = -date.getTimezoneOffset();
+  const sign = offsetMin >= 0 ? "+" : "-";
+  const abs = Math.abs(offsetMin);
+  const tz = `${sign}${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`;
+  return (
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}` +
+    `T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}` +
+    `.${String(date.getMilliseconds()).padStart(3, "0")}${tz}`
+  );
+}
+
+/** Filesystem-safe local stamp for the bundle name, e.g. 2026-07-31T07-18-13-481. */
+function localFileStamp(date: Date): string {
+  return (
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}` +
+    `T${pad2(date.getHours())}-${pad2(date.getMinutes())}-${pad2(date.getSeconds())}` +
+    `-${String(date.getMilliseconds()).padStart(3, "0")}`
+  );
+}
+
 export interface DebugLogPreviewFile {
   name: string;
   totalLines: number;
@@ -222,7 +248,7 @@ export async function buildDebugLogPreview(
 ): Promise<DebugLogPreview> {
   const { environment, appLogs, sessionLogs } = collectBundle(
     mode,
-    new Date().toISOString(),
+    formatLocalTimestamp(new Date()),
     conversationId
   );
   const files: DebugLogPreviewFile[] = [...appLogs, ...sessionLogs].map((f) => ({
@@ -254,8 +280,9 @@ export async function exportDebugLogs(
   mode: ExportMode,
   conversationId?: string
 ): Promise<{ path?: string; canceled?: boolean }> {
-  const exportedAt = new Date().toISOString();
-  const stamp = exportedAt.replace(/[:.]/g, "-");
+  const now = new Date();
+  const exportedAt = formatLocalTimestamp(now);
+  const stamp = localFileStamp(now);
   const result = await dialog.showSaveDialog(parent, {
     title: "Export debug logs",
     defaultPath: path.join(app.getPath("downloads"), `freebuddy-debug-${stamp}.zip`),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -324,10 +324,22 @@ function registerTaskNotificationIpc(): void {
         icon: loadAppIcon()
       });
       notification.on("click", () => {
-        if (win && !win.isDestroyed()) {
+        if (!win || win.isDestroyed()) return;
+        try {
+          // Restore from minimized/occluded state and raise to the foreground.
+          // On Windows the notification click grants a brief SetForegroundWindow
+          // permission to the app; claim it synchronously before focus() loses it.
           if (win.isMinimized()) win.restore();
           win.show();
+          win.moveTop();
           win.focus();
+          if (process.platform === "win32") win.flashFrame(false);
+          logMain().info("window", "notification clicked", {
+            visible: win.isVisible(),
+            minimized: win.isMinimized(),
+            focused: win.isFocused(),
+            conversationId: payload.conversationId
+          });
           if (payload.conversationId) {
             safeSendToWebContents(
               win.webContents,
@@ -335,7 +347,14 @@ function registerTaskNotificationIpc(): void {
               payload.conversationId
             );
           }
+        } catch (err) {
+          logMain().error("window", "notification click handler failed", {
+            message: (err as Error)?.message
+          });
         }
+      });
+      notification.on("failed", (_e, error) => {
+        logMain().error("window", "notification failed", { message: error });
       });
       notification.show();
     } catch {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -301,6 +301,7 @@ type TaskNotificationPayload = {
   kind: "success" | "failure";
   title: string;
   body?: string;
+  conversationId?: string;
 };
 
 function registerTaskNotificationIpc(): void {
@@ -325,7 +326,15 @@ function registerTaskNotificationIpc(): void {
       notification.on("click", () => {
         if (win && !win.isDestroyed()) {
           if (win.isMinimized()) win.restore();
+          win.show();
           win.focus();
+          if (payload.conversationId) {
+            safeSendToWebContents(
+              win.webContents,
+              "window:open-conversation",
+              payload.conversationId
+            );
+          }
         }
       });
       notification.show();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -310,10 +310,16 @@ const window = {
   resolveDraftTool(resolution: DraftToolResolution): Promise<boolean> {
     return ipcRenderer.invoke("draft-tool:resolve", resolution);
   },
+  onOpenConversation(cb: (conversationId: string) => void): () => void {
+    const handler = (_e: IpcRendererEvent, conversationId: string) => cb(conversationId);
+    ipcRenderer.on("window:open-conversation", handler);
+    return () => ipcRenderer.off("window:open-conversation", handler);
+  },
   notifyTask(payload: {
     kind: "success" | "failure";
     title: string;
     body?: string;
+    conversationId?: string;
   }): Promise<void> {
     return ipcRenderer.invoke("window:notify", payload);
   }

--- a/electron/shared/debugLogCore.ts
+++ b/electron/shared/debugLogCore.ts
@@ -13,6 +13,23 @@ export const LOG_RETENTION_DAYS = 7;
 export const MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_ROTATIONS = 2; // base file + .1 + .2 = 同日最多 3 份
 
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** ISO 8601 timestamp in the local timezone, e.g. 2026-07-31T07:18:13.481+08:00. */
+export function formatLocalTimestamp(date: Date): string {
+  const offsetMin = -date.getTimezoneOffset();
+  const sign = offsetMin >= 0 ? "+" : "-";
+  const abs = Math.abs(offsetMin);
+  const tz = `${sign}${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`;
+  return (
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}` +
+    `T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}` +
+    `.${String(date.getMilliseconds()).padStart(3, "0")}${tz}`
+  );
+}
+
 export interface DebugLogger {
   write(level: DebugLogLevel, scope: string, msg: string, data?: unknown, ts?: string): void;
   info(scope: string, msg: string, data?: unknown): void;
@@ -48,8 +65,8 @@ export function pruneOldLogs(dir: string, retentionDays: number, now = new Date(
   return removed;
 }
 
-function dayStamp(date: Date): string {
-  return date.toISOString().slice(0, 10);
+function dayStamp(date: Date, formatTimestamp: (d: Date) => string): string {
+  return formatTimestamp(date).slice(0, 10);
 }
 
 function rotateIfFull(file: string, maxFileBytes: number): void {
@@ -72,9 +89,11 @@ export function createDebugLogger(opts: {
   source: string;
   maxFileBytes?: number;
   now?: () => Date;
+  formatTimestamp?: (date: Date) => string;
 }): DebugLogger {
   const maxFileBytes = opts.maxFileBytes ?? MAX_LOG_FILE_BYTES;
   const now = opts.now ?? (() => new Date());
+  const formatTimestamp = opts.formatTimestamp ?? formatLocalTimestamp;
   let droppedLines = 0;
   try {
     fs.mkdirSync(opts.dir, { recursive: true });
@@ -85,15 +104,16 @@ export function createDebugLogger(opts: {
 
   const write = (level: DebugLogLevel, scope: string, msg: string, data?: unknown, ts?: string): void => {
     try {
+      const nowDate = now();
       const entry: Record<string, unknown> = {
-        ts: typeof ts === "string" && ts.length > 0 ? ts : now().toISOString(),
+        ts: typeof ts === "string" && ts.length > 0 ? ts : formatTimestamp(nowDate),
         level,
         scope,
         msg
       };
       if (data !== undefined) entry.data = data;
       const line = redactsecrets(JSON.stringify(entry));
-      const file = path.join(opts.dir, `${opts.source}-${dayStamp(now())}.log`);
+      const file = path.join(opts.dir, `${opts.source}-${dayStamp(nowDate, formatTimestamp)}.log`);
       rotateIfFull(file, maxFileBytes);
       fs.appendFileSync(file, line + "\n");
     } catch {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,15 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const off = window.freebuddy?.window?.onOpenConversation?.((conversationId) => {
+      void useConversationStore.getState().setActive(conversationId);
+    });
+    return () => {
+      off?.();
+    };
+  }, []);
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
       if (event.key.toLowerCase() !== "k") return;

--- a/src/services/debugLog.ts
+++ b/src/services/debugLog.ts
@@ -18,6 +18,23 @@ const FLUSH_INTERVAL_MS = 500;
 const MAX_BATCH = 100;
 const MAX_MSG_CHARS = 4000;
 
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** ISO 8601 timestamp in the local timezone, e.g. 2026-07-31T07:18:13.481+08:00. */
+function formatLocalTimestamp(date: Date): string {
+  const offsetMin = -date.getTimezoneOffset();
+  const sign = offsetMin >= 0 ? "+" : "-";
+  const abs = Math.abs(offsetMin);
+  const tz = `${sign}${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`;
+  return (
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}` +
+    `T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}` +
+    `.${String(date.getMilliseconds()).padStart(3, "0")}${tz}`
+  );
+}
+
 let queue: Entry[] = [];
 let timer: number | null = null;
 
@@ -32,7 +49,7 @@ function cloneData(data: unknown): unknown {
 
 function enqueue(level: Level, scope: string, msg: string, data?: unknown): void {
   queue.push({
-    ts: new Date().toISOString(),
+    ts: formatLocalTimestamp(new Date()),
     level,
     scope: scope.slice(0, 40),
     msg: String(msg).slice(0, MAX_MSG_CHARS),

--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -343,14 +343,16 @@ export function handleStreamEvent(
         notifyTaskFinished(
           "success",
           i18next.t("notifications.taskSucceededTitle"),
-          i18next.t("notifications.taskSucceededBody", { title: conversationTitle })
+          i18next.t("notifications.taskSucceededBody", { title: conversationTitle }),
+          conversationId
         );
       } else {
         playTaskFailure(true);
         notifyTaskFinished(
           "failure",
           i18next.t("notifications.taskFailedTitle"),
-          i18next.t("notifications.taskFailedBody", { title: conversationTitle })
+          i18next.t("notifications.taskFailedBody", { title: conversationTitle }),
+          conversationId
         );
       }
     }

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -279,10 +279,12 @@ declare global {
     ): () => void;
     onDraftTool(cb: (event: DraftToolEvent) => void): () => void;
     resolveDraftTool(resolution: DraftToolResolution): Promise<boolean>;
+    onOpenConversation(cb: (conversationId: string) => void): () => void;
     notifyTask(payload: {
       kind: "success" | "failure";
       title: string;
       body?: string;
+      conversationId?: string;
     }): Promise<void>;
   }
 

--- a/src/utils/soundEffects.ts
+++ b/src/utils/soundEffects.ts
@@ -56,8 +56,11 @@ export function playTaskFailure(backgroundOnly = true): void {
 export function notifyTaskFinished(
   kind: "success" | "failure",
   title: string,
-  body?: string
+  body?: string,
+  conversationId?: string
 ): void {
   if (!isAppInBackground()) return;
-  window.freebuddy?.window?.notifyTask?.({ kind, title, body })?.catch(() => {});
+  window.freebuddy?.window?.notifyTask
+    ?.({ kind, title, body, conversationId })
+    ?.catch(() => {});
 }

--- a/src/utils/soundEffects.ts
+++ b/src/utils/soundEffects.ts
@@ -1,6 +1,10 @@
+import { debugLogClient } from "@/services/debugLog";
+
+const baseUrl = import.meta.env?.BASE_URL ?? "./";
+
 const SOUNDS = {
-  success: "/sounds/finish.mp3",
-  failure: "/sounds/failed.mp3"
+  success: `${baseUrl}sounds/finish.mp3`,
+  failure: `${baseUrl}sounds/failed.mp3`
 } as const;
 
 let audioCache: Partial<Record<keyof typeof SOUNDS, HTMLAudioElement>> = {};
@@ -28,7 +32,12 @@ export function playTaskSuccess(backgroundOnly = true): void {
   const audio = getAudio("success");
   if (!audio) return;
   audio.currentTime = 0;
-  void audio.play().catch(() => {});
+  void audio.play().catch((err: unknown) => {
+    debugLogClient.error("sound", "success sound failed", {
+      src: audio.currentSrc,
+      message: err instanceof Error ? err.message : String(err)
+    });
+  });
 }
 
 export function playTaskFailure(backgroundOnly = true): void {
@@ -36,7 +45,12 @@ export function playTaskFailure(backgroundOnly = true): void {
   const audio = getAudio("failure");
   if (!audio) return;
   audio.currentTime = 0;
-  void audio.play().catch(() => {});
+  void audio.play().catch((err: unknown) => {
+    debugLogClient.error("sound", "failure sound failed", {
+      src: audio.currentSrc,
+      message: err instanceof Error ? err.message : String(err)
+    });
+  });
 }
 
 export function notifyTaskFinished(

--- a/tests/debug-log-rotation.test.mjs
+++ b/tests/debug-log-rotation.test.mjs
@@ -28,7 +28,13 @@ function tmpDir() {
 test("writes JSONL lines named by source and day, secrets redacted at write time", async () => {
   const { createDebugLogger } = await load();
   const dir = tmpDir();
-  const log = createDebugLogger({ dir, source: "main", now: () => new Date("2026-07-30T10:00:00Z") });
+  const utc = (d) => d.toISOString();
+  const log = createDebugLogger({
+    dir,
+    source: "main",
+    now: () => new Date("2026-07-30T10:00:00Z"),
+    formatTimestamp: utc
+  });
   log.info("acp", "started with sk-ant-abc123def456", { adapter: "codex" });
   const file = path.join(dir, "main-2026-07-30.log");
   const line = JSON.parse(fs.readFileSync(file, "utf8").trim());
@@ -43,7 +49,8 @@ test("rotates a full file to .1 then shifts .1 to .2", async () => {
   const { createDebugLogger } = await load();
   const dir = tmpDir();
   const now = () => new Date("2026-07-30T10:00:00Z");
-  const log = createDebugLogger({ dir, source: "main", maxFileBytes: 120, now });
+  const utc = (d) => d.toISOString();
+  const log = createDebugLogger({ dir, source: "main", maxFileBytes: 120, now, formatTimestamp: utc });
   for (let i = 0; i < 12; i += 1) log.info("s", `line-${i}-padding-padding-padding`);
   assert.ok(fs.existsSync(path.join(dir, "main-2026-07-30.log")));
   assert.ok(fs.existsSync(path.join(dir, "main-2026-07-30.log.1")));

--- a/tests/log-sanitize.test.mjs
+++ b/tests/log-sanitize.test.mjs
@@ -184,7 +184,7 @@ async function loadAppendLog() {
     fnMatch,
     "appendLog extraction regex no longer matches runtimeShared.ts — update the regex in this test"
   );
-  const combined = `${sanitizeSource}\n${fnMatch[0]
+  const combined = `function formatLocalTimestamp(d){return d.toISOString()}\n${sanitizeSource}\n${fnMatch[0]
     .replace(/^import[^\n]*\n/gm, "")
     .replace("export function appendLog", "function appendLog")
     .replace("fs.WriteStream | null", "unknown")}\nexport { appendLog };`;


### PR DESCRIPTION
## Summary

Fixes for the Windows installer: missing task-completion sound, UTC timestamps in exported logs, and notification clicks that didn't open the app/conversation.

### 1. Task completion sound never played in the packaged build
- \src/utils/soundEffects.ts\ used the absolute path \/sounds/*.mp3\. Under the \ile://\ loader used by the packaged app (\mainWindow.loadFile\), this resolves to the filesystem root and the audio fails to load. Dev worked only because the Vite dev server serves \public/\ at \/\.
- Prefix the path with \import.meta.env.BASE_URL\ (\./\) so it resolves relative to \index.html\ in both dev and packaged builds.
- \play().catch(() => {})\ silently swallowed load/playback errors. Forward the rejection to the debug log (scope \sound\) so failures are visible in exported logs.

### 2. Debug log timestamps were in UTC, not the user's timezone
- On-disk app logs (\main-*.log\, \enderer-*.log\), session transcripts (\sessions/*.jsonl\), and exported bundles used \	oISOString()\ (UTC, \Z\). Users saw times off by their UTC offset.
- Store local-timestamped lines everywhere: main process (\debugLogCore.ts\), renderer (\services/debugLog.ts\), and the session log writer (\ppendLog\ in \untimeShared.ts\). Derive the export bundle name / \exportedAt\ from local time; log files are named by the local date.
- \createDebugLogger\ accepts an injectable \ormatTimestamp\, so \debug-log-rotation\ tests stay deterministic across host timezones (inject UTC, keep existing assertions). The \log-sanitize\ test inlines \ppendLog\, so it injects a timestamp stub since it only asserts on redaction.

### 3. Clicking a task notification now opens the originating conversation
- The notification click only restored/focused the window and never navigated to the conversation that produced it. Thread \conversationId\ through \
otifyTaskFinished\ -> \window:notify\, and on click show + focus the window and emit \window:open-conversation\ so the renderer activates that conversation.
- Also call \win.show()\ so minimized/hidden windows are raised reliably on Windows (previously only restore+focus, which sometimes failed to bring the app to the foreground).

## Verification
- \	sc\ (renderer) + \uild:electron\ (tsc) pass
- \ite build\ produces \dist/sounds/{finish,failed}.mp3\
- \debug-log-rotation\, \debug-log-export\, \environment-info\, \log-sanitize\ tests pass (34 total)
- End-to-end: written log line reads \2026-07-31T07:40:57.491+08:00\ (local offset, not \Z\)