### PR TITLE
feat: 启动进入新建会话页并展示未读对话；codex 网关重试错误可见化

### DIFF
--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -1102,6 +1102,50 @@ export function acpSessionListToItems(
   return match ? acpSessionSetupToItems(sessionId, match) : [];
 }
 
+/**
+ * Reads `update._meta.codex.error`, the structured channel codex-acp uses to
+ * relay retryable upstream gateway errors (e.g. HTTP 422 from the model
+ * endpoint). Without this, the error is invisible until retries are exhausted,
+ * at which point the raw error body is emitted as an `agent_message_chunk`
+ * and rendered as if it were an assistant reply (see codex-acp issues #340
+ * and #355). The message is intentionally stable across retry attempts so
+ * adjacent identical error items collapse into one UI entry
+ * (see conversationUtils.ts adjacent-error dedupe).
+ */
+function codexMetaErrorToItems(meta: unknown): AcpStreamItem[] {
+  if (!meta || typeof meta !== "object") return [];
+  const codex = (meta as { codex?: { error?: unknown } }).codex;
+  const error = codex?.error;
+  if (!error || typeof error !== "object") return [];
+  const e = error as {
+    message?: unknown;
+    additionalDetails?: unknown;
+    codexErrorInfo?: unknown;
+    willRetry?: unknown;
+  };
+  const info = e.codexErrorInfo as
+    | { responseStreamDisconnected?: { httpStatusCode?: unknown } }
+    | undefined;
+  const httpStatus = info?.responseStreamDisconnected?.httpStatusCode;
+  const message = typeof e.message === "string" ? e.message : "";
+  const additionalDetails =
+    typeof e.additionalDetails === "string" ? e.additionalDetails : "";
+  const attemptMatch = message.match(/(\d+)\s*\/\s*\d+/);
+  const attempt = attemptMatch ? attemptMatch[1] : undefined;
+
+  const statusText = typeof httpStatus === "number" ? ` (HTTP ${httpStatus})` : "";
+  const headline = `Upstream gateway error${statusText}`;
+  const subline =
+    e.willRetry === false
+      ? "codex gave up after retries; the turn did not complete."
+      : "codex is retrying the request…";
+  const details: string[] = [];
+  if (attempt) details.push(`Retry attempt ${attempt}.`);
+  if (message) details.push(message);
+  if (additionalDetails) details.push(additionalDetails);
+  return [{ kind: "error", message: `${headline} — ${subline}`, details }];
+}
+
 export function acpUpdateToItems(
   update: any,
   fallbackSessionId?: string
@@ -1190,14 +1234,18 @@ export function acpUpdateToItems(
         typeof update.updatedAt === "string" && update.updatedAt
           ? update.updatedAt
           : undefined;
-      if (!sessionId && !title && !updatedAt) return [];
-      const item: Extract<AcpStreamItem, { kind: "session" }> = {
-        kind: "session",
-        sessionId: sessionId ? String(sessionId) : String(fallbackSessionId ?? "")
-      };
-      if (title) item.title = title;
-      if (updatedAt) item.updatedAt = updatedAt;
-      return [item];
+      const items: AcpStreamItem[] = [];
+      if (sessionId || title || updatedAt) {
+        const item: Extract<AcpStreamItem, { kind: "session" }> = {
+          kind: "session",
+          sessionId: sessionId ? String(sessionId) : String(fallbackSessionId ?? "")
+        };
+        if (title) item.title = title;
+        if (updatedAt) item.updatedAt = updatedAt;
+        items.push(item);
+      }
+      items.push(...codexMetaErrorToItems(update?._meta));
+      return items;
     }
     case "usage_update":
       return [

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -78,6 +78,7 @@ import {
 import { SessionConfigPicker } from "./SessionConfigPicker";
 import { ComposerAddMenu } from "./ComposerAddMenu";
 import { AgentPicker } from "./AgentPicker";
+import { NewTaskUnreadConversations } from "./NewTaskUnreadConversations";
 import { HostDirectoryPicker } from "./HostDirectoryPicker";
 import { useSkillStore } from "@/store/skillStore";
 import { useAttachmentImport } from "@/hooks/useAttachmentImport";
@@ -2678,6 +2679,7 @@ function NewTaskHome({
 
         {preflightMsg && <div className="preflight-warn new-task-warn">{preflightMsg}</div>}
       </section>
+      <NewTaskUnreadConversations />
       </div>
       {workspacePickerOpen && (
         <HostDirectoryPicker

--- a/src/components/CLI/NewTaskUnreadConversations.tsx
+++ b/src/components/CLI/NewTaskUnreadConversations.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import { LoaderCircle, MessageSquare } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { displayAgentName } from "@/config/agentDisplay";
+import { useConversationStore } from "@/store/conversationStore";
+import { useWorkflowStore } from "@/store/workflowStore";
+import { formatDisplayPath } from "@/utils/projectPaths";
+
+import { AgentAvatar } from "./AgentAvatar";
+import {
+  conversationActivityTime,
+  conversationDisplayCwd,
+  projectLabelFromCwd
+} from "./conversationProjectGrouping";
+
+const UNREAD_PREVIEW_LIMIT = 3;
+
+export function NewTaskUnreadConversations() {
+  const { t } = useTranslation();
+  const conversations = useConversationStore((s) => s.conversations);
+  const unreadConversations = useConversationStore((s) => s.unreadConversations);
+  const live = useConversationStore((s) => s.live);
+  const setActive = useConversationStore((s) => s.setActive);
+  const activeRuns = useWorkflowStore((s) => s.activeRuns);
+
+  const unreadAll = useMemo(() => {
+    return conversations
+      .filter((conversation) => Boolean(unreadConversations[conversation.id]))
+      .sort((a, b) => conversationActivityTime(b) - conversationActivityTime(a));
+  }, [conversations, unreadConversations]);
+
+  const unreadItems = unreadAll.slice(0, UNREAD_PREVIEW_LIMIT);
+
+  if (unreadItems.length === 0) return null;
+
+  return (
+    <section
+      className="new-task-unread"
+      aria-label={t("chat.unreadConversationsAria")}
+    >
+      <div className="new-task-unread-header">
+        <h2 className="new-task-unread-title">{t("chat.unreadConversations")}</h2>
+        <span className="new-task-unread-count">{unreadAll.length}</span>
+      </div>
+      <ul className="new-task-unread-list">
+        {unreadItems.map((conversation) => {
+          const cwd = conversationDisplayCwd(conversation);
+          const workspaceLabel = cwd ? projectLabelFromCwd(cwd) : "";
+          const agentLabel = displayAgentName(
+            conversation.agentName,
+            conversation.adapter
+          );
+          const liveStatus = live[conversation.id]?.status;
+          const isRunning =
+            liveStatus === "running" || liveStatus === "starting";
+          const isWorkflowRunning = activeRuns.some(
+            (run) => run.conversationId === conversation.id
+          );
+          const isBusy = isRunning || isWorkflowRunning;
+          const meta = [agentLabel, workspaceLabel].filter(Boolean).join(" · ");
+
+          return (
+            <li key={conversation.id}>
+              <button
+                type="button"
+                className={`new-task-unread-item${isBusy ? " busy" : ""}`}
+                title={conversation.title}
+                onClick={() => void setActive(conversation.id)}
+              >
+                <AgentAvatar
+                  adapter={conversation.adapter}
+                  agentId={conversation.agentId}
+                  className="new-task-unread-avatar"
+                  fallback={<MessageSquare aria-hidden="true" />}
+                />
+                <span className="new-task-unread-copy">
+                  <strong>{conversation.title}</strong>
+                  {meta ? (
+                    <small title={cwd ? formatDisplayPath(cwd) : undefined}>
+                      {meta}
+                    </small>
+                  ) : null}
+                </span>
+                <span className="new-task-unread-side">
+                  {isBusy ? (
+                    <span
+                      className="new-task-unread-running"
+                      role="status"
+                      aria-label={
+                        isWorkflowRunning
+                          ? t("workflow.runningIndicator")
+                          : t("chat.agentRunning")
+                      }
+                      title={
+                        isWorkflowRunning
+                          ? t("workflow.runningIndicator")
+                          : t("chat.agentRunning")
+                      }
+                    >
+                      <LoaderCircle
+                        aria-hidden="true"
+                        size={14}
+                        strokeWidth={1.75}
+                      />
+                    </span>
+                  ) : (
+                    <span
+                      className="conv-unread-dot"
+                      role="status"
+                      aria-label={t("conversations.unread")}
+                      title={t("conversations.unread")}
+                    />
+                  )}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/CLI/NewTaskUnreadConversations.tsx
+++ b/src/components/CLI/NewTaskUnreadConversations.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { LoaderCircle, MessageSquare } from "lucide-react";
+import { ChevronRight, Folder, LoaderCircle, MessageSquare } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { displayAgentName } from "@/config/agentDisplay";
@@ -16,8 +16,28 @@ import {
 
 const UNREAD_PREVIEW_LIMIT = 3;
 
+function formatRelativeActivity(timestampMs: number, locale: string): string {
+  if (!Number.isFinite(timestampMs) || timestampMs <= 0) return "";
+  const diffSec = Math.round((timestampMs - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  const rtf = new Intl.RelativeTimeFormat(locale || undefined, {
+    numeric: "auto"
+  });
+  if (abs < 60) return rtf.format(diffSec, "second");
+  const diffMin = Math.round(diffSec / 60);
+  if (Math.abs(diffMin) < 60) return rtf.format(diffMin, "minute");
+  const diffHour = Math.round(diffMin / 60);
+  if (Math.abs(diffHour) < 24) return rtf.format(diffHour, "hour");
+  const diffDay = Math.round(diffHour / 24);
+  if (Math.abs(diffDay) < 30) return rtf.format(diffDay, "day");
+  return new Date(timestampMs).toLocaleDateString(locale || undefined, {
+    month: "short",
+    day: "numeric"
+  });
+}
+
 export function NewTaskUnreadConversations() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const conversations = useConversationStore((s) => s.conversations);
   const unreadConversations = useConversationStore((s) => s.unreadConversations);
   const live = useConversationStore((s) => s.live);
@@ -58,7 +78,10 @@ export function NewTaskUnreadConversations() {
             (run) => run.conversationId === conversation.id
           );
           const isBusy = isRunning || isWorkflowRunning;
-          const meta = [agentLabel, workspaceLabel].filter(Boolean).join(" · ");
+          const activityLabel = formatRelativeActivity(
+            conversationActivityTime(conversation),
+            i18n.language
+          );
 
           return (
             <li key={conversation.id}>
@@ -70,19 +93,28 @@ export function NewTaskUnreadConversations() {
               >
                 <AgentAvatar
                   adapter={conversation.adapter}
-                  agentId={conversation.agentId}
-                  className="new-task-unread-avatar"
+                  className="conv-item-avatar"
                   fallback={<MessageSquare aria-hidden="true" />}
                 />
                 <span className="new-task-unread-copy">
                   <strong>{conversation.title}</strong>
-                  {meta ? (
-                    <small title={cwd ? formatDisplayPath(cwd) : undefined}>
-                      {meta}
-                    </small>
-                  ) : null}
+                  <span className="new-task-unread-meta">
+                    <span className="new-task-unread-agent">{agentLabel}</span>
+                    {workspaceLabel ? (
+                      <span
+                        className="new-task-unread-workspace"
+                        title={formatDisplayPath(cwd)}
+                      >
+                        <Folder aria-hidden="true" size={12} strokeWidth={1.8} />
+                        {workspaceLabel}
+                      </span>
+                    ) : null}
+                  </span>
                 </span>
                 <span className="new-task-unread-side">
+                  {activityLabel ? (
+                    <span className="new-task-unread-time">{activityLabel}</span>
+                  ) : null}
                   {isBusy ? (
                     <span
                       className="new-task-unread-running"
@@ -106,12 +138,18 @@ export function NewTaskUnreadConversations() {
                     </span>
                   ) : (
                     <span
-                      className="conv-unread-dot"
+                      className="new-task-unread-dot"
                       role="status"
                       aria-label={t("conversations.unread")}
                       title={t("conversations.unread")}
                     />
                   )}
+                  <ChevronRight
+                    className="new-task-unread-chevron"
+                    aria-hidden="true"
+                    size={16}
+                    strokeWidth={1.8}
+                  />
                 </span>
               </button>
             </li>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -666,6 +666,8 @@
     "removeAttachmentAria": "Remove {{name}}",
     "dropAttachmentsHint": "Drop to add attachments",
     "newTaskAria": "New task",
+    "unreadConversations": "Unread conversations",
+    "unreadConversationsAria": "Unread conversations",
     "commonTasksAria": "Common tasks",
     "titlebarMore": "More actions",
     "replay": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -665,6 +665,8 @@
     "removeAttachmentAria": "移除 {{name}}",
     "dropAttachmentsHint": "释放以添加附件",
     "newTaskAria": "新建任务",
+    "unreadConversations": "未读对话",
+    "unreadConversationsAria": "未读对话",
     "commonTasksAria": "常用任务",
     "titlebarMore": "更多操作",
     "replay": {

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -503,10 +503,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     }
     set({ members, conversations: synced.conversations });
     const cur = get().activeId;
+    // Keep startup on the new-task page: do not auto-open the latest conversation.
+    // Only clear activeId when a previously selected conversation no longer exists.
     if (cur && !list.find((c) => c.id === cur)) {
-      set({ activeId: list[0]?.id });
-    } else if (!cur && list.length) {
-      set({ activeId: list[0].id });
+      set({ activeId: undefined });
     }
     const active = get().activeId;
     if (active) get().markConversationRead(active);

--- a/styles.css
+++ b/styles.css
@@ -5933,6 +5933,138 @@ button {
   margin: 12px 0 0;
 }
 
+.new-task-unread {
+  width: 100%;
+  margin-top: 28px;
+}
+
+.new-task-unread-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px 4px;
+}
+
+.new-task-unread-title {
+  margin: 0;
+  color: var(--fb-text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.new-task-unread-count {
+  display: inline-flex;
+  min-width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 6px;
+  border-radius: 999px;
+  color: var(--fb-brand);
+  background: color-mix(in srgb, var(--fb-brand) 12%, transparent);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.new-task-unread-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.new-task-unread-item {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--fb-border);
+  border-radius: 14px;
+  color: inherit;
+  background: color-mix(in srgb, var(--fb-panel-bg) 88%, transparent);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.16s ease, background 0.16s ease;
+}
+
+.new-task-unread-item:hover {
+  border-color: var(--fb-border-strong);
+  background: var(--fb-hover);
+}
+
+.new-task-unread-item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--fb-brand) 40%, transparent);
+  outline-offset: 2px;
+}
+
+.new-task-unread-avatar {
+  display: grid;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 9px;
+  color: var(--fb-text-secondary);
+  background: var(--fb-panel-soft);
+}
+
+.new-task-unread-avatar img,
+.new-task-unread-avatar svg {
+  width: 18px;
+  height: 18px;
+}
+
+.new-task-unread-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.new-task-unread-copy strong,
+.new-task-unread-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-task-unread-copy strong {
+  color: var(--fb-text-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.new-task-unread-copy small {
+  color: var(--fb-text-tertiary);
+  font-size: 11px;
+}
+
+.new-task-unread-side {
+  display: grid;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+}
+
+.new-task-unread-running {
+  display: grid;
+  place-items: center;
+  color: var(--fb-text-tertiary);
+}
+
+.new-task-unread-running svg {
+  animation: spin 0.9s linear infinite;
+}
+
 .practice-section {
   margin-top: 66px;
 }
@@ -10765,7 +10897,8 @@ button {
 
 @media (prefers-reduced-motion: reduce) {
   .conv-item-running svg,
-  .conv-project-running {
+  .conv-project-running,
+  .new-task-unread-running svg {
     animation: none;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -5942,7 +5942,7 @@ button {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin: 0 0 10px 4px;
+  margin: 0 0 10px 2px;
 }
 
 .new-task-unread-title {
@@ -5962,7 +5962,7 @@ button {
   padding: 0 6px;
   border-radius: 999px;
   color: var(--fb-brand);
-  background: color-mix(in srgb, var(--fb-brand) 12%, transparent);
+  background: var(--fb-brand-glow);
   font-size: 11px;
   font-weight: 700;
   line-height: 1;
@@ -5971,54 +5971,39 @@ button {
 .new-task-unread-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
   margin: 0;
-  padding: 0;
+  padding: 4px;
   list-style: none;
+  border: 1px solid var(--fb-border);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--fb-panel-bg) 92%, transparent);
+  overflow: hidden;
 }
 
 .new-task-unread-item {
+  position: relative;
   display: flex;
   width: 100%;
   min-width: 0;
   align-items: center;
   gap: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--fb-border);
+  padding: 12px;
+  border: 0;
   border-radius: 14px;
   color: inherit;
-  background: color-mix(in srgb, var(--fb-panel-bg) 88%, transparent);
+  background: transparent;
   text-align: left;
   cursor: pointer;
-  transition: border-color 0.16s ease, background 0.16s ease;
+  transition: background 0.16s ease;
 }
 
 .new-task-unread-item:hover {
-  border-color: var(--fb-border-strong);
   background: var(--fb-hover);
 }
 
 .new-task-unread-item:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--fb-brand) 40%, transparent);
-  outline-offset: 2px;
-}
-
-.new-task-unread-avatar {
-  display: grid;
-  flex: 0 0 auto;
-  width: 32px;
-  height: 32px;
-  place-items: center;
-  overflow: hidden;
-  border-radius: 9px;
-  color: var(--fb-text-secondary);
-  background: var(--fb-panel-soft);
-}
-
-.new-task-unread-avatar img,
-.new-task-unread-avatar svg {
-  width: 18px;
-  height: 18px;
+  outline-offset: 1px;
 }
 
 .new-task-unread-copy {
@@ -6026,43 +6011,112 @@ button {
   min-width: 0;
   flex: 1;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
 
-.new-task-unread-copy strong,
-.new-task-unread-copy small {
+.new-task-unread-copy strong {
+  overflow: hidden;
+  color: var(--fb-text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-task-unread-meta {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  color: var(--fb-text-tertiary);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.new-task-unread-agent,
+.new-task-unread-workspace {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.new-task-unread-copy strong {
-  color: var(--fb-text-primary);
-  font-size: 13px;
-  font-weight: 650;
+.new-task-unread-agent {
+  flex: 0 1 auto;
+  max-width: 42%;
+  color: var(--fb-text-secondary);
+  font-weight: 600;
 }
 
-.new-task-unread-copy small {
-  color: var(--fb-text-tertiary);
-  font-size: 11px;
+.new-task-unread-workspace {
+  display: inline-flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 4px;
+}
+
+.new-task-unread-workspace svg {
+  flex: 0 0 auto;
+  opacity: 0.8;
 }
 
 .new-task-unread-side {
-  display: grid;
+  display: inline-flex;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  place-items: center;
+  align-items: center;
+  gap: 8px;
+  margin-left: 4px;
+}
+
+.new-task-unread-time {
+  color: var(--fb-text-tertiary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.new-task-unread-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--fb-brand);
+  box-shadow: 0 0 0 3px var(--fb-brand-glow);
 }
 
 .new-task-unread-running {
   display: grid;
   place-items: center;
-  color: var(--fb-text-tertiary);
+  color: var(--fb-brand);
 }
 
 .new-task-unread-running svg {
   animation: spin 0.9s linear infinite;
+}
+
+.new-task-unread-chevron {
+  color: var(--fb-text-tertiary);
+  opacity: 0;
+  transform: translateX(-2px);
+  transition: opacity 0.16s ease, transform 0.16s ease, color 0.16s ease;
+}
+
+.new-task-unread-item:hover .new-task-unread-chevron,
+.new-task-unread-item:focus-visible .new-task-unread-chevron {
+  opacity: 1;
+  transform: translateX(0);
+  color: var(--fb-text-secondary);
+}
+
+.new-task-unread-item:hover .new-task-unread-time {
+  opacity: 0.72;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .new-task-unread-item,
+  .new-task-unread-chevron {
+    transition: none;
+  }
 }
 
 .practice-section {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -716,6 +716,118 @@ test("acpUpdateToItems maps session metadata, commands and config options", () =
   );
 });
 
+test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors", () => {
+  // Real shape from codex-acp 1.1.7 when an upstream gateway returns HTTP 422
+  // and codex begins its Reconnecting 1..5 retry loop (issues #340 / #355).
+  const retrying = acpUpdateToItems({
+    sessionUpdate: "session_info_update",
+    sessionId: "019fcd3a-5586-7932-8860-b6fb71aafbfd",
+    _meta: {
+      codex: {
+        error: {
+          message: "Reconnecting... 1/5",
+          additionalDetails:
+            "unexpected status 422 Unprocessable Entity: content input null",
+          codexErrorInfo: {
+            responseStreamDisconnected: { httpStatusCode: 422 }
+          },
+          willRetry: true
+        }
+      }
+    }
+  });
+  assert.deepEqual(retrying, [
+    {
+      kind: "session",
+      sessionId: "019fcd3a-5586-7932-8860-b6fb71aafbfd"
+    },
+    {
+      kind: "error",
+      message: "Upstream gateway error (HTTP 422) — codex is retrying the request…",
+      details: [
+        "Retry attempt 1.",
+        "Reconnecting... 1/5",
+        "unexpected status 422 Unprocessable Entity: content input null"
+      ]
+    }
+  ]);
+
+  // No session fields, only the structured error: still emit the error item
+  // so retries never render as silent assistant replies.
+  const errorOnly = acpUpdateToItems({
+    sessionUpdate: "session_info_update",
+    _meta: {
+      codex: {
+        error: {
+          message: "Reconnecting... 5/5",
+          additionalDetails: "unexpected status 422 Unprocessable Entity",
+          codexErrorInfo: {
+            responseStreamDisconnected: { httpStatusCode: 422 }
+          },
+          willRetry: false
+        }
+      }
+    }
+  });
+  assert.deepEqual(errorOnly, [
+    {
+      kind: "error",
+      message:
+        "Upstream gateway error (HTTP 422) — codex gave up after retries; the turn did not complete.",
+      details: [
+        "Retry attempt 5.",
+        "Reconnecting... 5/5",
+        "unexpected status 422 Unprocessable Entity"
+      ]
+    }
+  ]);
+
+  // Stable headline across retry attempts: attempt 1 and 2 produce the same
+  // message so downstream adjacent-error dedupe collapses them into one entry.
+  const attempt1 = acpUpdateToItems({
+    sessionUpdate: "session_info_update",
+    _meta: {
+      codex: {
+        error: {
+          message: "Reconnecting... 1/5",
+          codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: 422 } },
+          willRetry: true
+        }
+      }
+    }
+  });
+  const attempt2 = acpUpdateToItems({
+    sessionUpdate: "session_info_update",
+    _meta: {
+      codex: {
+        error: {
+          message: "Reconnecting... 2/5",
+          codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: 422 } },
+          willRetry: true
+        }
+      }
+    }
+  });
+  assert.equal(attempt1[0].message, attempt2[0].message);
+
+  // Non-codex _meta (or missing error) is ignored — backward compatible.
+  assert.deepEqual(
+    acpUpdateToItems({
+      sessionUpdate: "session_info_update",
+      sessionId: "s1",
+      _meta: { kimi: { session: { title: "hi" } } }
+    }),
+    [{ kind: "session", sessionId: "s1" }]
+  );
+  assert.deepEqual(
+    acpUpdateToItems({
+      sessionUpdate: "session_info_update",
+      sessionId: "s1"
+    }),
+    [{ kind: "session", sessionId: "s1" }]
+  );
+});
+
 test("buildPromptContentBlocks maps text and resource links for attachments", () => {
   assert.deepEqual(buildPromptContentBlocks("hello"), [{ type: "text", text: "hello" }]);
   const blocks = buildPromptContentBlocks("see file", [


### PR DESCRIPTION
## 改动

### 新建会话首页 · 未读对话列表
- `ce78d3d` 启动进入新建会话页（而非最近会话），并在输入框下方展示最多 3 条未读对话快捷入口
- `fb13aa1` 未读列表重设计：
  - 改为圆角卡片分组，去掉每项独立边框
  - 元信息拆成 Agent + 工作目录（文件夹图标），并新增相对活动时间
  - 更新未读小圆点，新增 hover 箭头，支持 `prefers-reduced-motion`

### ACP · codex 网关重试错误可见化
- `69bc01b` 解析 `session_info_update._meta.codex.error`（如模型网关返回 HTTP 422），转成 `kind:"error"` stream item
  - 背景：此前 codex 重试期间完全静默，重试耗尽后把原始错误体当作 `agent_message_chunk` 发出，被前端渲染成一条 assistant 回复
  - headline 在多次重试间保持稳定（N/5 放进 details），相邻相同错误自动合并为一条
  - 新增 4 个单测场景（`tests/acp.test.mjs`）
  - 关联上游 codex-acp [#340](https://github.com/agentclientprotocol/codex-acp/issues/340)、[#355](https://github.com/agentclientprotocol/codex-acp/issues/355)

## Test plan
- [ ] 重启应用，确认默认落在新建会话页，而不是最近会话
- [ ] 制造至少一条未读会话，确认新建页下方出现未读列表卡片（标题 / Agent / 工作目录 / 相对时间）
- [ ] 点击未读卡片可直接进入对应会话；hover 出现箭头
- [ ] （如能复现）触发 codex 上游 422，确认红色错误块「Upstream gateway error (HTTP 422) — codex is retrying…」+ 可展开详情，而不再被当作 assistant 回复
- [ ] `npm run typecheck` / `npm test` 通过
