### PR TITLE
fix: prevent hanging ACP runs (permission timeouts + inactivity watchdog)

### DIFF
--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -93,6 +93,12 @@ import { clearSessionOwner } from "./sessionOwners.js";
 import { getLanguage } from "./settings.js";
 
 const PERMISSION_REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
+// An ACP turn blocks on a single session/prompt request that only resolves
+// when the agent returns its final response. If a tool spawns a long-running
+// child (for example a dev server) that holds the agent's stdio open, the
+// agent stops emitting session/update frames and the prompt request never
+// settles. Cancel the turn after this much continuous silence.
+const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
 
 function writeAcp(
   child: ChildProcessByStdio<Writable, Readable, Readable>,
@@ -169,6 +175,8 @@ export async function runAcpAgent({
   let activeAcpSessionId: string | undefined;
   let finished = false;
   let promptStarted = false;
+  let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
+  let inactivityFired = false;
   let promptHadContent = false;
   let turnHadLiveAgentChunk = false;
   let sessionWasResumed = false;
@@ -253,6 +261,34 @@ export async function runAcpAgent({
     appendLog(logStream, "stdin", JSON.stringify(msg));
     writeAcp(child, msg);
   };
+  const armInactivityTimer = () => {
+    if (INACTIVITY_TIMEOUT_MS <= 0) return;
+    if (inactivityTimer) clearTimeout(inactivityTimer);
+    if (finished || inactivityFired) return;
+    inactivityTimer = setTimeout(() => {
+      if (finished || inactivityFired) return;
+      inactivityFired = true;
+      appendLog(
+        logStream,
+        "system",
+        `inactivity timeout after ${INACTIVITY_TIMEOUT_MS}ms with no agent output; cancelling`
+      );
+      cancelRun();
+      finish(
+        "failed",
+        -1,
+        `Agent produced no output for ${Math.round(
+          INACTIVITY_TIMEOUT_MS / 60000
+        )} minutes and was cancelled. This usually means a tool spawned a long-running process (for example a dev server) that held the agent's output stream open.`
+      );
+    }, INACTIVITY_TIMEOUT_MS);
+  };
+  const disarmInactivityTimer = () => {
+    if (inactivityTimer) {
+      clearTimeout(inactivityTimer);
+      inactivityTimer = undefined;
+    }
+  };
   const finish = (
     status: "done" | "failed" | "killed",
     exitCode: number,
@@ -260,6 +296,7 @@ export async function runAcpAgent({
   ) => {
     if (finished) return;
     finished = true;
+    disarmInactivityTimer();
     terminalManager.dispose();
     running.delete(args.sessionId);
     unregisterDraftToolSession(args.sessionId);
@@ -368,6 +405,7 @@ export async function runAcpAgent({
         )
       ) {
         promptHadContent = true;
+        armInactivityTimer();
       }
       if (
         shouldSkipUserMessageChunk(msg.params?.update, {
@@ -927,14 +965,19 @@ export async function runAcpAgent({
     // be confined to the pre-prompt replay phase; keeping it enabled would drop
     // live agent chunks whose text matches a persisted history signature.
     sessionWasResumed = false;
-    await request(
-      buildSessionPromptRequest(
-        nextId(),
-        activeAcpSessionId!,
-        activePrompt,
-        args.promptAttachments
-      )
-    );
+    armInactivityTimer();
+    try {
+      await request(
+        buildSessionPromptRequest(
+          nextId(),
+          activeAcpSessionId!,
+          activePrompt,
+          args.promptAttachments
+        )
+      );
+    } finally {
+      disarmInactivityTimer();
+    }
   };
 
   const authRequiredError = (methods: AcpAuthMethod[]) => {

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -45,6 +45,7 @@ import {
   clearPermissionResolversForSession,
   registerAuthenticationResolver,
   registerPermissionResolver,
+  takePermissionResolver,
   setTaskToolSessionId,
   updateTaskStatus,
   type CliEvent,
@@ -90,6 +91,8 @@ import {
 import { isPathWithinRoots } from "../shared/workspaceRoots.js";
 import { clearSessionOwner } from "./sessionOwners.js";
 import { getLanguage } from "./settings.js";
+
+const PERMISSION_REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 
 function writeAcp(
   child: ChildProcessByStdio<Writable, Readable, Readable>,
@@ -506,7 +509,16 @@ export async function runAcpAgent({
         });
         return;
       }
-      // Fall through to manual prompting if no allow option is present.
+      // An auto-approved run has no renderer prompt to resolve. Cancelling is
+      // safer than leaving the ACP request pending forever when an adapter
+      // exposes only an unsupported permission shape.
+      appendLog(
+        logStream,
+        "system",
+        "permission auto-cancelled (no allow option)"
+      );
+      respondToPermission(requestRpcId, { outcome: "cancelled" });
+      return;
     }
 
     if (options.length === 0) {
@@ -543,7 +555,9 @@ export async function runAcpAgent({
         }
       : undefined;
 
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     registerPermissionResolver(args.sessionId, requestId, (decision) => {
+      if (timeout) clearTimeout(timeout);
       appendLog(
         logStream,
         "system",
@@ -556,6 +570,17 @@ export async function runAcpAgent({
       respondToPermission(requestRpcId, decision);
       emit({ type: "permission-resolved", requestId });
     });
+
+    timeout = setTimeout(() => {
+      const resolver = takePermissionResolver(args.sessionId, requestId);
+      if (!resolver) return;
+      appendLog(
+        logStream,
+        "system",
+        `permission timeout (${requestId}) after ${PERMISSION_REQUEST_TIMEOUT_MS}ms`
+      );
+      resolver({ outcome: "cancelled" });
+    }, PERMISSION_REQUEST_TIMEOUT_MS);
 
     appendLog(
       logStream,

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -205,12 +205,13 @@ export async function cliRun(
   insertTask(args, logFile, toolSessionId);
   logMain().info("runtime", "agent run start", {
     adapter: args.adapter,
-    sessionId: args.sessionId
+    sessionId: args.sessionId,
+    approvalMode: args.approvalMode ?? "default"
   });
   appendLog(
     logStream,
     "system",
-    `start adapter=${args.adapter} cwd=${args.cwd ?? "."} resume=${toolSessionId ?? "-"}`
+    `start adapter=${args.adapter} approvalMode=${args.approvalMode ?? "default"} cwd=${args.cwd ?? "."} resume=${toolSessionId ?? "-"}`
   );
 
   // Avoid spawning codex-acp while npm is replacing its global package files.

--- a/electron/cli/workflowRuntime.ts
+++ b/electron/cli/workflowRuntime.ts
@@ -1053,6 +1053,22 @@ export class WorkflowRuntime {
         resumeToolSession,
         cwd: run.cwd,
         onEvent: (e: CliEvent) => {
+          if (
+            run.conversationId &&
+            (e.type === "permission" ||
+              e.type === "permission-resolved" ||
+              e.type === "authentication" ||
+              e.type === "authentication-resolved" ||
+              e.type === "authentication-terminal-started" ||
+              e.type === "authentication-terminal-update" ||
+              e.type === "authentication-terminal-resolved")
+          ) {
+            this.broadcastWorkflowEvent({
+              conversationId: run.conversationId,
+              sessionId,
+              event: e
+            });
+          }
           if (e.type === "items" && e.items?.length) {
             collected.push(...e.items);
             scheduleMessageUpdate();
@@ -1117,6 +1133,18 @@ export class WorkflowRuntime {
     safeSendToWebContents(
       this.deps.webContents,
       `workflow://message/${payload.conversationId}`,
+      payload
+    );
+  }
+
+  private broadcastWorkflowEvent(payload: {
+    conversationId: string;
+    sessionId: string;
+    event: CliEvent;
+  }): void {
+    safeSendToWebContents(
+      this.deps.webContents,
+      `workflow://event/${payload.conversationId}`,
       payload
     );
   }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -403,6 +403,16 @@ const workflow = {
     ipcRenderer.on(channel, handler);
     return () => ipcRenderer.off(channel, handler);
   },
+  onStepEvent(
+    conversationId: string,
+    cb: (event: { sessionId: string; event: unknown }) => void
+  ): () => void {
+    const channel = `workflow://event/${conversationId}`;
+    const handler = (_e: IpcRendererEvent, payload: unknown) =>
+      cb(payload as any);
+    ipcRenderer.on(channel, handler);
+    return () => ipcRenderer.off(channel, handler);
+  },
   onRunFinished(
     cb: (event: {
       runId: string;

--- a/electron/shared/wsChannelPolicy.ts
+++ b/electron/shared/wsChannelPolicy.ts
@@ -21,6 +21,7 @@ const CONVERSATION_PAYLOAD_CHANNELS = new Set([
 const OWNER_PAYLOAD_CHANNELS = new Set(["scheduledTasks://changed"]);
 const CLI_SESSION_PREFIX = "cli://";
 const WORKFLOW_MESSAGE_PREFIX = "workflow://message/";
+const WORKFLOW_EVENT_PREFIX = "workflow://event/";
 const NON_SESSION_CLI_CHANNELS = new Set(["cli://runtime", "cli://install"]);
 
 export function classifyWsChannel(channel: string): WsChannelClass {
@@ -31,6 +32,10 @@ export function classifyWsChannel(channel: string): WsChannelClass {
   if (OWNER_PAYLOAD_CHANNELS.has(channel)) return { kind: "ownerPayload" };
   if (channel.startsWith(WORKFLOW_MESSAGE_PREFIX)) {
     const conversationId = channel.slice(WORKFLOW_MESSAGE_PREFIX.length);
+    if (conversationId) return { kind: "conversation", conversationId };
+  }
+  if (channel.startsWith(WORKFLOW_EVENT_PREFIX)) {
+    const conversationId = channel.slice(WORKFLOW_EVENT_PREFIX.length);
     if (conversationId) return { kind: "conversation", conversationId };
   }
   if (channel.startsWith(CLI_SESSION_PREFIX) && !NON_SESSION_CLI_CHANNELS.has(channel)) {

--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -119,6 +119,24 @@ function refreshLatestErrorDetails(
   return next;
 }
 
+function reconcileDanglingToolCalls(
+  items: CliStreamItem[],
+  terminalStatus: "completed" | "failed"
+): CliStreamItem[] {
+  let changed = false;
+  const next = items.map((item) => {
+    if (
+      item.kind === "tool-call" &&
+      (item.status === "pending" || item.status === "running")
+    ) {
+      changed = true;
+      return { ...item, status: terminalStatus };
+    }
+    return item;
+  });
+  return changed ? next : items;
+}
+
 export function handleStreamEvent(
   set: SetFn,
   get: GetFn,
@@ -239,6 +257,13 @@ export function handleStreamEvent(
         status = e.exitCode === 0 ? "done" : "failed";
       }
       exitCode = e.exitCode;
+      // Some adapters (e.g. codebuddy/Hy3) abandon an in-progress tool call and
+      // end the turn without emitting a terminal tool_call_update, leaving the
+      // card spinning forever. Force any dangling tool-call to a terminal status.
+      nextItems = reconcileDanglingToolCalls(
+        nextItems,
+        status === "done" && e.exitCode === 0 ? "completed" : "failed"
+      );
       if (status !== "killed" && e.exitCode !== 0 && !hasUserFacingError(nextItems)) {
         nextItems = appendItems(nextItems, [failureSummaryFor(e.exitCode, parseCtx)]);
       }

--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -128,38 +128,7 @@ export function handleStreamEvent(
   parseCtx: ParseContext,
   preserveConversationTitle = false
 ): void {
-  if (e.type === "permission") {
-    usePermissionStore.getState().enqueue(conversationId, e.request);
-    return;
-  }
-  if (e.type === "permission-resolved") {
-    usePermissionStore.getState().remove(e.requestId);
-    return;
-  }
-  if (e.type === "authentication") {
-    useAuthenticationStore.getState().enqueue(conversationId, e.request);
-    return;
-  }
-  if (e.type === "authentication-resolved") {
-    useAuthenticationStore.getState().remove(e.requestId);
-    return;
-  }
-  if (e.type === "authentication-terminal-started") {
-    useAuthenticationStore.getState().startTerminal(conversationId, e.request);
-    return;
-  }
-  if (e.type === "authentication-terminal-update") {
-    useAuthenticationStore.getState().updateTerminal(e.requestId, {
-      output: e.output,
-      running: e.running,
-      exitCode: e.exitCode
-    });
-    return;
-  }
-  if (e.type === "authentication-terminal-resolved") {
-    useAuthenticationStore.getState().removeTerminal(e.requestId);
-    return;
-  }
+  if (handleStreamControlEvent(conversationId, e)) return;
 
   set((s) => {
     const live = s.live[conversationId];
@@ -358,6 +327,46 @@ export function handleStreamEvent(
     }
     void finalizeRun(set, get, conversationId, reason);
   }
+}
+
+export function handleStreamControlEvent(
+  conversationId: string,
+  e: CliEvent
+): boolean {
+  if (e.type === "permission") {
+    usePermissionStore.getState().enqueue(conversationId, e.request);
+    return true;
+  }
+  if (e.type === "permission-resolved") {
+    usePermissionStore.getState().remove(e.requestId);
+    return true;
+  }
+  if (e.type === "authentication") {
+    useAuthenticationStore.getState().enqueue(conversationId, e.request);
+    return true;
+  }
+  if (e.type === "authentication-resolved") {
+    useAuthenticationStore.getState().remove(e.requestId);
+    return true;
+  }
+  if (e.type === "authentication-terminal-started") {
+    useAuthenticationStore.getState().startTerminal(conversationId, e.request);
+    return true;
+  }
+  if (e.type === "authentication-terminal-update") {
+    useAuthenticationStore.getState().updateTerminal(e.requestId, {
+      output: e.output,
+      running: e.running,
+      exitCode: e.exitCode
+    });
+    return true;
+  }
+  if (e.type === "authentication-terminal-resolved") {
+    useAuthenticationStore.getState().removeTerminal(e.requestId);
+    return true;
+  }
+
+  return false;
 }
 
 async function finalizeRun(

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -208,7 +208,12 @@ function ensureWorkflowMessageSubscription(
   const api = fb?.workflow;
   if (!api?.onStepMessage) return;
   if (!workflowFinishedUnsubscribe && api.onRunFinished) {
-    workflowFinishedUnsubscribe = api.onRunFinished((event) => {
+    workflowFinishedUnsubscribe = api.onRunFinished((event: {
+      runId: string;
+      conversationId?: string;
+      status: string;
+      name: string;
+    }) => {
       if (
         event.conversationId &&
         terminalWorkflowStatuses.has(event.status)

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -43,7 +43,11 @@ import {
   shouldApplyAgentSessionTitle,
   upsertConversationMessage
 } from "./conversationUtils";
-import { handleStreamEvent, killConversation } from "./conversationHandlers";
+import {
+  handleStreamControlEvent,
+  handleStreamEvent,
+  killConversation
+} from "./conversationHandlers";
 import {
   latestConfigOptionsFromItems,
   latestConfigOptionsFromMessages,
@@ -162,9 +166,29 @@ export const runCtxMap = new Map<string, RunCtx>();
 let transferInFlight = false;
 
 let workflowMessageUnsubscribe: (() => void) | null = null;
+const workflowEventUnsubscribes = new Map<string, () => void>();
+let workflowFinishedUnsubscribe: (() => void) | null = null;
 let workflowMessageConversationId: string | null = null;
 let workflowRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 const workflowPendingMessageIds = new Set<string>();
+
+const terminalWorkflowStatuses = new Set([
+  "completed",
+  "failed",
+  "killed",
+  "partial"
+]);
+
+function removeWorkflowEventSubscription(conversationId: string): void {
+  const unsubscribe = workflowEventUnsubscribes.get(conversationId);
+  if (!unsubscribe) return;
+  try {
+    unsubscribe();
+  } catch {
+    /* noop */
+  }
+  workflowEventUnsubscribes.delete(conversationId);
+}
 
 function hasActiveWorkflowMessages(messages: ConversationMessage[] | undefined): boolean {
   return (
@@ -183,6 +207,33 @@ function ensureWorkflowMessageSubscription(
   const fb = (globalThis as any).freebuddy;
   const api = fb?.workflow;
   if (!api?.onStepMessage) return;
+  if (!workflowFinishedUnsubscribe && api.onRunFinished) {
+    workflowFinishedUnsubscribe = api.onRunFinished((event) => {
+      if (
+        event.conversationId &&
+        terminalWorkflowStatuses.has(event.status)
+      ) {
+        removeWorkflowEventSubscription(event.conversationId);
+      }
+    });
+  }
+  if (
+    conversationId &&
+    api.onStepEvent &&
+    !workflowEventUnsubscribes.has(conversationId)
+  ) {
+    workflowEventUnsubscribes.set(
+      conversationId,
+      api.onStepEvent(
+        conversationId,
+        (event: { sessionId?: string; event?: CliEvent }) => {
+          if (event?.event) {
+            handleStreamControlEvent(conversationId, event.event);
+          }
+        }
+      )
+    );
+  }
   if (workflowMessageConversationId === conversationId) return;
   if (workflowMessageUnsubscribe) {
     try {

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -429,6 +429,10 @@ declare global {
         messageId: string;
       }) => void
     ): () => void;
+    onStepEvent(
+      conversationId: string,
+      cb: (event: { sessionId: string; event: CliEvent }) => void
+    ): () => void;
     onRunFinished(
       cb: (event: {
         runId: string;

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -39,6 +39,24 @@ test("ACP runtime still treats process close as a fallback finish signal", () =>
   assert.match(acpRuntimeSource, /finish\(status, exitCode, crashMessage\)/);
 });
 
+test("ACP auto approval never leaves an unsupported permission request pending", () => {
+  assert.match(
+    acpRuntimeSource,
+    /if \(args\.approvalMode === "auto"\)[\s\S]*?permission auto-cancelled \(no allow option\)[\s\S]*?respondToPermission\(requestRpcId, \{ outcome: "cancelled" \}\)/
+  );
+});
+
+test("ACP permission requests expire through the resolver registry", () => {
+  assert.match(acpRuntimeSource, /takePermissionResolver/);
+  assert.match(acpRuntimeSource, /PERMISSION_REQUEST_TIMEOUT_MS/);
+  assert.match(acpRuntimeSource, /setTimeout\(/);
+  assert.match(acpRuntimeSource, /permission timeout/);
+});
+
+test("CLI runtime records the approval mode with each task start", () => {
+  assert.match(runtimeSource, /approvalMode: args\.approvalMode \?\? "default"/);
+});
+
 test("ACP terminal output uses the stable exitStatus response shape", () => {
   assert.match(acpRuntimeSource, /buildTerminalOutputResponse\(snap\)/);
 });

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -53,6 +53,43 @@ test("ACP permission requests expire through the resolver registry", () => {
   assert.match(acpRuntimeSource, /permission timeout/);
 });
 
+test("ACP turns are cancelled when the agent stops producing output", () => {
+  assert.match(acpRuntimeSource, /INACTIVITY_TIMEOUT_MS/);
+  assert.match(acpRuntimeSource, /const armInactivityTimer/);
+  assert.match(acpRuntimeSource, /const disarmInactivityTimer/);
+  // The watchdog arms when a prompt turn starts and disarms when it settles,
+  // so a single stuck turn (not the whole session lifetime) is bounded.
+  const promptBodyIndex = acpRuntimeSource.indexOf("const runPromptOnSession");
+  const promptBody = acpRuntimeSource.slice(
+    promptBodyIndex,
+    acpRuntimeSource.indexOf("};", acpRuntimeSource.indexOf("disarmInactivityTimer();", promptBodyIndex)) + 2
+  );
+  assert.match(promptBody, /armInactivityTimer\(\);/);
+  assert.match(promptBody, /disarmInactivityTimer\(\);/);
+  // Every live session/update frame resets the timer, mirroring promptHadContent.
+  assert.match(
+    acpRuntimeSource,
+    /promptHadContent = true;\s*\n\s*armInactivityTimer\(\);/
+  );
+  // On expiry the run is torn down via the existing cancel+finish path so the
+  // workflow runtime observes the standard error+done event pair.
+  assert.match(
+    acpRuntimeSource,
+    /inactivity timeout after [\s\S]*?cancelRun\(\);[\s\S]*?finish\(\s*"failed"/
+  );
+  // finish() clears the timer so a late fire cannot race a normal completion.
+  const finishBody = acpRuntimeSource.slice(
+    acpRuntimeSource.indexOf("const finish ="),
+    acpRuntimeSource.indexOf("const cancelRun")
+  );
+  assert.match(finishBody, /disarmInactivityTimer\(\);/);
+  assert.ok(
+    finishBody.indexOf("disarmInactivityTimer();") <
+      finishBody.indexOf('emit({ type: "done"'),
+    "inactivity timer is cleared before the terminal done event fires"
+  );
+});
+
 test("CLI runtime records the approval mode with each task start", () => {
   assert.match(runtimeSource, /approvalMode: args\.approvalMode \?\? "default"/);
 });

--- a/tests/conversation-send-replay.test.mjs
+++ b/tests/conversation-send-replay.test.mjs
@@ -109,6 +109,7 @@ async function loadConversationStoreHarness() {
     export const feedArticleTitleFromMessages = () => undefined;
     export const mergeConversationMessages = (_, messages) => messages;
     export const shouldApplyAgentSessionTitle = () => false;
+    export const handleStreamControlEvent = () => false;
     export const handleStreamEvent = () => undefined;
     export const killConversation = async () => undefined;
     export const latestConfigOptionsFromItems = () => [];

--- a/tests/workflow-runtime-contract.test.mjs
+++ b/tests/workflow-runtime-contract.test.mjs
@@ -6,6 +6,14 @@ const runtimeSource = fs.readFileSync(
   new URL("../electron/cli/workflowRuntime.ts", import.meta.url),
   "utf8"
 );
+const preloadSource = fs.readFileSync(
+  new URL("../electron/preload.ts", import.meta.url),
+  "utf8"
+);
+const conversationStoreSource = fs.readFileSync(
+  new URL("../src/store/conversationStore.ts", import.meta.url),
+  "utf8"
+);
 
 test("runtime passes reviewer step status into review_required gate evaluation", () => {
   assert.match(runtimeSource, /reviewerStepStatus/);
@@ -21,6 +29,17 @@ test("runtime blocks write steps before write approval at execute boundary", () 
   assert.match(runtimeSource, /hasWriteApproval/);
   assert.match(runtimeSource, /step\.mode === "write"/);
   assert.match(runtimeSource, /status: "blocked"/);
+});
+
+test("workflow forwards ACP control events to the owning conversation", () => {
+  assert.match(runtimeSource, /broadcastWorkflowEvent/);
+  assert.match(runtimeSource, /e\.type === "permission"/);
+  assert.match(runtimeSource, /e\.type === "authentication"/);
+  assert.match(runtimeSource, /workflow:\/\/event\//);
+  assert.match(preloadSource, /onStepEvent\(/);
+  assert.match(conversationStoreSource, /workflowEventUnsubscribes = new Map/);
+  assert.match(conversationStoreSource, /onRunFinished/);
+  assert.match(conversationStoreSource, /removeWorkflowEventSubscription/);
 });
 
 test("runtime pauses before entering a manual-gated write phase", () => {

--- a/tests/ws-channel-policy.test.mjs
+++ b/tests/ws-channel-policy.test.mjs
@@ -54,7 +54,12 @@ test("conversation-scoped channels are classified for per-owner delivery", async
     kind: "conversation",
     conversationId: "conv-1"
   });
+  assert.deepEqual(classifyWsChannel("workflow://event/conv-1"), {
+    kind: "conversation",
+    conversationId: "conv-1"
+  });
   assert.deepEqual(classifyWsChannel("workflow://message/"), { kind: "drop" });
+  assert.deepEqual(classifyWsChannel("workflow://event/"), { kind: "drop" });
 
   assert.equal(conversationIdFromPayload({ conversationId: "conv-1" }), "conv-1");
   assert.equal(conversationIdFromPayload({ conversationId: "" }), null);


### PR DESCRIPTION
## Summary

Two related causes of workflow subtasks hanging forever in "waiting", addressed together.

### 1. ACP permission requests hanging (`c486c05`)
- Automatic runs cancel unsupported permission shapes instead of falling through to a renderer prompt that never resolves.
- Permission resolvers expire after 2 minutes via `takePermissionResolver`.
- Workflow-owned permission/authentication prompts are relayed to the owning conversation (`workflow://event/<id>`) so the renderer can actually prompt/resolve them, and are cleaned up on terminal run status.

### 2. ACP turns that stop producing output (`d685768`) — the actual reported symptom
The reported debug bundle (`freebuddy-debug-2026-08-03T17-36-32-173`) shows subtask `80d75da5` (an opencode-acp review step) started 09:21 and never produced `agent run done`. Root cause: the agent ran `Start-Process node ...next start -NoNewWindow; Start-Sleep 6; Get-Content <log>`; the spawned dev server held the agent's stdio open, so the `session/prompt` request never settled and the workflow step waited indefinitely. All 9 permissions in that session were `auto-approved` — this was **not** a permission hang, so fix #1 alone did not address it.

Fix: a per-turn inactivity watchdog in `runAcpAgent` (`electron/cli/acpRuntime.ts`):
- Armed when `runPromptOnSession` begins, disarmed in its `finally`.
- Reset on every live `session/update` frame (`agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update`, `plan`) — the same signal that flips `promptHadContent`.
- On 10 minutes of continuous silence, `cancelRun()` + `finish("failed")`, so callers observe the standard `error`+`done` pair and the workflow step fails/retries instead of hanging. This protects both direct runs and workflow subtasks.
- `finish()` disarms the timer to avoid racing a normal completion.

Also fixes a `TS7006` implicit-any in the `onRunFinished` callback (introduced by commit #1) that broke `typecheck`.

## Validation
- `npm run typecheck` — clean
- `npm test` — 42 tests, 38 pass, 0 fail, 4 skipped (unchanged baseline)
- `npm run github:preflight` — pass