### PR TITLE
fix: prevent renderer crashes under concurrent agent streams

### DIFF
--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -60,14 +60,15 @@ type StreamItemEntry = Extract<CliEvent, { type: "items" }>["items"][number];
  * chunks, tool calls, ...) into a single event flushed on a short timer or
  * before any non-items event. ACP agents can emit hundreds of small updates
  * per second; without batching every chunk triggers a renderer state update,
- * a JSON.stringify of the whole turn, a React render, and (in workflow mode)
- * a synchronous DB write + full-message reload. Batching caps that to ~60
- * flushes/sec while preserving ordering relative to permission/done/error.
+ * a React render and (in workflow mode) a synchronous DB write + full-message
+ * reload. A 12.5 Hz visual update rate remains smooth for text streaming while
+ * preventing several concurrent agents from collectively driving hundreds of
+ * renderer updates per second.
  */
 function createItemsBatchingEmit(
   send: (e: CliEvent) => void
 ): (e: CliEvent) => void {
-  const FLUSH_MS = 16;
+  const FLUSH_MS = 80;
   const MAX_BUFFER = 200;
   let buffer: StreamItemEntry[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, globalShortcut, ipcMain, Menu, nativeImage, Notification, protocol, screen, shell } from "electron";
+import { app, BrowserWindow, crashReporter, globalShortcut, ipcMain, Menu, nativeImage, Notification, protocol, screen, shell } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -55,6 +55,11 @@ app.setAboutPanelOptions({
   applicationName: APP_NAME,
   applicationVersion: APP_VERSION,
   version: APP_VERSION
+});
+crashReporter.start({
+  productName: APP_NAME,
+  uploadToServer: false,
+  compress: false
 });
 
 const PROTOCOL = "freebuddy";
@@ -230,6 +235,52 @@ let isQuittingApp = false;
 let trayController: TrayController | null = null;
 let butlerPetWindow: BrowserWindow | null = null;
 let butlerChatWindow: BrowserWindow | null = null;
+
+const RENDERER_RECOVERY_WINDOW_MS = 60_000;
+const MAX_RENDERER_RECOVERIES_PER_WINDOW = 2;
+const rendererRecoveryAttempts: number[] = [];
+
+function rendererProcessMetrics() {
+  try {
+    return app.getAppMetrics().map((metric) => ({
+      pid: metric.pid,
+      type: metric.type,
+      memoryWorkingSetKb: metric.memory.workingSetSize,
+      memoryPeakWorkingSetKb: metric.memory.peakWorkingSetSize
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function recoverMainRenderer(win: BrowserWindow, reason: string): void {
+  if (reason !== "crashed" && reason !== "oom" && reason !== "memory-eviction") {
+    return;
+  }
+  const now = Date.now();
+  while (
+    rendererRecoveryAttempts.length > 0 &&
+    now - rendererRecoveryAttempts[0] > RENDERER_RECOVERY_WINDOW_MS
+  ) {
+    rendererRecoveryAttempts.shift();
+  }
+  if (rendererRecoveryAttempts.length >= MAX_RENDERER_RECOVERIES_PER_WINDOW) {
+    logMain().error("crash", "renderer auto-recovery suppressed", {
+      reason,
+      attempts: rendererRecoveryAttempts.length
+    });
+    return;
+  }
+  rendererRecoveryAttempts.push(now);
+  setTimeout(() => {
+    if (isQuittingApp || mainWindow !== win || win.isDestroyed()) return;
+    logMain().info("crash", "reloading main window after renderer crash", {
+      reason,
+      attempt: rendererRecoveryAttempts.length
+    });
+    win.webContents.reload();
+  }, 250);
+}
 
 const BUTLER_PET_SIZE = 108;
 const BUTLER_CHAT_WIDTH = 360;
@@ -726,8 +777,11 @@ function createWindow() {
   mainWindow.webContents.on("render-process-gone", (_event, details) => {
     logMain().error("crash", "render process gone", {
       reason: details.reason,
-      exitCode: details.exitCode
+      exitCode: details.exitCode,
+      processes: rendererProcessMetrics()
     });
+    const crashedWindow = mainWindow;
+    if (crashedWindow) recoverMainRenderer(crashedWindow, details.reason);
   });
   logMain().info("window", "main window created");
 

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -948,10 +948,23 @@ export function ChatView({
       ? storeFrames[replayIndex]
       : undefined;
   const displayMessages = useMemo<ConversationMessage[]>(() => {
-    if (!replaying) return [...messages, ...previewMessages];
+    if (!replaying) {
+      const current = [...messages, ...previewMessages];
+      if (!live) return current;
+      const liveContent = JSON.stringify(live.items);
+      return current.map((message) =>
+        message.id === live.messageId
+          ? {
+              ...message,
+              status: live.status,
+              content: liveContent
+            }
+          : message
+      );
+    }
     if (!replayFrame) return [];
     return messages.slice(0, replayFrame.messageIndex + 1);
-  }, [replaying, replayFrame, messages, previewMessages]);
+  }, [replaying, replayFrame, messages, previewMessages, live]);
   const shareReferencesByMessageId = useMemo(
     () => assignShareReferencesToMessages(displayMessages, contextReferences),
     [displayMessages, contextReferences]

--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/services/cli/parsers";
 import { getParser } from "@/services/cli/parsers";
 import { cliClient } from "@/services/cli/client";
+import { debugLogClient } from "@/services/debugLog";
 import {
   notifyTaskFinished,
   playTaskFailure,
@@ -272,22 +273,13 @@ export function handleStreamEvent(
       ] as CliStreamItem[]);
     }
 
-    // Mirror items into the assistant message snapshot in `messages`
-    // so the renderer (which reads from messages) can show progressive output.
-    const messageList = s.messages[conversationId] ?? [];
-    const msgIdx = messageList.findIndex((m) => m.id === live.messageId);
-    let messages = s.messages;
     let conversations = s.conversations;
-    if (msgIdx >= 0) {
-      const updated = [...messageList];
-      updated[msgIdx] = {
-        ...updated[msgIdx],
-        status,
-        content: JSON.stringify(nextItems),
-        updatedAt: new Date().toISOString()
-      };
-      messages = { ...s.messages, [conversationId]: updated };
-    }
+
+    // Keep progressive output only in `live`. ChatView projects the active
+    // live snapshot over its assistant message for display. Mirroring the same
+    // data into `messages` used to stringify and duplicate every background
+    // turn on every stream batch, which creates severe allocation pressure
+    // when several complex tasks run concurrently.
 
     if (e.type === "items") {
       const title = sessionTitleFromItems(e.items);
@@ -314,7 +306,6 @@ export function handleStreamEvent(
           capturedSessionId
         }
       },
-      messages,
       conversations
     };
   });
@@ -408,12 +399,7 @@ async function finalizeRun(
       : live.exitCode === 0
         ? "done"
         : "failed";
-
-  await cliClient.updateMessage({
-    id: live.messageId,
-    status: finalStatus,
-    content: JSON.stringify(live.items)
-  });
+  const finalContent = JSON.stringify(live.items);
 
   const ctx = runCtxMap.get(live.taskSessionId);
   ctx?.unsubscribe();
@@ -421,9 +407,40 @@ async function finalizeRun(
 
   set((s) => {
     const next = { ...s.live };
-    delete next[conversationId];
-    return { live: next };
+    if (next[conversationId]?.taskSessionId === live.taskSessionId) {
+      delete next[conversationId];
+    }
+    const messageList = s.messages[conversationId] ?? [];
+    const messageIndex = messageList.findIndex(
+      (message) => message.id === live.messageId
+    );
+    if (messageIndex < 0) return { live: next };
+    const updated = [...messageList];
+    updated[messageIndex] = {
+      ...updated[messageIndex],
+      status: finalStatus,
+      content: finalContent,
+      updatedAt: new Date().toISOString()
+    };
+    return {
+      live: next,
+      messages: { ...s.messages, [conversationId]: updated }
+    };
   });
+
+  try {
+    await cliClient.updateMessage({
+      id: live.messageId,
+      status: finalStatus,
+      content: finalContent
+    });
+  } catch (error) {
+    debugLogClient.error("chat", "failed to persist finalized agent message", {
+      conversationId,
+      taskSessionId: live.taskSessionId,
+      errorMessage: (error as Error)?.message || String(error)
+    });
+  }
 }
 
 export async function killConversation(

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -33,6 +33,7 @@ import { useCliExecutorStore } from "./cliExecutorStore";
 import { useProjectStore } from "./projectStore";
 import {
   buildOrphanFollowupContext,
+  appendItems,
   collectStreamMessageIds,
   collectStreamAgentMessageIds,
   collectStreamContentSignatures,
@@ -1265,6 +1266,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     } catch (err) {
       const msg = (err as Error)?.message || String(err);
       debugLogClient.error("chat", "agent run failed", { errorMessage: msg });
+      const failedItems = appendItems(
+        get().live[conversationId]?.items ?? [],
+        [{ kind: "error", message: msg }]
+      );
       set((s) => {
         const live = s.live[conversationId];
         if (!live) return s;
@@ -1273,19 +1278,52 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
             ...s.live,
             [conversationId]: {
               ...live,
+              items: failedItems,
               status: "failed",
               errorMessage: msg
             }
           }
         };
       });
-      await cliClient.updateMessage({
-        id: assistantMsgId,
-        status: "failed",
-        content: JSON.stringify([{ kind: "error", message: msg }])
-      });
+      const failedContent = JSON.stringify(failedItems);
       runCtxMap.get(taskSessionId)?.unsubscribe();
       runCtxMap.delete(taskSessionId);
+      set((s) => {
+        const nextLive = { ...s.live };
+        if (nextLive[conversationId]?.taskSessionId === taskSessionId) {
+          delete nextLive[conversationId];
+        }
+        const messageList = s.messages[conversationId] ?? [];
+        const messageIndex = messageList.findIndex(
+          (message) => message.id === assistantMsgId
+        );
+        if (messageIndex < 0) return { live: nextLive };
+        const updated = [...messageList];
+        updated[messageIndex] = {
+          ...updated[messageIndex],
+          status: "failed",
+          content: failedContent,
+          updatedAt: new Date().toISOString()
+        };
+        return {
+          live: nextLive,
+          messages: { ...s.messages, [conversationId]: updated }
+        };
+      });
+      try {
+        await cliClient.updateMessage({
+          id: assistantMsgId,
+          status: "failed",
+          content: failedContent
+        });
+      } catch (persistError) {
+        debugLogClient.error("chat", "failed to persist rejected agent run", {
+          conversationId,
+          taskSessionId,
+          errorMessage:
+            (persistError as Error)?.message || String(persistError)
+        });
+      }
     }
     } catch (err) {
       releaseClaimedLive();

--- a/src/store/conversationUtils.ts
+++ b/src/store/conversationUtils.ts
@@ -14,18 +14,89 @@ type PlanItem = Extract<CliStreamItem, { kind: "plan" }>;
 type PlanEntry = PlanItem["entries"][number];
 type ToolCallItem = Extract<CliStreamItem, { kind: "tool-call" }>;
 
+/**
+ * These limits are applied after stream chunks are merged. The ingress guard in
+ * streamMedia.ts protects individual events, but an agent can emit thousands of
+ * individually-small chunks and otherwise grow one cumulative string without
+ * bound.
+ */
+export const MAX_MERGED_ASSISTANT_CHARS = 200_000;
+export const MAX_MERGED_OUTPUT_CHARS = 12_000;
+const MERGED_STREAM_TRUNCATION_MARKER = "\n… [stream truncated] …\n";
+
+function boundMergedStreamText(value: string, max: number): string {
+  if (value.length <= max) return value;
+  const available = Math.max(0, max - MERGED_STREAM_TRUNCATION_MARKER.length);
+  const headLength = Math.floor(available * 0.6);
+  const tailLength = available - headLength;
+  return (
+    value.slice(0, headLength) +
+    MERGED_STREAM_TRUNCATION_MARKER +
+    value.slice(-tailLength)
+  );
+}
+
+/** Append to an already-bounded stream while retaining its beginning and the
+ * latest tail. Once truncated, this avoids rebuilding the discarded middle on
+ * every subsequent chunk. */
+function appendBoundedStreamText(
+  current: string,
+  addition: string,
+  max: number
+): string {
+  if (current.length + addition.length <= max) return current + addition;
+
+  const markerIndex = current.indexOf(MERGED_STREAM_TRUNCATION_MARKER);
+  if (markerIndex < 0) {
+    return boundMergedStreamText(current + addition, max);
+  }
+
+  const available = Math.max(0, max - MERGED_STREAM_TRUNCATION_MARKER.length);
+  const headLength = Math.floor(available * 0.6);
+  const tailLength = available - headLength;
+  const head = current.slice(0, markerIndex).slice(0, headLength);
+  const previousTail = current.slice(
+    markerIndex + MERGED_STREAM_TRUNCATION_MARKER.length
+  );
+  return (
+    head +
+    MERGED_STREAM_TRUNCATION_MARKER +
+    (previousTail + addition).slice(-tailLength)
+  );
+}
+
 function mergeStreamText(
   prev: Extract<CliStreamItem, { kind: "text" }>,
   next: Extract<CliStreamItem, { kind: "text" }>
 ): Extract<CliStreamItem, { kind: "text" }> {
   if (next.append) {
-    return { ...prev, content: prev.content + next.content };
+    return {
+      ...prev,
+      content: appendBoundedStreamText(
+        prev.content,
+        next.content,
+        MAX_MERGED_ASSISTANT_CHARS
+      )
+    };
   }
   if (next.content === prev.content) return prev;
   if (next.content.startsWith(prev.content)) {
-    return { ...prev, content: next.content };
+    return {
+      ...prev,
+      content: boundMergedStreamText(
+        next.content,
+        MAX_MERGED_ASSISTANT_CHARS
+      )
+    };
   }
-  return { ...prev, ...next };
+  return {
+    ...prev,
+    ...next,
+    content: boundMergedStreamText(
+      next.content,
+      MAX_MERGED_ASSISTANT_CHARS
+    )
+  };
 }
 
 function mergeStreamThinking(
@@ -33,13 +104,33 @@ function mergeStreamThinking(
   next: Extract<CliStreamItem, { kind: "thinking" }>
 ): Extract<CliStreamItem, { kind: "thinking" }> {
   if (next.append) {
-    return { ...prev, content: prev.content + next.content };
+    return {
+      ...prev,
+      content: appendBoundedStreamText(
+        prev.content,
+        next.content,
+        MAX_MERGED_ASSISTANT_CHARS
+      )
+    };
   }
   if (next.content === prev.content) return prev;
   if (next.content.startsWith(prev.content)) {
-    return { ...prev, content: next.content };
+    return {
+      ...prev,
+      content: boundMergedStreamText(
+        next.content,
+        MAX_MERGED_ASSISTANT_CHARS
+      )
+    };
   }
-  return { ...prev, ...next };
+  return {
+    ...prev,
+    ...next,
+    content: boundMergedStreamText(
+      next.content,
+      MAX_MERGED_ASSISTANT_CHARS
+    )
+  };
 }
 
 export function collectStreamMessageIds(
@@ -273,13 +364,76 @@ function legacyTodoPlan(item: CliStreamItem): PlanItem | undefined {
   return undefined;
 }
 
+/**
+ * A main-process flush can contain hundreds of tiny token updates. Collapse
+ * adjacent append-only chunks before touching the already-large accumulated
+ * snapshot, otherwise one flush can rebuild the same 200k string hundreds of
+ * times.
+ */
+function coalesceIncomingItems(items: CliStreamItem[]): CliStreamItem[] {
+  const out: CliStreamItem[] = [];
+  for (const item of items) {
+    const last = out[out.length - 1];
+    if (
+      item.kind === "text" &&
+      item.append &&
+      last?.kind === "text" &&
+      last.role === item.role &&
+      last.messageId === item.messageId
+    ) {
+      out[out.length - 1] = {
+        ...last,
+        content: appendBoundedStreamText(
+          last.content,
+          item.content,
+          MAX_MERGED_ASSISTANT_CHARS
+        )
+      };
+      continue;
+    }
+    if (
+      item.kind === "thinking" &&
+      item.append &&
+      last?.kind === "thinking" &&
+      last.messageId === item.messageId
+    ) {
+      out[out.length - 1] = {
+        ...last,
+        content: appendBoundedStreamText(
+          last.content,
+          item.content,
+          MAX_MERGED_ASSISTANT_CHARS
+        )
+      };
+      continue;
+    }
+    if (
+      item.kind === "command-output" &&
+      last?.kind === "command-output" &&
+      last.stream === item.stream
+    ) {
+      out[out.length - 1] = {
+        ...last,
+        content: appendBoundedStreamText(
+          last.content,
+          `\n${item.content}`,
+          MAX_MERGED_OUTPUT_CHARS
+        )
+      };
+      continue;
+    }
+    out.push(item);
+  }
+  return out;
+}
+
 export function appendItems(
   prev: CliStreamItem[],
   next: CliStreamItem[]
 ): CliStreamItem[] {
   if (!next.length) return prev;
   const out = [...prev];
-  for (const rawItem of next) {
+  for (const rawItem of coalesceIncomingItems(next)) {
     const item = legacyTodoPlan(rawItem) ?? rawItem;
     const last = out[out.length - 1];
     if (item.kind === "text" && item.messageId) {
@@ -324,12 +478,25 @@ export function appendItems(
       last.role === item.role
     ) {
       if (item.append) {
-        out[out.length - 1] = { ...last, content: last.content + item.content };
+        out[out.length - 1] = {
+          ...last,
+          content: appendBoundedStreamText(
+            last.content,
+            item.content,
+            MAX_MERGED_ASSISTANT_CHARS
+          )
+        };
         continue;
       }
       if (item.content === last.content) continue;
       if (item.content.startsWith(last.content)) {
-        out[out.length - 1] = { ...last, content: item.content };
+        out[out.length - 1] = {
+          ...last,
+          content: boundMergedStreamText(
+            item.content,
+            MAX_MERGED_ASSISTANT_CHARS
+          )
+        };
         continue;
       }
     }
@@ -339,12 +506,25 @@ export function appendItems(
       last.kind === "thinking"
     ) {
       if (item.append) {
-        out[out.length - 1] = { ...last, content: last.content + item.content };
+        out[out.length - 1] = {
+          ...last,
+          content: appendBoundedStreamText(
+            last.content,
+            item.content,
+            MAX_MERGED_ASSISTANT_CHARS
+          )
+        };
         continue;
       }
       if (item.content === last.content) continue;
       if (item.content.startsWith(last.content)) {
-        out[out.length - 1] = { ...last, content: item.content };
+        out[out.length - 1] = {
+          ...last,
+          content: boundMergedStreamText(
+            item.content,
+            MAX_MERGED_ASSISTANT_CHARS
+          )
+        };
         continue;
       }
     }
@@ -401,7 +581,11 @@ export function appendItems(
     ) {
       out[out.length - 1] = {
         ...last,
-        content: `${last.content}\n${item.content}`
+        content: appendBoundedStreamText(
+          last.content,
+          `\n${item.content}`,
+          MAX_MERGED_OUTPUT_CHARS
+        )
       };
       continue;
     }

--- a/src/utils/streamMedia.ts
+++ b/src/utils/streamMedia.ts
@@ -90,6 +90,19 @@ export type ImagePreviewRegistrar = (
   image: ExtractedInlineImage
 ) => string | undefined;
 
+function compactUnknownStreamValue(value: unknown): unknown {
+  if (value == null) return value;
+  if (typeof value === "string") return truncateStreamText(value);
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized.length > MAX_TEXT_STREAM_CHARS
+      ? truncateStreamText(serialized)
+      : value;
+  } catch {
+    return truncateStreamText(String(value));
+  }
+}
+
 function isToolImagePreview(item: CliStreamItem): boolean {
   return item.kind === "content-block" && item.blockType === "image";
 }
@@ -103,6 +116,9 @@ export function sanitizeStreamItems(
   for (const item of items) {
     if (item.kind === "tool-call") {
       const next: Extract<CliStreamItem, { kind: "tool-call" }> = { ...item };
+      if (next.input !== undefined) {
+        next.input = compactUnknownStreamValue(next.input);
+      }
       if (typeof next.output === "string" && next.output.length > 0) {
         const { text, images } = extractDataUrlImages(next.output);
         next.output = summarizeMediaText(text, images);
@@ -116,6 +132,27 @@ export function sanitizeStreamItems(
         ) as Extract<CliStreamItem, { kind: "tool-call" }>["toolOutputs"];
       }
       out.push(next);
+      continue;
+    }
+
+    if (item.kind === "file-edit") {
+      out.push({
+        ...item,
+        ...(typeof item.patch === "string"
+          ? { patch: truncateStreamText(item.patch) }
+          : {}),
+        ...(typeof item.oldText === "string"
+          ? { oldText: truncateStreamText(item.oldText) }
+          : {}),
+        ...(typeof item.newText === "string"
+          ? { newText: truncateStreamText(item.newText) }
+          : {})
+      });
+      continue;
+    }
+
+    if (item.kind === "command-output") {
+      out.push({ ...item, content: truncateStreamText(item.content) });
       continue;
     }
 

--- a/tests/concurrent-stream-stability.test.mjs
+++ b/tests/concurrent-stream-stability.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(new URL(path, import.meta.url), "utf8");
+
+const runtime = read("../electron/cli/runtime.ts");
+const main = read("../electron/main.ts");
+const handlers = read("../src/store/conversationHandlers.ts");
+const chatView = read("../src/components/CLI/ChatView.tsx");
+
+test("high-frequency ACP events are batched below animation-frame frequency", () => {
+  assert.match(runtime, /const FLUSH_MS = 80/);
+  assert.match(runtime, /createItemsBatchingEmit/);
+});
+
+test("background streams keep one progressive snapshot instead of duplicating message JSON", () => {
+  assert.match(handlers, /Keep progressive output only in `live`/);
+  assert.match(chatView, /const liveContent = JSON\.stringify\(live\.items\)/);
+  assert.match(handlers, /const finalContent = JSON\.stringify\(live\.items\)/);
+});
+
+test("main renderer crash records dumps and reloads with loop protection", () => {
+  assert.match(main, /crashReporter\.start\(/);
+  assert.match(main, /MAX_RENDERER_RECOVERIES_PER_WINDOW = 2/);
+  assert.match(main, /win\.webContents\.reload\(\)/);
+  assert.match(main, /reason !== "crashed" && reason !== "oom"/);
+});

--- a/tests/conversation-utils.test.mjs
+++ b/tests/conversation-utils.test.mjs
@@ -717,6 +717,92 @@ test("appendItems upserts text and thinking chunks by messageId", async () => {
   ]);
 });
 
+test("appendItems bounds cumulative assistant chunks while retaining the latest tail", async () => {
+  const {
+    appendItems,
+    MAX_MERGED_ASSISTANT_CHARS
+  } = await loadConversationUtils();
+
+  let items = appendItems(
+    [
+      {
+        kind: "text",
+        role: "assistant",
+        content: "A".repeat(MAX_MERGED_ASSISTANT_CHARS - 100),
+        messageId: "msg-large"
+      }
+    ],
+    [
+      {
+        kind: "text",
+        role: "assistant",
+        content: "B".repeat(5_000),
+        append: true,
+        messageId: "msg-large"
+      }
+    ]
+  );
+
+  assert.ok(items[0].content.length <= MAX_MERGED_ASSISTANT_CHARS);
+  assert.ok(items[0].content.startsWith("A"));
+  assert.match(items[0].content, /stream truncated/);
+  assert.ok(items[0].content.endsWith("B".repeat(5_000)));
+
+  items = appendItems(items, [
+    {
+      kind: "text",
+      role: "assistant",
+      content: "C".repeat(5_000),
+      append: true,
+      messageId: "msg-large"
+    }
+  ]);
+
+  assert.ok(items[0].content.length <= MAX_MERGED_ASSISTANT_CHARS);
+  assert.ok(items[0].content.endsWith("C".repeat(5_000)));
+});
+
+test("appendItems coalesces a large batch of adjacent token chunks", async () => {
+  const {
+    appendItems,
+    MAX_MERGED_ASSISTANT_CHARS
+  } = await loadConversationUtils();
+  const chunks = Array.from({ length: 200 }, (_, index) => ({
+    kind: "text",
+    role: "assistant",
+    content: `token-${index}|`,
+    append: true,
+    messageId: "msg-batched"
+  }));
+  const items = appendItems(
+    [
+      {
+        kind: "text",
+        role: "assistant",
+        content: "A".repeat(MAX_MERGED_ASSISTANT_CHARS - 1_000),
+        messageId: "msg-batched"
+      }
+    ],
+    chunks
+  );
+
+  assert.equal(items.length, 1);
+  assert.ok(items[0].content.length <= MAX_MERGED_ASSISTANT_CHARS);
+  assert.ok(items[0].content.endsWith("token-199|"));
+});
+
+test("appendItems bounds cumulative command output", async () => {
+  const { appendItems, MAX_MERGED_OUTPUT_CHARS } = await loadConversationUtils();
+  const items = appendItems(
+    [{ kind: "command-output", content: "A".repeat(MAX_MERGED_OUTPUT_CHARS) }],
+    [{ kind: "command-output", content: "latest output", stream: undefined }]
+  );
+
+  assert.ok(items[0].content.length <= MAX_MERGED_OUTPUT_CHARS);
+  assert.match(items[0].content, /stream truncated/);
+  assert.ok(items[0].content.endsWith("latest output"));
+});
+
 test("appendItems upserts terminal embed snapshots by terminalId", async () => {
   const { appendItems } = await loadConversationUtils();
 

--- a/tests/stream-media.test.mjs
+++ b/tests/stream-media.test.mjs
@@ -178,6 +178,33 @@ test("sanitizeStreamItems guards oversized text without any base64 marker", asyn
   assert.match(textItem.content, /truncated/);
 });
 
+test("sanitizeStreamItems caps oversized tool inputs and file edit payloads", async () => {
+  const { sanitizeStreamItems, MAX_TEXT_STREAM_CHARS } = await loadStreamMedia();
+  const big = "x".repeat(MAX_TEXT_STREAM_CHARS + 5_000);
+  const items = sanitizeStreamItems([
+    { kind: "tool-call", id: "large-input", tool: "edit", input: { text: big } },
+    {
+      kind: "file-edit",
+      path: "/tmp/large.txt",
+      action: "update",
+      patch: big,
+      oldText: big,
+      newText: big
+    },
+    { kind: "command-output", content: big }
+  ]);
+
+  const call = items[0];
+  const edit = items[1];
+  const output = items[2];
+  assert.equal(typeof call.input, "string");
+  assert.match(call.input, /truncated/);
+  assert.ok(edit.patch.length < big.length);
+  assert.ok(edit.oldText.length < big.length);
+  assert.ok(edit.newText.length < big.length);
+  assert.ok(output.content.length < big.length);
+});
+
 test("extractDataUrlImages fast-paths text without a base64 marker", async () => {
   const { extractDataUrlImages } = await loadStreamMedia();
   const input = "普通的分析文字，不含任何 data url。";


### PR DESCRIPTION
## Summary

- throttle and coalesce high-frequency ACP stream updates across concurrent tasks
- keep progressive assistant output in a single live snapshot and persist it once on completion
- bound accumulated assistant text, command output, tool inputs, and file-edit payloads
- clean up failed live sessions and add renderer crash diagnostics plus guarded auto-reload
- add regression coverage for concurrent stream stability and cumulative payload limits

## Root cause

The Windows debug bundle recorded three genuine renderer process crashes while several long-running complex tasks were active. ACP sessions produced thousands of updates in short intervals. Each batch previously duplicated the growing assistant snapshot into both `live` and `messages`, repeatedly serialized the full turn, and could accumulate many individually small chunks without a cumulative bound. The resulting allocation pressure could terminate the renderer, leaving only the BrowserWindow's blue background.

## User impact

Five concurrent complex tasks now generate substantially fewer renderer updates and bounded snapshots. If the renderer still crashes, FreeBuddy records local diagnostics and reloads the main window with loop protection instead of remaining permanently blue.

Very large transcript blocks are intentionally truncated with a visible marker: assistant text at 200,000 characters and command/tool/file-edit payloads at 12,000 characters.

## Validation

- `npm run github:preflight`
- full test suite: 918 passed, 0 failed, 51 skipped
- targeted stability tests: 49 passed
- `npm run typecheck`
- `npm run build:renderer`
- `git diff --check`
