### PR TITLE
fix(butlerbuddy): 宠物浮窗可控制主端主题/设置

### DIFF
--- a/electron/butlerToolService.ts
+++ b/electron/butlerToolService.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { fileURLToPath } from "node:url";
-import type { WebContents } from "electron";
+import type { BrowserWindow, WebContents } from "electron";
 
 import { waitForActiveBridgePort } from "./agentBridge.js";
 import type { AcpStdioMcpServer } from "./shared/draftToolProtocol.js";
@@ -52,6 +52,38 @@ interface ButlerToolBinding {
 
 const bindingsByToken = new Map<string, ButlerToolBinding>();
 const tokensByTaskSession = new Map<string, string>();
+
+// Pet/chat companions bind butler tools to their own webContents. UI shell
+// mutations (theme, settings) must still reach the main FreeBuddy window.
+let butlerAppWindowGetter: (() => BrowserWindow | null) | null = null;
+
+export function setButlerAppWindowGetter(
+  getter: () => BrowserWindow | null
+): void {
+  butlerAppWindowGetter = getter;
+}
+
+function resolveButlerAppWebContents(
+  fallback?: WebContents
+): WebContents | undefined {
+  const win = butlerAppWindowGetter?.() ?? null;
+  if (win && !win.isDestroyed()) {
+    return win.webContents;
+  }
+  if (fallback && !fallback.isDestroyed()) {
+    return fallback;
+  }
+  return undefined;
+}
+
+function focusButlerAppWindow(): boolean {
+  const win = butlerAppWindowGetter?.() ?? null;
+  if (!win || win.isDestroyed()) return false;
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  return true;
+}
 
 type ButlerToolAction =
   | "status_get"
@@ -441,11 +473,13 @@ async function dispatchButlerAction(
     }
     case "settings_open": {
       const tab = String(params.tab ?? "cli");
-      if (binding.webContents) {
-        safeSendToWebContents(binding.webContents, "freebuddy://open-settings", { tab });
-        return { ok: true, tab };
+      const target = resolveButlerAppWebContents(binding.webContents);
+      if (!target) {
+        return { ok: false, error: "No active window to open settings." };
       }
-      return { ok: false, error: "No active window to open settings." };
+      focusButlerAppWindow();
+      safeSendToWebContents(target, "freebuddy://open-settings", { tab });
+      return { ok: true, tab };
     }
     case "set_appearance": {
       const theme = String(params.theme ?? "").trim();
@@ -453,8 +487,9 @@ async function dispatchButlerAction(
         return { ok: false, error: "theme must be one of: system, light, dark." };
       }
       setSetting("theme", theme);
-      if (binding.webContents) {
-        safeSendToWebContents(binding.webContents, "freebuddy://appearance-changed", {
+      const target = resolveButlerAppWebContents(binding.webContents);
+      if (target) {
+        safeSendToWebContents(target, "freebuddy://appearance-changed", {
           theme
         });
       }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,7 @@ import { handleDraftRequest } from "./draftProtocol.js";
 import { startPreviewServer } from "./previewServer.js";
 import { startWebUIServer } from "./webUIServer.js";
 import { setLocalInvokeWindowGetter } from "./invokeRegistry.js";
+import { setButlerAppWindowGetter } from "./butlerToolService.js";
 import { ensureOwnerUser, getOwnerUser } from "./cli/users.js";
 import { bindConversationNotifier } from "./cli/conversations.js";
 import { applyOwnerBackfill } from "./cli/ownerBackfill.js";
@@ -785,6 +786,9 @@ app.whenReady().then(async () => {
     applyOwnerBackfill(existingOwner.id);
   }
   setLocalInvokeWindowGetter(() =>
+    mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
+  );
+  setButlerAppWindowGetter(() =>
     mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
   );
   const remoteEnabled =

--- a/tests/butlerbuddy.test.mjs
+++ b/tests/butlerbuddy.test.mjs
@@ -192,3 +192,32 @@ test("the ButlerBuddy popover is a persisted real conversation, not a fake panel
   assert.match(chat, /butler-chat-header-controls/);
   assert.doesNotMatch(chat, /打开插件管理|检查所有 Agent|查看更新/);
 });
+
+test("Butler UI tools notify the main FreeBuddy window from the pet chat companion", () => {
+  // Pet/chat cli:run binds butler tools to the companion webContents. Theme and
+  // settings IPC must still target the main App window, which owns the UI shell.
+  const service = fs.readFileSync(
+    new URL("../electron/butlerToolService.ts", import.meta.url),
+    "utf8"
+  );
+  const main = fs.readFileSync(
+    new URL("../electron/main.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(service, /export function setButlerAppWindowGetter/);
+  assert.match(service, /function resolveButlerAppWebContents/);
+  assert.match(
+    service,
+    /case "set_appearance":[\s\S]*?resolveButlerAppWebContents\(binding\.webContents\)/
+  );
+  assert.match(
+    service,
+    /case "settings_open":[\s\S]*?resolveButlerAppWebContents\(binding\.webContents\)/
+  );
+  assert.match(
+    service,
+    /case "settings_open":[\s\S]*?focusButlerAppWindow\(\)/
+  );
+  assert.match(main, /setButlerAppWindowGetter\(\(\) =>/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
从桌面宠物浮窗聊天里让 ButlerBuddy 切换暗黑模式等主端 UI 操作时，工具会返回成功，但主窗口界面不变。主端内的 ButlerBuddy 对话则正常。

## 根因
宠物浮窗 / 迷你聊天是独立 `BrowserWindow`。`cli:run` 用发送方窗口绑定 butler 工具 session，因此 `freebuddy_set_appearance` / `freebuddy_settings_open` 的 IPC 只打到 companion 窗口；而监听 `onAppearanceChanged` / 设置页的只有主窗口 `App`。

## 修复
- 在 `butlerToolService` 增加主窗口 getter（`setButlerAppWindowGetter`）
- `set_appearance` / `settings_open` 优先通知并聚焦主 FreeBuddy 窗口（无主窗口时回退到 binding）
- `main.ts` 在启动时注册主窗口 getter
- 增加契约测试锁定该行为

## 验证
- `node --test --test-force-exit tests/butlerbuddy.test.mjs`（8/8 通过）
- `npx tsc -p tsconfig.electron.json --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-592d68f6-24bf-4f03-9eb7-f5a4e3861fb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-592d68f6-24bf-4f03-9eb7-f5a4e3861fb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

