### PR TITLE
fix: SkillPicker 将已选 Skills 与可添加项分组显示

### DIFF
--- a/src/components/CLI/SkillPicker.tsx
+++ b/src/components/CLI/SkillPicker.tsx
@@ -4,6 +4,29 @@ import { useTranslation } from "react-i18next";
 
 import type { SkillRecord } from "@/services/skills/types";
 
+export function partitionPickerSkills(
+  skills: SkillRecord[],
+  selectedIds: string[],
+  query: string
+): { selected: SkillRecord[]; available: SkillRecord[] } {
+  const enabled = skills.filter((skill) => skill.enabled && skill.trusted);
+  const needle = query.trim().toLocaleLowerCase();
+  const matches = (skill: SkillRecord) =>
+    !needle ||
+    `${skill.name} ${skill.description}`.toLocaleLowerCase().includes(needle);
+  const byId = new Map(enabled.map((skill) => [skill.id, skill]));
+  const selectedSet = new Set(selectedIds);
+  const selected: SkillRecord[] = [];
+  for (const id of selectedIds) {
+    const skill = byId.get(id);
+    if (skill && matches(skill)) selected.push(skill);
+  }
+  const available = enabled.filter(
+    (skill) => !selectedSet.has(skill.id) && matches(skill)
+  );
+  return { selected, available };
+}
+
 export function SkillPicker({
   skills,
   selectedIds,
@@ -17,17 +40,39 @@ export function SkillPicker({
 }) {
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
-  const available = skills.filter((skill) => skill.enabled && skill.trusted);
-  const needle = query.trim().toLocaleLowerCase();
-  const filtered = available.filter((skill) =>
-    !needle || `${skill.name} ${skill.description}`.toLocaleLowerCase().includes(needle)
-  );
   const selected = new Set(selectedIds);
+  const { selected: selectedSkills, available: availableSkills } =
+    partitionPickerSkills(skills, selectedIds, query);
+  const hasCatalog = skills.some((skill) => skill.enabled && skill.trusted);
+  const hasResults = selectedSkills.length > 0 || availableSkills.length > 0;
+
+  const renderSkill = (skill: SkillRecord) => (
+    <label key={skill.id}>
+      <input
+        type="checkbox"
+        checked={selected.has(skill.id)}
+        onChange={(event) => {
+          const next = new Set(selected);
+          if (event.currentTarget.checked) next.add(skill.id);
+          else next.delete(skill.id);
+          onChange([...next]);
+        }}
+      />
+      <span>
+        <b>{skill.name}</b>
+        <small>{skill.description}</small>
+      </span>
+    </label>
+  );
+
   return (
     <details className="skill-picker">
-      <summary className={`composer-tool-chip${disabled ? " disabled" : ""}`} onClick={(event) => {
-        if (disabled) event.preventDefault();
-      }}>
+      <summary
+        className={`composer-tool-chip${disabled ? " disabled" : ""}`}
+        onClick={(event) => {
+          if (disabled) event.preventDefault();
+        }}
+      >
         <Sparkles size={14} />
         {t("skills.picker", { count: selectedIds.length })}
       </summary>
@@ -44,23 +89,24 @@ export function SkillPicker({
           />
         </label>
         <div className="skill-picker-list">
-          {!available.length ? <p>{t("skills.none")}</p> : null}
-          {available.length && !filtered.length ? <p>{t("skills.noResults")}</p> : null}
-          {filtered.map((skill) => (
-            <label key={skill.id}>
-              <input
-                type="checkbox"
-                checked={selected.has(skill.id)}
-                onChange={(event) => {
-                  const next = new Set(selected);
-                  if (event.currentTarget.checked) next.add(skill.id);
-                  else next.delete(skill.id);
-                  onChange([...next]);
-                }}
-              />
-              <span><b>{skill.name}</b><small>{skill.description}</small></span>
-            </label>
-          ))}
+          {!hasCatalog ? <p>{t("skills.none")}</p> : null}
+          {hasCatalog && !hasResults ? <p>{t("skills.noResults")}</p> : null}
+          {selectedSkills.length > 0 ? (
+            <div className="skill-picker-group">
+              <div className="skill-picker-group-label">
+                {t("skills.selectedGroup", { count: selectedSkills.length })}
+              </div>
+              {selectedSkills.map(renderSkill)}
+            </div>
+          ) : null}
+          {availableSkills.length > 0 ? (
+            <div className="skill-picker-group">
+              <div className="skill-picker-group-label">
+                {t("skills.availableGroup", { count: availableSkills.length })}
+              </div>
+              {availableSkills.map(renderSkill)}
+            </div>
+          ) : null}
         </div>
       </div>
     </details>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -226,6 +226,8 @@
     "deleteConfirm": "Delete imported skill “{{name}}”?",
     "picker": "Skills {{count}}",
     "activeForTask": "Active for this task",
+    "selectedGroup": "Selected {{count}}",
+    "availableGroup": "Available {{count}}",
     "required": "Required",
     "agentDefaults": "Default skills",
     "agentDefaultsHint": "Automatically selected when a new task uses this agent.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -226,6 +226,8 @@
     "deleteConfirm": "删除已导入的 Skill“{{name}}”？",
     "picker": "Skills {{count}}",
     "activeForTask": "本任务启用",
+    "selectedGroup": "已选择 {{count}}",
+    "availableGroup": "可添加 {{count}}",
     "required": "必选",
     "agentDefaults": "默认 Skills",
     "agentDefaultsHint": "使用这个 Agent 新建任务时自动选中。",

--- a/styles.css
+++ b/styles.css
@@ -4348,6 +4348,18 @@ html[data-surface="butler-chat"] #root {
 .skill-picker-search input { width: 100%; min-width: 0; padding: 0; border: 0; outline: 0; background: transparent; color: var(--fb-text-primary); font: inherit; font-size: 11px; }
 .skill-picker-search input::-webkit-search-cancel-button { cursor: pointer; }
 .skill-picker-list { min-height: 0; overflow-y: auto; }
+.skill-picker-group + .skill-picker-group { margin-top: 4px; padding-top: 4px; border-top: 1px solid var(--fb-border); }
+.skill-picker-group-label {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 6px 5px 4px;
+  background: var(--fb-panel-bg);
+  color: var(--fb-text-tertiary);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+}
 .skill-picker-list label { display: flex; gap: 8px; padding: 7px 5px; border-radius: 8px; cursor: pointer; }
 .skill-picker-list label:hover { background: var(--fb-panel-soft); }
 .skill-picker-list label span { display: flex; min-width: 0; flex-direction: column; gap: 2px; }

--- a/tests/skill-picker.test.mjs
+++ b/tests/skill-picker.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const pickerSource = fs.readFileSync(
+  new URL("../src/components/CLI/SkillPicker.tsx", import.meta.url),
+  "utf8"
+);
+const stylesSource = fs.readFileSync(
+  new URL("../styles.css", import.meta.url),
+  "utf8"
+);
+const zhSource = fs.readFileSync(
+  new URL("../src/locales/zh-CN.json", import.meta.url),
+  "utf8"
+);
+const enSource = fs.readFileSync(
+  new URL("../src/locales/en.json", import.meta.url),
+  "utf8"
+);
+
+test("skill picker partitions selected skills above available skills", () => {
+  assert.match(pickerSource, /export function partitionPickerSkills/);
+  assert.match(pickerSource, /skills\.selectedGroup/);
+  assert.match(pickerSource, /skills\.availableGroup/);
+  assert.match(pickerSource, /skill-picker-group-label/);
+  assert.match(
+    pickerSource,
+    /for \(const id of selectedIds\)[\s\S]*selected\.push\(skill\)/
+  );
+  assert.match(
+    pickerSource,
+    /!selectedSet\.has\(skill\.id\) && matches\(skill\)/
+  );
+});
+
+test("skill picker selected/available group copy exists in locales", () => {
+  assert.match(zhSource, /"selectedGroup": "已选择 \{\{count\}\}"/);
+  assert.match(zhSource, /"availableGroup": "可添加 \{\{count\}\}"/);
+  assert.match(enSource, /"selectedGroup": "Selected \{\{count\}\}"/);
+  assert.match(enSource, /"availableGroup": "Available \{\{count\}\}"/);
+});
+
+test("skill picker group labels stick while scrolling", () => {
+  assert.match(
+    stylesSource,
+    /\.skill-picker-group-label\s*\{[^}]*position:\s*sticky;[^}]*top:\s*0;/m
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 团队角色添加 Skills 时，已选与未选混在同一列表，难以快速确认当前启用项。
- `SkillPicker` 现在把列表分成「已选择」和「可添加」两组：已选项置顶并保持原选择顺序，未选项在下方。
- 分组标题在滚动时 sticky，便于长列表浏览。

## Test plan
- [ ] 打开工作流团队编辑 → 角色卡片 → Skills
- [ ] 已有选中 Skills 时，确认它们出现在「已选择」分组顶部
- [ ] 未选 Skills 出现在「可添加」分组
- [ ] 勾选/取消勾选后分组即时更新
- [ ] 搜索时两组均按关键词过滤
- [ ] Agent 默认 Skills 设置页的同一选择器行为一致

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d062172-686c-4c47-a447-699d1297f294?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d062172-686c-4c47-a447-699d1297f294&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

