### PR TITLE
fix: install DeepSeek ACP from the next dist-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
 </details>
 

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -242,7 +242,9 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     },
     toolSessionArgs: [],
     toolSessionArgPrefixes: [],
-    installHint: "npm install -g @deepseek-ai/dsh-acp-demo",
+    // `latest` is still 0.0.1-rc.1; that release's peer packages 404 on the
+    // public registry. The working public line is currently tagged `next`.
+    installHint: "npm install -g @deepseek-ai/dsh-acp-demo@next",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -172,7 +172,7 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     capabilities: { toolSession: true },
     toolSessionArgs: [],
     toolSessionArgPrefixes: [],
-    installHint: "npm install -g @deepseek-ai/dsh-acp-demo",
+    installHint: "npm install -g @deepseek-ai/dsh-acp-demo@next",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -52,14 +52,14 @@ test("agy-acp checks agy-acp binary probe", () => {
   });
 });
 
-test("dsh-acp checks dsh-acp-demo binary probe", () => {
+test("dsh-acp install uses the next dist-tag because latest peers 404", () => {
   assert.deepEqual(getCliCheckProbe("dsh-acp"), {
     args: ["--version"],
     versionOptional: true
   });
   assert.equal(
     getAdapterDefinition("dsh-acp")?.installHint,
-    "npm install -g @deepseek-ai/dsh-acp-demo"
+    "npm install -g @deepseek-ai/dsh-acp-demo@next"
   );
   assert.equal(getAdapterDefinition("dsh-acp")?.defaultBinary, "dsh-acp-demo");
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unversioned `npm install -g @deepseek-ai/dsh-acp-demo` resolves `latest`, which is still `0.0.1-rc.1`. That release lists peer packages such as `@deepseek-ai/dsh-workspace-context` that 404 on the public npm registry, so FreeBuddy’s DeepSeek **Install** button fails with `E404`.

The working public line is tagged `next` (currently `0.1.0-rc.6`, `publishConfig.access: public`). Dry-run of `@next` resolved 78 packages with no 404s.

This updates the adapter `installHint`, README install tables, and the cli-check assertion so Settings → Coding Agents installs a package graph that actually exists.

## Test plan

- [ ] `npm run build:electron && node --test --test-force-exit tests/cli-check.test.mjs tests/acp.test.mjs`
- [ ] Confirm `npm install -g @deepseek-ai/dsh-acp-demo@next` succeeds and `dsh-acp-demo` is on PATH
- [ ] Confirm unversioned `npm install -g @deepseek-ai/dsh-acp-demo` still 404s on `latest` until DeepSeek promotes the tag
- [ ] In Settings → Coding Agents, DeepSeek **Install** runs the `@next` command

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83d368c6-5d56-4ae8-b3a2-3b34366b255d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83d368c6-5d56-4ae8-b3a2-3b34366b255d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

