### PR TITLE
feat(cli): integrate Antigravity (agy-acp) CLI agent

### DIFF
--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -12,6 +12,7 @@ export type CLIAdapterId =
   | "qoder-acp"
   | "codebuddy-acp"
   | "grok-acp"
+  | "agy-acp"
   | (string & {});
 
 export type CLIStreamMode =
@@ -211,6 +212,20 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
         ? "irm https://x.ai/cli/install.ps1 | iex"
         : "curl -fsSL https://x.ai/cli/install.sh | bash",
     docsUrl: "https://docs.x.ai/build/cli/reference",
+    protocol: "acp"
+  },
+  {
+    id: "agy-acp",
+    label: "Antigravity",
+    defaultBinary: "agy-acp",
+    checkProbe: { args: ["--version"], versionOptional: true },
+    streamMode: "raw",
+    commandGroup: "antigravity",
+    capabilities: { toolSession: true, skills: { mode: "native", nativeDirs: [".agents/skills"], reloadPolicy: "process-start" } },
+    toolSessionArgs: [],
+    toolSessionArgPrefixes: [],
+    installHint: "npm install -g agy-acp-bridge",
+    docsUrl: "https://github.com/maojindao55/agy-acp",
     protocol: "acp"
   }
 ];
@@ -540,6 +555,15 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
     }
     case "grok-acp": {
       const args: string[] = [...extra, "agent", "stdio"];
+      return {
+        bin,
+        args,
+        promptViaStdin: false,
+        protocol: "acp"
+      };
+    }
+    case "agy-acp": {
+      const args: string[] = [...extra];
       return {
         bin,
         args,

--- a/electron/cli/cliMemberBuiltins.ts
+++ b/electron/cli/cliMemberBuiltins.ts
@@ -61,5 +61,11 @@ export const builtinCliMembers: CLIMember[] = [
     name: "Grok",
     enabled: true,
     cli: { adapter: "grok-acp", approvalMode: "auto", showStderr: true }
+  },
+  {
+    id: "cli-agy-acp",
+    name: "Antigravity",
+    enabled: true,
+    cli: { adapter: "agy-acp", approvalMode: "auto", showStderr: true }
   }
 ];

--- a/electron/cli/sandboxRuntime.ts
+++ b/electron/cli/sandboxRuntime.ts
@@ -637,6 +637,13 @@ function adapterConfigPaths(adapter: string): string[] {
   if (adapter.includes("grok")) {
     paths.push(path.join(home, ".grok"), path.join(home, ".config", "grok"));
   }
+  if (adapter.includes("agy") || adapter.includes("antigravity")) {
+    paths.push(
+      path.join(home, ".gemini"),
+      path.join(home, ".config", "antigravity"),
+      path.join(home, ".antigravity")
+    );
+  }
   return existing(paths);
 }
 

--- a/electron/telemetryPrivacy.ts
+++ b/electron/telemetryPrivacy.ts
@@ -9,7 +9,8 @@ const KNOWN_ADAPTERS = new Set([
   "kimi-acp",
   "qoder-acp",
   "codebuddy-acp",
-  "grok-acp"
+  "grok-acp",
+  "agy-acp"
 ]);
 
 export type TelemetryErrorCategory =

--- a/src/config/agentIcon.tsx
+++ b/src/config/agentIcon.tsx
@@ -12,7 +12,8 @@ const defaultAgentIcon: Partial<Record<CLIAdapterId, string>> = {
   "kimi-acp": "Kimi",
   "qoder-acp": "Qoder",
   "codebuddy-acp": "CodeBuddy",
-  "grok-acp": "Grok"
+  "grok-acp": "Grok",
+  "agy-acp": "Gemini"
 };
 
 /**

--- a/src/config/aiMembers.ts
+++ b/src/config/aiMembers.ts
@@ -91,5 +91,14 @@ export const builtinCliMembers: CLIMember[] = [
     source: "builtin",
     enabled: true,
     cli: { adapter: "grok-acp", approvalMode: "auto", showStderr: true }
+  },
+  {
+    id: "cli-agy-acp",
+    kind: "cli",
+    name: "Antigravity",
+    description: "Local Antigravity coding agent via ACP.",
+    source: "builtin",
+    enabled: true,
+    cli: { adapter: "agy-acp", approvalMode: "auto", showStderr: true }
   }
 ];

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -10,6 +10,7 @@ export type CLIAdapterId =
   | "qoder-acp"
   | "codebuddy-acp"
   | "grok-acp"
+  | "agy-acp"
   | (string & {});
 
 export type CLIStreamMode =
@@ -146,6 +147,19 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     installHint:
       "curl -fsSL https://x.ai/cli/install.sh | bash",
     docsUrl: "https://docs.x.ai/build/cli/reference",
+    protocol: "acp"
+  },
+  {
+    id: "agy-acp",
+    label: "Antigravity",
+    defaultBinary: "agy-acp",
+    streamMode: "raw",
+    commandGroup: "antigravity",
+    capabilities: { toolSession: true },
+    toolSessionArgs: [],
+    toolSessionArgPrefixes: [],
+    installHint: "npm install -g agy-acp-bridge",
+    docsUrl: "https://github.com/maojindao55/agy-acp",
     protocol: "acp"
   }
 ];

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -131,7 +131,8 @@ test("visible adapter definitions are ACP-only with product names", () => {
       { id: "kimi-acp", label: "Kimi", protocol: "acp" },
       { id: "qoder-acp", label: "Qoder", protocol: "acp" },
       { id: "codebuddy-acp", label: "CodeBuddy", protocol: "acp" },
-      { id: "grok-acp", label: "Grok", protocol: "acp" }
+      { id: "grok-acp", label: "Grok", protocol: "acp" },
+      { id: "agy-acp", label: "Antigravity", protocol: "acp" }
     ]
   );
 });

--- a/tests/agent-usage-core.test.mjs
+++ b/tests/agent-usage-core.test.mjs
@@ -20,6 +20,7 @@ test("usage adapter mapping only includes session-attributable tokscale clients"
   assert.equal(tokscaleClientForAdapter("grok-acp"), "grok");
   assert.equal(tokscaleClientForAdapter("cursor-agent-acp"), undefined);
   assert.equal(tokscaleClientForAdapter("qoder-acp"), undefined);
+  assert.equal(tokscaleClientForAdapter("agy-acp"), undefined);
 });
 
 test("Codex rollout filenames and ACP UUIDs normalize to the same session key", () => {

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -44,3 +44,10 @@ test("legacy adapters still require a version response", () => {
     versionOptional: false
   });
 });
+
+test("agy-acp checks agy-acp binary probe", () => {
+  assert.deepEqual(getCliCheckProbe("agy-acp"), {
+    args: ["--version"],
+    versionOptional: true
+  });
+});

--- a/tests/workflow-ipc-wiring.test.mjs
+++ b/tests/workflow-ipc-wiring.test.mjs
@@ -75,4 +75,5 @@ test("builtin members module exports the ACP agents", () => {
   assert.match(members, /cli-qoder-acp/);
   assert.match(members, /cli-codebuddy-acp/);
   assert.match(members, /cli-grok-acp/);
+  assert.match(members, /cli-agy-acp/);
 });


### PR DESCRIPTION
## Description

Adds support for the Google Antigravity (`agy-acp-bridge`) CLI Agent over ACP protocol.

### Key Changes
- Add `agy-acp` adapter definition and built-in member configuration.
- Add `npm install -g agy-acp-bridge` as official install hint.
- Add `agy` configuration paths to sandbox allowed paths.
- Add unit tests for `agy-acp` check probe and builtin member wiring.
