### PR TITLE
fix: fall back to session/new when saved ACP sessions are gone

### DIFF
--- a/electron/butlerToolService.ts
+++ b/electron/butlerToolService.ts
@@ -42,6 +42,7 @@ import { cliCheck, listRuntimes } from "./cli/check.js";
 import { setSetting } from "./cli/settings.js";
 import { safeSendToWebContents } from "./cli/ipcSend.js";
 import { prepareAgentSelfCheckLogs } from "./debugLogExport.js";
+import { logMain } from "./debugLog.js";
 import { getMainWindowPresence } from "./uiPresence.js";
 
 const BUTLER_TOOL_PATH = "/freebuddy/butler-tool";
@@ -321,6 +322,14 @@ async function dispatchButlerAction(
   action: ButlerToolAction,
   params: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
+  if (action.startsWith("team_")) {
+    logMain().info("workflowTeams", "caller", {
+      caller: "butler",
+      op: action,
+      teamId: params.id ?? params.teamId,
+      pid: process.pid
+    });
+  }
   switch (action) {
     case "status_get": {
       const members = withCaller(binding, () => listCliMembers());
@@ -722,6 +731,15 @@ async function dispatchButlerAction(
     }
     case "team_list": {
       const teams = listWorkflowTeams();
+      for (const team of teams) {
+        if (team.roles.every((r) => (r.skillIds?.length ?? 0) === 0)) {
+          logMain().warn("workflowTeams", "team_list read empty skills", {
+            teamId: team.id,
+            pid: process.pid,
+            updatedAt: team.updatedAt
+          });
+        }
+      }
       return { teams: teams.map(publicTeam) };
     }
     case "team_get": {
@@ -729,6 +747,15 @@ async function dispatchButlerAction(
       const team = getWorkflowTeam(id);
       if (!team) {
         return { ok: false, error: "Team not found." };
+      }
+      const skillCounts = team.roles.map((r) => ({ id: r.id, n: r.skillIds?.length ?? 0 }));
+      if (skillCounts.every((s) => s.n === 0)) {
+        logMain().warn("workflowTeams", "team_get read empty skills", {
+          teamId: id,
+          pid: process.pid,
+          skillCounts,
+          updatedAt: team.updatedAt
+        });
       }
       return {
         team: {

--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -299,6 +299,38 @@ export function selectAcpSessionStartMode(
   return "new";
 }
 
+/**
+ * Detect ACP session/load or session/resume failures where the saved session
+ * id is gone (process died, session GC'd, etc.). Cursor reports this as
+ * `-32602 Invalid params` with nested `Session "…" not found`; other agents
+ * may use `-32002` / "resource not found".
+ */
+export function isMissingSavedSessionError(err: unknown): boolean {
+  const e = err as Error & { code?: number; data?: unknown };
+  const parts: string[] = [String(e?.message ?? err)];
+  if (typeof e?.data === "string") {
+    parts.push(e.data);
+  } else if (e?.data && typeof e.data === "object") {
+    const data = e.data as Record<string, unknown>;
+    if (typeof data.message === "string") parts.push(data.message);
+    try {
+      parts.push(JSON.stringify(e.data));
+    } catch {
+      /* noop */
+    }
+  }
+  const haystack = parts.join(" ");
+  if (/session\s+["'`]?[^"'`\s]+["'`]?\s+not found/i.test(haystack)) {
+    return true;
+  }
+  if (e?.code === -32002 && /resource not found/i.test(haystack)) {
+    return true;
+  }
+  return /saved (?:agent )?session.*(?:not found|no longer available|unavailable)/i.test(
+    haystack
+  );
+}
+
 export function buildSessionNewRequest(
   id: AcpRequestId,
   cwd?: string,

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -27,6 +27,7 @@ import {
   shouldEmitAcpUpdate,
   shouldSkipUserMessageChunk,
   textFromContent,
+  isMissingSavedSessionError,
   type AcpAuthMethod,
   type AcpMessage,
   type AcpSessionMeta,
@@ -37,6 +38,7 @@ import { updateRuntimeRun } from "./check.js";
 import {
   hasCliByokModels,
   mergeCliByokModelOption,
+  clearToolSession,
   saveToolSession
 } from "./store.js";
 import {
@@ -1151,11 +1153,6 @@ export async function runAcpAgent({
     );
   };
 
-  const isMissingSavedSessionError = (err: unknown) => {
-    const e = err as Error & { code?: number };
-    return e?.code === -32002 && /resource not found/i.test(e.message ?? "");
-  };
-
   const isContextWindowError = (err: unknown) => {
     const message = String((err as Error)?.message ?? err).toLowerCase();
     return /context window|context length|input exceeds|prompt is too long|too many tokens/.test(
@@ -1163,11 +1160,28 @@ export async function runAcpAgent({
     );
   };
 
-  const savedSessionUnavailableError = (sessionId: string, err: unknown) => {
-    const message = (err as Error)?.message || String(err);
-    return new Error(
-      `Saved agent session is no longer available (${sessionId}). The agent returned: ${message}. Start a new conversation or choose a workspace and retry so FreeBuddy can create a fresh agent session.`
+  const abandonStaleToolSession = (sessionId: string, err: unknown) => {
+    const detail = (err as Error)?.message || String(err);
+    appendLog(
+      logStream,
+      "system",
+      `saved ACP session unavailable (${sessionId}); starting a fresh session: ${detail}`
     );
+    emit({
+      type: "stderr",
+      content:
+        "Previous agent session is no longer available; starting a fresh session."
+    });
+    if (toolSessionScope) {
+      try {
+        clearToolSession(args.agentId, toolSessionScope);
+      } catch {
+        /* best-effort */
+      }
+    }
+    requestedToolSessionId = undefined;
+    activeAcpSessionId = undefined;
+    sessionWasResumed = false;
   };
 
   try {
@@ -1251,7 +1265,8 @@ export async function runAcpAgent({
         requestedToolSessionId &&
         isMissingSavedSessionError(sessionErr)
       ) {
-        throw savedSessionUnavailableError(requestedToolSessionId, sessionErr);
+        abandonStaleToolSession(requestedToolSessionId, sessionErr);
+        await establishSession();
       } else {
         throw sessionErr;
       }

--- a/electron/cli/store.ts
+++ b/electron/cli/store.ts
@@ -854,3 +854,19 @@ export function clearToolSessionsForAgent(agentId: string): void {
     .prepare("DELETE FROM cli_tool_sessions WHERE agent_id = ?")
     .run(agentId);
 }
+
+export function clearToolSession(
+  agentId: string,
+  workspacePath: string
+): void {
+  const ownerId = getCallerUserId();
+  const db = getDb();
+  db.prepare("DELETE FROM cli_tool_sessions WHERE key = ?").run(
+    toolSessionKey(agentId, workspacePath, ownerId)
+  );
+  if (isCallerAdmin() || ownerId === null) {
+    db.prepare("DELETE FROM cli_tool_sessions WHERE key = ?").run(
+      toolSessionKey(agentId, workspacePath, null)
+    );
+  }
+}

--- a/electron/cli/workflowIpc.ts
+++ b/electron/cli/workflowIpc.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow, type IpcMainInvokeEvent } from "electron";
 import { registerHandler } from "../invokeRegistry.js";
+import { logMain } from "../debugLog.js";
 
 import { listCliMembers } from "./members.js";
 import {
@@ -167,6 +168,7 @@ export function registerWorkflowIpc() {
   registerHandler(
     "workflowTeams:create",
     (_e, input: UpsertWorkflowTeamInput) => {
+      logMain().info("workflowTeams", "caller", { caller: "ipc", op: "create", pid: process.pid });
       const validation = validateWorkflowTeam(
         { ...input, createdAt: "", updatedAt: "" } as WorkflowTeam,
         workflowAgents()
@@ -179,6 +181,13 @@ export function registerWorkflowIpc() {
   registerHandler(
     "workflowTeams:update",
     (_e, args: { id: string; patch: UpdateWorkflowTeamPatch }) => {
+      logMain().info("workflowTeams", "caller", {
+        caller: "ipc",
+        op: "update",
+        teamId: args.id,
+        changedRoles: args.patch.roles !== undefined,
+        pid: process.pid
+      });
       const existing = getWorkflowTeam(args.id);
       if (!existing) return { ok: false as const, errors: ["team not found"] };
       const merged: WorkflowTeam = {
@@ -203,9 +212,13 @@ export function registerWorkflowIpc() {
   );
   registerHandler(
     "workflowTeams:delete",
-    (_e, id: string) => deleteWorkflowTeam(id)
+    (_e, id: string) => {
+      logMain().info("workflowTeams", "caller", { caller: "ipc", op: "delete", teamId: id, pid: process.pid });
+      return deleteWorkflowTeam(id);
+    }
   );
   registerHandler("workflowTeams:seedBuiltins", () => {
+    logMain().info("workflowTeams", "caller", { caller: "ipc", op: "seedBuiltins", pid: process.pid });
     seedBuiltinWorkflowTeams();
     return listWorkflowTeams();
   });

--- a/electron/cli/workflowTeams.ts
+++ b/electron/cli/workflowTeams.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from "electron";
 import { getDb } from "./db.js";
+import { logMain } from "../debugLog.js";
 import { safeSendToWebContents } from "./ipcSend.js";
 import type {
   WorkflowTeam,
@@ -12,6 +13,33 @@ import { builtinWorkflowTeams } from "./workflowTeamBuiltins.js";
 function notifyWorkflowTeamsChanged(): void {
   for (const win of BrowserWindow.getAllWindows()) {
     safeSendToWebContents(win.webContents, "workflowTeams://changed", undefined);
+  }
+}
+
+/**
+ * Audit every workflow_teams write so exported debug logs can pinpoint which
+ * process / caller mutated a team's roles (esp. skillIds). The pid field is the
+ * key signal for the multi-process clobber scenario; skillCounts reveals whether
+ * the write cleared or preserved per-role skills.
+ */
+function auditTeamWrite(
+  action: string,
+  teamId: string,
+  roles: WorkflowTeamRole[] | undefined,
+  extra?: Record<string, unknown>
+): void {
+  try {
+    logMain().info("workflowTeams", "audit write", {
+      action,
+      teamId,
+      pid: process.pid,
+      ppid: process.ppid,
+      roleCount: roles?.length ?? 0,
+      skillCounts: roles?.map((r) => ({ id: r.id, n: r.skillIds?.length ?? 0 })),
+      ...extra
+    });
+  } catch {
+    /* audit logging must never disrupt the write path */
   }
 }
 
@@ -59,6 +87,7 @@ export interface UpsertWorkflowTeamInput {
 
 export function insertWorkflowTeam(input: UpsertWorkflowTeamInput): WorkflowTeam {
   const now = new Date().toISOString();
+  auditTeamWrite("insert", input.id, input.roles, { source: input.source });
   getDb()
     .prepare(
       `INSERT INTO workflow_teams
@@ -101,6 +130,13 @@ export function updateWorkflowTeam(
 ): WorkflowTeam | undefined {
   const existing = getWorkflowTeam(id);
   if (!existing) return undefined;
+
+  auditTeamWrite(
+    "update",
+    id,
+    patch.roles ?? existing.roles,
+    patch.roles !== undefined ? { changedRoles: true } : { changedRoles: false }
+  );
 
   const fields: string[] = ["updated_at = ?"];
   const params: any[] = [new Date().toISOString()];
@@ -145,6 +181,7 @@ export function deleteWorkflowTeam(id: string): boolean {
   const team = getWorkflowTeam(id);
   if (!team) return false;
   if (team.source === "builtin") return false;
+  auditTeamWrite("delete", id, team.roles, { source: team.source });
   getDb().prepare("DELETE FROM workflow_teams WHERE id = ?").run(id);
   notifyWorkflowTeamsChanged();
   return true;
@@ -192,9 +229,18 @@ function mergeBuiltinPolicy(
 }
 
 export function seedBuiltinWorkflowTeams(): void {
+  logMain().info("workflowTeams", "seed builtins start", { pid: process.pid });
   const db = getDb();
   for (const id of removedBuiltinWorkflowTeamIds) {
+    const row = db
+      .prepare("SELECT id, source, roles_json FROM workflow_teams WHERE id = ?")
+      .get(id) as any;
     db.prepare("DELETE FROM workflow_teams WHERE id = ? AND source = 'builtin'").run(id);
+    if (row) {
+      auditTeamWrite("seed-retire", id, row.roles_json ? JSON.parse(row.roles_json) : undefined, {
+        source: row.source
+      });
+    }
   }
 
   const existing = listWorkflowTeams();
@@ -202,10 +248,15 @@ export function seedBuiltinWorkflowTeams(): void {
   for (const team of builtinWorkflowTeams()) {
     const saved = existingById.get(team.id);
     if (!saved) {
+      auditTeamWrite("seed-insert", team.id, team.roles, { reason: "missing" });
       insertWorkflowTeam(team);
       continue;
     }
     if (saved.source !== "builtin") continue;
+    const mergedRoles = mergeBuiltinRoles(saved, team);
+    auditTeamWrite("seed-merge", team.id, mergedRoles, {
+      savedSkillCounts: saved.roles.map((r) => ({ id: r.id, n: r.skillIds?.length ?? 0 }))
+    });
     updateWorkflowTeam(team.id, {
       name: team.name,
       description: team.description,
@@ -216,4 +267,5 @@ export function seedBuiltinWorkflowTeams(): void {
       policy: mergeBuiltinPolicy(saved, team)
     });
   }
+  logMain().info("workflowTeams", "seed builtins done", { pid: process.pid });
 }

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -18,6 +18,7 @@ import {
   buildSessionSetConfigOptionRequest,
   buildTerminalOutputResponse,
   contentBlockToItems,
+  isMissingSavedSessionError,
   parseAcpLine,
   selectAcpAuthMethod,
   selectAcpSessionStartMode,
@@ -462,6 +463,31 @@ test("buildSessionLoadRequest loads Cursor-style ACP sessions", () => {
   });
 });
 
+test("isMissingSavedSessionError recognizes Cursor Invalid params Session not found", () => {
+  const cursorErr = Object.assign(new Error("Invalid params"), {
+    code: -32602,
+    data: {
+      message: 'Session "8140ff9a-7f50-426d-987e-3e8c5c2b0ece" not found'
+    }
+  });
+  assert.equal(isMissingSavedSessionError(cursorErr), true);
+
+  const resourceErr = Object.assign(new Error("Resource not found"), {
+    code: -32002
+  });
+  assert.equal(isMissingSavedSessionError(resourceErr), true);
+
+  const authErr = Object.assign(new Error("Authentication required"), {
+    code: -32000
+  });
+  assert.equal(isMissingSavedSessionError(authErr), false);
+
+  const invalidParamsUnrelated = Object.assign(new Error("Invalid params"), {
+    code: -32602
+  });
+  assert.equal(isMissingSavedSessionError(invalidParamsUnrelated), false);
+});
+
 test("ACP session lifecycle injects FreeBuddy stdio MCP servers", () => {
   const mcpServers = [
     {
@@ -532,8 +558,7 @@ test("ACP session setup can forward Claude SDK settings through _meta", () => {
   );
 });
 
-test("ACP runtime authenticates standard auth-required errors and separates missing sessions", () => {
-  assert.match(acpRuntimeSource, /Saved agent session is no longer available/);
+test("ACP runtime authenticates standard auth-required errors and recovers missing sessions", () => {
   assert.match(acpRuntimeSource, /isAuthenticationRequiredError/);
   assert.match(acpRuntimeSource, /e\?\.code === -32000/);
   assert.match(
@@ -543,6 +568,15 @@ test("ACP runtime authenticates standard auth-required errors and separates miss
   assert.match(
     acpRuntimeSource,
     /requestedToolSessionId\s*&&\s*isMissingSavedSessionError\(sessionErr\)/
+  );
+  assert.match(acpRuntimeSource, /abandonStaleToolSession/);
+  assert.match(
+    acpRuntimeSource,
+    /Previous agent session is no longer available; starting a fresh session/
+  );
+  assert.match(
+    acpRuntimeSource,
+    /abandonStaleToolSession\(requestedToolSessionId, sessionErr\);\s*await establishSession\(\);/
   );
   assert.match(acpRuntimeSource, /Unsupported ACP protocol version/);
 });


### PR DESCRIPTION
## Summary
- Recognize Cursor-style `Session "…" not found` (`-32602 Invalid params`) and other ACP missing-session errors when `session/load` / `session/resume` fails.
- Clear the stale tool-session resume id and automatically start a fresh `session/new` instead of failing follow-up turns (e.g. ButlerBuddy floating chat after cancel/exit 143).
- Cover the detection and recovery path with unit/source tests.

## Test plan
- [ ] Reproduce: start ButlerBuddy float chat, cancel a turn quickly, send another message — expect recovery note and a successful new session instead of `Invalid params`.
- [ ] Confirm Cursor ACP resume failure with `Session not found` auto-falls back to `session/new`.
- [ ] Spot-check another ACP adapter that still has a valid saved session still resumes normally.
- [ ] `node --test --test-force-exit tests/acp.test.mjs tests/acp-runtime-contract.test.mjs`


Made with [Cursor](https://cursor.com)