### PR TITLE
fix: resolve Codex BYOK wrapper to codex-acp bundled binary

### DIFF
--- a/electron/cli/codexBinaryHint.ts
+++ b/electron/cli/codexBinaryHint.ts
@@ -1,0 +1,253 @@
+/**
+ * Resolve the real Codex CLI for FreeBuddy's BYOK wrapper.
+ *
+ * Prefer the `@openai/codex` dependency bundled inside an installed
+ * `@agentclientprotocol/codex-acp` package — the same default codex-acp uses
+ * when CODEX_PATH is unset — then fall back to a globally installed `codex`.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const CODEX_ACP_PACKAGE = "@agentclientprotocol/codex-acp";
+const BUNDLED_CODEX_JS = "@openai/codex/bin/codex.js";
+
+export type CodexBinaryHintOptions = {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  homedir?: string;
+  pathEnv?: string;
+  /** Optional absolute/relative path to a codex-acp binary from agent overrides. */
+  acpBinaryHint?: string;
+  isFile?: (candidate: string) => boolean;
+};
+
+function defaultIsFile(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function pathDirs(pathEnv: string | undefined, delimiter: string): string[] {
+  return (pathEnv || "")
+    .split(delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/** Candidate install roots for the codex-acp npm package. */
+export function codexAcpInstallRoots(
+  options: CodexBinaryHintOptions = {}
+): string[] {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const home = options.homedir ?? os.homedir();
+  const roots: string[] = [];
+  const push = (candidate: string | undefined) => {
+    if (candidate) roots.push(path.normalize(candidate));
+  };
+
+  if (options.acpBinaryHint?.trim()) {
+    push(resolveAcpRootFromBinary(options.acpBinaryHint.trim(), options));
+  }
+
+  if (platform === "win32") {
+    if (env.APPDATA) {
+      push(
+        path.join(
+          env.APPDATA,
+          "npm",
+          "node_modules",
+          CODEX_ACP_PACKAGE
+        )
+      );
+    }
+    if (env.LOCALAPPDATA) {
+      push(
+        path.join(
+          env.LOCALAPPDATA,
+          "pnpm",
+          "global",
+          "5",
+          "node_modules",
+          CODEX_ACP_PACKAGE
+        )
+      );
+    }
+  } else {
+    push(path.join(home, ".npm-global", "lib", "node_modules", CODEX_ACP_PACKAGE));
+    push(path.join(home, ".local", "lib", "node_modules", CODEX_ACP_PACKAGE));
+    push("/usr/local/lib/node_modules/" + CODEX_ACP_PACKAGE);
+    push("/opt/homebrew/lib/node_modules/" + CODEX_ACP_PACKAGE);
+  }
+
+  const delimiter = platform === "win32" ? ";" : ":";
+  const dirs = pathDirs(options.pathEnv ?? env.PATH, delimiter);
+  const names =
+    platform === "win32"
+      ? ["codex-acp.cmd", "codex-acp.exe", "codex-acp"]
+      : ["codex-acp"];
+  for (const dir of dirs) {
+    for (const name of names) {
+      const bin = path.join(dir, name);
+      if ((options.isFile ?? defaultIsFile)(bin)) {
+        push(resolveAcpRootFromBinary(bin, options));
+      }
+    }
+    // npm prefix layout: <prefix>/codex-acp(.cmd) next to <prefix>/node_modules/...
+    push(path.join(dir, "node_modules", CODEX_ACP_PACKAGE));
+    // Homebrew / usr/local: <prefix>/bin -> <prefix>/lib/node_modules/...
+    push(path.join(dir, "..", "lib", "node_modules", CODEX_ACP_PACKAGE));
+  }
+
+  return [...new Set(roots)];
+}
+
+export function resolveAcpRootFromBinary(
+  binPath: string,
+  options: CodexBinaryHintOptions = {}
+): string | undefined {
+  const isFile = options.isFile ?? defaultIsFile;
+  const absolute = path.resolve(binPath);
+
+  try {
+    const real = fs.realpathSync(absolute);
+    if (real.endsWith(`${path.sep}dist${path.sep}index.js`)) {
+      return path.dirname(path.dirname(real));
+    }
+  } catch {
+    /* keep lexical path checks */
+  }
+
+  const dir = path.dirname(absolute);
+  const besidePrefix = path.join(dir, "node_modules", CODEX_ACP_PACKAGE);
+  if (isFile(path.join(besidePrefix, "package.json"))) return besidePrefix;
+
+  const libPrefix = path.join(dir, "..", "lib", "node_modules", CODEX_ACP_PACKAGE);
+  if (isFile(path.join(libPrefix, "package.json"))) return path.normalize(libPrefix);
+
+  return undefined;
+}
+
+/** Resolve `@openai/codex/bin/codex.js` from a codex-acp package root. */
+export function resolveBundledCodexFromAcpRoot(
+  acpRoot: string,
+  options: CodexBinaryHintOptions = {}
+): string | undefined {
+  const isFile = options.isFile ?? defaultIsFile;
+  const root = path.normalize(acpRoot);
+
+  try {
+    const req = createRequire(path.join(root, "dist", "index.js"));
+    const resolved = req.resolve(BUNDLED_CODEX_JS);
+    if (isFile(resolved)) return resolved;
+  } catch {
+    /* fall through to lexical candidates */
+  }
+
+  for (const candidate of [
+    path.join(root, "node_modules", "@openai", "codex", "bin", "codex.js"),
+    path.join(root, "..", "..", "@openai", "codex", "bin", "codex.js")
+  ]) {
+    const normalized = path.normalize(candidate);
+    if (isFile(normalized)) return normalized;
+  }
+  return undefined;
+}
+
+function resolveGlobalCodexBinary(
+  options: CodexBinaryHintOptions
+): string | undefined {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const home = options.homedir ?? os.homedir();
+  const isFile = options.isFile ?? defaultIsFile;
+  const candidates: string[] = [];
+
+  if (platform === "win32") {
+    if (env.APPDATA) {
+      candidates.push(path.join(env.APPDATA, "npm", "codex.cmd"));
+      candidates.push(path.join(env.APPDATA, "npm", "codex.exe"));
+    }
+    if (env.LOCALAPPDATA) {
+      candidates.push(
+        path.join(env.LOCALAPPDATA, "Yarn", "bin", "codex.cmd")
+      );
+      candidates.push(path.join(env.LOCALAPPDATA, "pnpm", "codex.cmd"));
+    }
+  } else {
+    candidates.push(
+      "/opt/homebrew/bin/codex",
+      "/usr/local/bin/codex",
+      path.join(home, ".local", "bin", "codex"),
+      path.join(home, ".npm-global", "bin", "codex")
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (isFile(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Best-effort sync lookup for the real Codex CLI (not the BYOK wrapper).
+ * Order: explicit FREEBUDDY_CODEX_BIN → bundled with codex-acp → global codex.
+ */
+export function resolveCodexBinaryHint(
+  options: CodexBinaryHintOptions = {}
+): string | undefined {
+  const env = options.env ?? process.env;
+  const isFile = options.isFile ?? defaultIsFile;
+
+  const fromEnv = env.FREEBUDDY_CODEX_BIN?.trim();
+  if (fromEnv && isFile(fromEnv)) return fromEnv;
+
+  for (const root of codexAcpInstallRoots(options)) {
+    const bundled = resolveBundledCodexFromAcpRoot(root, options);
+    if (bundled) return bundled;
+  }
+
+  return resolveGlobalCodexBinary(options);
+}
+
+/** Absolute `node` for invoking bundled `codex.js` from the Windows/Unix wrapper. */
+export function resolveNodeBinaryHint(
+  options: CodexBinaryHintOptions = {}
+): string | undefined {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const isFile = options.isFile ?? defaultIsFile;
+  const fromEnv = env.FREEBUDDY_NODE_BIN?.trim();
+  if (fromEnv && isFile(fromEnv)) return fromEnv;
+
+  const delimiter = platform === "win32" ? ";" : ":";
+  const dirs = pathDirs(options.pathEnv ?? env.PATH, delimiter);
+  const names =
+    platform === "win32" ? ["node.exe", "node.cmd", "node"] : ["node"];
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      if (isFile(candidate)) return candidate;
+    }
+  }
+
+  if (platform === "win32") {
+    const programFiles = env.ProgramFiles || "C:\\Program Files";
+    const programFilesX86 =
+      env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+    for (const dir of [
+      path.join(programFiles, "nodejs"),
+      path.join(programFilesX86, "nodejs")
+    ]) {
+      const candidate = path.join(dir, "node.exe");
+      if (isFile(candidate)) return candidate;
+    }
+  }
+
+  return undefined;
+}

--- a/electron/cli/codexByokWrapper.ts
+++ b/electron/cli/codexByokWrapper.ts
@@ -16,14 +16,24 @@ export function buildCodexAppServerWrapperContent(
     // so a .cmd launcher is required (.sh is not executable under cmd.exe).
     // Keep the catalog path in its own variable so nested quotes from
     // JSON.stringify do not break `set "VAR=..."`.
+    // FREEBUDDY_CODEX_BIN may point at the bundled `@openai/codex/bin/codex.js`
+    // (same entry codex-acp uses when CODEX_PATH is unset); invoke that via node.
     const catalogPathCmd = modelCatalogPath
       .replace(/\//g, "\\")
       .replace(/%/g, "%%");
     const script = `@echo off
 setlocal EnableExtensions
 set "FREEBUDDY_CATALOG_PATH=${catalogPathCmd}"
+set "NODE_BIN=node"
+if defined FREEBUDDY_NODE_BIN if exist "%FREEBUDDY_NODE_BIN%" set "NODE_BIN=%FREEBUDDY_NODE_BIN%"
 if defined FREEBUDDY_CODEX_BIN if exist "%FREEBUDDY_CODEX_BIN%" (
-  "%FREEBUDDY_CODEX_BIN%" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+  if /i "%FREEBUDDY_CODEX_BIN:~-3%"==".js" (
+    "%NODE_BIN%" "%FREEBUDDY_CODEX_BIN%" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+  ) else if /i "%FREEBUDDY_CODEX_BIN:~-4%"==".cmd" (
+    call "%FREEBUDDY_CODEX_BIN%" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+  ) else (
+    "%FREEBUDDY_CODEX_BIN%" %* -c "model_catalog_json=%FREEBUDDY_CATALOG_PATH%"
+  )
   exit /b %ERRORLEVEL%
 )
 where codex >nul 2>nul
@@ -50,7 +60,18 @@ exit /b 127
   const catalogArg = `model_catalog_json=${JSON.stringify(modelCatalogPath)}`;
   const script = `#!/bin/sh
 catalog_arg=${shellSingleQuote(catalogArg)}
-for candidate in "$FREEBUDDY_CODEX_BIN" "$(command -v codex 2>/dev/null)" "/opt/homebrew/bin/codex" "/usr/local/bin/codex"; do
+node_bin=\${FREEBUDDY_NODE_BIN:-node}
+if [ -n "$FREEBUDDY_CODEX_BIN" ] && [ -f "$FREEBUDDY_CODEX_BIN" ]; then
+  case "$FREEBUDDY_CODEX_BIN" in
+    *.js) exec "$node_bin" "$FREEBUDDY_CODEX_BIN" "$@" -c "$catalog_arg" ;;
+    *)
+      if [ -x "$FREEBUDDY_CODEX_BIN" ]; then
+        exec "$FREEBUDDY_CODEX_BIN" "$@" -c "$catalog_arg"
+      fi
+      ;;
+  esac
+fi
+for candidate in "$(command -v codex 2>/dev/null)" "/opt/homebrew/bin/codex" "/usr/local/bin/codex"; do
   if [ -n "$candidate" ] && [ -x "$candidate" ]; then
     exec "$candidate" "$@" -c "$catalog_arg"
   fi

--- a/electron/cli/store.ts
+++ b/electron/cli/store.ts
@@ -3,6 +3,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { CLIAdapterId } from "./adapters.js";
+import {
+  resolveCodexBinaryHint,
+  resolveNodeBinaryHint
+} from "./codexBinaryHint.js";
 import { buildCodexAppServerWrapperContent } from "./codexByokWrapper.js";
 import { getDataDir, getDb } from "./db.js";
 import { getCallerUserId, isCallerAdmin } from "./callerContext.js";
@@ -248,48 +252,12 @@ function createCodexByokModelCatalog(
   return file;
 }
 
-function isExecutableFile(candidate: string): boolean {
-  try {
-    const stat = fs.statSync(candidate);
-    if (!stat.isFile()) return false;
-    if (process.platform === "win32") return true;
-    return (stat.mode & 0o111) !== 0;
-  } catch {
-    return false;
-  }
-}
-
-/** Best-effort sync lookup for the real Codex CLI (not the BYOK wrapper). */
-function resolveCodexBinaryHint(): string | undefined {
-  const fromEnv = process.env.FREEBUDDY_CODEX_BIN?.trim();
-  if (fromEnv && isExecutableFile(fromEnv)) return fromEnv;
-
-  if (process.platform === "win32") {
-    const candidates: string[] = [];
-    if (process.env.APPDATA) {
-      candidates.push(path.join(process.env.APPDATA, "npm", "codex.cmd"));
-      candidates.push(path.join(process.env.APPDATA, "npm", "codex.exe"));
-    }
-    if (process.env.LOCALAPPDATA) {
-      candidates.push(
-        path.join(process.env.LOCALAPPDATA, "Yarn", "bin", "codex.cmd")
-      );
-    }
-    for (const candidate of candidates) {
-      if (isExecutableFile(candidate)) return candidate;
-    }
-    return undefined;
-  }
-
-  for (const candidate of [
-    "/opt/homebrew/bin/codex",
-    "/usr/local/bin/codex",
-    path.join(os.homedir(), ".local", "bin", "codex"),
-    path.join(os.homedir(), ".npm-global", "bin", "codex")
-  ]) {
-    if (isExecutableFile(candidate)) return candidate;
-  }
-  return undefined;
+function readOverrideBinary(id: string): string | undefined {
+  const row = getDb()
+    .prepare(`SELECT binary FROM cli_executor_overrides WHERE id = ?`)
+    .get(id) as { binary: string | null } | undefined;
+  const binary = row?.binary?.trim();
+  return binary || undefined;
 }
 
 function createCodexAppServerWrapper(
@@ -532,8 +500,12 @@ export function resolveCodexByokEnv(
     MODEL_PROVIDER: providerId
   };
   if (codexPath) env.CODEX_PATH = codexPath;
-  const codexBin = resolveCodexBinaryHint();
+  const codexBin = resolveCodexBinaryHint({
+    acpBinaryHint: readOverrideBinary(overrideId)
+  });
   if (codexBin) env.FREEBUDDY_CODEX_BIN = codexBin;
+  const nodeBin = resolveNodeBinaryHint();
+  if (nodeBin) env.FREEBUDDY_NODE_BIN = nodeBin;
   if (apiKey) env[envKey] = apiKey;
   return env;
 }

--- a/tests/codex-binary-hint.test.mjs
+++ b/tests/codex-binary-hint.test.mjs
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+let resolveCodexBinaryHint;
+let resolveBundledCodexFromAcpRoot;
+let resolveNodeBinaryHint;
+let codexAcpInstallRoots;
+
+try {
+  ({
+    resolveCodexBinaryHint,
+    resolveBundledCodexFromAcpRoot,
+    resolveNodeBinaryHint,
+    codexAcpInstallRoots
+  } = await import("../dist-electron/cli/codexBinaryHint.js"));
+} catch {
+  // build:electron runs before tests in npm test
+}
+
+test("bundled Codex under codex-acp wins over missing global codex", async (t) => {
+  if (!resolveCodexBinaryHint) {
+    t.skip("dist-electron codexBinaryHint not built yet");
+    return;
+  }
+
+  const acpRoot = path.join(
+    "C:",
+    "Users",
+    "demo",
+    "AppData",
+    "Roaming",
+    "npm",
+    "node_modules",
+    "@agentclientprotocol",
+    "codex-acp"
+  );
+  const bundled = path.join(
+    acpRoot,
+    "node_modules",
+    "@openai",
+    "codex",
+    "bin",
+    "codex.js"
+  );
+  const files = new Set([
+    path.join(acpRoot, "package.json"),
+    path.join(acpRoot, "dist", "index.js"),
+    bundled
+  ]);
+
+  const resolved = resolveCodexBinaryHint({
+    platform: "win32",
+    env: {
+      APPDATA: path.join("C:", "Users", "demo", "AppData", "Roaming"),
+      PATH: ""
+    },
+    pathEnv: "",
+    isFile: (candidate) => files.has(path.normalize(candidate))
+  });
+
+  assert.equal(path.normalize(resolved), path.normalize(bundled));
+});
+
+test("explicit FREEBUDDY_CODEX_BIN overrides bundled lookup", async (t) => {
+  if (!resolveCodexBinaryHint) {
+    t.skip("dist-electron codexBinaryHint not built yet");
+    return;
+  }
+
+  const explicit = path.join("D:", "tools", "codex.exe");
+  const resolved = resolveCodexBinaryHint({
+    platform: "win32",
+    env: {
+      FREEBUDDY_CODEX_BIN: explicit,
+      APPDATA: path.join("C:", "Users", "demo", "AppData", "Roaming")
+    },
+    isFile: (candidate) => path.normalize(candidate) === path.normalize(explicit)
+  });
+  assert.equal(path.normalize(resolved), path.normalize(explicit));
+});
+
+test("resolveBundledCodexFromAcpRoot checks nested and hoisted layouts", async (t) => {
+  if (!resolveBundledCodexFromAcpRoot) {
+    t.skip("dist-electron codexBinaryHint not built yet");
+    return;
+  }
+
+  const acpRoot = "/usr/local/lib/node_modules/@agentclientprotocol/codex-acp";
+  const hoisted = "/usr/local/lib/node_modules/@openai/codex/bin/codex.js";
+  assert.equal(
+    resolveBundledCodexFromAcpRoot(acpRoot, {
+      isFile: (candidate) => path.normalize(candidate) === path.normalize(hoisted)
+    }),
+    path.normalize(hoisted)
+  );
+});
+
+test("codexAcpInstallRoots includes Windows npm global package path", async (t) => {
+  if (!codexAcpInstallRoots) {
+    t.skip("dist-electron codexBinaryHint not built yet");
+    return;
+  }
+
+  const appData = path.join("C:", "Users", "demo", "AppData", "Roaming");
+  const roots = codexAcpInstallRoots({
+    platform: "win32",
+    env: { APPDATA: appData, PATH: "" },
+    pathEnv: ""
+  });
+  assert.ok(
+    roots.some((root) =>
+      root.endsWith(
+        path.join(
+          "npm",
+          "node_modules",
+          "@agentclientprotocol",
+          "codex-acp"
+        )
+      )
+    )
+  );
+});
+
+test("resolveNodeBinaryHint finds node.exe on PATH", async (t) => {
+  if (!resolveNodeBinaryHint) {
+    t.skip("dist-electron codexBinaryHint not built yet");
+    return;
+  }
+
+  const nodeExe = path.join("C:", "Program Files", "nodejs", "node.exe");
+  assert.equal(
+    path.normalize(
+      resolveNodeBinaryHint({
+        platform: "win32",
+        env: { PATH: path.dirname(nodeExe) },
+        pathEnv: path.dirname(nodeExe),
+        isFile: (candidate) => path.normalize(candidate) === path.normalize(nodeExe)
+      })
+    ),
+    path.normalize(nodeExe)
+  );
+});

--- a/tests/codex-byok-windows.test.mjs
+++ b/tests/codex-byok-windows.test.mjs
@@ -32,6 +32,16 @@ test("resolveCodexByokEnv sets FREEBUDDY_CODEX_BIN for the wrapper", () => {
     /env\.FREEBUDDY_CODEX_BIN\s*=/,
     "BYOK env must set FREEBUDDY_CODEX_BIN so the wrapper can find the real binary"
   );
+  assert.match(
+    storeSource,
+    /from ["']\.\/codexBinaryHint/,
+    "binary hint resolution lives in codexBinaryHint"
+  );
+  assert.match(
+    storeSource,
+    /env\.FREEBUDDY_NODE_BIN\s*=/,
+    "BYOK env should pass FREEBUDDY_NODE_BIN so the wrapper can run bundled codex.js"
+  );
 });
 
 test("ACP auth selection uses the agent child env so BYOK keys win over ChatGPT login", () => {
@@ -76,7 +86,13 @@ test("buildCodexAppServerWrapperContent emits Windows cmd and Unix sh scripts", 
   assert.match(win.script, /%\*/);
   assert.match(win.script, /-c /);
   assert.match(win.script, /FREEBUDDY_CODEX_BIN/);
+  assert.match(win.script, /FREEBUDDY_NODE_BIN/);
   assert.match(win.script, /codex\.cmd/);
+  assert.match(
+    win.script,
+    /FREEBUDDY_CODEX_BIN:~-3%"=="\.js"/,
+    "Windows wrapper must detect bundled codex.js and run it via node"
+  );
   assert.match(
     win.script,
     /set "FREEBUDDY_CATALOG_PATH=C:\\Users\\demo\\/,
@@ -89,4 +105,10 @@ test("buildCodexAppServerWrapperContent emits Windows cmd and Unix sh scripts", 
   assert.match(unix.script, /^#!\/bin\/sh/);
   assert.match(unix.script, /command -v codex/);
   assert.match(unix.script, /\/opt\/homebrew\/bin\/codex/);
+  assert.match(
+    unix.script,
+    /\*\.js\)/,
+    "Unix wrapper must run bundled codex.js via node"
+  );
+  assert.match(unix.script, /FREEBUDDY_NODE_BIN/);
 });


### PR DESCRIPTION
## Summary
- Codex BYOK wrapper no longer depends on a globally installed `codex` binary
- Resolve `@openai/codex/bin/codex.js` bundled inside `@agentclientprotocol/codex-acp` (same default as when `CODEX_PATH` is unset)
- Invoke bundled `.js` via `node` / `FREEBUDDY_NODE_BIN`, with explicit env override and global `codex` as fallbacks

## Test plan
- [x] `npm run build:electron && node --test --test-force-exit tests/codex-binary-hint.test.mjs tests/codex-byok-windows.test.mjs`
- [ ] On Windows with only `codex-acp` installed (no global `codex`), enable Codex BYOK with a custom model and confirm a conversation starts
- [ ] With `FREEBUDDY_CODEX_BIN` set, confirm the override still wins
- [ ] Without BYOK / without model catalog, confirm existing Codex flows still work


Made with [Cursor](https://cursor.com)