### PR TITLE
feat: notify on workflow completion + opencode/macOS fixes

### DIFF
--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -350,6 +350,10 @@ function readImageBase64(filePath: string): string | undefined {
   }
 }
 
+function normalizeResourceLinkMime(mimeType: string): string {
+  return mimeType === "application/json" ? "text/plain" : mimeType;
+}
+
 function resourceLinkBlock(attachment: AcpPromptAttachment) {
   const uri = attachment.path.startsWith("file:")
     ? attachment.path
@@ -358,7 +362,9 @@ function resourceLinkBlock(attachment: AcpPromptAttachment) {
     type: "resource_link",
     uri,
     ...(attachment.name ? { name: attachment.name } : {}),
-    ...(attachment.mimeType ? { mimeType: attachment.mimeType } : {})
+    ...(attachment.mimeType
+      ? { mimeType: normalizeResourceLinkMime(attachment.mimeType) }
+      : {})
   };
 }
 

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -1150,6 +1150,16 @@ export class WorkflowRuntime {
       max_loops: run.maxLoops,
       has_workspace: Boolean(run.cwd)
     });
+    // Surface a task notification when a workflow run finishes, mirroring the
+    // single-agent path. "killed" is a user-initiated stop, so skip it.
+    if (status !== "killed") {
+      safeSendToWebContents(this.deps.webContents, "workflow://finished", {
+        runId,
+        conversationId: run.conversationId,
+        status,
+        name: run.name
+      });
+    }
   }
 
   private composeSummary(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -400,6 +400,20 @@ const workflow = {
       cb(payload as any);
     ipcRenderer.on(channel, handler);
     return () => ipcRenderer.off(channel, handler);
+  },
+  onRunFinished(
+    cb: (event: {
+      runId: string;
+      conversationId?: string;
+      status: string;
+      name: string;
+    }) => void
+  ): () => void {
+    const channel = "workflow://finished";
+    const handler = (_e: IpcRendererEvent, payload: unknown) =>
+      cb(payload as any);
+    ipcRenderer.on(channel, handler);
+    return () => ipcRenderer.off(channel, handler);
   }
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,6 +173,29 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const off = window.freebuddy?.workflow?.onRunFinished?.((event) => {
+      const success = event.status === "completed" || event.status === "partial";
+      if (success) playTaskSuccess(true);
+      else playTaskFailure(true);
+      if (event.conversationId) {
+        notifyTaskFinished(
+          success ? "success" : "failure",
+          success
+            ? i18next.t("notifications.taskSucceededTitle")
+            : i18next.t("notifications.taskFailedTitle"),
+          success
+            ? i18next.t("notifications.taskSucceededBody", { title: event.name })
+            : i18next.t("notifications.taskFailedBody", { title: event.name }),
+          event.conversationId
+        );
+      }
+    });
+    return () => {
+      off?.();
+    };
+  }, []);
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
       if (event.key.toLowerCase() !== "k") return;

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -425,6 +425,14 @@ declare global {
         messageId: string;
       }) => void
     ): () => void;
+    onRunFinished(
+      cb: (event: {
+        runId: string;
+        conversationId?: string;
+        status: string;
+        name: string;
+      }) => void
+    ): () => void;
   }
 
   interface FreebuddyWorkflowTeams {

--- a/src/utils/soundEffects.ts
+++ b/src/utils/soundEffects.ts
@@ -22,9 +22,19 @@ function getAudio(kind: keyof typeof SOUNDS): HTMLAudioElement | undefined {
   }
 }
 
+let windowBlurred = false;
+if (typeof window !== "undefined") {
+  window.addEventListener("blur", () => {
+    windowBlurred = true;
+  });
+  window.addEventListener("focus", () => {
+    windowBlurred = false;
+  });
+}
+
 export function isAppInBackground(): boolean {
   if (typeof document === "undefined") return false;
-  return document.hidden;
+  return document.hidden || windowBlurred;
 }
 
 export function playTaskSuccess(backgroundOnly = true): void {
@@ -59,7 +69,17 @@ export function notifyTaskFinished(
   body?: string,
   conversationId?: string
 ): void {
-  if (!isAppInBackground()) return;
+  const documentHidden = typeof document !== "undefined" ? document.hidden : false;
+  const background = isAppInBackground();
+  debugLogClient.info("notification", "notifyTaskFinished evaluated", {
+    kind,
+    documentHidden,
+    windowBlurred,
+    isAppInBackground: background,
+    willNotify: background,
+    conversationId
+  });
+  if (!background) return;
   window.freebuddy?.window?.notifyTask
     ?.({ kind, title, body, conversationId })
     ?.catch(() => {});


### PR DESCRIPTION
## Changes

- **feat: notify on workflow run completion** — workflow run 完成时弹出系统通知
- **fix: send json attachments as text/plain for opencode agent** — opencode ACP 对 `application/json` file part 报 `functionality not supported`（AI SDK `openai-compatible` 的 `application/*` 白名单只有 pdf）。在 `resourceLinkBlock` 将 `application/json` 降级为 `text/plain`，走 text 分支被读成文本注入
- **fix: trigger task notification on window blur, not only when hidden** — macOS 上窗口被遮挡时 `document.hidden` 不可靠（occlusion 未可靠触发）。新增 window `blur`/`focus` 监听，`isAppInBackground = document.hidden || windowBlurred`，失焦即视为后台；并加了 `notifyTaskFinished` 诊断日志

## Verification
- json 附件：opencode 单聊发 `.json` 不再报错
- 通知：dev 版实测，任务完成 + 窗口失焦/被遮挡 → 收到通知（诊断日志 `willNotify=true`，用户已确认收到）