### PR TITLE
feat(desktop): add app tray, native macOS menu, and unread badge

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,6 +20,8 @@ extraResources:
     to: skills
   - from: assets/app-icon.png
     to: app-icon.png
+  - from: assets/sidebar-logo.png
+    to: tray-icon.png
   - from: .build/tokscale
     to: tokscale
 

--- a/electron/cli/i18n.ts
+++ b/electron/cli/i18n.ts
@@ -1,9 +1,12 @@
 type AppLocale = "en" | "zh-CN";
 
 const DICT: Record<string, Record<AppLocale, string>> = {
+  "menu.app.about": { en: "About", "zh-CN": "关于" },
+  "menu.app.hide": { en: "Hide", "zh-CN": "隐藏" },
+  "menu.app.hideOthers": { en: "Hide Others", "zh-CN": "隐藏其他" },
+  "menu.app.unhide": { en: "Show All", "zh-CN": "显示全部" },
+  "menu.app.quit": { en: "Quit", "zh-CN": "退出" },
   "menu.edit": { en: "Edit", "zh-CN": "编辑" },
-  "menu.view": { en: "View", "zh-CN": "视图" },
-  "menu.window": { en: "Window", "zh-CN": "窗口" },
   "dialog.supportedAttachments": { en: "Supported attachments", "zh-CN": "支持的附件" },
   "dialog.allFiles": { en: "All files", "zh-CN": "所有文件" },
   "main.fileLoadFailed": { en: "Failed to load file: {{message}}", "zh-CN": "加载文件失败：{{message}}" },

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, globalShortcut, ipcMain, Menu, nativeImage, Notification, protocol, screen, shell } from "electron";
+import { app, BrowserWindow, globalShortcut, ipcMain, Menu, nativeImage, Notification, protocol, screen, shell } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -37,14 +37,19 @@ import { initializeAgentUsageReconciler } from "./cli/usageReconciler.js";
 import { initDebugLog, logMain } from "./debugLog.js";
 import {
   clearMainWindowPresence,
-  setMainWindowPresence
+  setMainWindowPresence,
+  getMainWindowPresence
 } from "./uiPresence.js";
+import { createAppTray, type TrayController } from "./tray.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isDev = Boolean(process.env.VITE_DEV_SERVER_URL);
 
 app.setName(APP_NAME);
 app.setAppUserModelId("dev.freebuddy.app");
+if (process.platform === "darwin") {
+  app.setActivationPolicy("regular");
+}
 process.env.FB_APP_VERSION = APP_VERSION;
 app.setAboutPanelOptions({
   applicationName: APP_NAME,
@@ -85,6 +90,7 @@ app.on("open-url", (event, url) => {
 app.on("second-instance", (_event, argv) => {
   const url = argv.find((arg) => arg.startsWith(`${PROTOCOL}://`));
   if (url) handleSchemeUrl(url);
+  revealMainWindow();
 });
 
 function resolveAppIconPath() {
@@ -95,6 +101,17 @@ function resolveAppIconPath() {
 
 function loadAppIcon() {
   const icon = nativeImage.createFromPath(resolveAppIconPath());
+  return icon.isEmpty() ? undefined : icon;
+}
+
+function resolveTrayIconPath() {
+  return app.isPackaged
+    ? path.join(process.resourcesPath, "tray-icon.png")
+    : path.join(__dirname, "../assets/sidebar-logo.png");
+}
+
+function loadTrayIcon() {
+  const icon = nativeImage.createFromPath(resolveTrayIconPath());
   return icon.isEmpty() ? undefined : icon;
 }
 
@@ -210,7 +227,7 @@ async function injectShellPath() {
 
 let mainWindow: BrowserWindow | null = null;
 let isQuittingApp = false;
-let isShowingCloseConfirm = false;
+let trayController: TrayController | null = null;
 let butlerPetWindow: BrowserWindow | null = null;
 let butlerChatWindow: BrowserWindow | null = null;
 
@@ -590,7 +607,9 @@ function registerButlerBuddyWindowIpc() {
   ipcMain.on("freebuddy:uiPresence", (event, payload) => {
     const win = mainWindow;
     if (!win || win.isDestroyed() || event.sender !== win.webContents) return;
-    setMainWindowPresence(payload);
+    if (setMainWindowPresence(payload)) {
+      applyUnreadBadge(getMainWindowPresence()?.unreadCount ?? 0);
+    }
   });
   ipcMain.on("freebuddy:themeBroadcast", (event, theme) => {
     if (theme !== "system" && theme !== "light" && theme !== "dark") return;
@@ -621,6 +640,51 @@ function windowChromeOptions() {
     : {};
 }
 
+function revealMainWindow() {
+  const win = mainWindow;
+  if (!win || win.isDestroyed()) return;
+  if (win.isMinimized()) win.restore();
+  if (!win.isVisible()) win.show();
+  win.moveTop();
+  win.focus();
+}
+
+function quitApp() {
+  isQuittingApp = true;
+  app.quit();
+}
+
+function applyUnreadBadge(count: number) {
+  // setBadgeCount is supported on macOS (Dock badge) and Linux (Unity launcher);
+  // it is unsupported on Windows, so guard it. On Windows the unread count is
+  // still surfaced via the tray tooltip and context-menu label.
+  if (process.platform !== "win32") {
+    app.setBadgeCount(count);
+  }
+  trayController?.setUnreadCount(count);
+}
+
+function createTrayForApp() {
+  trayController = createAppTray({
+    getMainWindow: () => mainWindow,
+    getIcon: () => loadAppIcon(),
+    getTrayIcon: () => loadTrayIcon(),
+    isPetVisible: () => readButlerBuddyPreferences().visible,
+    getUnreadCount: () => getMainWindowPresence()?.unreadCount ?? 0,
+    onNewConversation: () => {
+      const win = mainWindow;
+      if (!win || win.isDestroyed()) return;
+      safeSendToWebContents(win.webContents, "window:new-conversation", undefined);
+    },
+    onTogglePet: () => {
+      const next = !readButlerBuddyPreferences().visible;
+      updateButlerBuddyPreferences({ visible: next });
+      trayController?.refresh();
+    },
+    onQuit: () => quitApp()
+  });
+}
+
 function createWindow() {
   const appIcon = loadAppIcon();
 
@@ -642,7 +706,7 @@ function createWindow() {
   });
 
   mainWindow.on("close", (event) => {
-    if (isQuittingApp || process.platform !== "darwin" || isShowingCloseConfirm) {
+    if (isQuittingApp) {
       return;
     }
     const win = mainWindow;
@@ -650,27 +714,7 @@ function createWindow() {
       return;
     }
     event.preventDefault();
-    isShowingCloseConfirm = true;
-    void dialog
-      .showMessageBox(win, {
-        type: "warning",
-        buttons: ["退出", "取消"],
-        defaultId: 1,
-        cancelId: 1,
-        title: APP_NAME,
-        message: `退出 ${APP_NAME}？`,
-        detail: "关闭主窗口将退出应用程序及其桌面宠物，确定要退出吗？"
-      })
-      .then((result) => {
-        isShowingCloseConfirm = false;
-        if (result.response === 0) {
-          isQuittingApp = true;
-          app.quit();
-        }
-      })
-      .catch(() => {
-        isShowingCloseConfirm = false;
-      });
+    win.hide();
   });
 
   mainWindow.on("closed", () => {
@@ -712,13 +756,9 @@ function createWindow() {
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.flashFrame(false);
     }
-    if (process.platform === "darwin" && app.dock) {
-      app.dock.setBadge("");
-    }
   });
 
-  // The app menu is hidden (Menu.setApplicationMenu(null)) and we use
-  // titleBarStyle: "hiddenInset", so macOS' default Esc-to-leave-fullscreen
+  // With titleBarStyle: "hiddenInset", macOS' default Esc-to-leave-fullscreen
   // shortcut has no menu item to bind to. Restore it manually.
   mainWindow.webContents.on("before-input-event", (_event, input) => {
     if (
@@ -880,10 +920,17 @@ app.whenReady().then(async () => {
   });
   registerUpdaterIpc();
   const appIcon = loadAppIcon();
-  if (process.platform === "darwin" && app.dock && appIcon) {
-    app.dock.setIcon(appIcon);
+  if (process.platform === "darwin" && app.dock) {
+    void app.dock.show();
+    if (appIcon) {
+      app.dock.setIcon(appIcon);
+    }
   }
   createWindow();
+  if (process.platform === "darwin") {
+    app.focus();
+  }
+  createTrayForApp();
   const butlerPreferences = readButlerBuddyPreferences();
   const shortcutError = updateButlerShortcutRegistration(
     butlerPreferences.shortcutEnabled,
@@ -903,19 +950,22 @@ app.whenReady().then(async () => {
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();
+    } else {
+      revealMainWindow();
     }
   });
 });
 
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    app.quit();
-  }
+  // The app lives in the tray. Only the tray's "Quit" entry or an explicit
+  // Cmd+Q / before-quit should terminate the process.
 });
 
 let telemetryShutdownStarted = false;
 app.on("before-quit", (event) => {
   isQuittingApp = true;
+  trayController?.destroy();
+  trayController = null;
   if (telemetryShutdownStarted) return;
   telemetryShutdownStarted = true;
   event.preventDefault();

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -8,44 +8,44 @@ export function buildAppMenu(lang: "en" | "zh-CN") {
     {
       label: APP_NAME,
       submenu: [
-        { role: "about" },
+        { role: "about", label: tMain("menu.app.about", lang) },
         { type: "separator" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "unhide" },
+        { role: "hide", label: tMain("menu.app.hide", lang) },
+        { role: "hideOthers", label: tMain("menu.app.hideOthers", lang) },
+        { role: "unhide", label: tMain("menu.app.unhide", lang) },
         { type: "separator" },
-        { role: "quit" }
+        { role: "quit", label: `${tMain("menu.app.quit", lang)} ${APP_NAME}` }
       ]
     },
     {
       label: tMain("menu.edit", lang),
       submenu: [
-        { role: "undo" }, { role: "redo" }, { type: "separator" },
-        { role: "cut" }, { role: "copy" }, { role: "paste" }, { role: "selectAll" }
+        { role: "undo", label: tMain("contextMenu.undo", lang) },
+        { role: "redo", label: tMain("contextMenu.redo", lang) },
+        { type: "separator" },
+        { role: "cut", label: tMain("contextMenu.cut", lang) },
+        { role: "copy", label: tMain("contextMenu.copy", lang) },
+        { role: "paste", label: tMain("contextMenu.paste", lang) },
+        { role: "selectAll", label: tMain("contextMenu.selectAll", lang) }
       ]
-    },
-    {
-      label: tMain("menu.view", lang),
-      submenu: [
-        { role: "reload" }, { role: "toggleDevTools" }, { type: "separator" },
-        { role: "resetZoom" }, { role: "zoomIn" }, { role: "zoomOut" }, { type: "separator" },
-        { role: "togglefullscreen" }
-      ]
-    },
-    {
-      label: tMain("menu.window", lang),
-      submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }]
     }
   ]);
 }
 
 export function setApplicationMenuForLanguage(lang: "en" | "zh-CN") {
+  // The application menu is a macOS convention (and macOS needs the Edit-menu
+  // roles for Cmd+C/V/X/A/Z in text fields). On Windows/Linux the text-edit
+  // shortcuts are handled natively by the OS, so we hide the in-window menu
+  // bar there to keep the UI clean.
+  if (process.platform !== "darwin") {
+    Menu.setApplicationMenu(null);
+    return;
+  }
   Menu.setApplicationMenu(buildAppMenu(lang));
 }
 
 export function initApplicationMenu() {
-  const lang = getLanguage();
-  Menu.setApplicationMenu(buildAppMenu(lang));
+  setApplicationMenuForLanguage(getLanguage());
 }
 
 export function setupContextMenu(window: BrowserWindow, isDev: boolean) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -317,6 +317,11 @@ const window = {
     ipcRenderer.on("window:open-conversation", handler);
     return () => ipcRenderer.off("window:open-conversation", handler);
   },
+  onNewConversation(cb: () => void): () => void {
+    const handler = () => cb();
+    ipcRenderer.on("window:new-conversation", handler);
+    return () => ipcRenderer.off("window:new-conversation", handler);
+  },
   onOpenView(
     cb: (payload: {
       view: string;

--- a/electron/tray.ts
+++ b/electron/tray.ts
@@ -1,0 +1,111 @@
+import { Tray, Menu, nativeImage, type BrowserWindow, type NativeImage } from "electron";
+import { APP_NAME } from "./app-meta.js";
+import { logMain } from "./debugLog.js";
+
+export interface TrayDeps {
+  getMainWindow: () => BrowserWindow | null;
+  getIcon: () => NativeImage | undefined;
+  getTrayIcon: () => NativeImage | undefined;
+  isPetVisible: () => boolean;
+  getUnreadCount: () => number;
+  onNewConversation: () => void;
+  onTogglePet: () => void;
+  onQuit: () => void;
+}
+
+export interface TrayController {
+  destroy(): void;
+  refresh(): void;
+  setUnreadCount(count: number): void;
+}
+
+export function createAppTray(deps: TrayDeps): TrayController {
+  const isMac = process.platform === "darwin";
+  const source = isMac
+    ? deps.getTrayIcon() ?? deps.getIcon()
+    : deps.getIcon();
+  let trayIcon: NativeImage | undefined;
+  if (source && !source.isEmpty()) {
+    if (isMac) {
+      trayIcon = source.resize({ width: 22, height: 22 });
+      trayIcon.setTemplateImage(true);
+    } else {
+      trayIcon = source;
+    }
+  }
+
+  const tray = new Tray(trayIcon ?? nativeImage.createEmpty());
+
+  const applyUnreadChrome = (count: number) => {
+    tray.setToolTip(count > 0 ? `${APP_NAME}（${count} 条未读）` : APP_NAME);
+    if (isMac) {
+      tray.setTitle(count > 0 ? String(count) : "");
+    }
+  };
+
+  applyUnreadChrome(0);
+
+  const revealMainWindow = () => {
+    const win = deps.getMainWindow();
+    if (!win || win.isDestroyed()) return;
+    if (win.isMinimized()) win.restore();
+    if (!win.isVisible()) win.show();
+    win.moveTop();
+    win.focus();
+  };
+
+  const buildMenu = () => {
+    const petVisible = deps.isPetVisible();
+    const unread = deps.getUnreadCount();
+    const showLabel = unread > 0 ? `显示主窗口（${unread} 条未读）` : "显示主窗口";
+    return Menu.buildFromTemplate([
+      {
+        label: showLabel,
+        click: () => revealMainWindow()
+      },
+      { type: "separator" },
+      {
+        label: "新建对话",
+        click: () => {
+          revealMainWindow();
+          deps.onNewConversation();
+        }
+      },
+      {
+        label: petVisible ? "隐藏宠物" : "显示宠物",
+        click: () => deps.onTogglePet()
+      },
+      { type: "separator" },
+      {
+        label: `退出 ${APP_NAME}`,
+        click: () => deps.onQuit()
+      }
+    ]);
+  };
+
+  const applyMenu = () => {
+    tray.setContextMenu(buildMenu());
+  };
+
+  applyMenu();
+
+  tray.on("click", () => revealMainWindow());
+
+  logMain().info("tray", "app tray created");
+
+  return {
+    destroy() {
+      try {
+        tray.destroy();
+      } catch {
+        /* best-effort */
+      }
+    },
+    refresh() {
+      applyMenu();
+    },
+    setUnreadCount(count: number) {
+      applyUnreadChrome(count);
+    }
+  };
+}

--- a/electron/uiPresence.ts
+++ b/electron/uiPresence.ts
@@ -24,6 +24,7 @@ export interface MainWindowPresence {
     agentName: string;
   } | null;
   streaming: boolean;
+  unreadCount: number;
   updatedAt: string;
 }
 
@@ -93,12 +94,23 @@ export function parseMainWindowPresence(
     };
   }
 
+  // unreadCount is optional for backward compatibility with older renderers
+  // that don't send it yet; default to 0 when missing or invalid.
+  let unreadCount = 0;
+  if (value.unreadCount !== null && value.unreadCount !== undefined) {
+    if (typeof value.unreadCount !== "number" || !Number.isFinite(value.unreadCount)) {
+      return null;
+    }
+    unreadCount = Math.max(0, Math.floor(value.unreadCount));
+  }
+
   return {
     workspaceView: value.workspaceView as MainWorkspaceView,
     settingsOpen: value.settingsOpen,
     settingsTab,
     activeConversation,
     streaming: value.streaming,
+    unreadCount,
     updatedAt: value.updatedAt
   };
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,6 +185,15 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const off = window.freebuddy?.window?.onNewConversation?.(() => {
+      startNewTask();
+    });
+    return () => {
+      off?.();
+    };
+  }, []);
+
+  useEffect(() => {
     const off = window.freebuddy?.window?.onOpenSettings?.((tab) => {
       setSettingsInitialTab(tab as SettingsTab);
       setSettingsOpen(true);
@@ -353,6 +362,12 @@ function App() {
   }, []);
 
   const conversations = useConversationStore((s) => s.conversations);
+  const unreadCount = useConversationStore((s) =>
+    s.conversations.reduce(
+      (n, c) => n + (s.unreadConversations[c.id] ? 1 : 0),
+      0
+    )
+  );
   const members = useConversationStore((s) => s.members);
   const activeId = useConversationStore((s) => s.activeId);
   const setActive = useConversationStore((s) => s.setActive);
@@ -382,6 +397,7 @@ function App() {
           }
         : null,
       streaming: activeConversationRunning,
+      unreadCount,
       updatedAt: new Date().toISOString()
     };
     const timer = window.setTimeout(() => {
@@ -397,6 +413,7 @@ function App() {
     activeConversation?.agentId,
     activeConversation?.agentName,
     activeConversationRunning,
+    unreadCount,
     members
   ]);
 

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -284,6 +284,7 @@ declare global {
     onDraftTool(cb: (event: DraftToolEvent) => void): () => void;
     resolveDraftTool(resolution: DraftToolResolution): Promise<boolean>;
     onOpenConversation(cb: (conversationId: string) => void): () => void;
+    onNewConversation(cb: () => void): () => void;
     onOpenView(
       cb: (payload: {
         view: "chat" | "scheduledTasks" | "workflowTeams" | "usage" | string;
@@ -312,6 +313,7 @@ declare global {
         agentName: string;
       } | null;
       streaming: boolean;
+      unreadCount: number;
       updatedAt: string;
     }): void;
     broadcastTheme(theme: "system" | "light" | "dark" | string): void;


### PR DESCRIPTION
## 概述

新增桌面端集成功能，并确保 Windows/Linux 兼容。

## 改动

### 1. 应用托盘 (`electron/tray.ts` 新增)
- 关闭主窗口 → 驻留托盘（全平台），仅托盘"退出"或 Cmd+Q 真正退出
- 右键菜单：显示主窗口 / 新建对话 / 显示·隐藏宠物 / 退出
- 左键单击唤出主窗口；再次启动实例也唤出窗口
- macOS 用单色模板图（`sidebar-logo.png` 轮廓 + `setTemplateImage`），其他平台用彩色应用图标

### 2. 原生 macOS 应用菜单 (`electron/menu.ts`)
- FreeBuddy 菜单（关于/隐藏/隐藏其他/显示全部/退出）+ 编辑菜单
- 全项 i18n 中英切换（跟随应用语言，改语言实时重建）
- **macOS 专属**：Windows/Linux 不显示窗口菜单栏（系统原生支持 Ctrl+C/V 等快捷键）
- 修复应用未接管菜单栏/Dock 的问题（显式 `setActivationPolicy("regular")` + `app.focus()` + `dock.show()`）

### 3. 未读数角标
- 通过现有 `uiPresence` 通道（250ms 防抖）同步未读会话数到主进程
- macOS Dock 红色角标（`app.setBadgeCount`）+ 菜单栏托盘数字（`tray.setTitle`）+ 托盘 tooltip + 右键菜单标签
- Windows 上通过托盘 tooltip/菜单显示（Dock 角标仅 macOS）

### 4. 新建对话
- 托盘/菜单的"新建对话"路由到新建会话主页（`startNewTask`），不立即创建会话

## Windows/Linux 兼容性
- 所有平台专属 API（dock / setActivationPolicy / focus / setBadgeCount / tray.setTitle / setTemplateImage）均有平台守卫
- `app.setBadgeCount` 加 `!== "win32"` 守卫
- typecheck + electron 构建通过

## 测试
- `npm run typecheck` ✅
- `npm run build:electron` ✅
- `npm run github:preflight` ✅
- macOS 运行验证：托盘驻留、菜单栏显示、未读角标、单色模板图标均正常