### PR TITLE
fix(workflow-teams): preserve role skills across restarts

### DIFF
--- a/electron/cli/workflowTeams.ts
+++ b/electron/cli/workflowTeams.ts
@@ -161,7 +161,8 @@ function mergeBuiltinRoles(
       ...(savedRole?.model ? { model: savedRole.model } : {}),
       ...(savedRole?.modelOptionId
         ? { modelOptionId: savedRole.modelOptionId }
-        : {})
+        : {}),
+      skillIds: savedRole?.skillIds ?? role.skillIds
     };
   });
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:electron": "tsc -p tsconfig.electron.json && tsc -p tsconfig.preload.json && node scripts/write-telemetry-config.mjs",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.preload.json --noEmit",
     "test": "npm run build:electron && node --test --test-force-exit tests/*.mjs && npm run test:handoff-db",
-    "test:handoff-db": "node scripts/run-electron-node-test.mjs tests/handoff-brief-db.test.mjs tests/conversation-context-db.test.mjs tests/agent-usage-db.test.mjs tests/users-db.test.mjs tests/conversations-owner-db.test.mjs tests/scheduled-tasks-owner-db.test.mjs tests/session-persistence-db.test.mjs tests/remote-workspaces-db.test.mjs tests/tasks-owner-db.test.mjs tests/sandbox-runtime-smoke.test.mjs",
+    "test:handoff-db": "node scripts/run-electron-node-test.mjs tests/handoff-brief-db.test.mjs tests/conversation-context-db.test.mjs tests/agent-usage-db.test.mjs tests/users-db.test.mjs tests/conversations-owner-db.test.mjs tests/scheduled-tasks-owner-db.test.mjs tests/session-persistence-db.test.mjs tests/remote-workspaces-db.test.mjs tests/tasks-owner-db.test.mjs tests/sandbox-runtime-smoke.test.mjs tests/workflow-teams-db.test.mjs",
     "predist": "node scripts/ensure-tokscale-platform.mjs",
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && node scripts/ensure-tokscale-platform.mjs --platform darwin --arch arm64 && node scripts/ensure-tokscale-platform.mjs --platform darwin --arch x64 && electron-builder --mac --x64 --arm64",

--- a/tests/workflow-teams-db.test.mjs
+++ b/tests/workflow-teams-db.test.mjs
@@ -1,0 +1,51 @@
+import "./fixtures/electron-stub.mjs";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+let Database;
+let bindingAvailable = true;
+try {
+  Database = (await import("better-sqlite3")).default;
+  new Database(":memory:").close();
+} catch {
+  bindingAvailable = false;
+}
+
+test("seeding builtin workflow teams preserves role skills", async (t) => {
+  if (!bindingAvailable) {
+    t.skip("better-sqlite3 native binding unavailable");
+    return;
+  }
+
+  const db = new Database(":memory:");
+  const { migrate, setDbForTest } = await import("../dist-electron/cli/db.js");
+  const {
+    getWorkflowTeam,
+    seedBuiltinWorkflowTeams,
+    updateWorkflowTeam
+  } = await import("../dist-electron/cli/workflowTeams.js");
+  migrate(db);
+  setDbForTest(db);
+  t.after(() => {
+    setDbForTest(null);
+    db.close();
+  });
+
+  seedBuiltinWorkflowTeams();
+  const team = getWorkflowTeam("team-delivery-example");
+  assert.ok(team);
+
+  const roleId = "role-planner";
+  const skillIds = ["skill-debug", "skill-review"];
+  updateWorkflowTeam(team.id, {
+    roles: team.roles.map((role) =>
+      role.id === roleId ? { ...role, skillIds } : role
+    )
+  });
+
+  seedBuiltinWorkflowTeams();
+
+  const restartedTeam = getWorkflowTeam(team.id);
+  const restartedRole = restartedTeam?.roles.find((role) => role.id === roleId);
+  assert.deepEqual(restartedRole?.skillIds, skillIds);
+});


### PR DESCRIPTION
## Summary

Built-in team roles now retain their selected Skills after FreeBuddy restarts. Startup seeding keeps persisted `skillIds` while still refreshing built-in role defaults. Custom teams are unchanged.

## Validation

An in-memory database regression saves role Skills, reruns startup seeding, and verifies that every selected Skill ID survives. `npm test` and `npm run typecheck` pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
