### PR TITLE
fix: probe agent liveness before cancelling inactive ACP turns

### DIFF
--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -99,6 +99,15 @@ const PERMISSION_REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 // agent stops emitting session/update frames and the prompt request never
 // settles. Cancel the turn after this much continuous silence.
 const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
+// When the inactivity watchdog fires, probe the agent with a read-only
+// session/list before killing the run. If the agent responds, its main process
+// is alive (most likely blocked on a silent long-running tool such as a
+// sub-agent task) and the run is granted more time. Requires the adapter to
+// implement session/list (advertised in agentCapabilities.sessionCapabilities);
+// adapters that reject the probe are treated as unresponsive. Reprieves are
+// capped so a permanently silent run still gets killed eventually.
+const INACTIVITY_PING_TIMEOUT_MS = 15_000;
+const MAX_INACTIVITY_REPRIEVES = 2;
 
 function writeAcp(
   child: ChildProcessByStdio<Writable, Readable, Readable>,
@@ -177,6 +186,7 @@ export async function runAcpAgent({
   let promptStarted = false;
   let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
   let inactivityFired = false;
+  let inactivityReprieves = 0;
   let promptHadContent = false;
   let turnHadLiveAgentChunk = false;
   let sessionWasResumed = false;
@@ -261,6 +271,67 @@ export async function runAcpAgent({
     appendLog(logStream, "stdin", JSON.stringify(msg));
     writeAcp(child, msg);
   };
+  const probeAgentLiveness = (): Promise<boolean> =>
+    new Promise<boolean>((resolve) => {
+      const probeId = nextId();
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        pending.delete(String(probeId));
+        resolve(false);
+      }, INACTIVITY_PING_TIMEOUT_MS);
+      pending.set(String(probeId), {
+        resolve: () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(true);
+        },
+        reject: () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(false);
+        }
+      });
+      const probeMsg = buildSessionListRequest(probeId);
+      appendLog(logStream, "stdin", JSON.stringify(probeMsg));
+      writeAcp(child, probeMsg);
+    });
+
+  const onInactivityExpired = async () => {
+    if (finished) return;
+    const alive = await probeAgentLiveness();
+    if (finished) return;
+    const minutes = Math.round(INACTIVITY_TIMEOUT_MS / 60000);
+    if (alive && inactivityReprieves < MAX_INACTIVITY_REPRIEVES) {
+      inactivityReprieves += 1;
+      appendLog(
+        logStream,
+        "system",
+        `inactivity after ${INACTIVITY_TIMEOUT_MS}ms; agent responded to liveness probe; continuing (reprieve ${inactivityReprieves}/${MAX_INACTIVITY_REPRIEVES})`
+      );
+      inactivityFired = false;
+      disarmInactivityTimer();
+      armInactivityTimer();
+      return;
+    }
+    appendLog(
+      logStream,
+      "system",
+      `inactivity timeout after ${INACTIVITY_TIMEOUT_MS}ms with no agent output; cancelling`
+    );
+    cancelRun();
+    finish(
+      "failed",
+      -1,
+      alive
+        ? `Agent produced no output for ${minutes} minutes and was still silent after ${MAX_INACTIVITY_REPRIEVES} liveness probes. This usually means a tool spawned a long-running process (for example a dev server or sub-agent) that held the agent's output stream open.`
+        : `Agent produced no output for ${minutes} minutes and did not respond to a liveness probe. This usually means a tool spawned a long-running process (for example a dev server) that held the agent's output stream open.`
+    );
+  };
+
   const armInactivityTimer = () => {
     if (INACTIVITY_TIMEOUT_MS <= 0) return;
     if (inactivityTimer) clearTimeout(inactivityTimer);
@@ -268,19 +339,7 @@ export async function runAcpAgent({
     inactivityTimer = setTimeout(() => {
       if (finished || inactivityFired) return;
       inactivityFired = true;
-      appendLog(
-        logStream,
-        "system",
-        `inactivity timeout after ${INACTIVITY_TIMEOUT_MS}ms with no agent output; cancelling`
-      );
-      cancelRun();
-      finish(
-        "failed",
-        -1,
-        `Agent produced no output for ${Math.round(
-          INACTIVITY_TIMEOUT_MS / 60000
-        )} minutes and was cancelled. This usually means a tool spawned a long-running process (for example a dev server) that held the agent's output stream open.`
-      );
+      void onInactivityExpired();
     }, INACTIVITY_TIMEOUT_MS);
   };
   const disarmInactivityTimer = () => {
@@ -961,6 +1020,7 @@ export async function runAcpAgent({
     promptStarted = true;
     promptHadContent = false;
     turnHadLiveAgentChunk = false;
+    inactivityReprieves = 0;
     // Live generation begins here. Replay suppression (sessionWasResumed) must
     // be confined to the pre-prompt replay phase; keeping it enabled would drop
     // live agent chunks whose text matches a persisted history signature.

--- a/styles.css
+++ b/styles.css
@@ -11929,10 +11929,15 @@ button.ghost:disabled {
 
 .plan-card {
   display: flex;
-  min-height: 0;
-  flex: 1 1 auto;
+  min-height: 240px;
+  flex: 1 1 240px;
   flex-direction: column;
   overflow: hidden;
+}
+
+.workspace-cards > .info-data-card,
+.workspace-cards > .feed-card {
+  flex: 0 0 auto;
 }
 
 .plan-list {

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -90,6 +90,36 @@ test("ACP turns are cancelled when the agent stops producing output", () => {
   );
 });
 
+test("ACP inactivity watchdog probes liveness before cancelling and caps reprieves", () => {
+  // Before killing a silent run, the runtime sends a read-only session/list
+  // probe. A responsive agent gets extra time (reprieve); an unresponsive one
+  // or one that exhausted reprieves is still cancelled.
+  assert.match(acpRuntimeSource, /const probeAgentLiveness/);
+  assert.match(acpRuntimeSource, /buildSessionListRequest\(probeId\)/);
+  assert.match(acpRuntimeSource, /INACTIVITY_PING_TIMEOUT_MS/);
+  assert.match(acpRuntimeSource, /MAX_INACTIVITY_REPRIEVES/);
+  // Reprieve path increments a counter and re-arms the timer instead of
+  // cancelling, so a silent-but-alive sub-agent task isn't killed immediately.
+  assert.match(acpRuntimeSource, /inactivityReprieves \+= 1/);
+  assert.match(
+    acpRuntimeSource,
+    /inactivityFired = false;\s*\n\s*disarmInactivityTimer\(\);\s*\n\s*armInactivityTimer\(\);/
+  );
+  // Reprieves reset per prompt turn.
+  const promptBodyIndex = acpRuntimeSource.indexOf("const runPromptOnSession");
+  const promptBody = acpRuntimeSource.slice(
+    promptBodyIndex,
+    acpRuntimeSource.indexOf("};", acpRuntimeSource.indexOf("armInactivityTimer();", promptBodyIndex)) + 2
+  );
+  assert.match(promptBody, /inactivityReprieves = 0/);
+  // The kill path is preserved (probe timed out / unsupported, or reprieves
+  // exhausted) and still tears the run down via cancel+finish.
+  assert.match(
+    acpRuntimeSource,
+    /inactivity timeout after [\s\S]*?cancelRun\(\);[\s\S]*?finish\(\s*"failed"/
+  );
+});
+
 test("CLI runtime records the approval mode with each task start", () => {
   assert.match(runtimeSource, /approvalMode: args\.approvalMode \?\? "default"/);
 });

--- a/tests/workspace-plan-card.test.mjs
+++ b/tests/workspace-plan-card.test.mjs
@@ -19,10 +19,15 @@ test("agent plan card scrolls internally when it has many entries", () => {
   assert.match(styles, /\.workspace-panel\s*\{[^}]*display:\s*flex/s);
   assert.match(styles, /\.workspace-panel\s*\{[^}]*min-height:\s*0/s);
   assert.match(styles, /\.plan-card\s*\{[^}]*flex:\s*1/s);
-  assert.match(styles, /\.plan-card\s*\{[^}]*min-height:\s*0/s);
   assert.match(styles, /\.plan-list\s*\{[^}]*overflow-y:\s*auto/s);
   assert.match(styles, /\.plan-list\s*\{[^}]*flex:\s*1/s);
   assert.equal(/\.plan-list\s*\{[^}]*max-height:/s.test(styles), false);
+});
+
+test("agent plan card keeps a usable min-height ahead of secondary info cards", () => {
+  assert.match(styles, /\.plan-card\s*\{[^}]*min-height:\s*240px/s);
+  assert.match(styles, /\.plan-card\s*\{[^}]*flex:\s*1 1 240px/s);
+  assert.match(styles, /\.workspace-cards > \.info-data-card,\s*\.workspace-cards > \.feed-card\s*\{[^}]*flex:\s*0 0 auto/s);
 });
 
 test("third column card stack scrolls within the visible overview space", () => {


### PR DESCRIPTION
## Problem

The inactivity watchdog (`armInactivityTimer`) cancelled any ACP turn that stayed silent for 10 minutes. This misfired on long-running but healthy sub-agent tasks — e.g. OpenCode's `task` tool spawns sub-agents that emit **no** `session/update` frames to the client while running. Confirmed in a real failure: two parallel `explore` sub-tasks ran; one completed at 07:36, the other hung, and after 10 min of client-side silence the whole turn was killed.

Investigation confirmed upstream emits no progress/keepalive signal during sub-agent execution, so the client cannot tell "working but silent" from "dead".

## Fix

Before cancelling, send a read-only `session/list` probe (`acpRuntime.ts`):

| Probe result | Action |
|---|---|
| Agent responds (main process alive, likely a silent sub-agent) | **Reprieve** — reset the timer, up to `MAX_INACTIVITY_REPRIEVES = 2` per turn |
| Probe times out / rejected (main process stuck or `session/list` unsupported) | Cancel via the existing `cancelRun() + finish('failed')` path |
| Reprieves exhausted | Cancel even if probe responds (hard cap, no infinite wait) |

- Reprieve counter resets each prompt turn (`runPromptOnSession`).
- Kill path preserves the existing `inactivity timeout ... -> cancelRun() -> finish('failed')` contract.

## Test

- New contract test: `ACP inactivity watchdog probes liveness before cancelling and caps reprieves`.
- `npm run typecheck` (electron) clean.
- All 11 `acp-runtime-contract` tests pass.

## Known limitations

- The probe only proves the main process event loop is alive, not that a sub-agent is making progress. If OpenCode serves `session/list` concurrently (likely), the probe returns instantly and the `MAX_INACTIVITY_REPRIEVES` cap is what bounds the run. A true fix still needs upstream (OpenCode/ACP) to emit progress frames during `task` execution.
- For adapters that don't implement `session/list`, behavior degrades to the original "cancel shortly after 10 min" (probe fails fast).
