### PR TITLE
feat(release): generate changelog notes

### DIFF
--- a/.github/release-installation.md
+++ b/.github/release-installation.md
@@ -1,0 +1,36 @@
+## 下载安装包
+
+| 平台 | 文件 | 说明 |
+|------|------|------|
+| macOS Apple Silicon | `FreeBuddy_macOS-Apple-Silicon-{{version}}.dmg` | M 系列芯片 Mac |
+| macOS Intel | `FreeBuddy_macOS-Intel-{{version}}.dmg` | Intel 芯片 Mac |
+| Windows | `FreeBuddy_Windows_x64-{{version}}.exe` | Windows 10/11 64 位 |
+| Ubuntu / Debian (x64) | `FreeBuddy_Ubuntu_x64-{{version}}.deb` | Ubuntu 22.04/24.04 及 Debian 系发行版 |
+| Linux AppImage (x64) | `FreeBuddy_Linux_x64-{{version}}.AppImage` | 免安装的通用 Linux 包 |
+
+### macOS 安装提示
+
+如果提示无法打开，请在终端执行：
+
+```bash
+xattr -cr /Applications/FreeBuddy.app
+```
+
+### Windows 安装提示
+
+如果 SmartScreen 弹出警告，点击「更多信息」后选择「仍要运行」。
+
+### Ubuntu / Linux 安装提示
+
+Ubuntu / Debian 推荐安装 DEB：
+
+```bash
+sudo apt install ./FreeBuddy_Ubuntu_x64-{{version}}.deb
+```
+
+AppImage 下载后可直接授权运行：
+
+```bash
+chmod +x FreeBuddy_Linux_x64-{{version}}.AppImage
+./FreeBuddy_Linux_x64-{{version}}.AppImage
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,52 +4,45 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag to rebuild or publish (for example, v1.2.3)
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Create release notes
+        run: node scripts/release-notes.mjs --version "${{ env.RELEASE_TAG }}" --output .release-notes.md
+
       - name: Create draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            gh release create "${{ github.ref_name }}" \
+          if ! gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "${{ env.RELEASE_TAG }}" \
               --repo "${{ github.repository }}" \
-              --title "FreeBuddy ${{ github.ref_name }}" \
+              --title "FreeBuddy ${{ env.RELEASE_TAG }}" \
               --draft \
-              --notes "## 下载安装包
-
-          | 平台 | 文件 | 说明 |
-          |------|------|------|
-          | macOS Apple Silicon | \`FreeBuddy_macOS-Apple-Silicon-${{ github.ref_name }}.dmg\` | M 系列芯片 Mac |
-          | macOS Intel | \`FreeBuddy_macOS-Intel-${{ github.ref_name }}.dmg\` | Intel 芯片 Mac |
-          | Windows | \`FreeBuddy_Windows_x64-${{ github.ref_name }}.exe\` | Windows 10/11 64 位 |
-          | Ubuntu / Debian (x64) | \`FreeBuddy_Ubuntu_x64-${{ github.ref_name }}.deb\` | Ubuntu 22.04/24.04 及 Debian 系发行版 |
-          | Linux AppImage (x64) | \`FreeBuddy_Linux_x64-${{ github.ref_name }}.AppImage\` | 免安装的通用 Linux 包 |
-
-          ## macOS 安装提示
-          如果提示无法打开，请在终端执行：
-          \`\`\`bash
-          xattr -cr /Applications/FreeBuddy.app
-          \`\`\`
-
-          ## Windows 安装提示
-          如果 SmartScreen 弹出警告，点击「更多信息」后选择「仍要运行」。
-
-          ## Ubuntu / Linux 安装提示
-          Ubuntu / Debian 推荐安装 DEB：
-          \`\`\`bash
-          sudo apt install ./FreeBuddy_Ubuntu_x64-${{ github.ref_name }}.deb
-          \`\`\`
-          AppImage 下载后可直接授权运行：
-          \`\`\`bash
-          chmod +x FreeBuddy_Linux_x64-${{ github.ref_name }}.AppImage
-          ./FreeBuddy_Linux_x64-${{ github.ref_name }}.AppImage
-          \`\`\`"
+              --notes-file .release-notes.md
           fi
 
   build:
@@ -91,6 +84,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -138,7 +133,7 @@ jobs:
               exit 1
             fi
             cp "$FILE" "$asset_name"
-            gh release upload "${{ github.ref_name }}" "$asset_name" \
+            gh release upload "${{ env.RELEASE_TAG }}" "$asset_name" \
               --repo "${{ github.repository }}" --clobber
           done <<'ASSETS'
           ${{ matrix.assets }}
@@ -150,7 +145,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          tag="${{ github.ref_name }}"
+          tag="${{ env.RELEASE_TAG }}"
           repo="${{ github.repository }}"
           version_suffix="v$(node -p "require('./package.json').version")"
           arm_dmg="FreeBuddy_macOS-Apple-Silicon-${version_suffix}.dmg"
@@ -212,7 +207,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          tag="${{ github.ref_name }}"
+          tag="${{ env.RELEASE_TAG }}"
           repo="${{ github.repository }}"
           version_suffix="v$(node -p "require('./package.json').version")"
           appimage_name="FreeBuddy_Linux_x64-${version_suffix}.AppImage"
@@ -259,7 +254,7 @@ jobs:
               exit 1
             }
             Copy-Item $file.FullName $assetName
-            gh release upload "${{ github.ref_name }}" $assetName `
+            gh release upload "${{ env.RELEASE_TAG }}" $assetName `
               --repo "${{ github.repository }}" --clobber
           }
 
@@ -269,7 +264,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: pwsh
         run: |
-          $tag = "${{ github.ref_name }}"
+          $tag = "${{ env.RELEASE_TAG }}"
           $repo = "${{ github.repository }}"
           $appVersion = (Get-Content package.json | ConvertFrom-Json).version
           $windowsAssetName = "FreeBuddy_Windows_x64-v$appVersion.exe"
@@ -297,6 +292,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -309,7 +306,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tag="${{ github.ref_name }}"
+          tag="${{ env.RELEASE_TAG }}"
           repo="${{ github.repository }}"
           mkdir -p _mac_meta
           gh release download "$tag" --repo "$repo" \
@@ -334,7 +331,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release edit "${{ github.ref_name }}" \
+          gh release edit "${{ env.RELEASE_TAG }}" \
             --repo "${{ github.repository }}" \
             --draft=false \
             --latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+记录面向用户的版本变更。每次执行 `npm run release` 时，系统会从上一个 tag 之后的提交生成初稿；如需使用人工或 Agent 润色的文案，可传入 `--notes-file <路径>`。

--- a/scripts/changelog-lib.mjs
+++ b/scripts/changelog-lib.mjs
@@ -1,0 +1,106 @@
+const SECTION_ORDER = ["新功能", "问题修复", "体验优化"];
+const INTERNAL_COMMIT_TYPES = new Set(["build", "chore", "ci", "docs", "test"]);
+const IMPROVEMENT_COMMIT_TYPES = new Set(["perf", "refactor", "style"]);
+
+function normaliseVersion(version) {
+  return String(version).replace(/^v/, "");
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function groupCommitSubjects(subjects) {
+  const groups = Object.fromEntries(SECTION_ORDER.map((section) => [section, []]));
+
+  for (const rawSubject of subjects) {
+    const subject = rawSubject.trim();
+    if (!subject) continue;
+
+    const match = subject.match(/^([a-z]+)(?:\([^)]*\))?!?:\s+(.+)$/i);
+    const type = match?.[1].toLowerCase();
+    const description = match?.[2]?.trim() || subject;
+
+    if (type && INTERNAL_COMMIT_TYPES.has(type)) continue;
+    if (type === "fix") {
+      groups["问题修复"].push(description);
+    } else if (type && IMPROVEMENT_COMMIT_TYPES.has(type)) {
+      groups["体验优化"].push(description);
+    } else {
+      groups["新功能"].push(description);
+    }
+  }
+
+  return Object.fromEntries(
+    SECTION_ORDER
+      .map((section) => [section, unique(groups[section])])
+      .filter(([, entries]) => entries.length > 0)
+  );
+}
+
+export function formatReleaseNotes(groups) {
+  return SECTION_ORDER
+    .filter((section) => groups[section]?.length > 0)
+    .map((section) => [
+      `### ${section}`,
+      "",
+      ...groups[section].map((entry) => `- ${entry}`)
+    ].join("\n"))
+    .join("\n\n");
+}
+
+export function formatChangelogSection({ version, date, notes }) {
+  const normalizedVersion = normaliseVersion(version);
+  const normalizedNotes = notes.trim();
+  if (!normalizedVersion) throw new Error("版本号不能为空");
+  if (!date) throw new Error("发布日期不能为空");
+  if (!normalizedNotes) throw new Error("变更说明不能为空");
+
+  return `## [${normalizedVersion}] - ${date}\n\n${normalizedNotes}`;
+}
+
+export function prependChangelogSection(changelog, section) {
+  const header = "# Changelog";
+  const normalizedSection = section.trim();
+  const existing = changelog.trimEnd();
+
+  if (!existing) return `${header}\n\n${normalizedSection}\n`;
+  if (!existing.startsWith(header)) {
+    throw new Error("CHANGELOG.md 必须以 # Changelog 开头");
+  }
+
+  const remainder = existing.slice(header.length).trim();
+  const firstVersion = /^## \[/m.exec(remainder);
+  const introduction = firstVersion ? remainder.slice(0, firstVersion.index).trim() : remainder;
+  const history = firstVersion ? remainder.slice(firstVersion.index).trim() : "";
+  return [header, introduction, normalizedSection, history]
+    .filter(Boolean)
+    .join("\n\n")
+    .concat("\n");
+}
+
+export function extractChangelogSection(changelog, version) {
+  const normalizedVersion = normaliseVersion(version);
+  const heading = new RegExp(`^## \\[${escapeRegExp(normalizedVersion)}\\] - .*$(?:\\r?\\n)?`, "m");
+  const match = heading.exec(changelog);
+  if (!match) {
+    throw new Error(`CHANGELOG.md 中找不到 v${normalizedVersion} 的变更说明`);
+  }
+
+  const afterHeading = match.index + match[0].length;
+  const followingHeading = /^## \[/m;
+  const nextMatch = followingHeading.exec(changelog.slice(afterHeading));
+  const end = nextMatch ? afterHeading + nextMatch.index : changelog.length;
+  return changelog.slice(afterHeading, end).trim();
+}
+
+export function buildPublishedReleaseNotes({ changelog, version, installationInstructions = "" }) {
+  return [
+    extractChangelogSection(changelog, version),
+    installationInstructions.trim()
+  ].filter(Boolean).join("\n\n");
+}

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -23,13 +23,25 @@ export function validateSemver(version) {
   }
 }
 
+export function hasOnlyAllowedWorkingTreeChange(porcelain, allowedPath) {
+  if (!allowedPath) return false;
+  const records = porcelain.split("\0").filter(Boolean);
+  return records.length > 0 && records.every((record) => {
+    const status = record.slice(0, 2);
+    const filePath = record.slice(3);
+    return ["??", " M"].includes(status) && filePath === allowedPath;
+  });
+}
+
 export function parseReleaseArgs(argv) {
   let bumpType = "patch";
   let explicitVersion = "";
   let dryRun = false;
   let skipConfirm = false;
   let help = false;
-  for (const arg of argv) {
+  let notesFile = "";
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
     if (arg === "--dry-run") {
       dryRun = true;
     } else if (arg === "-y" || arg === "--yes") {
@@ -40,11 +52,18 @@ export function parseReleaseArgs(argv) {
       explicitVersion = arg.replace(/^v/, "");
     } else if (arg === "-h" || arg === "--help") {
       help = true;
+    } else if (arg === "--notes-file") {
+      const filePath = argv[index + 1];
+      if (!filePath || filePath.startsWith("-")) {
+        throw new Error("--notes-file 需要提供文件路径");
+      }
+      notesFile = filePath;
+      index += 1;
     } else {
       throw new Error(`未知参数: ${arg}\n运行 node scripts/release.mjs --help 查看用法`);
     }
   }
-  return { help, bumpType, explicitVersion, dryRun, skipConfirm };
+  return { help, bumpType, explicitVersion, dryRun, skipConfirm, notesFile };
 }
 
 export const RELEASE_HELP = `自动发布新版本：同步版本号 → 提交 → 打 tag → 推送到 origin
@@ -55,6 +74,7 @@ export const RELEASE_HELP = `自动发布新版本：同步版本号 → 提交 
   node scripts/release.mjs minor        # v1.0.5 → v1.1.0
   node scripts/release.mjs major        # v1.0.5 → v2.0.0
   node scripts/release.mjs 1.0.6        # 指定版本
+  node scripts/release.mjs --notes-file notes.md # 使用人工或 Agent 润色的 Markdown
   node scripts/release.mjs --dry-run    # 仅预览，不执行
   node scripts/release.mjs -y patch     # 跳过确认
 `;

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { buildPublishedReleaseNotes } from "./changelog-lib.mjs";
+
+const rootDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function parseArgs(argv) {
+  const options = {
+    version: "",
+    changelog: "CHANGELOG.md",
+    installation: ".github/release-installation.md",
+    output: ""
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      return { ...options, help: true };
+    }
+    if (!["--version", "--changelog", "--installation", "--output"].includes(arg)) {
+      throw new Error(`未知参数: ${arg}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${arg} 需要提供值`);
+    options[arg.slice(2)] = value;
+    index += 1;
+  }
+
+  if (!options.version) throw new Error("--version 需要提供发布版本");
+  return options;
+}
+
+function readFile(relativePath) {
+  const filePath = path.resolve(rootDir, relativePath);
+  if (!fs.existsSync(filePath)) throw new Error(`找不到文件: ${relativePath}`);
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write("用法: node scripts/release-notes.mjs --version v1.2.3 [--output release-notes.md]\n");
+    return;
+  }
+
+  const installationInstructions = readFile(options.installation).replaceAll("{{version}}", options.version);
+  const notes = buildPublishedReleaseNotes({
+    changelog: readFile(options.changelog),
+    version: options.version,
+    installationInstructions
+  });
+
+  if (options.output) {
+    fs.writeFileSync(path.resolve(rootDir, options.output), `${notes}\n`);
+  } else {
+    process.stdout.write(`${notes}\n`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error?.message || error);
+  process.exit(1);
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -9,7 +9,19 @@ import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { bumpVersion, validateSemver, parseReleaseArgs, RELEASE_HELP } from "./release-lib.mjs";
+import {
+  bumpVersion,
+  hasOnlyAllowedWorkingTreeChange,
+  validateSemver,
+  parseReleaseArgs,
+  RELEASE_HELP
+} from "./release-lib.mjs";
+import {
+  formatChangelogSection,
+  formatReleaseNotes,
+  groupCommitSubjects,
+  prependChangelogSection
+} from "./changelog-lib.mjs";
 
 const rootDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 process.chdir(rootDir);
@@ -22,10 +34,49 @@ function gitQuiet(args) {
   git(args, { stdio: "ignore" });
 }
 
-function getLatestTagVersion() {
+function getRepositoryRelativePath(filePath) {
+  if (!filePath) return "";
+  const relativePath = path.relative(rootDir, path.resolve(rootDir, filePath));
+  if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) return "";
+  return relativePath.split(path.sep).join("/");
+}
+
+function getLatestTag() {
   const out = git(["tag", "-l", "v[0-9]*.[0-9]*.[0-9]*", "--sort=-v:refname"], { stdio: ["ignore", "pipe", "ignore"] });
   const latest = out.split(/\r?\n/).find((l) => l.trim().length > 0);
-  return latest ? latest.replace(/^v/, "") : "0.0.0";
+  return latest || "";
+}
+
+function getCommitSubjectsSince(tag) {
+  const range = tag ? `${tag}..HEAD` : "HEAD";
+  return git(["log", "--no-merges", "--format=%s", range], { stdio: ["ignore", "pipe", "ignore"] })
+    .split(/\r?\n/)
+    .filter(Boolean);
+}
+
+function readReleaseNotes(notesFile, latestTag) {
+  if (notesFile) {
+    const notesPath = path.resolve(rootDir, notesFile);
+    if (!fs.existsSync(notesPath)) {
+      throw new Error(`找不到变更说明文件: ${notesFile}`);
+    }
+    const notes = fs.readFileSync(notesPath, "utf8").trim();
+    if (!notes) throw new Error(`变更说明文件为空: ${notesFile}`);
+    return notes;
+  }
+
+  const notes = formatReleaseNotes(groupCommitSubjects(getCommitSubjectsSince(latestTag)));
+  return notes || "### 其他更新\n\n- 常规维护与稳定性改进";
+}
+
+function updateChangelog(version, notes) {
+  const changelogPath = path.join(rootDir, "CHANGELOG.md");
+  const existing = fs.existsSync(changelogPath)
+    ? fs.readFileSync(changelogPath, "utf8")
+    : "# Changelog\n";
+  const date = new Date().toISOString().slice(0, 10);
+  const section = formatChangelogSection({ version, date, notes });
+  fs.writeFileSync(changelogPath, prependChangelogSection(existing, section));
 }
 
 function updateVersionFiles(version) {
@@ -89,8 +140,8 @@ async function main() {
     process.exit(1);
   }
 
-  const porcelain = git(["status", "--porcelain"], { stdio: ["ignore", "pipe", "ignore"] });
-  if (porcelain.trim().length > 0) {
+  const porcelain = git(["status", "--porcelain=v1", "-z"], { stdio: ["ignore", "pipe", "ignore"] });
+  if (porcelain.length > 0 && !hasOnlyAllowedWorkingTreeChange(porcelain, getRepositoryRelativePath(opts.notesFile))) {
     console.error("工作区有未提交的改动，请先 commit 或 stash：");
     console.error(git(["status", "--short"]));
     process.exit(1);
@@ -106,7 +157,8 @@ async function main() {
 
   gitQuiet(["fetch", "origin", "--tags", "--quiet"]);
 
-  const latestVersion = getLatestTagVersion();
+  const latestTag = getLatestTag();
+  const latestVersion = latestTag ? latestTag.replace(/^v/, "") : "0.0.0";
   const newVersion = opts.explicitVersion || bumpVersion(latestVersion, opts.bumpType);
   validateSemver(newVersion);
   const newTag = `v${newVersion}`;
@@ -124,13 +176,18 @@ async function main() {
     process.exit(1);
   }
 
+  const releaseNotes = readReleaseNotes(opts.notesFile, latestTag);
+
   console.log("");
   console.log("发布预览");
   console.log(`  当前最新 tag : v${latestVersion}`);
   console.log(`  新版本       : ${newVersion}`);
   console.log(`  新 tag       : ${newTag}`);
   console.log(`  分支         : ${currentBranch}`);
-  console.log("  将更新文件   : package.json, package-lock.json, desktop/macos/Info.plist");
+  console.log("  将更新文件   : package.json, package-lock.json, desktop/macos/Info.plist, CHANGELOG.md");
+  console.log("");
+  console.log("变更说明预览");
+  console.log(releaseNotes);
   console.log("");
 
   if (!opts.skipConfirm && !opts.dryRun) {
@@ -141,7 +198,7 @@ async function main() {
   }
 
   const steps = [
-    ["git add package.json package-lock.json desktop/macos/Info.plist", () => gitQuiet(["add", "package.json", "package-lock.json", "desktop/macos/Info.plist"])],
+    ["git add package.json package-lock.json desktop/macos/Info.plist CHANGELOG.md", () => gitQuiet(["add", "package.json", "package-lock.json", "desktop/macos/Info.plist", "CHANGELOG.md"])],
     [`git commit -m "chore: release ${newTag}"`, () => gitQuiet(["commit", "-m", `chore: release ${newTag}`])],
     [`git tag ${newTag}`, () => gitQuiet(["tag", newTag])],
     [`git push origin ${currentBranch}`, () => gitQuiet(["push", "origin", currentBranch])],
@@ -149,12 +206,13 @@ async function main() {
   ];
 
   if (opts.dryRun) {
-    console.log(`[dry-run] 将更新 package.json, package-lock.json, desktop/macos/Info.plist → ${newVersion}`);
+    console.log(`[dry-run] 将更新 package.json, package-lock.json, desktop/macos/Info.plist, CHANGELOG.md → ${newVersion}`);
     run(steps, true);
     console.log("");
     console.log("[dry-run] 完成，未实际修改仓库。");
   } else {
     updateVersionFiles(newVersion);
+    updateChangelog(newVersion, releaseNotes);
     run(steps, false);
     console.log("");
     console.log(`发布完成: ${newTag}`);

--- a/tests/changelog.test.mjs
+++ b/tests/changelog.test.mjs
@@ -1,0 +1,172 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  buildPublishedReleaseNotes,
+  extractChangelogSection,
+  formatChangelogSection,
+  formatReleaseNotes,
+  groupCommitSubjects,
+  prependChangelogSection
+} from "../scripts/changelog-lib.mjs";
+
+test("groups conventional commits into user-facing release note sections", () => {
+  assert.deepEqual(groupCommitSubjects([
+    "feat(workspaces): add multi-folder projects",
+    "fix(runtime): preserve workspace roots",
+    "perf: speed up workspace discovery",
+    "style(sidebar): polish project expander",
+    "docs: explain workspace roots",
+    "test: cover workspace roots",
+    "chore: release v0.6.9",
+    "Show isolated workspace source paths"
+  ]), {
+    "新功能": ["add multi-folder projects", "Show isolated workspace source paths"],
+    "问题修复": ["preserve workspace roots"],
+    "体验优化": ["speed up workspace discovery", "polish project expander"]
+  });
+});
+
+test("formats user-facing release notes and omits internal-only commits", () => {
+  const notes = formatReleaseNotes(groupCommitSubjects([
+    "feat: add workspace isolation",
+    "fix: avoid a Windows sandbox crash",
+    "docs: update architecture notes"
+  ]));
+
+  assert.equal(notes, [
+    "### 新功能",
+    "",
+    "- add workspace isolation",
+    "",
+    "### 问题修复",
+    "",
+    "- avoid a Windows sandbox crash"
+  ].join("\n"));
+});
+
+test("creates, prepends, and extracts a single version changelog section", () => {
+  const section = formatChangelogSection({
+    version: "0.6.9",
+    date: "2026-07-29",
+    notes: "### 新功能\n\n- add workspace isolation"
+  });
+  const changelog = prependChangelogSection([
+    "# Changelog",
+    "",
+    "## [0.6.8] - 2026-07-20",
+    "",
+    "### 问题修复",
+    "",
+    "- fix an earlier issue",
+    ""
+  ].join("\n"), section);
+
+  assert.equal(changelog, [
+    "# Changelog",
+    "",
+    "## [0.6.9] - 2026-07-29",
+    "",
+    "### 新功能",
+    "",
+    "- add workspace isolation",
+    "",
+    "## [0.6.8] - 2026-07-20",
+    "",
+    "### 问题修复",
+    "",
+    "- fix an earlier issue",
+    ""
+  ].join("\n"));
+  assert.equal(
+    extractChangelogSection(changelog, "v0.6.9"),
+    "### 新功能\n\n- add workspace isolation"
+  );
+});
+
+test("preserves the changelog introduction outside version release notes", () => {
+  const section = formatChangelogSection({
+    version: "0.6.9",
+    date: "2026-07-29",
+    notes: "### 新功能\n\n- add workspace isolation"
+  });
+  const changelog = prependChangelogSection("# Changelog\n\n记录面向用户的版本变更。\n", section);
+
+  assert.match(changelog, /^# Changelog\n\n记录面向用户的版本变更。\n\n## \[0\.6\.9\]/);
+  assert.equal(
+    extractChangelogSection(changelog, "0.6.9"),
+    "### 新功能\n\n- add workspace isolation"
+  );
+});
+
+test("extracting a missing release notes section fails clearly", () => {
+  assert.throws(
+    () => extractChangelogSection("# Changelog\n", "0.6.9"),
+    /CHANGELOG\.md 中找不到 v0\.6\.9 的变更说明/
+  );
+});
+
+test("builds GitHub release notes from one changelog section and installation guidance", () => {
+  const changelog = [
+    "# Changelog",
+    "",
+    "## [0.6.9] - 2026-07-29",
+    "",
+    "### 新功能",
+    "",
+    "- add workspace isolation"
+  ].join("\n");
+
+  assert.equal(
+    buildPublishedReleaseNotes({
+      changelog,
+      version: "0.6.9",
+      installationInstructions: "## 安装说明\n\n- Download the package for your platform."
+    }),
+    [
+      "### 新功能",
+      "",
+      "- add workspace isolation",
+      "",
+      "## 安装说明",
+      "",
+      "- Download the package for your platform."
+    ].join("\n")
+  );
+});
+
+test("release notes CLI combines the requested changelog version with installation guidance", () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "freebuddy-release-notes-"));
+  const changelogPath = path.join(fixtureDir, "CHANGELOG.md");
+  const installationPath = path.join(fixtureDir, "installation.md");
+  const outputPath = path.join(fixtureDir, "release-notes.md");
+  fs.writeFileSync(changelogPath, "# Changelog\n\n## [0.6.9] - 2026-07-29\n\n### 新功能\n\n- add workspace isolation\n");
+  fs.writeFileSync(installationPath, "## 安装说明\n\n下载 {{version}} 对应的安装包。\n");
+
+  try {
+    execFileSync(process.execPath, [
+      "scripts/release-notes.mjs",
+      "--version", "v0.6.9",
+      "--changelog", changelogPath,
+      "--installation", installationPath,
+      "--output", outputPath
+    ], { cwd: new URL("..", import.meta.url) });
+
+    assert.equal(fs.readFileSync(outputPath, "utf8"), [
+      "### 新功能",
+      "",
+      "- add workspace isolation",
+      "",
+      "## 安装说明",
+      "",
+      "下载 v0.6.9 对应的安装包。",
+      ""
+    ].join("\n"));
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/tests/release-script.test.mjs
+++ b/tests/release-script.test.mjs
@@ -2,7 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-import { bumpVersion, validateSemver, parseReleaseArgs } from "../scripts/release-lib.mjs";
+import {
+  bumpVersion,
+  hasOnlyAllowedWorkingTreeChange,
+  validateSemver,
+  parseReleaseArgs
+} from "../scripts/release-lib.mjs";
 
 const packageJson = JSON.parse(
   fs.readFileSync(new URL("../package.json", import.meta.url), "utf8")
@@ -38,22 +43,38 @@ test("validateSemver accepts valid and rejects invalid versions", () => {
 
 test("parseReleaseArgs parses bump, explicit version, dry-run, yes, help", () => {
   assert.deepEqual(parseReleaseArgs(["minor"]), {
-    help: false, bumpType: "minor", explicitVersion: "", dryRun: false, skipConfirm: false
+    help: false, bumpType: "minor", explicitVersion: "", dryRun: false, skipConfirm: false, notesFile: ""
   });
   assert.deepEqual(parseReleaseArgs(["1.2.3"]), {
-    help: false, bumpType: "patch", explicitVersion: "1.2.3", dryRun: false, skipConfirm: false
+    help: false, bumpType: "patch", explicitVersion: "1.2.3", dryRun: false, skipConfirm: false, notesFile: ""
   });
   assert.deepEqual(parseReleaseArgs(["v2.0.0", "--dry-run", "-y"]), {
-    help: false, bumpType: "patch", explicitVersion: "2.0.0", dryRun: true, skipConfirm: true
+    help: false, bumpType: "patch", explicitVersion: "2.0.0", dryRun: true, skipConfirm: true, notesFile: ""
   });
+  assert.equal(parseReleaseArgs(["--notes-file", "release-notes.md"]).notesFile, "release-notes.md");
   assert.equal(parseReleaseArgs(["--help"]).help, true);
   assert.throws(() => parseReleaseArgs(["--nope"]), /未知参数/);
+  assert.throws(() => parseReleaseArgs(["--notes-file"]), /--notes-file 需要提供文件路径/);
+});
+
+test("allows an untracked Agent-authored notes file but no other dirty worktree changes", () => {
+  assert.equal(hasOnlyAllowedWorkingTreeChange("?? release-notes.md\0", "release-notes.md"), true);
+  assert.equal(
+    hasOnlyAllowedWorkingTreeChange("?? release-notes.md\0 M scripts/release.mjs\0", "release-notes.md"),
+    false
+  );
+  assert.equal(hasOnlyAllowedWorkingTreeChange(" M release-notes.md\0", "release-notes.md"), true);
+  assert.equal(hasOnlyAllowedWorkingTreeChange("M  release-notes.md\0", "release-notes.md"), false);
 });
 
 test("release runner updates Electron version files and performs git ops", () => {
   assert.ok(releaseScript.includes("package.json"));
   assert.ok(releaseScript.includes("package-lock.json"));
   assert.ok(releaseScript.includes("desktop/macos/Info.plist"));
+  assert.ok(releaseScript.includes("CHANGELOG.md"));
+  assert.ok(releaseScript.includes("notesFile"));
+  assert.ok(releaseScript.includes("hasOnlyAllowedWorkingTreeChange"));
+  assert.ok(releaseScript.includes("--no-merges"));
   assert.match(releaseScript, /CFBundleShortVersionString/);
   assert.match(releaseScript, /dry-run/);
   assert.match(releaseScript, /git/);

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -37,6 +37,12 @@ test("electron-builder config packages FreeBuddy for desktop platforms", () => {
 test("release workflow uploads version-suffixed assets and update metadata for every platform", () => {
   assert.match(workflow, /name:\s+Release/);
   assert.match(workflow, /tags:\s+\['v\*'\]/);
+  assert.match(workflow, /workflow_dispatch:[\s\S]*inputs:[\s\S]*tag:[\s\S]*required:\s+true/);
+  assert.match(workflow, /RELEASE_TAG:\s+\$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.tag \|\| github\.ref_name \}\}/);
+  assert.match(workflow, /ref:\s+\$\{\{ env\.RELEASE_TAG \}\}/);
+  assert.match(workflow, /Create release notes/);
+  assert.match(workflow, /node scripts\/release-notes\.mjs --version "\$\{\{ env\.RELEASE_TAG \}\}"/);
+  assert.match(workflow, /--notes-file \.release-notes\.md/);
   assert.match(workflow, /FreeBuddy_macOS-Apple-Silicon-__VERSION__\.dmg/);
   assert.match(workflow, /FreeBuddy_macOS-Apple-Silicon-__VERSION__\.zip/);
   assert.match(workflow, /FreeBuddy_macOS-Intel-__VERSION__\.dmg/);


### PR DESCRIPTION
## Summary

Release publishing now generates a user-facing changelog from commits and carries the matching version section into GitHub Release notes. Human- or Agent-authored Markdown can replace the generated draft when needed.

- Add a dated `CHANGELOG.md` entry during `npm run release`, grouped as features, fixes, and improvements.
- Build Release notes from that version entry plus centralized installation guidance.
- Require a tag for manual Release workflow runs and use it consistently for checkout, uploads, and publishing.

## Validation

- Passed: `npm run typecheck`.
- Passed: `node --test tests/changelog.test.mjs tests/release-script.test.mjs tests/release-workflow.test.mjs` (17 tests).
- `npm test` is blocked in this environment by a missing installed dependency file: `@agentclientprotocol/sdk/schema/schema.json` in `tests/acp-official-schema.test.mjs`; this file is outside the change scope.
