### PR TITLE
feat: add DeepSeek ACP adapter and support deepseek-harness-acp standalone runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 .DS_Store
 .superpowers/
 .worktrees/
+.sessions/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
 | **DeepSeek** | `dsh-acp-demo` | `npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
+FreeBuddy starts DeepSeek with a bundled `cordis.yml` (`--config`). A `cordis.yml` in the workspace root wins if present. Set `DEEPSEEK_API_KEY` under **Settings → Coding Agents**.
+
 </details>
 
 Open **Settings → Coding Agents** to:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **A desktop workbench for local coding agents.** ⚡
 
-Use Codex, ClaudeCode, OpenCode, Cursor, Kimi, Qoder, and CodeBuddy side by side in one interface — each agent runs in its own workspace, with all tasks tracked in one place. Two modes are supported:
+Use Codex, ClaudeCode, OpenCode, Cursor, Kimi, Qoder, CodeBuddy, and DeepSeek Harness side by side in one interface — each agent runs in its own workspace, with all tasks tracked in one place. Two modes are supported:
 * **Normal Mode**
 ![hero](assets/fbd-hero.png)
 
@@ -59,6 +59,7 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
   <a href="https://code.kimi.com"><kbd><img src="https://www.google.com/s2/favicons?domain=moonshot.cn&sz=64" alt="Kimi logo" width="16" valign="middle" /> Kimi</kbd></a> &nbsp;
   <a href="https://qoder.com/install"><kbd><img src="https://www.google.com/s2/favicons?domain=qoder.com&sz=64" alt="Qoder logo" width="16" valign="middle" /> Qoder</kbd></a> &nbsp;
   <a href="https://www.npmjs.com/package/@tencent-ai/codebuddy-code"><kbd><img src="https://www.google.com/s2/favicons?domain=codebuddy.cn&sz=64" alt="CodeBuddy logo" width="16" valign="middle" /> CodeBuddy</kbd></a> &nbsp;
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><kbd><img src="https://www.google.com/s2/favicons?domain=deepseek.com&sz=64" alt="DeepSeek logo" width="16" valign="middle" /> DeepSeek</kbd></a> &nbsp;
   <kbd>+ any CLI agent</kbd>
 </p>
 
@@ -74,6 +75,7 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo` | 🆕 |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | Settings → Coding Agents → **Install** (`@deepseek-ai/dsh-acp-demo@next` plus the official ACP plugin tree) | 🆕 |
 
-FreeBuddy starts DeepSeek with a bundled `cordis.yml` (`--config`). A `cordis.yml` in the workspace root wins if present. Set `DEEPSEEK_API_KEY` under **Settings → Coding Agents**.
+FreeBuddy starts DeepSeek with a bundled `cordis.yml` (`--config`). A `cordis.yml` in the workspace root wins if present. The published ACP demo has no runtime dependencies, so Install also pulls `@deepseek-ai/dsh-llm-deepseek` and the rest of that plugin tree. Set `DEEPSEEK_API_KEY` under **Settings → Coding Agents**.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
 | **DeepSeek** | `dsh-acp-demo` | Settings → Coding Agents → **Install** (`@deepseek-ai/dsh-acp-demo@next` plus the official ACP plugin tree) | 🆕 |
 
-FreeBuddy starts DeepSeek with a bundled `cordis.yml` (`--config`). A `cordis.yml` in the workspace root wins if present. The published ACP demo has no runtime dependencies, so Install also pulls `@deepseek-ai/dsh-llm-deepseek` and the rest of that plugin tree. Set `DEEPSEEK_API_KEY` under **Settings → Coding Agents**.
+FreeBuddy starts DeepSeek with a bundled `cordis.yml` (`--config`). A `cordis.yml` in the workspace root wins if present. The published ACP demo has no runtime dependencies, so Install pulls `@deepseek-ai/dsh-llm-deepseek` and the rest of that plugin tree into FreeBuddy's own runtime directory (not a bin-only global install). Set `DEEPSEEK_API_KEY` under **Settings → Coding Agents**.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ FreeBuddy is compatible with **all CLI-based AI coding tools** — if it runs in
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo@next` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo@next` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,7 +78,7 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
 | **DeepSeek** | `dsh-acp-demo` | 设置 → 编码 Agent → **安装**（`@deepseek-ai/dsh-acp-demo@next` 以及官方 ACP 插件树） | 🆕 |
 
-FreeBuddy 启动 DeepSeek 时会带上内置的 `cordis.yml`（`--config`）。工作区根目录若已有 `cordis.yml` 则优先使用。发布到 npm 的 ACP demo **不含运行时依赖**，所以安装还会一并拉取 `@deepseek-ai/dsh-llm-deepseek` 等插件包。请在 **设置 → 编码 Agent** 中配置 `DEEPSEEK_API_KEY`。
+FreeBuddy 启动 DeepSeek 时会带上内置的 `cordis.yml`（`--config`）。工作区根目录若已有 `cordis.yml` 则优先使用。发布到 npm 的 ACP demo **不含运行时依赖**，所以安装会把 `@deepseek-ai/dsh-llm-deepseek` 等插件装进 FreeBuddy 自己的运行时目录，而不是只装一个全局 bin。请在 **设置 → 编码 Agent** 中配置 `DEEPSEEK_API_KEY`。
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,9 +76,9 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
-| **DeepSeek** | `dsh-acp-demo` | `npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | 设置 → 编码 Agent → **安装**（`@deepseek-ai/dsh-acp-demo@next` 以及官方 ACP 插件树） | 🆕 |
 
-FreeBuddy 启动 DeepSeek 时会带上内置的 `cordis.yml`（`--config`）。工作区根目录若已有 `cordis.yml` 则优先使用。请在 **设置 → 编码 Agent** 中配置 `DEEPSEEK_API_KEY`。
+FreeBuddy 启动 DeepSeek 时会带上内置的 `cordis.yml`（`--config`）。工作区根目录若已有 `cordis.yml` 则优先使用。发布到 npm 的 ACP demo **不含运行时依赖**，所以安装还会一并拉取 `@deepseek-ai/dsh-llm-deepseek` 等插件包。请在 **设置 → 编码 Agent** 中配置 `DEEPSEEK_API_KEY`。
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,6 +78,8 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
 | **DeepSeek** | `dsh-acp-demo` | `npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next` | 🆕 |
 
+FreeBuddy 启动 DeepSeek 时会带上内置的 `cordis.yml`（`--config`）。工作区根目录若已有 `cordis.yml` 则优先使用。请在 **设置 → 编码 Agent** 中配置 `DEEPSEEK_API_KEY`。
+
 </details>
 
 打开 **设置 → 编码 Agent** 可以：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 **面向本地编码 Agent 的桌面工作台。** ⚡
 
-把 Codex、ClaudeCode、OpenCode、Cursor、Kimi、Qoder 和 CodeBuddy 放在一个界面里并行使用 —— 每个 Agent 在独立的工作区运行，所有任务统一追踪。支持两大模式：
+把 Codex、ClaudeCode、OpenCode、Cursor、Kimi、Qoder、CodeBuddy 和 DeepSeek Harness 放在一个界面里并行使用 —— 每个 Agent 在独立的工作区运行，所有任务统一追踪。支持两大模式：
 * **普通模式**
 ![hero](assets/fbd-hero.png)
 
@@ -60,6 +60,7 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
   <a href="https://code.kimi.com"><kbd><img src="https://www.google.com/s2/favicons?domain=moonshot.cn&sz=64" alt="Kimi logo" width="16" valign="middle" /> Kimi</kbd></a> &nbsp;
   <a href="https://qoder.com/install"><kbd><img src="https://www.google.com/s2/favicons?domain=qoder.com&sz=64" alt="Qoder logo" width="16" valign="middle" /> Qoder</kbd></a> &nbsp;
   <a href="https://www.npmjs.com/package/@tencent-ai/codebuddy-code"><kbd><img src="https://www.google.com/s2/favicons?domain=codebuddy.cn&sz=64" alt="CodeBuddy logo" width="16" valign="middle" /> CodeBuddy</kbd></a> &nbsp;
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><kbd><img src="https://www.google.com/s2/favicons?domain=deepseek.com&sz=64" alt="DeepSeek logo" width="16" valign="middle" /> DeepSeek</kbd></a> &nbsp;
   <kbd>+ any CLI agent</kbd>
 </p>
 
@@ -75,6 +76,7 @@ FreeBuddy 兼容**所有基于 CLI 的 AI 编码工具** —— 只要它能在�
 | **Kimi** | `kimi` | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | ✅ |
 | **Qoder** | `qodercli` | `curl -fsSL https://qoder.com/install \| bash` | ✅ |
 | **CodeBuddy** | `codebuddy` | `npm install -g @tencent-ai/codebuddy-code` | 🆕 |
+| **DeepSeek** | `dsh-acp-demo` | `npm install -g @deepseek-ai/dsh-acp-demo` | 🆕 |
 
 </details>
 

--- a/assets/dsh/cordis.win32.yml
+++ b/assets/dsh/cordis.win32.yml
@@ -1,0 +1,198 @@
+# Bundled by FreeBuddy as the Windows composition for `dsh-acp-demo`.
+# Derived from cordis.yml with one change: the native sandbox stack is replaced
+# by the non-sandboxed local bash executor.
+#
+# Why: `@deepseek-ai/dsh-sandbox-local` loads `dsh-sandbox-windows-acl`, which
+# calls `koffi` (`koffi.pointer`/`koffi.struct`) at module import. The koffi
+# native addon aborts Windows ACP children with STATUS_ACCESS_VIOLATION
+# (0xC0000005). Stubbing koffi is not viable because the ACL module needs real
+# struct definitions at import. `dsh-bash-local` (`@deepseek-ai/dsh-subprocess-local`
+# for process-tree management) provides the `shell` service and the bash tool
+# without any native addon, so the hooks and the rest of the tree activate.
+# Filesystem fencing still comes from `dsh-sandbox-policy` + `dsh-fs-sandbox`
+# (pure JS); only the native process sandbox is dropped.
+# Source: https://github.com/deepseek-ai/deepseek-harness/blob/master/examples/acp-agent/cordis.yml
+
+# The DeepSeek adapter. Shipped default: full thinking at max effort on every
+# request; exact-model resolution materializes request defaults before logging.
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    thinking: enabled
+    reasoningEffort: max
+    models:
+      - id: deepseek-v4-flash
+      - id: deepseek-v4-pro
+
+# `dsh-sandbox-local` is intentionally NOT mounted on Windows; see file header.
+# The pure-JS policy still provides ctx.sandboxPolicy for dsh-fs-sandbox.
+# DSH_PERMISSION_MODE provides the deployment/test override; the sandbox default
+# + fallback root live on ctx.sandboxPolicy; agent calls resolve both families
+# against the session cwd.
+- id: sandbox-policy
+  name: '@deepseek-ai/dsh-sandbox-policy'
+  config:
+    mode: !!js "process.env.DSH_PERMISSION_MODE ?? (process.env.DSH_SNAPSHOT === undefined ? 'workspace-write' : 'danger-full-access')"
+    workspaceRoot: !!js process.cwd()
+
+# Managed child-process groups for the bash executor (spawn/kill/output plumbing).
+- id: subprocess
+  name: '@deepseek-ai/dsh-subprocess-local'
+
+# Windows uses the non-sandboxed local bash executor. `dsh-bash-sandbox` would
+# wait on the `sandbox` service that the omitted `dsh-sandbox-local` provides.
+- id: bash
+  name: '@deepseek-ai/dsh-bash-local'
+
+- id: approval
+  name: '@deepseek-ai/dsh-user-approval'
+  config:
+    policy: !!js "(process.env.DSH_PERMISSION_MODE ?? (process.env.DSH_SNAPSHOT === undefined ? 'workspace-write' : 'danger-full-access')) === 'danger-full-access' ? 'never' : 'ask'"
+
+# The ACP automation app: agent spine + JSONL persistence + protocol bridge.
+# Persistence root: $DSH_SNAPSHOT_SESSIONS_ROOT when the snapshot harness sets it
+# (so it can harvest / isolate the log), else ./.sessions for the demo.
+# `persistenceCompression: none` avoids the koffi/zstd Win32 durable-publish
+# crash; the JSONL overlay applied by FreeBuddy covers the same surface.
+- id: acp-agent
+  name: '@deepseek-ai/dsh-acp-demo'
+  config:
+    provider: deepseek-official
+    model: deepseek-v4-pro
+    persistenceRoot: !!js process.env.DSH_SNAPSHOT_SESSIONS_ROOT ?? './.sessions'
+    persistenceCompression: none
+    workspaceContext:
+      maxBytes: 65536
+    # Keep the persona to identity and behavior; tool plugins own tool guidance.
+    # The loop resolves {{model}} and each ACP session's client-supplied {{cwd}}.
+    persona: |
+      You are a coding assistant powered by the {{model}} model. Your working directory is {{cwd}}. Your bash tool runs under a file sandbox — a `[sandbox: file access denied …]` result is policy, not a command bug.
+
+      Verify your work by running the code or tests. Keep answers brief and factual.
+
+# Replay-aware request pressure; the routed adapter supplies model capacity.
+- id: token-meter
+  name: '@deepseek-ai/dsh-token-meter'
+
+# Summarize an older range after measured pressure or a canonical provider overflow.
+# Ratios scale against the routed model's context window.
+- id: compaction-basic
+  name: '@deepseek-ai/dsh-compaction-basic'
+  config:
+    thresholdRatio: 0.8
+    retainRatio: 0.08
+    maxTokens: 8192
+    compactionRetries: 1
+
+# Projection registry: subagent catalog identity (mode/label) folds through
+# its registered units; the catalog surfaces (`list_agents`, subagent listing)
+# fail loud without the capability.
+- id: session-projection
+  name: '@deepseek-ai/dsh-session-projection'
+
+# Expose fresh-child `spawn` and completed-prefix `fork` through separate tool
+# names so multi-child scenarios exercise both transports. These leaves follow
+# the app because it provides `ctx.agents` and `ctx.tools`.
+- id: subagent
+  name: '@deepseek-ai/dsh-subagent'
+
+- id: subagent-spawn-in-process
+  name: '@deepseek-ai/dsh-subagent-spawn-in-process'
+  config:
+    providerName: spawn
+
+- id: subagent-fork-in-process
+  name: '@deepseek-ai/dsh-subagent-fork-in-process'
+  config:
+    providerName: fork
+
+# Continuable background children are selected per delegation tool. The
+# separately loaded control package registers the global `send_message`; its
+# list plugin registers `list_agents`, served through the sessionProjections
+# registry mounted above. `report` is installed only in continuable child scopes.
+- id: tool-subagent-control
+  name: '@deepseek-ai/dsh-tool-subagent-control'
+
+- id: tool-subagent-list-agents
+  name: '@deepseek-ai/dsh-tool-subagent-control/list-agents'
+
+- id: tool-subagent-report
+  name: '@deepseek-ai/dsh-tool-subagent-report'
+
+- id: tool-subagent
+  name: '@deepseek-ai/dsh-tool-subagent'
+  config:
+    provider: spawn
+    toolName: subagent
+    backgroundMode: continuable
+    maxDepth: 1
+
+# Fork stays one-shot because a continuable child's `report` tool and prompt
+# section precede the inherited history a fork reuses; `run_in_background` is off
+# because this example mounts no task service. See .agents/notes/implemented/architecture/2026-08-10-fork-children-stay-one-shot.md.
+- id: tool-subagent-fork
+  name: '@deepseek-ai/dsh-tool-subagent'
+  config:
+    provider: fork
+    toolName: subagent_fork
+    backgroundMode: one-shot
+    enableRunInBackground: false
+    maxDepth: 1
+
+
+# The worker-thread workflow engine fans a model-written JavaScript script's
+# `agent()` calls out through the spawn backend; the adjacent tool exposes it to the model.
+- id: workflow-worker-thread
+  name: '@deepseek-ai/dsh-workflow-worker-thread'
+  config:
+    provider: spawn
+
+- id: tool-workflow
+  name: '@deepseek-ai/dsh-tool-workflow'
+
+- id: tool-ralph
+  name: '@deepseek-ai/dsh-tool-ralph'
+# `todo_write` replaces the logged whole list for later model requests.
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+# Identical repeat calls trigger advisory context, never a block, at the default
+# thresholds [3, 5, 8]. Only the repeat-tool-reminder snapshot scenario reaches them.
+- id: repeat-tool-reminder
+  name: '@deepseek-ai/dsh-repeat-tool-reminder'
+
+# The filesystem stack rides the SAME sandbox policy as bash: dsh-fs-sandbox
+# replaces dsh-fs-local behind ctx.fs and fences write/edit by the effective
+# mode (read-only denies, workspace-write contains to the workspace + temp
+# roots, danger-full-access passes through), so read/write/edit are available
+# under every mode. fs-observation-policy (read-before-edit) composes orthogonally on top.
+- id: fs-sandbox
+  name: '@deepseek-ai/dsh-fs-sandbox'
+  config:
+    cwd: !!js process.cwd()
+
+- id: fs-observation-policy
+  name: '@deepseek-ai/dsh-fs-observation-policy'
+
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'
+
+# `configPath` is read once at load and resolves from the server launch cwd, not
+# `session/new.cwd`; one `hooks.json` therefore applies to every session and a
+# project-local file is not discovered. Missing config registers nothing. Hook
+# commands still run in the session cwd. Warnings use `ctx.logger`, never stdout;
+# see packages/hooks/hooks-claude-code/README.md for the deferred per-session design.
+- id: hooks-claude-code
+  name: '@deepseek-ai/dsh-hooks-claude-code'
+  config:
+    configPath: ./hooks.json
+
+# Codex uses its own `codex-hooks.json` and snake_case five-event dialect; it
+# cannot share Claude's file. It has the same process-level, read-once, missing-is-no-op,
+# logger-only contract. Shipping both bridges lets a scenario seed and exercise either dialect.
+- id: hooks-codex
+  name: '@deepseek-ai/dsh-hooks-codex'
+  config:
+    configPath: ./codex-hooks.json

--- a/assets/dsh/cordis.yml
+++ b/assets/dsh/cordis.yml
@@ -1,0 +1,196 @@
+# Bundled by FreeBuddy as the default composition for `dsh-acp-demo`.
+# Source: https://github.com/deepseek-ai/deepseek-harness/blob/master/examples/acp-agent/cordis.yml
+# A workspace-root `cordis.yml` takes precedence over this file.
+
+# ACP automation server and backend snapshot-record composition. With
+# `DSH_SNAPSHOT=record`, the app bin runs the real DeepSeek adapter and the
+# harness harvests its persisted log. The bin loads the gitignored root `.env`
+# before this config. This tree has no stdout logger or HMR because stdout
+# carries ACP JSON-RPC.
+
+# The DeepSeek adapter. Shipped default: full thinking at max effort on every
+# request; exact-model resolution materializes request defaults before logging.
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    thinking: enabled
+    reasoningEffort: max
+    models:
+      - id: deepseek-v4-flash
+      - id: deepseek-v4-pro
+
+# The default composition confines bash AND the filesystem tools to the
+# workspace and asks before a wider retry. Snapshot runs select
+# danger-full-access so the established scenarios remain runner-independent;
+# DSH_PERMISSION_MODE provides the same explicit deployment/test override
+# outside the snapshot harness. The sandbox default + fallback root live on
+# ctx.sandboxPolicy; agent calls resolve both families against the session cwd.
+- id: sandbox
+  name: '@deepseek-ai/dsh-sandbox-local'
+
+- id: sandbox-policy
+  name: '@deepseek-ai/dsh-sandbox-policy'
+  config:
+    mode: !!js "process.env.DSH_PERMISSION_MODE ?? (process.env.DSH_SNAPSHOT === undefined ? 'workspace-write' : 'danger-full-access')"
+    workspaceRoot: !!js process.cwd()
+
+# Managed child-process groups for the bash executor (spawn/kill/output plumbing).
+- id: subprocess
+  name: '@deepseek-ai/dsh-subprocess-local'
+
+- id: bash
+  name: '@deepseek-ai/dsh-bash-sandbox'
+  config:
+    timeoutMs: 60000
+
+- id: approval
+  name: '@deepseek-ai/dsh-user-approval'
+  config:
+    policy: !!js "(process.env.DSH_PERMISSION_MODE ?? (process.env.DSH_SNAPSHOT === undefined ? 'workspace-write' : 'danger-full-access')) === 'danger-full-access' ? 'never' : 'ask'"
+
+# The ACP automation app: agent spine + JSONL persistence + protocol bridge.
+# Persistence root: $DSH_SNAPSHOT_SESSIONS_ROOT when the snapshot harness sets it
+# (so it can harvest / isolate the log), else ./.sessions for the demo.
+# Snapshot modes use raw JSONL fixtures; ordinary runs keep the compressed default.
+- id: acp-agent
+  name: '@deepseek-ai/dsh-acp-demo'
+  config:
+    provider: deepseek-official
+    model: deepseek-v4-pro
+    persistenceRoot: !!js process.env.DSH_SNAPSHOT_SESSIONS_ROOT ?? './.sessions'
+    persistenceCompression: !!js "process.env.DSH_SNAPSHOT === undefined ? 'zstd' : 'none'"
+    workspaceContext:
+      maxBytes: 65536
+    # Keep the persona to identity and behavior; tool plugins own tool guidance.
+    # The loop resolves {{model}} and each ACP session's client-supplied {{cwd}}.
+    persona: |
+      You are a coding assistant powered by the {{model}} model. Your working directory is {{cwd}}. Your bash tool runs under a file sandbox — a `[sandbox: file access denied …]` result is policy, not a command bug.
+
+      Verify your work by running the code or tests. Keep answers brief and factual.
+
+# Replay-aware request pressure; the routed adapter supplies model capacity.
+- id: token-meter
+  name: '@deepseek-ai/dsh-token-meter'
+
+# Summarize an older range after measured pressure or a canonical provider overflow.
+# Ratios scale against the routed model's context window.
+- id: compaction-basic
+  name: '@deepseek-ai/dsh-compaction-basic'
+  config:
+    thresholdRatio: 0.8
+    retainRatio: 0.08
+    maxTokens: 8192
+    compactionRetries: 1
+
+# Projection registry: subagent catalog identity (mode/label) folds through
+# its registered units; the catalog surfaces (`list_agents`, subagent listing)
+# fail loud without the capability.
+- id: session-projection
+  name: '@deepseek-ai/dsh-session-projection'
+
+# Expose fresh-child `spawn` and completed-prefix `fork` through separate tool
+# names so multi-child scenarios exercise both transports. These leaves follow
+# the app because it provides `ctx.agents` and `ctx.tools`.
+- id: subagent
+  name: '@deepseek-ai/dsh-subagent'
+
+- id: subagent-spawn-in-process
+  name: '@deepseek-ai/dsh-subagent-spawn-in-process'
+  config:
+    providerName: spawn
+
+- id: subagent-fork-in-process
+  name: '@deepseek-ai/dsh-subagent-fork-in-process'
+  config:
+    providerName: fork
+
+# Continuable background children are selected per delegation tool. The
+# separately loaded control package registers the global `send_message`; its
+# list plugin registers `list_agents`, served through the sessionProjections
+# registry mounted above. `report` is installed only in continuable child scopes.
+- id: tool-subagent-control
+  name: '@deepseek-ai/dsh-tool-subagent-control'
+
+- id: tool-subagent-list-agents
+  name: '@deepseek-ai/dsh-tool-subagent-control/list-agents'
+
+- id: tool-subagent-report
+  name: '@deepseek-ai/dsh-tool-subagent-report'
+
+- id: tool-subagent
+  name: '@deepseek-ai/dsh-tool-subagent'
+  config:
+    provider: spawn
+    toolName: subagent
+    backgroundMode: continuable
+    maxDepth: 1
+
+# Fork stays one-shot because a continuable child's `report` tool and prompt
+# section precede the inherited history a fork reuses; `run_in_background` is off
+# because this example mounts no task service. See .agents/notes/implemented/architecture/2026-08-10-fork-children-stay-one-shot.md.
+- id: tool-subagent-fork
+  name: '@deepseek-ai/dsh-tool-subagent'
+  config:
+    provider: fork
+    toolName: subagent_fork
+    backgroundMode: one-shot
+    enableRunInBackground: false
+    maxDepth: 1
+
+
+# The worker-thread workflow engine fans a model-written JavaScript script's
+# `agent()` calls out through the spawn backend; the adjacent tool exposes it to the model.
+- id: workflow-worker-thread
+  name: '@deepseek-ai/dsh-workflow-worker-thread'
+  config:
+    provider: spawn
+
+- id: tool-workflow
+  name: '@deepseek-ai/dsh-tool-workflow'
+
+- id: tool-ralph
+  name: '@deepseek-ai/dsh-tool-ralph'
+# `todo_write` replaces the logged whole list for later model requests.
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+# Identical repeat calls trigger advisory context, never a block, at the default
+# thresholds [3, 5, 8]. Only the repeat-tool-reminder snapshot scenario reaches them.
+- id: repeat-tool-reminder
+  name: '@deepseek-ai/dsh-repeat-tool-reminder'
+
+# The filesystem stack rides the SAME sandbox policy as bash: dsh-fs-sandbox
+# replaces dsh-fs-local behind ctx.fs and fences write/edit by the effective
+# mode (read-only denies, workspace-write contains to the workspace + temp
+# roots, danger-full-access passes through), so read/write/edit are available
+# under every mode. fs-observation-policy (read-before-edit) composes orthogonally on top.
+- id: fs-sandbox
+  name: '@deepseek-ai/dsh-fs-sandbox'
+  config:
+    cwd: !!js process.cwd()
+
+- id: fs-observation-policy
+  name: '@deepseek-ai/dsh-fs-observation-policy'
+
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'
+
+# `configPath` is read once at load and resolves from the server launch cwd, not
+# `session/new.cwd`; one `hooks.json` therefore applies to every session and a
+# project-local file is not discovered. Missing config registers nothing. Hook
+# commands still run in the session cwd. Warnings use `ctx.logger`, never stdout;
+# see packages/hooks/hooks-claude-code/README.md for the deferred per-session design.
+- id: hooks-claude-code
+  name: '@deepseek-ai/dsh-hooks-claude-code'
+  config:
+    configPath: ./hooks.json
+
+# Codex uses its own `codex-hooks.json` and snake_case five-event dialect; it
+# cannot share Claude's file. It has the same process-level, read-once, missing-is-no-op,
+# logger-only contract. Shipping both bridges lets a scenario seed and exercise either dialect.
+- id: hooks-codex
+  name: '@deepseek-ai/dsh-hooks-codex'
+  config:
+    configPath: ./codex-hooks.json

--- a/assets/dsh/cordis.yml
+++ b/assets/dsh/cordis.yml
@@ -27,6 +27,10 @@
 # ctx.sandboxPolicy; agent calls resolve both families against the session cwd.
 - id: sandbox
   name: '@deepseek-ai/dsh-sandbox-local'
+  # windows-acl loads koffi at import and calls native Win32 APIs on the first
+  # confined spawn. That has aborted Windows Electron children with
+  # STATUS_ACCESS_VIOLATION. Chat/prompt can run without this runner.
+  disabled: !!js process.platform === 'win32'
 
 - id: sandbox-policy
   name: '@deepseek-ai/dsh-sandbox-policy'

--- a/assets/dsh/cordis.yml
+++ b/assets/dsh/cordis.yml
@@ -27,10 +27,6 @@
 # ctx.sandboxPolicy; agent calls resolve both families against the session cwd.
 - id: sandbox
   name: '@deepseek-ai/dsh-sandbox-local'
-  # windows-acl loads koffi at import and calls native Win32 APIs on the first
-  # confined spawn. That has aborted Windows Electron children with
-  # STATUS_ACCESS_VIOLATION. Chat/prompt can run without this runner.
-  disabled: !!js process.platform === 'win32'
 
 - id: sandbox-policy
   name: '@deepseek-ai/dsh-sandbox-policy'

--- a/assets/dsh/cordis.yml
+++ b/assets/dsh/cordis.yml
@@ -58,7 +58,10 @@
     provider: deepseek-official
     model: deepseek-v4-pro
     persistenceRoot: !!js process.env.DSH_SNAPSHOT_SESSIONS_ROOT ?? './.sessions'
-    persistenceCompression: !!js "process.env.DSH_SNAPSHOT === undefined ? 'zstd' : 'none'"
+    # Official snapshot runs use `none`. The default `zstd` path plus koffi's
+    # Win32 durable-publish bindings have aborted Windows desktop sessions with
+    # STATUS_ACCESS_VIOLATION (0xC0000005) immediately after session/prompt.
+    persistenceCompression: none
     workspaceContext:
       maxBytes: 65536
     # Keep the persona to identity and behavior; tool plugins own tool guidance.

--- a/assets/dsh/koffi-guard.mjs
+++ b/assets/dsh/koffi-guard.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register(new URL("./koffi-hooks.mjs", import.meta.url));

--- a/assets/dsh/koffi-hooks.mjs
+++ b/assets/dsh/koffi-hooks.mjs
@@ -1,0 +1,25 @@
+const stubUrl = new URL("./koffi-stub.mjs", import.meta.url).href;
+
+function isKoffiSpecifier(specifier, context) {
+  if (
+    specifier === "koffi" ||
+    specifier.startsWith("koffi/") ||
+    specifier.startsWith("koffi\\")
+  ) {
+    return true;
+  }
+  let href = specifier;
+  try {
+    href = new URL(specifier, context.parentURL).href;
+  } catch {
+    href = specifier;
+  }
+  return /(?:^|[/\\])node_modules[/\\]koffi(?:[/\\]|$)/i.test(href);
+}
+
+export async function resolve(specifier, context, nextResolve) {
+  if (isKoffiSpecifier(specifier, context)) {
+    return { url: stubUrl, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}

--- a/assets/dsh/koffi-stub.mjs
+++ b/assets/dsh/koffi-stub.mjs
@@ -15,6 +15,18 @@ function func() {
   return failClosed;
 }
 
+// `dsh-sandbox-windows-acl` builds its FFI type table at module import
+// (top-level `koffi.struct(...)`/`koffi.pointer(...)`), so the stub must
+// expose every API referenced there or the import throws before the
+// package's platform guard can skip the Win32 calls on non-Windows.
+function struct() {
+  return {};
+}
+
+function encode() {
+  return undefined;
+}
+
 function load() {
   return {
     func,
@@ -23,9 +35,11 @@ function load() {
     pointer() {
       return {};
     },
+    struct,
     alloc() {
       return {};
     },
+    encode,
     decode() {
       return null;
     },
@@ -41,9 +55,11 @@ const api = {
   pointer() {
     return {};
   },
+  struct,
   alloc() {
     return {};
   },
+  encode,
   decode() {
     return null;
   },

--- a/assets/dsh/koffi-stub.mjs
+++ b/assets/dsh/koffi-stub.mjs
@@ -1,0 +1,59 @@
+/**
+ * Fail-closed JavaScript stand-in for `koffi`.
+ *
+ * Official DeepSeek JSONL / Windows ACL call `koffi.load("kernel32.dll")`
+ * and then stdcall Win32 APIs. Loading that native addon from an Electron
+ * child on Windows aborts with STATUS_ACCESS_VIOLATION (0xC0000005).
+ * Returning 0 makes those callers throw a JS error instead of crashing.
+ */
+
+function failClosed() {
+  return 0;
+}
+
+function func() {
+  return failClosed;
+}
+
+function load() {
+  return {
+    func,
+    cdecl: func,
+    stdcall: func,
+    pointer() {
+      return {};
+    },
+    alloc() {
+      return {};
+    },
+    decode() {
+      return null;
+    },
+    address() {
+      return 0n;
+    }
+  };
+}
+
+const api = {
+  load,
+  func,
+  pointer() {
+    return {};
+  },
+  alloc() {
+    return {};
+  },
+  decode() {
+    return null;
+  },
+  address() {
+    return 0n;
+  },
+  types: {},
+  proto: func,
+  register: func
+};
+
+export default api;
+export { load, func };

--- a/docs/dsh-acp-windows-sandbox.md
+++ b/docs/dsh-acp-windows-sandbox.md
@@ -1,0 +1,81 @@
+# DeepSeek ACP Windows 崩溃修复（方案 A：弃用原生沙箱）
+
+记录 `cursor/dsh-harness-fork-255d` 分支针对 Windows 下 DeepSeek ACP（`dsh-acp` adapter）持续失败的根因与修复。
+
+## 背景
+
+FreeBuddy 在 Windows 上接入 DeepSeek ACP 后，会话一直失败：进程退出码 `3221225477`（`0xC0000005` STATUS_ACCESS_VIOLATION）。在此之前的几次尝试（覆盖官方 JSONL、用 koffi 桩拦截、把 ACL 沙箱关掉、改用 node 拉起 bin）都未能根治。
+
+## 根因
+
+`dsh-sandbox-local` 在 Windows 上拉入 `dsh-sandbox-windows-acl`，后者在**模块导入时**就调用 `koffi` 原生 addon：
+
+```
+dsh-sandbox-windows-acl/lib/types-*.js:79  const PVOID = koffi.pointer("void");
+dsh-sandbox-windows-acl/lib/types-*.js:82  … koffi.struct(…)
+```
+
+文件注释虽称"koffi 懒加载"，但结构体定义是顶层立即执行的。于是形成两条死路：
+
+| 跑法 | 结果 |
+| --- | --- |
+| 真加载 koffi（无 guard） | 模型能正常返回，但进程退出 `0xC0000005`，FreeBuddy 据此把会话标记为 failed |
+| 用 koffi 桩拦截（`koffi-stub.mjs`） | 桩缺 `.struct`，sandbox-windows-acl 导入即抛 `koffi.struct is not a function`，插件树加载失败，退出码 1 |
+
+并且 freebuddy 原有的 koffi 桩在 **Node 24 上根本加载不上**：`dshAcpKoffiGuardImportFlag()` 用裸 `C:\…` 路径作 `--import` 值，Node 24 直接抛 `ERR_UNSUPPORTED_ESM_URL_SCHEME`（代码注释里"裸路径可行 / `file:///` 会坏"的假设在现代 Node 上是反的）。所以实际线上落入第一种崩溃。
+
+崩溃是 **Windows + koffi + Electron 子进程**特有的：macOS 走 seatbelt（`sandbox-exec`）、Linux 走 Landlock/bwrap，都不碰 koffi。
+
+## 修复
+
+### 1. Windows 专用 composition：`assets/dsh/cordis.win32.yml`
+
+在 Windows 上彻底不挂原生沙箱栈，改用无原生 addon 的本地 bash 执行器：
+
+- 移除 `dsh-sandbox-local`（koffi 的唯一来源）
+- `bash`：`dsh-bash-sandbox` → `@deepseek-ai/dsh-bash-local`（依赖已有的 `dsh-subprocess-local` 做进程树管理，提供 `shell` 服务，使 hooks 等正常激活）
+- 保留 `dsh-sandbox-policy` + `dsh-fs-sandbox`（纯 JS，继续对 `ctx.fs` 做 workspace 写围栏；仅丢弃原生的**进程**沙箱）
+
+### 2. 单点切换：`bundledDshAcpConfigPath()`
+
+`electron/cli/adapters.ts` 中 `bundledDshAcpConfigPath()` 在 `process.platform === 'win32'` 时返回 `cordis.win32.yml`，否则原 `cordis.yml`（带"平台变体缺失则回退"的兜底）。
+
+由于**安装列表、spawn config、UI installHint 全部从此函数派生**（`parseDshAcpCompositionPackages` 解析该文件），切换后：
+
+- `dshAcpInstallCommand()` 自动包含 `@deepseek-ai/dsh-bash-local@next`、剔除 `dsh-bash-sandbox` / `dsh-sandbox-local`
+- `resolveDshAcpConfigPath()` / `syncDshAcpManagedConfig()` 在 Windows 落到 win32 配置
+- 打包：`electron-builder.yml` 的 `extraResources` 整目录拷贝 `assets/dsh`，新文件自动带上
+
+### 3. koffi 桩按需注入：`withDshAcpSqliteWarningSuppressed()`
+
+koffi 桩只在 composition **真的引用 `dsh-sandbox-local`** 时才注入（新增 `dshAcpConfigUsesNativeSandbox()` 读取 `--config` 指向的文件判定）。win32 配置不含 `dsh-sandbox-local`，于是不再注入——既没必要（不加载 koffi），也避开了 Node 24 的裸路径 `--import` 崩溃。非 Windows 的 `cordis.yml` 仍含 `dsh-sandbox-local`，行为与改动前完全一致。
+
+## 平台影响
+
+| 平台 | composition | 原生沙箱后端 | 行为变化 |
+| --- | --- | --- | --- |
+| Windows | `cordis.win32.yml` | （移除，改 `dsh-bash-local`） | **修复崩溃** |
+| macOS | `cordis.yml` | seatbelt（`sandbox-exec`） | 无变化 |
+| Linux | `cordis.yml` | Landlock / bwrap | 无变化 |
+
+macOS/Linux 不 import koffi，koffi 桩的 resolve hook 永不命中（空操作）；且裸路径 `--import` 在 POSIX 上无 drive-colon 问题，照常加载。
+
+## 验证
+
+通过 FreeBuddy 真实 `buildCommand` 端到端实测（全局 `dsh-acp-demo@0.1.0-rc.6` + 真实 DeepSeek key）：
+
+- `bin: node`，`--config cordis.win32.yml`，**koffi-guard 未注入**
+- `initialize` / `session/new` 成功
+- `session/prompt` 执行 bash 工具（`echo BASH_LOCAL_OK`）成功，`end_turn`
+- **进程退出码 `0`**（无 `0xC0000005`、无 ESM scheme 错误）
+
+`tsc -p tsconfig.electron.json --noEmit` 通过。
+
+## 安装
+
+Windows 已全局补装 `@deepseek-ai/dsh-bash-local@next`。新用户点「安装」时，`prepareDshAcpManagedInstall()` 派生出的命令在 Windows 上自动包含 `dsh-bash-local`、不含原生沙箱包。
+
+## 取舍
+
+- 代价：Windows 下 bash 失去原生的**进程级**沙箱围栏（文件级围栏由 `dsh-fs-sandbox` 保留）。FreeBuddy 已用 `DSH_PERMISSION_MODE` + approval 层兜底，可接受。
+- 这是对 koffi 原生崩溃的根治；koffi 桩作为"自定义 cordis 仍带 sandbox-local 时的兜底"保留，但其在 Node 24+ 上的裸路径加载问题属既有缺陷，不在本次范围内（自定义 workspace `cordis.yml` 在 Windows 上若仍带 `dsh-sandbox-local`，仍会触发该既有问题）。

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,6 +20,8 @@ extraResources:
     to: skills
   - from: assets/dsh
     to: dsh
+  - from: third_party/deepseek-harness/overlays
+    to: dsh-harness-overlays
   - from: assets/app-icon.png
     to: app-icon.png
   - from: assets/sidebar-logo.png

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,6 +18,8 @@ files:
 extraResources:
   - from: assets/skills
     to: skills
+  - from: assets/dsh
+    to: dsh
   - from: assets/app-icon.png
     to: app-icon.png
   - from: assets/sidebar-logo.png

--- a/electron/butlerToolService.ts
+++ b/electron/butlerToolService.ts
@@ -534,7 +534,7 @@ async function dispatchButlerAction(
           agentName: conv.agentName,
           adapter: conv.adapter
         },
-        hint: "Read README.txt, environment.json, logs/, and sessions/ under logDirectory, then produce a structured self-check report."
+        hint: "Read README.txt, environment.json, dsh-acp-runtime.json, logs/, and sessions/ under logDirectory, then produce a structured self-check report."
       };
     }
     case "conversation_messages": {

--- a/electron/cli/acpAuth.ts
+++ b/electron/cli/acpAuth.ts
@@ -6,6 +6,8 @@ import spawn from "cross-spawn";
 import {
   buildCommand,
   dshAcpManagedRoot,
+  ensureDshAcpCwd,
+  syncDshAcpManagedConfig,
   type CLIAdapterId
 } from "./adapters.js";
 import { getDataDir } from "./db.js";
@@ -44,12 +46,17 @@ async function withAcpAgent<T>(
   args: CliAuthControlArgs,
   operation: (request: (message: AcpMessage) => Promise<any>) => Promise<T>
 ): Promise<T> {
+  const cwd =
+    args.adapter === "dsh-acp"
+      ? ensureDshAcpCwd(args.cwd, getDataDir())
+      : args.cwd;
+  if (args.adapter === "dsh-acp") syncDshAcpManagedConfig(getDataDir());
   const built = buildCommand({
     adapter: args.adapter,
     binary: args.binary,
     extraArgs: args.extraArgs,
     prompt: "",
-    cwd: args.cwd,
+    cwd,
     dshAcpRuntimeRoot:
       args.adapter === "dsh-acp" ? dshAcpManagedRoot(getDataDir()) : undefined
   });
@@ -68,7 +75,7 @@ async function withAcpAgent<T>(
     )
   );
   const child = spawn(built.bin, built.args, {
-    cwd: args.cwd,
+    cwd,
     env,
     stdio: ["pipe", "pipe", "pipe"]
   }) as ChildProcessByStdio<Writable, Readable, Readable>;

--- a/electron/cli/acpAuth.ts
+++ b/electron/cli/acpAuth.ts
@@ -7,6 +7,7 @@ import {
   buildCommand,
   dshAcpManagedRoot,
   ensureDshAcpCwd,
+  patchDshAcpRuntimeFromCommand,
   syncDshAcpManagedConfig,
   type CLIAdapterId
 } from "./adapters.js";
@@ -60,6 +61,7 @@ async function withAcpAgent<T>(
     dshAcpRuntimeRoot:
       args.adapter === "dsh-acp" ? dshAcpManagedRoot(getDataDir()) : undefined
   });
+  if (args.adapter === "dsh-acp") patchDshAcpRuntimeFromCommand(built);
   if (built.protocol !== "acp") {
     throw new Error("Authentication control requires an ACP agent.");
   }

--- a/electron/cli/acpAuth.ts
+++ b/electron/cli/acpAuth.ts
@@ -5,8 +5,10 @@ import spawn from "cross-spawn";
 
 import {
   buildCommand,
+  dshAcpManagedRoot,
   type CLIAdapterId
 } from "./adapters.js";
+import { getDataDir } from "./db.js";
 import {
   buildInitializeRequest,
   buildLogoutRequest,
@@ -47,7 +49,9 @@ async function withAcpAgent<T>(
     binary: args.binary,
     extraArgs: args.extraArgs,
     prompt: "",
-    cwd: args.cwd
+    cwd: args.cwd,
+    dshAcpRuntimeRoot:
+      args.adapter === "dsh-acp" ? dshAcpManagedRoot(getDataDir()) : undefined
   });
   if (built.protocol !== "acp") {
     throw new Error("Authentication control requires an ACP agent.");

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -865,7 +865,7 @@ export async function runAcpAgent({
       if (finished) return;
       appendLog(logStream, "system", `exit code=${exitCode}`);
       const status = exitCode === 0 ? "done" : "failed";
-      const stderrTail = recentStderr.slice(-10).join("\n").trim();
+      const stderrTail = recentStderr.slice(-40).join("\n").trim();
       const commandTail = lastToolCommand.slice(-500).trim();
       const agentTail = lastAgentText.slice(-800).trim();
       const crashMessage =

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -98,7 +98,10 @@ import {
 import { isPathWithinRoots } from "../shared/workspaceRoots.js";
 import { clearSessionOwner } from "./sessionOwners.js";
 import { getLanguage } from "./settings.js";
-import { adapterAcceptsClientMcpServers } from "./adapters.js";
+import {
+  adapterAcceptsClientMcpServers,
+  isDshAcpExperimentalWarningLine
+} from "./adapters.js";
 
 const PERMISSION_REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 // An ACP turn blocks on a single session/prompt request that only resolves
@@ -841,6 +844,12 @@ export async function runAcpAgent({
     rlErr.on("line", (line) => {
       if (epoch !== connectionEpoch) return;
       appendLog(logStream, "stderr", line);
+      if (
+        args.adapter === "dsh-acp" &&
+        isDshAcpExperimentalWarningLine(line)
+      ) {
+        return;
+      }
       recentStderr.push(line);
       if (recentStderr.length > 50) recentStderr.shift();
       if (args.showStderr !== false) emit({ type: "stderr", content: line });

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -98,6 +98,7 @@ import {
 import { isPathWithinRoots } from "../shared/workspaceRoots.js";
 import { clearSessionOwner } from "./sessionOwners.js";
 import { getLanguage } from "./settings.js";
+import { adapterAcceptsClientMcpServers } from "./adapters.js";
 
 const PERMISSION_REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 // An ACP turn blocks on a single session/prompt request that only resolves
@@ -1197,50 +1198,53 @@ export async function runAcpAgent({
     // and launch an Electron child process. Remote WebUI callers use the
     // authenticated HTTP Draft endpoints instead, so do not expose either
     // desktop-only capability to isolated remote users.
-    if (args.conversationId && !remoteIsolated) {
-      mcpServers.push(
-        await registerDraftToolSession({
-          taskSessionId: args.sessionId,
-          conversationId: args.conversationId,
-          // Keep an unscoped conversation unscoped. ACP itself requires a cwd
-          // and falls back to process.cwd(), but Draft must not treat the app's
-          // launch directory as a user-selected workspace.
-          cwd: args.cwd ?? "",
-          webContents
-        }),
-        await registerBrowserToolSession(args.sessionId)
-      );
-    }
-    if (args.skills?.length) {
-      mcpServers.push(registerSkillToolSession(args.sessionId, args.skills));
-    }
-    if (args.agentId === BUTLERBUDDY_AGENT_ID && !remoteIsolated) {
-      mcpServers.push(
-        await registerButlerToolSession({
-          taskSessionId: args.sessionId,
-          agentId: args.agentId,
-          userId: getCallerUserId(),
-          webContents
-        })
-      );
-    }
-    if (args.contextReferences?.length) {
-      mcpServers.push(
-        registerContextToolSession(args.sessionId, args.contextReferences)
-      );
-    }
-    const roots = (args.workspaceRoots ?? [])
-      .map((root) => (typeof root === "string" ? root.trim() : ""))
-      .filter(Boolean);
-    if (roots.length > 1) {
-      const primary = args.cwd || roots[0];
-      mcpServers.push(
-        await registerWorkspaceFsToolSession({
-          taskSessionId: args.sessionId,
-          roots,
-          primary
-        })
-      );
+    // DeepSeek Harness ACP rejects non-empty mcpServers on session/new.
+    if (adapterAcceptsClientMcpServers(args.adapter)) {
+      if (args.conversationId && !remoteIsolated) {
+        mcpServers.push(
+          await registerDraftToolSession({
+            taskSessionId: args.sessionId,
+            conversationId: args.conversationId,
+            // Keep an unscoped conversation unscoped. ACP itself requires a cwd
+            // and falls back to process.cwd(), but Draft must not treat the app's
+            // launch directory as a user-selected workspace.
+            cwd: args.cwd ?? "",
+            webContents
+          }),
+          await registerBrowserToolSession(args.sessionId)
+        );
+      }
+      if (args.skills?.length) {
+        mcpServers.push(registerSkillToolSession(args.sessionId, args.skills));
+      }
+      if (args.agentId === BUTLERBUDDY_AGENT_ID && !remoteIsolated) {
+        mcpServers.push(
+          await registerButlerToolSession({
+            taskSessionId: args.sessionId,
+            agentId: args.agentId,
+            userId: getCallerUserId(),
+            webContents
+          })
+        );
+      }
+      if (args.contextReferences?.length) {
+        mcpServers.push(
+          registerContextToolSession(args.sessionId, args.contextReferences)
+        );
+      }
+      const roots = (args.workspaceRoots ?? [])
+        .map((root) => (typeof root === "string" ? root.trim() : ""))
+        .filter(Boolean);
+      if (roots.length > 1) {
+        const primary = args.cwd || roots[0];
+        mcpServers.push(
+          await registerWorkspaceFsToolSession({
+            taskSessionId: args.sessionId,
+            roots,
+            primary
+          })
+        );
+      }
     }
     if (mcpServers.length) {
       appendLog(

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -100,6 +100,7 @@ import { clearSessionOwner } from "./sessionOwners.js";
 import { getLanguage } from "./settings.js";
 import {
   adapterAcceptsClientMcpServers,
+  formatAcpAgentExitMessage,
   isDshAcpExperimentalWarningLine
 } from "./adapters.js";
 
@@ -858,7 +859,7 @@ export async function runAcpAgent({
       if (epoch !== connectionEpoch) return;
       const exitCode = code ?? -1;
       for (const waiter of pending.values()) {
-        waiter.reject(new Error(`ACP agent exited with code ${exitCode}`));
+        waiter.reject(new Error(formatAcpAgentExitMessage(exitCode, getLanguage())));
       }
       pending.clear();
       if (finished) return;
@@ -872,7 +873,7 @@ export async function runAcpAgent({
           ? stderrTail ||
             (commandTail ? `Last command before exit: ${commandTail}` : "") ||
             (agentTail ? `Agent output before exit: ${agentTail}` : "") ||
-            `ACP agent exited with code ${exitCode}`
+            formatAcpAgentExitMessage(exitCode, getLanguage())
           : undefined;
       finish(status, exitCode, crashMessage);
     });

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -859,7 +859,11 @@ export async function runAcpAgent({
       if (epoch !== connectionEpoch) return;
       const exitCode = code ?? -1;
       for (const waiter of pending.values()) {
-        waiter.reject(new Error(formatAcpAgentExitMessage(exitCode, getLanguage())));
+        waiter.reject(
+          new Error(
+            formatAcpAgentExitMessage(exitCode, getLanguage(), args.adapter)
+          )
+        );
       }
       pending.clear();
       if (finished) return;
@@ -873,7 +877,7 @@ export async function runAcpAgent({
           ? stderrTail ||
             (commandTail ? `Last command before exit: ${commandTail}` : "") ||
             (agentTail ? `Agent output before exit: ${agentTail}` : "") ||
-            formatAcpAgentExitMessage(exitCode, getLanguage())
+            formatAcpAgentExitMessage(exitCode, getLanguage(), args.adapter)
           : undefined;
       finish(status, exitCode, crashMessage);
     });

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -242,7 +242,9 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     },
     toolSessionArgs: [],
     toolSessionArgPrefixes: [],
-    installHint: "npm install -g @deepseek-ai/dsh-acp-demo",
+    // `latest` is still 0.0.1-rc.1; that release's peer packages 404 on the
+    // public registry. The working public line is currently tagged `next`.
+    installHint: "npm install -g @deepseek-ai/dsh-acp-demo@next",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -251,7 +251,7 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
   },
   {
     id: "dsh-acp",
-    label: "DeepSeek",
+    label: "DeepSeek Harness",
     defaultBinary: "dsh-acp-demo",
     // The bin only accepts `--config`; `--version` exits non-zero via parseArgs.
     checkProbe: { args: [], versionOptional: true, skipSpawn: true },
@@ -544,9 +544,17 @@ function withDshAcpSqliteWarningSuppressed(command: BuiltCommand): BuiltCommand 
   const configUsesNativeSandbox = dshAcpConfigUsesNativeSandbox(
     dshAcpConfigPathFromArgs(command.args) ?? bundledDshAcpConfigPath()
   );
+  // The koffi guard stubs the native addon so the Win32 calls return 0
+  // (a catchable JS error) instead of aborting Electron children with
+  // STATUS_ACCESS_VIOLATION (0xC0000005). On macOS/Linux the real koffi
+  // loads cleanly and `dsh-sandbox-windows-acl` asserts its struct layouts
+  // (STARTUPINFOW=104, PROCESS_INFORMATION=24) against real koffi at import,
+  // so the stub must stay Windows-only.
+  const needsKoffiGuard =
+    process.platform === "win32" && configUsesNativeSandbox;
   const flags = [
     DSH_ACP_NODE_DISABLE_WARNING,
-    configUsesNativeSandbox ? dshAcpKoffiGuardImportFlag() : undefined
+    needsKoffiGuard ? dshAcpKoffiGuardImportFlag() : undefined
   ].filter((flag): flag is string => Boolean(flag));
   let env = command.env;
   for (const flag of flags) {

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -3,8 +3,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  realpathSync as fsRealpath,
-  writeFileSync
+  realpathSync as fsRealpath
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -424,8 +423,8 @@ export function formatAcpAgentExitMessage(
 ): string {
   if (isWindowsAccessViolationExit(code)) {
     return language === "zh-CN"
-      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL 首次落盘会用 koffi 调用 MoveFileExW；本版本启动时会改走 Node 文件系统。若仍看到此错误，请确认已重新编译本版本（无需重装 DeepSeek）。"
-      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL publishes the first log with koffi MoveFileExW; this build rewrites that path onto Node fs at spawn. If this still happens, rebuild this version — you do not need to reinstall DeepSeek.";
+      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL 首次落盘会用 koffi 调用 MoveFileExW；本版本会用 harness 薄补丁整文件覆盖该包并改走 Node 文件系统。若仍看到此错误，请确认已重新编译本版本（无需重装 DeepSeek）。"
+      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL publishes the first log with koffi MoveFileExW; this build overlays the harness fork (Node fs) onto the installed package. If this still happens, rebuild this version — you do not need to reinstall DeepSeek.";
   }
   return `ACP agent exited with code ${code}`;
 }
@@ -532,73 +531,54 @@ export function dshAcpManagedRoot(dataDir: string): string {
   return path.join(dataDir, "runtimes", "dsh-acp");
 }
 
-const DSH_ACP_JSONL_WIN32_DISPATCH =
-  'if (process.platform === "win32") await this.materializeWin32';
-const DSH_ACP_JSONL_WIN32_DISPATCH_PATCHED =
-  "if (false) await this.materializeWin32";
-const DSH_ACP_JSONL_SYNC_DIR =
-  'async syncDirPosix(dir) {\n\t\tconst handle = await open(dir, "r");';
-const DSH_ACP_JSONL_SYNC_DIR_PATCHED =
-  'async syncDirPosix(dir) {\n\t\tif (process.platform === "win32") return;\n\t\tconst handle = await open(dir, "r");';
-const DSH_ACP_DEMO_SQLITE =
-  'ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, "session-query.db") })';
-const DSH_ACP_DEMO_SQLITE_PATCHED =
-  'ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, "session-query.db"), openAt: "never" })';
-
-function replaceOnceIfNeeded(
-  text: string,
-  find: string,
-  replace: string
-): string {
-  if (text.includes(replace) || !text.includes(find)) return text;
-  return text.replace(find, replace);
-}
-
-function patchManagedFile(
-  file: string,
-  replacements: Array<[string, string]>
-): void {
-  if (!existsSync(file)) return;
-  const original = readFileSync(file, "utf8");
-  let next = original;
-  for (const [find, replace] of replacements) {
-    next = replaceOnceIfNeeded(next, find, replace);
-  }
-  if (next !== original) writeFileSync(file, next);
-}
-
-/**
- * Official JSONL durable-publish loads koffi and calls MoveFileExW the first
- * time a session is written. That aborts Windows Electron children with
- * STATUS_ACCESS_VIOLATION (0xC0000005) on session/prompt. Rewrite the installed
- * packages onto Node fs and keep SQLite closed.
- */
-export function patchDshAcpManagedRuntime(root: string): void {
-  patchManagedFile(
-    path.join(
-      root,
+const DSH_HARNESS_OVERLAY_FILES = [
+  [
+    path.join("dsh-session-persistence-jsonl", "lib", "index.js"),
+    [
       "node_modules",
       "@deepseek-ai",
       "dsh-session-persistence-jsonl",
       "lib",
       "index.js"
-    ),
-    [
-      [DSH_ACP_JSONL_WIN32_DISPATCH, DSH_ACP_JSONL_WIN32_DISPATCH_PATCHED],
-      [DSH_ACP_JSONL_SYNC_DIR, DSH_ACP_JSONL_SYNC_DIR_PATCHED]
     ]
+  ],
+  [
+    path.join("dsh-acp-demo", "lib", "index.js"),
+    ["node_modules", "@deepseek-ai", "dsh-acp-demo", "lib", "index.js"]
+  ]
+] as const;
+
+/** Packaged extraResources, else the repo `third_party/deepseek-harness/overlays`. */
+export function dshHarnessOverlayDir(): string {
+  const fromSource = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "third_party",
+    "deepseek-harness",
+    "overlays"
   );
-  patchManagedFile(
-    path.join(
-      root,
-      "node_modules",
-      "@deepseek-ai",
-      "dsh-acp-demo",
-      "lib",
-      "index.js"
-    ),
-    [[DSH_ACP_DEMO_SQLITE, DSH_ACP_DEMO_SQLITE_PATCHED]]
-  );
+  const packaged =
+    typeof process.resourcesPath === "string"
+      ? path.join(process.resourcesPath, "dsh-harness-overlays")
+      : "";
+  if (packaged && existsSync(packaged)) return packaged;
+  return fromSource;
+}
+
+/**
+ * Copy the thin harness-fork overlays onto an installed official runtime.
+ * Official JSONL durable-publish aborts Windows Electron children with
+ * STATUS_ACCESS_VIOLATION (0xC0000005) on session/prompt.
+ */
+export function patchDshAcpManagedRuntime(root: string): void {
+  const overlayRoot = dshHarnessOverlayDir();
+  for (const [rel, destParts] of DSH_HARNESS_OVERLAY_FILES) {
+    const from = path.join(overlayRoot, rel);
+    const to = path.join(root, ...destParts);
+    if (!existsSync(from) || !existsSync(to)) continue;
+    copyFileSync(from, to);
+  }
 }
 
 /** Refresh the managed composition from the bundled default before spawn/install. */

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -7,7 +7,7 @@ import {
   realpathSync as fsRealpath
 } from "node:fs";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 const DSH_ACP_NPM_TAG = "next";
 
@@ -334,8 +334,12 @@ export function isDshAcpExperimentalWarningLine(line: string): boolean {
   return /Use `node --trace-warnings/i.test(text);
 }
 
+function dshAcpBinaryBaseName(binary: string): string {
+  return binary.split(/[/\\]/).pop()?.toLowerCase() ?? "";
+}
+
 function isNodeBinary(bin: string): boolean {
-  const base = path.basename(bin).toLowerCase();
+  const base = dshAcpBinaryBaseName(bin);
   return base === "node" || base === "node.exe";
 }
 
@@ -348,15 +352,76 @@ const DSH_ACP_DEFAULT_BINARIES = new Set([
 ]);
 
 /**
- * Settings persist `defaultBinary` even when the user did not pick a custom
- * path. That name must still launch the managed runtime, not a PATH global
- * install (global npm `dsh-acp-demo`).
+ * Settings persist `defaultBinary`, and Windows Check/PATH resolution often
+ * stores `%AppData%\\npm\\dsh-acp-demo.cmd`. Those are still the stock demo.
  */
 export function isDefaultDshAcpBinary(binary?: string): boolean {
   const trimmed = binary?.trim();
   if (!trimmed) return true;
-  if (/[\\/]/.test(trimmed)) return false;
-  return DSH_ACP_DEFAULT_BINARIES.has(path.basename(trimmed).toLowerCase());
+  const base = dshAcpBinaryBaseName(trimmed);
+  if (!DSH_ACP_DEFAULT_BINARIES.has(base)) return false;
+  if (!/[\\/]/.test(trimmed)) return true;
+  const normalized = trimmed.replace(/\\/g, "/").toLowerCase();
+  return (
+    /\/npm\/dsh-acp-demo(?:\.cmd|\.exe|\.bat|\.ps1)?$/i.test(normalized) ||
+    /\/node_modules\/@deepseek-ai\/dsh-acp-demo\/lib\/bin\.js$/i.test(normalized)
+  );
+}
+
+function dshAcpDemoBinJsFromDir(demoDir: string): string | undefined {
+  const binJs = path.join(demoDir, "lib", "bin.js");
+  return existsSync(binJs) ? binJs : undefined;
+}
+
+function dshAcpDemoBinJsFromBinaryHint(binary?: string): string | undefined {
+  const trimmed = binary?.trim();
+  if (!trimmed || !/[\\/]/.test(trimmed)) return undefined;
+  if (/dsh-acp-demo[/\\]lib[/\\]bin\.js$/i.test(trimmed) && existsSync(trimmed)) {
+    return trimmed;
+  }
+  const demoDir = resolveDshAcpDemoDirFromBinary(trimmed);
+  return demoDir ? dshAcpDemoBinJsFromDir(demoDir) : undefined;
+}
+
+function wellKnownGlobalDshAcpDemoBinJs(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const residue =
+    dshAcpWindowsResiduePath(env) ??
+    (env.APPDATA?.trim()
+      ? path.join(env.APPDATA.trim(), "npm", "node_modules", "@deepseek-ai")
+      : undefined);
+  if (!residue) return undefined;
+  return dshAcpDemoBinJsFromDir(path.join(residue, "dsh-acp-demo"));
+}
+
+/** Resolve the `dsh-acp-demo` entry we should spawn with `node`, if any. */
+export function resolveDshAcpDemoBinJs(input: {
+  binary?: string;
+  dshAcpRuntimeRoot?: string;
+}): string | undefined {
+  const managedBin = input.dshAcpRuntimeRoot
+    ? path.join(
+        input.dshAcpRuntimeRoot,
+        "node_modules",
+        "@deepseek-ai",
+        "dsh-acp-demo",
+        "lib",
+        "bin.js"
+      )
+    : "";
+  const managedReady =
+    Boolean(managedBin) &&
+    existsSync(managedBin) &&
+    dshAcpCompositionReady(managedBin);
+  if (isDefaultDshAcpBinary(input.binary) && managedReady) return managedBin;
+  const fromHint = dshAcpDemoBinJsFromBinaryHint(input.binary);
+  if (fromHint) return fromHint;
+  if (isDefaultDshAcpBinary(input.binary)) {
+    const globalBin = wellKnownGlobalDshAcpDemoBinJs();
+    if (globalBin) return globalBin;
+  }
+  return undefined;
 }
 
 const ELECTRON_CHILD_ENV_BLOCKLIST = [
@@ -681,7 +746,10 @@ export function dshAcpKoffiGuardPath(): string {
 export function dshAcpKoffiGuardImportFlag(): string | undefined {
   const file = dshAcpKoffiGuardPath();
   if (!existsSync(file)) return undefined;
-  return `--import=${pathToFileURL(file).href}`;
+  // Use a filesystem path. `file:///C:/...` is misparsed inside Windows
+  // NODE_OPTIONS because of the drive colon, and PATH `.cmd` shims only
+  // receive the guard through NODE_OPTIONS.
+  return `--import=${file}`;
 }
 
 export interface DshAcpRuntimeDiagnostics {
@@ -694,7 +762,32 @@ export interface DshAcpRuntimeDiagnostics {
   persistenceCompressionNone: boolean;
   sandboxDisabledOnWin32: boolean;
   koffiGuardPresent: boolean;
+  spawnBin?: string;
+  spawnKind?: string;
+  koffiGuardOnArgv?: boolean;
   jsonlRelatives: Array<{ path: string; usesKoffi: boolean }>;
+}
+
+function classifyDshAcpSpawnKind(
+  spawnBin: string | undefined,
+  spawnArgs: string[] | undefined,
+  runtimeRoot: string
+): string | undefined {
+  if (!spawnBin) return undefined;
+  if (!isNodeBinary(spawnBin)) return dshAcpBinaryBaseName(spawnBin);
+  const entry = spawnArgs?.find((arg) =>
+    /dsh-acp-demo[/\\]lib[/\\]bin\.js$/i.test(arg)
+  );
+  if (!entry) return "node";
+  const posix = entry.split(path.sep).join("/");
+  const managed = runtimeRoot.split(path.sep).join("/");
+  if (managed && posix.toLowerCase().includes(managed.toLowerCase())) {
+    return "managed-node";
+  }
+  if (/\/npm\/node_modules\/@deepseek-ai\/dsh-acp-demo\/lib\/bin\.js$/i.test(posix)) {
+    return "npm-global-node";
+  }
+  return "node-entry";
 }
 
 /** Snapshot of the managed DeepSeek runtime for debug-log export. */
@@ -702,6 +795,8 @@ export function buildDshAcpRuntimeDiagnostics(input: {
   runtimeRoot: string;
   overlayDir?: string;
   configPath?: string;
+  spawnBin?: string;
+  spawnArgs?: string[];
 }): DshAcpRuntimeDiagnostics {
   const root = input.runtimeRoot;
   const overlayDir = input.overlayDir ?? dshHarnessOverlayDir();
@@ -727,6 +822,15 @@ export function buildDshAcpRuntimeDiagnostics(input: {
     sandboxDisabledOnWin32:
       /dsh-sandbox-local[\s\S]{0,400}disabled:/.test(cordis),
     koffiGuardPresent: existsSync(dshAcpKoffiGuardPath()),
+    spawnBin: input.spawnBin ? dshAcpBinaryBaseName(input.spawnBin) : undefined,
+    spawnKind: classifyDshAcpSpawnKind(
+      input.spawnBin,
+      input.spawnArgs,
+      root
+    ),
+    koffiGuardOnArgv: Boolean(
+      input.spawnArgs?.some((arg) => arg.includes("koffi-guard"))
+    ),
     jsonlRelatives
   };
 }
@@ -834,9 +938,12 @@ export function resolveDshAcpDemoDirFromBinary(
         /node_modules[/\\]@deepseek-ai[/\\]dsh-acp-demo[/\\]lib[/\\]bin\.js/i
       );
       if (match) {
+        const relative = match[0]
+          .replace(/[/\\]lib[/\\]bin\.js$/i, "")
+          .replace(/\\/g, "/");
         const pkg = path.resolve(
           path.dirname(current),
-          match[0].replace(/[/\\]lib[/\\]bin\.js$/i, "")
+          ...relative.split("/").filter(Boolean)
         );
         if (existsSync(path.join(pkg, "package.json"))) return pkg;
       }
@@ -1206,21 +1313,10 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
       };
     }
     case "dsh-acp": {
-      const managedBin = input.dshAcpRuntimeRoot
-        ? path.join(
-            input.dshAcpRuntimeRoot,
-            "node_modules",
-            "@deepseek-ai",
-            "dsh-acp-demo",
-            "lib",
-            "bin.js"
-          )
-        : "";
-      const useManaged =
-        isDefaultDshAcpBinary(input.binary) &&
-        Boolean(managedBin) &&
-        existsSync(managedBin) &&
-        dshAcpCompositionReady(managedBin);
+      const nodeEntry = resolveDshAcpDemoBinJs({
+        binary: input.binary,
+        dshAcpRuntimeRoot: input.dshAcpRuntimeRoot
+      });
       const args = extraArgsHaveDshConfig(extra)
         ? [...extra]
         : [
@@ -1228,10 +1324,10 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
             resolveDshAcpConfigPath(input.cwd, input.dshAcpRuntimeRoot),
             ...extra
           ];
-      if (useManaged) {
+      if (nodeEntry) {
         return withDshAcpSqliteWarningSuppressed({
           bin: "node",
-          args: [managedBin, ...args],
+          args: [nodeEntry, ...args],
           promptViaStdin: false,
           protocol: "acp"
         });

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -13,6 +13,7 @@ export type CLIAdapterId =
   | "codebuddy-acp"
   | "grok-acp"
   | "agy-acp"
+  | "dsh-acp"
   | (string & {});
 
 export type CLIStreamMode =
@@ -227,6 +228,23 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     installHint: "npm install -g agy-acp-bridge",
     docsUrl: "https://github.com/maojindao55/agy-acp",
     protocol: "acp"
+  },
+  {
+    id: "dsh-acp",
+    label: "DeepSeek",
+    defaultBinary: "dsh-acp-demo",
+    checkProbe: { args: ["--version"], versionOptional: true },
+    streamMode: "raw",
+    commandGroup: "deepseek",
+    capabilities: {
+      toolSession: true,
+      skills: { mode: "native", nativeDirs: [".dsh/skills"], reloadPolicy: "process-start" }
+    },
+    toolSessionArgs: [],
+    toolSessionArgPrefixes: [],
+    installHint: "npm install -g @deepseek-ai/dsh-acp-demo",
+    docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
+    protocol: "acp"
   }
 ];
 
@@ -256,6 +274,14 @@ export function getCliCheckProbe(adapter: string): CliCheckProbe {
       versionOptional: false
     }
   );
+}
+
+/**
+ * DeepSeek Harness ACP is automation-only and rejects non-empty `mcpServers`
+ * on `session/new`. Other adapters accept FreeBuddy's Draft/Browser/skill MCP.
+ */
+export function adapterAcceptsClientMcpServers(adapter: string): boolean {
+  return adapter !== "dsh-acp";
 }
 
 export function hasExplicitToolSessionArg(
@@ -563,6 +589,15 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
       };
     }
     case "agy-acp": {
+      const args: string[] = [...extra];
+      return {
+        bin,
+        args,
+        promptViaStdin: false,
+        protocol: "acp"
+      };
+    }
+    case "dsh-acp": {
       const args: string[] = [...extra];
       return {
         bin,

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -49,6 +49,11 @@ export interface CLIAdapterDefinition {
 export interface CliCheckProbe {
   args: string[];
   versionOptional: boolean;
+  /**
+   * Skip spawning the binary. Used for ACP stdio servers that have no
+   * `--version` and would otherwise hang on stdin.
+   */
+  skipSpawn?: boolean;
 }
 
 const legacyAdapterDefinitions: CLIAdapterDefinition[] = [
@@ -233,7 +238,8 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     id: "dsh-acp",
     label: "DeepSeek",
     defaultBinary: "dsh-acp-demo",
-    checkProbe: { args: ["--version"], versionOptional: true },
+    // The bin only accepts `--config`; `--version` exits non-zero via parseArgs.
+    checkProbe: { args: [], versionOptional: true, skipSpawn: true },
     streamMode: "raw",
     commandGroup: "deepseek",
     capabilities: {

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -244,7 +244,11 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     toolSessionArgPrefixes: [],
     // `latest` is still 0.0.1-rc.1; that release's peer packages 404 on the
     // public registry. The working public line is currently tagged `next`.
-    installHint: "npm install -g @deepseek-ai/dsh-acp-demo@next",
+    // koffi's install script rebuilds from source when the optional platform
+    // binary is missing; that CMake path exceeds Windows MAX_PATH under the
+    // nested global install, so keep the prebuild and skip lifecycle scripts.
+    installHint:
+      "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -7,7 +7,7 @@ import {
   realpathSync as fsRealpath
 } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const DSH_ACP_NPM_TAG = "next";
 
@@ -424,29 +424,31 @@ export function formatAcpAgentExitMessage(
 ): string {
   if (isWindowsAccessViolationExit(code)) {
     return language === "zh-CN"
-      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL 会用 koffi 调 MoveFileExW；本版本会覆盖所有嵌套副本并在 Windows 上关掉 ACL sandbox。请再编一次本版本（无需重装 DeepSeek）。"
-      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL publishes the first log with koffi MoveFileExW; this build overlays the harness fork (Node fs) onto the installed package. If this still happens, rebuild this version — you do not need to reinstall DeepSeek.";
+      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL / Windows ACL 会用 koffi 调 Win32（含 MoveFileExW）；本版本会覆盖 JSONL、关掉 ACL sandbox，并用 Node --import 拦截 koffi。请重新编译本版本后再试（无需重装 DeepSeek）。若仍崩溃，请用「导出调试日志」把 zip 发回来。"
+      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL / Windows ACL call Win32 through koffi (including MoveFileExW). This build overlays JSONL, disables the ACL sandbox, and intercepts koffi with Node --import. Rebuild this version — you do not need to reinstall DeepSeek. If it still crashes, export debug logs and send the zip.";
   }
   return `ACP agent exited with code ${code}`;
 }
 
 function withDshAcpSqliteWarningSuppressed(command: BuiltCommand): BuiltCommand {
-  const env = {
-    ...command.env,
-    NODE_OPTIONS: mergeNodeOptions(
-      command.env?.NODE_OPTIONS,
-      DSH_ACP_NODE_DISABLE_WARNING
-    )
-  };
-  if (
-    !isNodeBinary(command.bin) ||
-    command.args.includes(DSH_ACP_NODE_DISABLE_WARNING)
-  ) {
+  const flags = [
+    DSH_ACP_NODE_DISABLE_WARNING,
+    dshAcpKoffiGuardImportFlag()
+  ].filter((flag): flag is string => Boolean(flag));
+  let env = command.env;
+  for (const flag of flags) {
+    env = {
+      ...env,
+      NODE_OPTIONS: mergeNodeOptions(env?.NODE_OPTIONS, flag)
+    };
+  }
+  if (!isNodeBinary(command.bin)) {
     return { ...command, env };
   }
+  const prepend = flags.filter((flag) => !command.args.includes(flag));
   return {
     ...command,
-    args: [DSH_ACP_NODE_DISABLE_WARNING, ...command.args],
+    args: [...prepend, ...command.args],
     env
   };
 }
@@ -562,17 +564,14 @@ export function dshHarnessOverlayDir(): string {
  * nest it under another `@deepseek-ai/*` plugin; covering only the prefix
  * root left the running import unpatched.
  */
-export function findDshPackageLibIndex(
-  root: string,
-  packageName: string
-): string[] {
+export function findDshPackageDirs(root: string, packageName: string): string[] {
   const found = new Set<string>();
   const visit = (dir: string, depth: number) => {
     if (depth > 8) return;
     const nm = path.join(dir, "node_modules");
     if (!existsSync(nm)) return;
-    const index = path.join(nm, packageName, "lib", "index.js");
-    if (existsSync(index)) found.add(index);
+    const pkg = path.join(nm, packageName);
+    if (existsSync(pkg)) found.add(pkg);
     let entries: string[] = [];
     try {
       entries = readdirSync(nm);
@@ -589,7 +588,7 @@ export function findDshPackageLibIndex(
         } catch {
           continue;
         }
-        for (const pkg of scoped) visit(path.join(child, pkg), depth + 1);
+        for (const nested of scoped) visit(path.join(child, nested), depth + 1);
       } else {
         visit(child, depth + 1);
       }
@@ -599,12 +598,117 @@ export function findDshPackageLibIndex(
   return [...found];
 }
 
-export function dshAcpJsonlStillUsesKoffi(root: string): string[] {
-  return findDshPackageLibIndex(root, DSH_JSONL_PACKAGE).filter((file) =>
-    /(?:import\(|from\s+|load\()["']koffi["']|koffi\.load/.test(
-      readFileSync(file, "utf8")
-    )
+export function findDshPackageLibIndex(
+  root: string,
+  packageName: string
+): string[] {
+  return findDshPackageDirs(root, packageName)
+    .map((dir) => path.join(dir, "lib", "index.js"))
+    .filter((file) => existsSync(file));
+}
+
+const DSH_KOFFI_IMPORT_RE =
+  /(?:import\(|from\s+|load\()["']koffi["']|koffi\.load/;
+
+function fileUsesKoffi(file: string): boolean {
+  try {
+    return DSH_KOFFI_IMPORT_RE.test(readFileSync(file, "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+function packageJsUsesKoffi(pkgDir: string): boolean {
+  const lib = path.join(pkgDir, "lib");
+  let names: string[] = [];
+  try {
+    names = existsSync(lib) ? readdirSync(lib) : [];
+  } catch {
+    return false;
+  }
+  return names.some(
+    (name) => name.endsWith(".js") && fileUsesKoffi(path.join(lib, name))
   );
+}
+
+function toPosixRelative(root: string, file: string): string {
+  return path.relative(root, file).split(path.sep).join("/");
+}
+
+export function dshAcpJsonlStillUsesKoffi(root: string): string[] {
+  return findDshPackageLibIndex(root, DSH_JSONL_PACKAGE).filter(fileUsesKoffi);
+}
+
+const DSH_WINDOWS_ACL_PACKAGE = "@deepseek-ai/dsh-sandbox-windows-acl";
+
+export function dshAcpKoffiGuardPath(): string {
+  const fromSource = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "assets",
+    "dsh",
+    "koffi-guard.mjs"
+  );
+  const packaged =
+    typeof process.resourcesPath === "string"
+      ? path.join(process.resourcesPath, "dsh", "koffi-guard.mjs")
+      : "";
+  if (packaged && existsSync(packaged)) return packaged;
+  return fromSource;
+}
+
+export function dshAcpKoffiGuardImportFlag(): string | undefined {
+  const file = dshAcpKoffiGuardPath();
+  if (!existsSync(file)) return undefined;
+  return `--import=${pathToFileURL(file).href}`;
+}
+
+export interface DshAcpRuntimeDiagnostics {
+  runtimePresent: boolean;
+  overlayDirPresent: boolean;
+  jsonlCopyCount: number;
+  jsonlKoffiCopyCount: number;
+  windowsAclPresent: boolean;
+  windowsAclUsesKoffi: boolean;
+  persistenceCompressionNone: boolean;
+  sandboxDisabledOnWin32: boolean;
+  koffiGuardPresent: boolean;
+  jsonlRelatives: Array<{ path: string; usesKoffi: boolean }>;
+}
+
+/** Snapshot of the managed DeepSeek runtime for debug-log export. */
+export function buildDshAcpRuntimeDiagnostics(input: {
+  runtimeRoot: string;
+  overlayDir?: string;
+  configPath?: string;
+}): DshAcpRuntimeDiagnostics {
+  const root = input.runtimeRoot;
+  const overlayDir = input.overlayDir ?? dshHarnessOverlayDir();
+  const jsonlFiles = findDshPackageLibIndex(root, DSH_JSONL_PACKAGE);
+  const jsonlRelatives = jsonlFiles.map((file) => ({
+    path: toPosixRelative(root, file),
+    usesKoffi: fileUsesKoffi(file)
+  }));
+  const aclDirs = findDshPackageDirs(root, DSH_WINDOWS_ACL_PACKAGE);
+  const configPath =
+    input.configPath && existsSync(input.configPath)
+      ? input.configPath
+      : path.join(root, "cordis.yml");
+  const cordis = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
+  return {
+    runtimePresent: existsSync(root),
+    overlayDirPresent: existsSync(overlayDir),
+    jsonlCopyCount: jsonlFiles.length,
+    jsonlKoffiCopyCount: jsonlRelatives.filter((file) => file.usesKoffi).length,
+    windowsAclPresent: aclDirs.length > 0,
+    windowsAclUsesKoffi: aclDirs.some((dir) => packageJsUsesKoffi(dir)),
+    persistenceCompressionNone: /persistenceCompression:\s*none/.test(cordis),
+    sandboxDisabledOnWin32:
+      /dsh-sandbox-local[\s\S]{0,400}disabled:/.test(cordis),
+    koffiGuardPresent: existsSync(dshAcpKoffiGuardPath()),
+    jsonlRelatives
+  };
 }
 
 export function patchDshAcpManagedRuntime(root: string): number {

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -1,4 +1,10 @@
-import { existsSync, readFileSync, realpathSync as fsRealpath } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync as fsRealpath
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -332,6 +338,97 @@ function isNodeBinary(bin: string): boolean {
   return base === "node" || base === "node.exe";
 }
 
+const ELECTRON_CHILD_ENV_BLOCKLIST = [
+  "ELECTRON_RUN_AS_NODE",
+  "ELECTRON_NO_ASAR",
+  "ELECTRON_NO_ATTACH_CONSOLE",
+  "CHROME_CRASHPAD_PIPE_NAME",
+  "ELECTRON_CRASHPAD_PIPE_NAME"
+] as const;
+
+/** NTSTATUS STATUS_ACCESS_VIOLATION; Node reports it as signed or unsigned. */
+export const WINDOWS_STATUS_ACCESS_VIOLATION = 0xc0000005;
+
+export function isWindowsAccessViolationExit(code: number): boolean {
+  return (code >>> 0) === WINDOWS_STATUS_ACCESS_VIOLATION;
+}
+
+/**
+ * Chromium/Electron env inherited by `spawn("node")` can make native addons
+ * (koffi, node:sqlite) abort with 0xC0000005 on Windows.
+ */
+export function sanitizeCliAgentEnv(
+  env: Record<string, string | undefined>
+): Record<string, string | undefined> {
+  const next = { ...env };
+  for (const key of ELECTRON_CHILD_ENV_BLOCKLIST) {
+    delete next[key];
+  }
+  if (typeof next.NODE_OPTIONS === "string") {
+    const kept = sanitizeNodeOptions(next.NODE_OPTIONS);
+    if (kept) next.NODE_OPTIONS = kept;
+    else delete next.NODE_OPTIONS;
+  }
+  return next;
+}
+
+const NODE_OPTIONS_PATH_FLAGS = new Set([
+  "--require",
+  "-r",
+  "--import",
+  "--loader",
+  "--experimental-loader"
+]);
+
+function sanitizeNodeOptions(value: string): string | undefined {
+  const tokens = value.split(/\s+/).filter(Boolean);
+  const kept: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (/electron|asar/i.test(token)) continue;
+    const eq = token.indexOf("=");
+    const flag = eq === -1 ? token : token.slice(0, eq);
+    const inline = eq === -1 ? "" : token.slice(eq + 1);
+    if (NODE_OPTIONS_PATH_FLAGS.has(flag)) {
+      const arg = inline || tokens[i + 1];
+      if (arg && /electron|asar/i.test(arg)) {
+        if (!inline) i += 1;
+        continue;
+      }
+    }
+    kept.push(token);
+  }
+  return kept.length ? kept.join(" ") : undefined;
+}
+
+export function dshAcpFallbackWorkspace(dataDir: string): string {
+  return path.join(dshAcpManagedRoot(dataDir), "workspace");
+}
+
+/** DeepSeek's sandbox/persistence use `process.cwd()`; never spawn with no cwd. */
+export function ensureDshAcpCwd(
+  cwd: string | undefined,
+  dataDir: string
+): string {
+  const trimmed = cwd?.trim();
+  if (trimmed) return trimmed;
+  const fallback = dshAcpFallbackWorkspace(dataDir);
+  mkdirSync(fallback, { recursive: true });
+  return fallback;
+}
+
+export function formatAcpAgentExitMessage(
+  code: number,
+  language?: string
+): string {
+  if (isWindowsAccessViolationExit(code)) {
+    return language === "zh-CN"
+      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。这通常是 koffi 或 Node zstd/SQLite 原生模块中止，而不是 ACP 协议错误。请用本版本重新编译后再试。"
+      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. This is usually a koffi or Node zstd/SQLite native abort, not an ACP protocol error. Rebuild this version and retry.";
+  }
+  return `ACP agent exited with code ${code}`;
+}
+
 function withDshAcpSqliteWarningSuppressed(command: BuiltCommand): BuiltCommand {
   const env = {
     ...command.env,
@@ -432,6 +529,14 @@ export const DSH_ACP_PROBE_PACKAGE = "@deepseek-ai/dsh-llm-deepseek";
 
 export function dshAcpManagedRoot(dataDir: string): string {
   return path.join(dataDir, "runtimes", "dsh-acp");
+}
+
+/** Refresh the managed composition from the bundled default before spawn/install. */
+export function syncDshAcpManagedConfig(dataDir: string): string {
+  const root = dshAcpManagedRoot(dataDir);
+  mkdirSync(root, { recursive: true });
+  copyFileSync(bundledDshAcpConfigPath(), path.join(root, "cordis.yml"));
+  return root;
 }
 
 export function dshAcpManagedDemoBin(dataDir: string): string {

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -339,6 +339,26 @@ function isNodeBinary(bin: string): boolean {
   return base === "node" || base === "node.exe";
 }
 
+const DSH_ACP_DEFAULT_BINARIES = new Set([
+  "dsh-acp-demo",
+  "dsh-acp-demo.cmd",
+  "dsh-acp-demo.exe",
+  "dsh-acp-demo.bat",
+  "dsh-acp-demo.ps1"
+]);
+
+/**
+ * Settings persist `defaultBinary` even when the user did not pick a custom
+ * path. That name must still launch the managed runtime, not a PATH global
+ * install (global npm `dsh-acp-demo`).
+ */
+export function isDefaultDshAcpBinary(binary?: string): boolean {
+  const trimmed = binary?.trim();
+  if (!trimmed) return true;
+  if (/[\\/]/.test(trimmed)) return false;
+  return DSH_ACP_DEFAULT_BINARIES.has(path.basename(trimmed).toLowerCase());
+}
+
 const ELECTRON_CHILD_ENV_BLOCKLIST = [
   "ELECTRON_RUN_AS_NODE",
   "ELECTRON_NO_ASAR",
@@ -424,8 +444,8 @@ export function formatAcpAgentExitMessage(
 ): string {
   if (isWindowsAccessViolationExit(code)) {
     return language === "zh-CN"
-      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL / Windows ACL 会用 koffi 调 Win32（含 MoveFileExW）；本版本会覆盖 JSONL、关掉 ACL sandbox，并用 Node --import 拦截 koffi。请重新编译本版本后再试（无需重装 DeepSeek）。若仍崩溃，请用「导出调试日志」把 zip 发回来。"
-      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL / Windows ACL call Win32 through koffi (including MoveFileExW). This build overlays JSONL, disables the ACL sandbox, and intercepts koffi with Node --import. Rebuild this version — you do not need to reinstall DeepSeek. If it still crashes, export debug logs and send the zip.";
+      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL / Windows ACL 会用 koffi 调 Win32（含 MoveFileExW）；本版本会覆盖 JSONL，并用 Node --import 拦截 koffi。请重新编译本版本后再试（无需重装 DeepSeek）。若仍崩溃，请用「导出调试日志」把 zip 发回来。"
+      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL / Windows ACL call Win32 through koffi (including MoveFileExW). This build overlays JSONL and intercepts koffi with Node --import. Rebuild this version — you do not need to reinstall DeepSeek. If it still crashes, export debug logs and send the zip.";
   }
   return `ACP agent exited with code ${code}`;
 }
@@ -1197,7 +1217,7 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
           )
         : "";
       const useManaged =
-        !input.binary?.trim() &&
+        isDefaultDshAcpBinary(input.binary) &&
         Boolean(managedBin) &&
         existsSync(managedBin) &&
         dshAcpCompositionReady(managedBin);

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -4,6 +4,10 @@ import { fileURLToPath } from "node:url";
 
 const DSH_ACP_NPM_TAG = "next";
 
+/** Node 22+ emits this for `node:sqlite`; DeepSeek ACP uses it via session-query-sqlite. */
+export const DSH_ACP_NODE_DISABLE_WARNING =
+  "--disable-warning=ExperimentalWarning";
+
 export type CLIAdapterId =
   | "codex"
   | "codex-acp"
@@ -299,6 +303,54 @@ export function getCliCheckProbe(adapter: string): CliCheckProbe {
  */
 export function adapterAcceptsClientMcpServers(adapter: string): boolean {
   return adapter !== "dsh-acp";
+}
+
+export function mergeNodeOptions(
+  current: string | undefined,
+  patch: string
+): string {
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const token of [...(current ?? "").split(/\s+/), ...patch.split(/\s+/)]) {
+    if (!token || seen.has(token)) continue;
+    seen.add(token);
+    tokens.push(token);
+  }
+  return tokens.join(" ");
+}
+
+export function isDshAcpExperimentalWarningLine(line: string): boolean {
+  const text = line.trim();
+  if (/ExperimentalWarning:\s*SQLite is an experimental feature/i.test(text)) {
+    return true;
+  }
+  return /Use `node --trace-warnings/i.test(text);
+}
+
+function isNodeBinary(bin: string): boolean {
+  const base = path.basename(bin).toLowerCase();
+  return base === "node" || base === "node.exe";
+}
+
+function withDshAcpSqliteWarningSuppressed(command: BuiltCommand): BuiltCommand {
+  const env = {
+    ...command.env,
+    NODE_OPTIONS: mergeNodeOptions(
+      command.env?.NODE_OPTIONS,
+      DSH_ACP_NODE_DISABLE_WARNING
+    )
+  };
+  if (
+    !isNodeBinary(command.bin) ||
+    command.args.includes(DSH_ACP_NODE_DISABLE_WARNING)
+  ) {
+    return { ...command, env };
+  }
+  return {
+    ...command,
+    args: [DSH_ACP_NODE_DISABLE_WARNING, ...command.args],
+    env
+  };
 }
 
 /**
@@ -827,19 +879,19 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
             ...extra
           ];
       if (useManaged) {
-        return {
+        return withDshAcpSqliteWarningSuppressed({
           bin: "node",
           args: [managedBin, ...args],
           promptViaStdin: false,
           protocol: "acp"
-        };
+        });
       }
-      return {
+      return withDshAcpSqliteWarningSuppressed({
         bin,
         args,
         promptViaStdin: false,
         protocol: "acp"
-      };
+      });
     }
     case "claude": {
       const args: string[] = [

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -1,4 +1,6 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export type CLIAdapterId =
   | "codex"
@@ -323,6 +325,46 @@ export function dshAcpWindowsResiduePath(
   return path.join(appdata, "npm", "node_modules", "@deepseek-ai");
 }
 
+export function extraArgsHaveDshConfig(args: string[]): boolean {
+  return args.some(
+    (arg) =>
+      arg === "-c" ||
+      arg === "--config" ||
+      arg.startsWith("-c=") ||
+      arg.startsWith("--config=")
+  );
+}
+
+/** Packaged extraResources, else the repo `assets/dsh/cordis.yml` used in dev. */
+export function bundledDshAcpConfigPath(): string {
+  const fromSource = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "assets",
+    "dsh",
+    "cordis.yml"
+  );
+  const packaged =
+    typeof process.resourcesPath === "string"
+      ? path.join(process.resourcesPath, "dsh", "cordis.yml")
+      : "";
+  if (packaged && existsSync(packaged)) return packaged;
+  return fromSource;
+}
+
+/**
+ * `dsh-acp-demo` defaults to `./cordis.yml` in the session cwd. Prefer a
+ * workspace file when present; otherwise use FreeBuddy's bundled default.
+ */
+export function resolveDshAcpConfigPath(cwd?: string): string {
+  if (cwd) {
+    const local = path.join(cwd, "cordis.yml");
+    if (existsSync(local)) return local;
+  }
+  return bundledDshAcpConfigPath();
+}
+
 export function hasExplicitToolSessionArg(
   adapter: string | null | undefined,
   extraArgs: string[] | null | undefined
@@ -637,7 +679,9 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
       };
     }
     case "dsh-acp": {
-      const args: string[] = [...extra];
+      const args = extraArgsHaveDshConfig(extra)
+        ? [...extra]
+        : ["--config", resolveDshAcpConfigPath(input.cwd), ...extra];
       return {
         bin,
         args,

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -1,6 +1,8 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+const DSH_ACP_NPM_TAG = "next";
 
 export type CLIAdapterId =
   | "codex"
@@ -252,11 +254,12 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     toolSessionArgPrefixes: [],
     // `latest` is still 0.0.1-rc.1; that release's peer packages 404 on the
     // public registry. The working public line is currently tagged `next`.
-    // koffi's install script rebuilds from source when the optional platform
-    // binary is missing; that CMake path exceeds Windows MAX_PATH under the
-    // nested global install, so keep the prebuild and skip lifecycle scripts.
-    installHint:
-      "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next",
+    // The published ACP demo has no runtime dependencies; cordis.yml plugins
+    // must be installed alongside it. koffi's install script rebuilds from
+    // source when the optional platform binary is missing; that CMake path
+    // exceeds Windows MAX_PATH under the nested global install, so keep the
+    // prebuild and skip lifecycle scripts.
+    installHint: dshAcpInstallCommand(),
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }
@@ -363,6 +366,34 @@ export function resolveDshAcpConfigPath(cwd?: string): string {
     if (existsSync(local)) return local;
   }
   return bundledDshAcpConfigPath();
+}
+
+/** Bare npm package names referenced by the bundled ACP composition. */
+export function parseDshAcpCompositionPackages(yamlText: string): string[] {
+  const names = new Set<string>(["@deepseek-ai/dsh-acp-demo"]);
+  for (const match of yamlText.matchAll(/^\s*name:\s*'(@deepseek-ai\/[^']+)'/gm)) {
+    names.add(match[1].split("/").slice(0, 2).join("/"));
+  }
+  return [...names];
+}
+
+/**
+ * `dsh-acp-demo` ships with `deps: none`. Installing only the bin leaves
+ * cordis unable to import `@deepseek-ai/dsh-llm-deepseek` and the rest of
+ * the official ACP plugin tree (`ERR_MODULE_NOT_FOUND`).
+ */
+export function dshAcpInstallCommand(
+  yamlText = readFileSync(bundledDshAcpConfigPath(), "utf8")
+): string {
+  const specs = parseDshAcpCompositionPackages(yamlText).map(
+    (pkg) => `${pkg}@${DSH_ACP_NPM_TAG}`
+  );
+  specs.sort((a, b) => {
+    if (a.startsWith("@deepseek-ai/dsh-acp-demo@")) return -1;
+    if (b.startsWith("@deepseek-ai/dsh-acp-demo@")) return 1;
+    return a.localeCompare(b);
+  });
+  return `npm install -g --include=optional --ignore-scripts ${specs.join(" ")}`;
 }
 
 export function hasExplicitToolSessionArg(

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -290,6 +290,33 @@ export function adapterAcceptsClientMcpServers(adapter: string): boolean {
   return adapter !== "dsh-acp";
 }
 
+/**
+ * Force koffi to keep its optional platform prebuild. Its install script
+ * otherwise rebuilds from source, and that CMake path exceeds Windows MAX_PATH
+ * under the nested global `@deepseek-ai/dsh-acp-demo` install.
+ */
+export function applyDshAcpNpmInstallEnv(
+  adapter: string,
+  env: NodeJS.ProcessEnv
+): NodeJS.ProcessEnv {
+  if (adapter !== "dsh-acp") return env;
+  return {
+    ...env,
+    npm_config_ignore_scripts: "true",
+    npm_config_include: "optional",
+    npm_config_optional: "true"
+  };
+}
+
+export function dshAcpWindowsResiduePath(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  if (process.platform !== "win32") return undefined;
+  const appdata = env.APPDATA?.trim();
+  if (!appdata) return undefined;
+  return path.join(appdata, "npm", "node_modules", "@deepseek-ai");
+}
+
 export function hasExplicitToolSessionArg(
   adapter: string | null | undefined,
   extraArgs: string[] | null | undefined

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -253,7 +253,6 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     id: "dsh-acp",
     label: "DeepSeek Harness",
     defaultBinary: "dsh-acp-demo",
-    // The bin only accepts `--config`; `--version` exits non-zero via parseArgs.
     checkProbe: { args: [], versionOptional: true, skipSpawn: true },
     streamMode: "raw",
     commandGroup: "deepseek",
@@ -263,13 +262,6 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     },
     toolSessionArgs: [],
     toolSessionArgPrefixes: [],
-    // `latest` is still 0.0.1-rc.1; that release's peer packages 404 on the
-    // public registry. The working public line is currently tagged `next`.
-    // The published ACP demo has no runtime dependencies; cordis.yml plugins
-    // must be installed alongside it. koffi's install script rebuilds from
-    // source when the optional platform binary is missing; that CMake path
-    // exceeds Windows MAX_PATH under the nested global install, so keep the
-    // prebuild and skip lifecycle scripts.
     installHint: dshAcpInstallCommand(),
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
@@ -344,6 +336,16 @@ function isNodeBinary(bin: string): boolean {
 }
 
 const DSH_ACP_DEFAULT_BINARIES = new Set([
+  "deepseek-harness-acp",
+  "deepseek-harness-acp.cmd",
+  "deepseek-harness-acp.exe",
+  "deepseek-harness-acp.bat",
+  "deepseek-harness-acp.ps1",
+  "dsh-acp",
+  "dsh-acp.cmd",
+  "dsh-acp.exe",
+  "dsh-acp.bat",
+  "dsh-acp.ps1",
   "dsh-acp-demo",
   "dsh-acp-demo.cmd",
   "dsh-acp-demo.exe",
@@ -505,12 +507,18 @@ export function ensureDshAcpCwd(
 
 export function formatAcpAgentExitMessage(
   code: number,
-  language?: string
+  language?: string,
+  adapter?: string
 ): string {
   if (isWindowsAccessViolationExit(code)) {
+    if (adapter === "dsh-acp") {
+      return language === "zh-CN"
+        ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL / Windows ACL 会用 koffi 调 Win32（含 MoveFileExW）；本版本会覆盖 JSONL，并用 Node --import 拦截 koffi。请重新编译本版本后再试（无需重装 DeepSeek）。若仍崩溃，请用「导出调试日志」把 zip 发回来。"
+        : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL / Windows ACL call Win32 through koffi (including MoveFileExW). This build overlays JSONL and intercepts koffi with Node --import. Rebuild this version — you do not need to reinstall DeepSeek. If it still crashes, export debug logs and send the zip.";
+    }
     return language === "zh-CN"
-      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL / Windows ACL 会用 koffi 调 Win32（含 MoveFileExW）；本版本会覆盖 JSONL，并用 Node --import 拦截 koffi。请重新编译本版本后再试（无需重装 DeepSeek）。若仍崩溃，请用「导出调试日志」把 zip 发回来。"
-      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL / Windows ACL call Win32 through koffi (including MoveFileExW). This build overlays JSONL and intercepts koffi with Node --import. Rebuild this version — you do not need to reinstall DeepSeek. If it still crashes, export debug logs and send the zip.";
+      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。进程异常终止，请检查原生依赖或系统安全软件。"
+      : "ACP agent crashed with a Windows access violation (0xC0000005). The process aborted unexpectedly.";
   }
   return `ACP agent exited with code ${code}`;
 }
@@ -905,28 +913,44 @@ export function patchDshAcpManagedRuntime(root: string): number {
   );
   const demoFrom = path.join(overlayRoot, "dsh-acp-demo", "lib", "index.js");
   let count = 0;
-  if (existsSync(jsonlFrom)) {
-    for (const dest of findDshPackageLibIndex(root, DSH_JSONL_PACKAGE)) {
-      copyFileSync(jsonlFrom, dest);
-      count += 1;
+  try {
+    if (existsSync(jsonlFrom)) {
+      for (const dest of findDshPackageLibIndex(root, DSH_JSONL_PACKAGE)) {
+        try {
+          copyFileSync(jsonlFrom, dest);
+          count += 1;
+        } catch {
+          /* ignore unwriteable / permission-restricted files */
+        }
+      }
     }
-  }
-  if (existsSync(demoFrom)) {
-    for (const dest of findDshPackageLibIndex(root, DSH_DEMO_PACKAGE)) {
-      copyFileSync(demoFrom, dest);
+    if (existsSync(demoFrom)) {
+      for (const dest of findDshPackageLibIndex(root, DSH_DEMO_PACKAGE)) {
+        try {
+          copyFileSync(demoFrom, dest);
+        } catch {
+          /* ignore unwriteable / permission-restricted files */
+        }
+      }
     }
+  } catch {
+    /* ignore unreadable overlay dirs */
   }
   return count;
 }
 
 /** Overlay the npm prefix that owns a `dsh-acp-demo` bin, including PATH installs. */
 export function patchDshAcpRuntimeFromBin(binPath: string): void {
-  const demoDir = resolveDshAcpDemoDirFromBinary(binPath);
-  if (!demoDir) return;
-  const scoped = path.dirname(demoDir);
-  const nodeModules = path.dirname(scoped);
-  const prefix = path.dirname(nodeModules);
-  patchDshAcpManagedRuntime(prefix);
+  try {
+    const demoDir = resolveDshAcpDemoDirFromBinary(binPath);
+    if (!demoDir) return;
+    const scoped = path.dirname(demoDir);
+    const nodeModules = path.dirname(scoped);
+    const prefix = path.dirname(nodeModules);
+    patchDshAcpManagedRuntime(prefix);
+  } catch {
+    /* ignore permission / traversal errors */
+  }
 }
 
 export function patchDshAcpRuntimeFromCommand(command: {
@@ -942,8 +966,12 @@ export function patchDshAcpRuntimeFromCommand(command: {
 /** Refresh the managed composition from the bundled default before spawn/install. */
 export function syncDshAcpManagedConfig(dataDir: string): string {
   const root = dshAcpManagedRoot(dataDir);
-  mkdirSync(root, { recursive: true });
-  copyFileSync(bundledDshAcpConfigPath(), path.join(root, "cordis.yml"));
+  try {
+    mkdirSync(root, { recursive: true });
+    copyFileSync(bundledDshAcpConfigPath(), path.join(root, "cordis.yml"));
+  } catch {
+    /* ignore permission errors */
+  }
   patchDshAcpManagedRuntime(root);
   return root;
 }

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -3,7 +3,8 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  realpathSync as fsRealpath
+  realpathSync as fsRealpath,
+  writeFileSync
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -423,8 +424,8 @@ export function formatAcpAgentExitMessage(
 ): string {
   if (isWindowsAccessViolationExit(code)) {
     return language === "zh-CN"
-      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。这通常是 koffi 或 Node zstd/SQLite 原生模块中止，而不是 ACP 协议错误。请用本版本重新编译后再试。"
-      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. This is usually a koffi or Node zstd/SQLite native abort, not an ACP protocol error. Rebuild this version and retry.";
+      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL 首次落盘会用 koffi 调用 MoveFileExW；本版本启动时会改走 Node 文件系统。若仍看到此错误，请确认已重新编译本版本（无需重装 DeepSeek）。"
+      : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL publishes the first log with koffi MoveFileExW; this build rewrites that path onto Node fs at spawn. If this still happens, rebuild this version — you do not need to reinstall DeepSeek.";
   }
   return `ACP agent exited with code ${code}`;
 }
@@ -531,11 +532,81 @@ export function dshAcpManagedRoot(dataDir: string): string {
   return path.join(dataDir, "runtimes", "dsh-acp");
 }
 
+const DSH_ACP_JSONL_WIN32_DISPATCH =
+  'if (process.platform === "win32") await this.materializeWin32';
+const DSH_ACP_JSONL_WIN32_DISPATCH_PATCHED =
+  "if (false) await this.materializeWin32";
+const DSH_ACP_JSONL_SYNC_DIR =
+  'async syncDirPosix(dir) {\n\t\tconst handle = await open(dir, "r");';
+const DSH_ACP_JSONL_SYNC_DIR_PATCHED =
+  'async syncDirPosix(dir) {\n\t\tif (process.platform === "win32") return;\n\t\tconst handle = await open(dir, "r");';
+const DSH_ACP_DEMO_SQLITE =
+  'ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, "session-query.db") })';
+const DSH_ACP_DEMO_SQLITE_PATCHED =
+  'ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, "session-query.db"), openAt: "never" })';
+
+function replaceOnceIfNeeded(
+  text: string,
+  find: string,
+  replace: string
+): string {
+  if (text.includes(replace) || !text.includes(find)) return text;
+  return text.replace(find, replace);
+}
+
+function patchManagedFile(
+  file: string,
+  replacements: Array<[string, string]>
+): void {
+  if (!existsSync(file)) return;
+  const original = readFileSync(file, "utf8");
+  let next = original;
+  for (const [find, replace] of replacements) {
+    next = replaceOnceIfNeeded(next, find, replace);
+  }
+  if (next !== original) writeFileSync(file, next);
+}
+
+/**
+ * Official JSONL durable-publish loads koffi and calls MoveFileExW the first
+ * time a session is written. That aborts Windows Electron children with
+ * STATUS_ACCESS_VIOLATION (0xC0000005) on session/prompt. Rewrite the installed
+ * packages onto Node fs and keep SQLite closed.
+ */
+export function patchDshAcpManagedRuntime(root: string): void {
+  patchManagedFile(
+    path.join(
+      root,
+      "node_modules",
+      "@deepseek-ai",
+      "dsh-session-persistence-jsonl",
+      "lib",
+      "index.js"
+    ),
+    [
+      [DSH_ACP_JSONL_WIN32_DISPATCH, DSH_ACP_JSONL_WIN32_DISPATCH_PATCHED],
+      [DSH_ACP_JSONL_SYNC_DIR, DSH_ACP_JSONL_SYNC_DIR_PATCHED]
+    ]
+  );
+  patchManagedFile(
+    path.join(
+      root,
+      "node_modules",
+      "@deepseek-ai",
+      "dsh-acp-demo",
+      "lib",
+      "index.js"
+    ),
+    [[DSH_ACP_DEMO_SQLITE, DSH_ACP_DEMO_SQLITE_PATCHED]]
+  );
+}
+
 /** Refresh the managed composition from the bundled default before spawn/install. */
 export function syncDshAcpManagedConfig(dataDir: string): string {
   const root = dshAcpManagedRoot(dataDir);
   mkdirSync(root, { recursive: true });
   copyFileSync(bundledDshAcpConfigPath(), path.join(root, "cordis.yml"));
+  patchDshAcpManagedRuntime(root);
   return root;
 }
 

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -2,6 +2,7 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   realpathSync as fsRealpath
 } from "node:fs";
@@ -423,7 +424,7 @@ export function formatAcpAgentExitMessage(
 ): string {
   if (isWindowsAccessViolationExit(code)) {
     return language === "zh-CN"
-      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL 首次落盘会用 koffi 调用 MoveFileExW；本版本会用 harness 薄补丁整文件覆盖该包并改走 Node 文件系统。若仍看到此错误，请确认已重新编译本版本（无需重装 DeepSeek）。"
+      ? "ACP 进程发生 Windows 访问冲突 (0xC0000005)。initialize / session/new 已成功，崩溃发生在 session/prompt。官方 JSONL 会用 koffi 调 MoveFileExW；本版本会覆盖所有嵌套副本并在 Windows 上关掉 ACL sandbox。请再编一次本版本（无需重装 DeepSeek）。"
       : "ACP agent crashed with a Windows access violation (0xC0000005). initialize and session/new succeeded; the abort happened on session/prompt. Official JSONL publishes the first log with koffi MoveFileExW; this build overlays the harness fork (Node fs) onto the installed package. If this still happens, rebuild this version — you do not need to reinstall DeepSeek.";
   }
   return `ACP agent exited with code ${code}`;
@@ -531,22 +532,8 @@ export function dshAcpManagedRoot(dataDir: string): string {
   return path.join(dataDir, "runtimes", "dsh-acp");
 }
 
-const DSH_HARNESS_OVERLAY_FILES = [
-  [
-    path.join("dsh-session-persistence-jsonl", "lib", "index.js"),
-    [
-      "node_modules",
-      "@deepseek-ai",
-      "dsh-session-persistence-jsonl",
-      "lib",
-      "index.js"
-    ]
-  ],
-  [
-    path.join("dsh-acp-demo", "lib", "index.js"),
-    ["node_modules", "@deepseek-ai", "dsh-acp-demo", "lib", "index.js"]
-  ]
-] as const;
+const DSH_JSONL_PACKAGE = "@deepseek-ai/dsh-session-persistence-jsonl";
+const DSH_DEMO_PACKAGE = "@deepseek-ai/dsh-acp-demo";
 
 /** Packaged extraResources, else the repo `third_party/deepseek-harness/overlays`. */
 export function dshHarnessOverlayDir(): string {
@@ -570,15 +557,98 @@ export function dshHarnessOverlayDir(): string {
  * Copy the thin harness-fork overlays onto an installed official runtime.
  * Official JSONL durable-publish aborts Windows Electron children with
  * STATUS_ACCESS_VIOLATION (0xC0000005) on session/prompt.
+ *
+ * Walk every nested `node_modules` copy. npm may hoist the JSONL package or
+ * nest it under another `@deepseek-ai/*` plugin; covering only the prefix
+ * root left the running import unpatched.
  */
-export function patchDshAcpManagedRuntime(root: string): void {
+export function findDshPackageLibIndex(
+  root: string,
+  packageName: string
+): string[] {
+  const found = new Set<string>();
+  const visit = (dir: string, depth: number) => {
+    if (depth > 8) return;
+    const nm = path.join(dir, "node_modules");
+    if (!existsSync(nm)) return;
+    const index = path.join(nm, packageName, "lib", "index.js");
+    if (existsSync(index)) found.add(index);
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(nm);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (name === ".bin" || name.startsWith(".")) continue;
+      const child = path.join(nm, name);
+      if (name.startsWith("@")) {
+        let scoped: string[] = [];
+        try {
+          scoped = readdirSync(child);
+        } catch {
+          continue;
+        }
+        for (const pkg of scoped) visit(path.join(child, pkg), depth + 1);
+      } else {
+        visit(child, depth + 1);
+      }
+    }
+  };
+  visit(root, 0);
+  return [...found];
+}
+
+export function dshAcpJsonlStillUsesKoffi(root: string): string[] {
+  return findDshPackageLibIndex(root, DSH_JSONL_PACKAGE).filter((file) =>
+    /(?:import\(|from\s+|load\()["']koffi["']|koffi\.load/.test(
+      readFileSync(file, "utf8")
+    )
+  );
+}
+
+export function patchDshAcpManagedRuntime(root: string): number {
   const overlayRoot = dshHarnessOverlayDir();
-  for (const [rel, destParts] of DSH_HARNESS_OVERLAY_FILES) {
-    const from = path.join(overlayRoot, rel);
-    const to = path.join(root, ...destParts);
-    if (!existsSync(from) || !existsSync(to)) continue;
-    copyFileSync(from, to);
+  const jsonlFrom = path.join(
+    overlayRoot,
+    "dsh-session-persistence-jsonl",
+    "lib",
+    "index.js"
+  );
+  const demoFrom = path.join(overlayRoot, "dsh-acp-demo", "lib", "index.js");
+  let count = 0;
+  if (existsSync(jsonlFrom)) {
+    for (const dest of findDshPackageLibIndex(root, DSH_JSONL_PACKAGE)) {
+      copyFileSync(jsonlFrom, dest);
+      count += 1;
+    }
   }
+  if (existsSync(demoFrom)) {
+    for (const dest of findDshPackageLibIndex(root, DSH_DEMO_PACKAGE)) {
+      copyFileSync(demoFrom, dest);
+    }
+  }
+  return count;
+}
+
+/** Overlay the npm prefix that owns a `dsh-acp-demo` bin, including PATH installs. */
+export function patchDshAcpRuntimeFromBin(binPath: string): void {
+  const demoDir = resolveDshAcpDemoDirFromBinary(binPath);
+  if (!demoDir) return;
+  const scoped = path.dirname(demoDir);
+  const nodeModules = path.dirname(scoped);
+  const prefix = path.dirname(nodeModules);
+  patchDshAcpManagedRuntime(prefix);
+}
+
+export function patchDshAcpRuntimeFromCommand(command: {
+  bin: string;
+  args: string[];
+}): void {
+  const entry = isNodeBinary(command.bin)
+    ? command.args.find((arg) => /dsh-acp-demo[/\\]lib[/\\]bin\.js$/i.test(arg))
+    : command.bin;
+  if (entry) patchDshAcpRuntimeFromBin(entry);
 }
 
 /** Refresh the managed composition from the bundled default before spawn/install. */

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -515,10 +515,38 @@ export function formatAcpAgentExitMessage(
   return `ACP agent exited with code ${code}`;
 }
 
+/** Whether a composition file mounts the native `dsh-sandbox-local` (the only koffi source). */
+function dshAcpConfigUsesNativeSandbox(configPath: string | undefined): boolean {
+  // Unknown or missing config: assume it may use the native sandbox so the guard still applies.
+  if (!configPath || !existsSync(configPath)) return true;
+  return /name:\s*'@deepseek-ai\/dsh-sandbox-local'/.test(
+    readFileSync(configPath, "utf8")
+  );
+}
+
+/** Extract the `--config`/`-c` value from a dsh-acp argv, if present. */
+function dshAcpConfigPathFromArgs(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const token = args[i];
+    if (token === "--config" || token === "-c") return args[i + 1];
+    const match = token?.match(/^(?:--config|-c)=(.+)$/);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
 function withDshAcpSqliteWarningSuppressed(command: BuiltCommand): BuiltCommand {
+  // The koffi guard intercepts `dsh-sandbox-windows-acl` (loaded by
+  // `dsh-sandbox-local`). Compositions that omit the native sandbox never load
+  // koffi, so the guard is unnecessary — and its bare-path `--import` aborts
+  // Node 24+ with ERR_UNSUPPORTED_ESM_URL_SCHEME, so injecting it there would
+  // break the spawn. Apply it only when the active composition needs it.
+  const configUsesNativeSandbox = dshAcpConfigUsesNativeSandbox(
+    dshAcpConfigPathFromArgs(command.args) ?? bundledDshAcpConfigPath()
+  );
   const flags = [
     DSH_ACP_NODE_DISABLE_WARNING,
-    dshAcpKoffiGuardImportFlag()
+    configUsesNativeSandbox ? dshAcpKoffiGuardImportFlag() : undefined
   ].filter((flag): flag is string => Boolean(flag));
   let env = command.env;
   for (const flag of flags) {
@@ -575,21 +603,45 @@ export function extraArgsHaveDshConfig(args: string[]): boolean {
   );
 }
 
+/**
+ * The platform-specific composition basename. Windows mounts
+ * `cordis.win32.yml`, which replaces the native sandbox stack
+ * (`dsh-sandbox-local` → `dsh-sandbox-windows-acl` → `koffi`) with the
+ * non-sandboxed `dsh-bash-local` executor; koffi aborts Windows ACP children
+ * with STATUS_ACCESS_VIOLATION (0xC0000005). Other platforms use `cordis.yml`.
+ */
+function bundledDshAcpConfigBasename(): string {
+  return process.platform === "win32" ? "cordis.win32.yml" : "cordis.yml";
+}
+
 /** Packaged extraResources, else the repo `assets/dsh/cordis.yml` used in dev. */
 export function bundledDshAcpConfigPath(): string {
+  const basename = bundledDshAcpConfigBasename();
   const fromSource = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
     "..",
     "assets",
     "dsh",
-    "cordis.yml"
+    basename
   );
   const packaged =
     typeof process.resourcesPath === "string"
-      ? path.join(process.resourcesPath, "dsh", "cordis.yml")
+      ? path.join(process.resourcesPath, "dsh", basename)
       : "";
   if (packaged && existsSync(packaged)) return packaged;
+  // Fall back to the cross-platform file if the platform variant is absent
+  // (e.g. an older packaged build without cordis.win32.yml).
+  if (basename !== "cordis.yml" && !existsSync(fromSource)) {
+    return path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "..",
+      "assets",
+      "dsh",
+      "cordis.yml"
+    );
+  }
   return fromSource;
 }
 

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync as fsRealpath } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -360,12 +360,98 @@ export function bundledDshAcpConfigPath(): string {
  * `dsh-acp-demo` defaults to `./cordis.yml` in the session cwd. Prefer a
  * workspace file when present; otherwise use FreeBuddy's bundled default.
  */
-export function resolveDshAcpConfigPath(cwd?: string): string {
+export function resolveDshAcpConfigPath(
+  cwd?: string,
+  runtimeRoot?: string
+): string {
   if (cwd) {
     const local = path.join(cwd, "cordis.yml");
     if (existsSync(local)) return local;
   }
+  if (runtimeRoot) {
+    const managed = path.join(runtimeRoot, "cordis.yml");
+    if (existsSync(managed)) return managed;
+  }
   return bundledDshAcpConfigPath();
+}
+
+export const DSH_ACP_PLUGIN_TREE_MISSING = "DeepSeek ACP plugin tree missing";
+export const DSH_ACP_PROBE_PACKAGE = "@deepseek-ai/dsh-llm-deepseek";
+
+export function dshAcpManagedRoot(dataDir: string): string {
+  return path.join(dataDir, "runtimes", "dsh-acp");
+}
+
+export function dshAcpManagedDemoBin(dataDir: string): string {
+  return path.join(
+    dshAcpManagedRoot(dataDir),
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-acp-demo",
+    "lib",
+    "bin.js"
+  );
+}
+
+export function quoteForShell(value: string): string {
+  if (process.platform === "win32") {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Walk up from `startDir` looking for `node_modules/<package>`. */
+export function nodeModulesHasPackage(
+  startDir: string,
+  packageName: string
+): boolean {
+  let dir = path.resolve(startDir);
+  for (;;) {
+    if (existsSync(path.join(dir, "node_modules", packageName, "package.json"))) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+}
+
+export function resolveDshAcpDemoDirFromBinary(
+  binPath: string
+): string | undefined {
+  let current = path.resolve(binPath);
+  try {
+    current = fsRealpath(binPath);
+  } catch {
+    /* keep resolved path */
+  }
+  if (/\.(cmd|ps1|bat)$/i.test(current)) {
+    try {
+      const text = readFileSync(current, "utf8");
+      const match = text.match(
+        /node_modules[/\\]@deepseek-ai[/\\]dsh-acp-demo[/\\]lib[/\\]bin\.js/i
+      );
+      if (match) {
+        const pkg = path.resolve(
+          path.dirname(current),
+          match[0].replace(/[/\\]lib[/\\]bin\.js$/i, "")
+        );
+        if (existsSync(path.join(pkg, "package.json"))) return pkg;
+      }
+    } catch {
+      /* ignore unreadable shims */
+    }
+  }
+  if (current.endsWith(`${path.sep}lib${path.sep}bin.js`)) {
+    const pkg = path.dirname(path.dirname(current));
+    if (existsSync(path.join(pkg, "package.json"))) return pkg;
+  }
+  return undefined;
+}
+
+export function dshAcpCompositionReady(binPath: string): boolean {
+  const pkgDir = resolveDshAcpDemoDirFromBinary(binPath) ?? path.dirname(binPath);
+  return nodeModulesHasPackage(pkgDir, DSH_ACP_PROBE_PACKAGE);
 }
 
 /** Bare npm package names referenced by the bundled ACP composition. */
@@ -382,9 +468,12 @@ export function parseDshAcpCompositionPackages(yamlText: string): string[] {
  * cordis unable to import `@deepseek-ai/dsh-llm-deepseek` and the rest of
  * the official ACP plugin tree (`ERR_MODULE_NOT_FOUND`).
  */
-export function dshAcpInstallCommand(
-  yamlText = readFileSync(bundledDshAcpConfigPath(), "utf8")
-): string {
+export function dshAcpInstallCommand(options?: {
+  yamlText?: string;
+  prefix?: string;
+}): string {
+  const yamlText =
+    options?.yamlText ?? readFileSync(bundledDshAcpConfigPath(), "utf8");
   const specs = parseDshAcpCompositionPackages(yamlText).map(
     (pkg) => `${pkg}@${DSH_ACP_NPM_TAG}`
   );
@@ -393,7 +482,10 @@ export function dshAcpInstallCommand(
     if (b.startsWith("@deepseek-ai/dsh-acp-demo@")) return 1;
     return a.localeCompare(b);
   });
-  return `npm install -g --include=optional --ignore-scripts ${specs.join(" ")}`;
+  const target = options?.prefix
+    ? `--prefix ${quoteForShell(options.prefix)}`
+    : "-g";
+  return `npm install ${target} --include=optional --ignore-scripts ${specs.join(" ")}`;
 }
 
 export function hasExplicitToolSessionArg(
@@ -419,6 +511,8 @@ export interface BuildCommandInput {
   toolSessionId?: string;
   /** Absolute multi-folder project roots; OpenCode gets external_directory allows when length > 1. */
   workspaceRoots?: string[];
+  /** FreeBuddy-managed `runtimes/dsh-acp` prefix; used when no custom binary. */
+  dshAcpRuntimeRoot?: string;
 }
 
 export interface BuiltCommand {
@@ -710,9 +804,36 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
       };
     }
     case "dsh-acp": {
+      const managedBin = input.dshAcpRuntimeRoot
+        ? path.join(
+            input.dshAcpRuntimeRoot,
+            "node_modules",
+            "@deepseek-ai",
+            "dsh-acp-demo",
+            "lib",
+            "bin.js"
+          )
+        : "";
+      const useManaged =
+        !input.binary?.trim() &&
+        Boolean(managedBin) &&
+        existsSync(managedBin) &&
+        dshAcpCompositionReady(managedBin);
       const args = extraArgsHaveDshConfig(extra)
         ? [...extra]
-        : ["--config", resolveDshAcpConfigPath(input.cwd), ...extra];
+        : [
+            "--config",
+            resolveDshAcpConfigPath(input.cwd, input.dshAcpRuntimeRoot),
+            ...extra
+          ];
+      if (useManaged) {
+        return {
+          bin: "node",
+          args: [managedBin, ...args],
+          promptViaStdin: false,
+          protocol: "acp"
+        };
+      }
       return {
         bin,
         args,

--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -368,6 +368,12 @@ export async function cliCheck(
     return { installed: false };
   }
   const probe = getCliCheckProbe(adapter);
+  if (probe.skipSpawn) {
+    const result: CliCheckResult = { installed: true, path: resolved };
+    upsertRuntime(runtimeKey, true, resolved);
+    trackAgentSetup(adapter, "check", "detected");
+    return result;
+  }
   const probeResult = await runCheckProbe(
     resolved,
     probe.args,

--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -5,10 +5,16 @@ import { BrowserWindow } from "electron";
 import {
   adapterBinary,
   applyDshAcpNpmInstallEnv,
+  bundledDshAcpConfigPath,
+  dshAcpCompositionReady,
+  dshAcpInstallCommand,
+  dshAcpManagedDemoBin,
+  dshAcpManagedRoot,
   dshAcpWindowsResiduePath,
+  DSH_ACP_PLUGIN_TREE_MISSING,
   getCliCheckProbe
 } from "./adapters.js";
-import { getDb } from "./db.js";
+import { getDataDir, getDb } from "./db.js";
 import { safeSendToWebContents } from "./ipcSend.js";
 import { compareSemver, extractSemver } from "./version.js";
 import { trackTelemetryEvent } from "../telemetry.js";
@@ -362,6 +368,35 @@ export async function cliCheck(
     ...(env || {})
   });
   const resolved = await which(bin, effectiveEnv as Record<string, string>);
+  if (adapter === "dsh-acp") {
+    const managedBin = dshAcpManagedDemoBin(getDataDir());
+    if (fs.existsSync(managedBin) && dshAcpCompositionReady(managedBin)) {
+      const result: CliCheckResult = { installed: true, path: managedBin };
+      upsertRuntime(runtimeKey, true, managedBin);
+      trackAgentSetup(adapter, "check", "detected");
+      return result;
+    }
+    if (!resolved) {
+      upsertRuntime(runtimeKey, false, undefined, undefined, "binary not found");
+      trackAgentSetup(adapter, "check", "missing", "binary not found");
+      return { installed: false };
+    }
+    if (!dshAcpCompositionReady(resolved)) {
+      upsertRuntime(
+        runtimeKey,
+        false,
+        resolved,
+        undefined,
+        DSH_ACP_PLUGIN_TREE_MISSING
+      );
+      trackAgentSetup(adapter, "check", "probe_failed", DSH_ACP_PLUGIN_TREE_MISSING);
+      return { installed: false };
+    }
+    const result: CliCheckResult = { installed: true, path: resolved };
+    upsertRuntime(runtimeKey, true, resolved);
+    trackAgentSetup(adapter, "check", "detected");
+    return result;
+  }
   if (!resolved) {
     upsertRuntime(runtimeKey, false, undefined, undefined, "binary not found");
     trackAgentSetup(adapter, "check", "missing", "binary not found");
@@ -847,17 +882,21 @@ async function removeDshAcpWindowsResidue(
     .catch(() => undefined);
 }
 
+function prepareDshAcpManagedInstall(): string {
+  const root = dshAcpManagedRoot(getDataDir());
+  fs.mkdirSync(root, { recursive: true });
+  fs.copyFileSync(bundledDshAcpConfigPath(), path.join(root, "cordis.yml"));
+  return dshAcpInstallCommand({ prefix: root });
+}
+
 export function cliInstall(command: string, adapter = "custom"): Promise<CliInstallResult> {
   return new Promise((resolve, reject) => {
     void (async () => {
-      const trimmed = command.trim();
+      const trimmed =
+        adapter === "dsh-acp" ? prepareDshAcpManagedInstall() : command.trim();
       if (!trimmed) {
         reject(new Error("install command required"));
         return;
-      }
-
-      if (adapter === "dsh-acp") {
-        await removeDshAcpWindowsResidue();
       }
 
       const isWindows = process.platform === "win32";
@@ -940,9 +979,6 @@ export function cliInstallStream(
       if (!trimmed) throw new Error("install command required");
 
       const preflight = await prepareInstallEnvironment(trimmed, adapter);
-      if (adapter === "dsh-acp") {
-        await removeDshAcpWindowsResidue(preflight.env);
-      }
       if (preflight.failureCode) {
         const error = preflight.error || "Install environment check failed";
         const exitCode = preflight.failureCode === "tool_missing" ? 127 : 1;
@@ -958,7 +994,8 @@ export function cliInstallStream(
         return;
       }
 
-      const installCommand = preflight.command;
+      const installCommand =
+        adapter === "dsh-acp" ? prepareDshAcpManagedInstall() : preflight.command;
       const isWindows = process.platform === "win32";
       const isPowerShellCommand =
         preflight.requiresPowerShell ||

--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -2,7 +2,12 @@ import path from "node:path";
 import fs from "node:fs";
 import spawn from "cross-spawn";
 import { BrowserWindow } from "electron";
-import { adapterBinary, getCliCheckProbe } from "./adapters.js";
+import {
+  adapterBinary,
+  applyDshAcpNpmInstallEnv,
+  dshAcpWindowsResiduePath,
+  getCliCheckProbe
+} from "./adapters.js";
 import { getDb } from "./db.js";
 import { safeSendToWebContents } from "./ipcSend.js";
 import { compareSemver, extractSemver } from "./version.js";
@@ -763,7 +768,12 @@ async function prepareInstallEnvironment(
   adapter: string
 ): Promise<InstallPreflightResult> {
   const tool = requiredInstallTool(command);
-  if (!tool) return { env: { ...process.env }, command };
+  if (!tool) {
+    return {
+      env: applyDshAcpNpmInstallEnv(adapter, { ...process.env }),
+      command
+    };
+  }
 
   const env = await getFreshWindowsEnvironment(process.env);
   const executable = await which(tool, env as Record<string, string>);
@@ -780,6 +790,7 @@ async function prepareInstallEnvironment(
   env.PATH = [path.dirname(executable), env.PATH || ""]
     .filter(Boolean)
     .join(path.delimiter);
+  Object.assign(env, applyDshAcpNpmInstallEnv(adapter, env));
 
   if (
     tool === "npm" &&
@@ -809,70 +820,101 @@ async function prepareInstallEnvironment(
   return { env, ...absoluteInstallCommand(command, executable) };
 }
 
+function windowsExtendedPath(target: string): string {
+  if (process.platform !== "win32") return target;
+  if (target.startsWith("\\\\?\\")) return target;
+  return `\\\\?\\${path.resolve(target)}`;
+}
+
+async function removeDshAcpWindowsResidue(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+  const target = dshAcpWindowsResiduePath(env);
+  if (!target) return;
+  await fs.promises
+    .rm(windowsExtendedPath(target), {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 250
+    })
+    .catch(() => undefined);
+}
+
 export function cliInstall(command: string, adapter = "custom"): Promise<CliInstallResult> {
   return new Promise((resolve, reject) => {
-    const trimmed = command.trim();
-    if (!trimmed) return reject(new Error("install command required"));
+    void (async () => {
+      const trimmed = command.trim();
+      if (!trimmed) {
+        reject(new Error("install command required"));
+        return;
+      }
 
-    const isWindows = process.platform === "win32";
-    const isPowerShellCommand =
-      /^irm\s/i.test(trimmed) ||
-      /\|\s*iex\b/i.test(trimmed) ||
-      /Invoke-(WebRequest|Expression)/i.test(trimmed);
+      if (adapter === "dsh-acp") {
+        await removeDshAcpWindowsResidue();
+      }
 
-    let shell: string;
-    let args: string[];
-    if (isWindows && isPowerShellCommand) {
-      shell = "powershell";
-      args = [
-        "-ExecutionPolicy", "Bypass",
-        "-OutputFormat", "Text",
-        "-Command",
-        "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8; " +
-          trimmed
-      ];
-    } else if (isWindows) {
-      shell = "cmd";
-      args = ["/C", trimmed];
-    } else {
-      shell = process.env.SHELL || "/bin/sh";
-      args = ["-lc", trimmed];
-    }
+      const isWindows = process.platform === "win32";
+      const isPowerShellCommand =
+        /^irm\s/i.test(trimmed) ||
+        /\|\s*iex\b/i.test(trimmed) ||
+        /Invoke-(WebRequest|Expression)/i.test(trimmed);
 
-    const child = spawn(shell, args, { env: process.env });
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
-    let setupTracked = false;
-    const reportSetup = (result: "installed" | "failed" | "timeout", error?: unknown) => {
-      if (setupTracked) return;
-      setupTracked = true;
-      trackAgentSetup(adapter, "install", result, error);
-    };
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill();
-    }, 10 * 60 * 1000);
-    child.stdout!.on("data", (d) => (stdout += d.toString()));
-    child.stderr!.on("data", (d) => (stderr += d.toString()));
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      reportSetup("failed", err);
-      reject(err);
-    });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      reportSetup(
-        timedOut ? "timeout" : code === 0 ? "installed" : "failed",
-        timedOut ? "timeout" : code === 0 ? undefined : `process exited ${code ?? "unknown"}`
-      );
-      resolve({
-        success: code === 0,
-        exitCode: code,
-        stdout,
-        stderr
+      let shell: string;
+      let args: string[];
+      if (isWindows && isPowerShellCommand) {
+        shell = "powershell";
+        args = [
+          "-ExecutionPolicy", "Bypass",
+          "-OutputFormat", "Text",
+          "-Command",
+          "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8; " +
+            trimmed
+        ];
+      } else if (isWindows) {
+        shell = "cmd";
+        args = ["/C", trimmed];
+      } else {
+        shell = process.env.SHELL || "/bin/sh";
+        args = ["-lc", trimmed];
+      }
+
+      const env = applyDshAcpNpmInstallEnv(adapter, { ...process.env });
+      const child = spawn(shell, args, { env });
+      let stdout = "";
+      let stderr = "";
+      let timedOut = false;
+      let setupTracked = false;
+      const reportSetup = (result: "installed" | "failed" | "timeout", error?: unknown) => {
+        if (setupTracked) return;
+        setupTracked = true;
+        trackAgentSetup(adapter, "install", result, error);
+      };
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill();
+      }, 10 * 60 * 1000);
+      child.stdout!.on("data", (d) => (stdout += d.toString()));
+      child.stderr!.on("data", (d) => (stderr += d.toString()));
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        reportSetup("failed", err);
+        reject(err);
       });
-    });
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        reportSetup(
+          timedOut ? "timeout" : code === 0 ? "installed" : "failed",
+          timedOut ? "timeout" : code === 0 ? undefined : `process exited ${code ?? "unknown"}`
+        );
+        resolve({
+          success: code === 0,
+          exitCode: code,
+          stdout,
+          stderr
+        });
+      });
+    })().catch(reject);
   });
 }
 
@@ -892,6 +934,9 @@ export function cliInstallStream(
       if (!trimmed) throw new Error("install command required");
 
       const preflight = await prepareInstallEnvironment(trimmed, adapter);
+      if (adapter === "dsh-acp") {
+        await removeDshAcpWindowsResidue(preflight.env);
+      }
       if (preflight.failureCode) {
         const error = preflight.error || "Install environment check failed";
         const exitCode = preflight.failureCode === "tool_missing" ? 127 : 1;

--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -5,14 +5,14 @@ import { BrowserWindow } from "electron";
 import {
   adapterBinary,
   applyDshAcpNpmInstallEnv,
-  bundledDshAcpConfigPath,
   dshAcpCompositionReady,
   dshAcpInstallCommand,
   dshAcpManagedDemoBin,
   dshAcpManagedRoot,
   dshAcpWindowsResiduePath,
   DSH_ACP_PLUGIN_TREE_MISSING,
-  getCliCheckProbe
+  getCliCheckProbe,
+  syncDshAcpManagedConfig
 } from "./adapters.js";
 import { getDataDir, getDb } from "./db.js";
 import { safeSendToWebContents } from "./ipcSend.js";
@@ -883,9 +883,7 @@ async function removeDshAcpWindowsResidue(
 }
 
 function prepareDshAcpManagedInstall(): string {
-  const root = dshAcpManagedRoot(getDataDir());
-  fs.mkdirSync(root, { recursive: true });
-  fs.copyFileSync(bundledDshAcpConfigPath(), path.join(root, "cordis.yml"));
+  const root = syncDshAcpManagedConfig(getDataDir());
   return dshAcpInstallCommand({ prefix: root });
 }
 

--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -12,6 +12,7 @@ import {
   dshAcpWindowsResiduePath,
   DSH_ACP_PLUGIN_TREE_MISSING,
   getCliCheckProbe,
+  patchDshAcpManagedRuntime,
   syncDshAcpManagedConfig
 } from "./adapters.js";
 import { getDataDir, getDb } from "./db.js";
@@ -946,6 +947,9 @@ export function cliInstall(command: string, adapter = "custom"): Promise<CliInst
       });
       child.on("close", (code) => {
         clearTimeout(timer);
+        if (adapter === "dsh-acp" && code === 0) {
+          patchDshAcpManagedRuntime(dshAcpManagedRoot(getDataDir()));
+        }
         reportSetup(
           timedOut ? "timeout" : code === 0 ? "installed" : "failed",
           timedOut ? "timeout" : code === 0 ? undefined : `process exited ${code ?? "unknown"}`
@@ -1072,6 +1076,9 @@ export function cliInstallStream(
       });
       child.on("close", (code) => {
         if (settled) return;
+        if (adapter === "dsh-acp" && code === 0) {
+          patchDshAcpManagedRuntime(dshAcpManagedRoot(getDataDir()));
+        }
         reportSetup(
           code === 0 ? "installed" : "failed",
           code === 0 ? undefined : `process exited ${code ?? "unknown"}`

--- a/electron/cli/cliMemberBuiltins.ts
+++ b/electron/cli/cliMemberBuiltins.ts
@@ -87,7 +87,7 @@ export const builtinCliMembers: CLIMember[] = [
   },
   {
     id: "cli-dsh-acp",
-    name: "DeepSeek",
+    name: "DeepSeek Harness",
     enabled: true,
     cli: { adapter: "dsh-acp", approvalMode: "auto", showStderr: true }
   }

--- a/electron/cli/cliMemberBuiltins.ts
+++ b/electron/cli/cliMemberBuiltins.ts
@@ -84,5 +84,11 @@ export const builtinCliMembers: CLIMember[] = [
     name: "Antigravity",
     enabled: true,
     cli: { adapter: "agy-acp", approvalMode: "auto", showStderr: true }
+  },
+  {
+    id: "cli-dsh-acp",
+    name: "DeepSeek",
+    enabled: true,
+    cli: { adapter: "dsh-acp", approvalMode: "auto", showStderr: true }
   }
 ];

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -12,6 +12,7 @@ import {
   getAdapterDefinition,
   hasExplicitToolSessionArg,
   mergeNodeOptions,
+  patchDshAcpRuntimeFromCommand,
   sanitizeCliAgentEnv,
   syncDshAcpManagedConfig
 } from "./adapters.js";
@@ -271,6 +272,9 @@ export async function cliRun(
           ? dshAcpManagedRoot(getDataDir())
           : undefined
     });
+    if (executionArgs.adapter === "dsh-acp") {
+      patchDshAcpRuntimeFromCommand(built);
+    }
   } catch (e) {
     const msg = `build command failed: ${(e as Error)?.message || e}`;
     appendLog(logStream, "system", msg);

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -8,7 +8,9 @@ import type { Readable, Writable } from "node:stream";
 import {
   buildCommand,
   buildDshAcpRuntimeDiagnostics,
+  dshAcpKoffiGuardPath,
   dshAcpManagedRoot,
+  dshAcpWindowsResiduePath,
   ensureDshAcpCwd,
   getAdapterDefinition,
   hasExplicitToolSessionArg,
@@ -292,7 +294,9 @@ export async function cliRun(
         `dsh-acp runtime ${JSON.stringify(
           buildDshAcpRuntimeDiagnostics({
             runtimeRoot: dshAcpManagedRoot(getDataDir()),
-            configPath
+            configPath,
+            spawnBin: built.bin,
+            spawnArgs: built.args
           })
         )}`
       );
@@ -340,7 +344,11 @@ export async function cliRun(
           ),
           ...(executionArgs.skills ?? []).map((skill) => skill.rootPath),
           ...(executionArgs.adapter === "dsh-acp"
-            ? [dshAcpManagedRoot(getDataDir())]
+            ? [
+                dshAcpManagedRoot(getDataDir()),
+                dshAcpKoffiGuardPath(),
+                dshAcpWindowsResiduePath() ?? ""
+              ].filter(Boolean)
             : [])
         ]
       });

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -7,6 +7,7 @@ import type { Readable, Writable } from "node:stream";
 
 import {
   buildCommand,
+  buildDshAcpRuntimeDiagnostics,
   dshAcpManagedRoot,
   ensureDshAcpCwd,
   getAdapterDefinition,
@@ -274,6 +275,27 @@ export async function cliRun(
     });
     if (executionArgs.adapter === "dsh-acp") {
       patchDshAcpRuntimeFromCommand(built);
+      const configIdx = built.args.findIndex(
+        (arg) => arg === "--config" || arg === "-c"
+      );
+      const configPath =
+        configIdx >= 0
+          ? built.args[configIdx + 1]
+          : built.args
+              .find((arg) => arg.startsWith("--config=") || arg.startsWith("-c="))
+              ?.split("=")
+              .slice(1)
+              .join("=");
+      appendLog(
+        logStream,
+        "system",
+        `dsh-acp runtime ${JSON.stringify(
+          buildDshAcpRuntimeDiagnostics({
+            runtimeRoot: dshAcpManagedRoot(getDataDir()),
+            configPath
+          })
+        )}`
+      );
     }
   } catch (e) {
     const msg = `build command failed: ${(e as Error)?.message || e}`;

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -7,12 +7,13 @@ import type { Readable, Writable } from "node:stream";
 
 import {
   buildCommand,
+  dshAcpManagedRoot,
   getAdapterDefinition,
   hasExplicitToolSessionArg
 } from "./adapters.js";
 import { runAcpAgent } from "./acpRuntime.js";
 import { runLegacyCliAgent } from "./legacyRuntime.js";
-import { getLogDir } from "./db.js";
+import { getDataDir, getLogDir } from "./db.js";
 import { updateRuntimeRun, waitForCodexToolchainAutoUpdate } from "./check.js";
 import { safeSendToWebContents } from "./ipcSend.js";
 import { getToolSession } from "./store.js";
@@ -248,7 +249,11 @@ export async function cliRun(
       extraArgs: executionArgs.extraArgs,
       cwd: executionArgs.cwd,
       toolSessionId,
-      workspaceRoots: args.workspaceRoots
+      workspaceRoots: args.workspaceRoots,
+      dshAcpRuntimeRoot:
+        executionArgs.adapter === "dsh-acp"
+          ? dshAcpManagedRoot(getDataDir())
+          : undefined
     });
   } catch (e) {
     const msg = `build command failed: ${(e as Error)?.message || e}`;
@@ -291,7 +296,10 @@ export async function cliRun(
           ...(executionArgs.promptAttachments ?? []).map(
             (attachment) => attachment.path
           ),
-          ...(executionArgs.skills ?? []).map((skill) => skill.rootPath)
+          ...(executionArgs.skills ?? []).map((skill) => skill.rootPath),
+          ...(executionArgs.adapter === "dsh-acp"
+            ? [dshAcpManagedRoot(getDataDir())]
+            : [])
         ]
       });
     } catch (error) {

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -8,9 +8,12 @@ import type { Readable, Writable } from "node:stream";
 import {
   buildCommand,
   dshAcpManagedRoot,
+  ensureDshAcpCwd,
   getAdapterDefinition,
   hasExplicitToolSessionArg,
-  mergeNodeOptions
+  mergeNodeOptions,
+  sanitizeCliAgentEnv,
+  syncDshAcpManagedConfig
 } from "./adapters.js";
 import { runAcpAgent } from "./acpRuntime.js";
 import { runLegacyCliAgent } from "./legacyRuntime.js";
@@ -146,8 +149,8 @@ export function mergeBuiltEnv(
   base: Record<string, string | undefined>,
   patch?: Record<string, string>
 ) {
-  if (!patch) return base;
-  const next = { ...base };
+  if (!patch) return sanitizeCliAgentEnv(base);
+  const next: Record<string, string | undefined> = { ...base };
   for (const [key, value] of Object.entries(patch)) {
     next[key] =
       key === "OPENCODE_CONFIG_CONTENT" || key === "CODEX_CONFIG"
@@ -156,7 +159,7 @@ export function mergeBuiltEnv(
           ? mergeNodeOptions(next[key], value)
           : value;
   }
-  return next;
+  return sanitizeCliAgentEnv(next);
 }
 
 export async function cliRun(
@@ -236,12 +239,22 @@ export async function cliRun(
     args.announceSkills && args.skills?.length
       ? { ...args, prompt: buildSkillAnnouncement(args.prompt, args.skills) }
       : args;
+  const withWorkspace: CliRunArgs =
+    effectiveArgs.adapter === "dsh-acp"
+      ? {
+          ...effectiveArgs,
+          cwd: ensureDshAcpCwd(effectiveArgs.cwd, getDataDir())
+        }
+      : effectiveArgs;
+  if (withWorkspace.adapter === "dsh-acp") {
+    syncDshAcpManagedConfig(getDataDir());
+  }
   const isolatedCwd = remoteIsolated
-    ? await isolateRemoteCwdForCaller(effectiveArgs.cwd)
-    : effectiveArgs.cwd;
+    ? await isolateRemoteCwdForCaller(withWorkspace.cwd)
+    : withWorkspace.cwd;
   const executionArgs: CliRunArgs = remoteIsolated
-    ? { ...effectiveArgs, cwd: sandboxWorkingDirectory(isolatedCwd) }
-    : effectiveArgs;
+    ? { ...withWorkspace, cwd: sandboxWorkingDirectory(isolatedCwd) }
+    : { ...withWorkspace, cwd: isolatedCwd };
 
   let built;
   try {

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -9,7 +9,8 @@ import {
   buildCommand,
   dshAcpManagedRoot,
   getAdapterDefinition,
-  hasExplicitToolSessionArg
+  hasExplicitToolSessionArg,
+  mergeNodeOptions
 } from "./adapters.js";
 import { runAcpAgent } from "./acpRuntime.js";
 import { runLegacyCliAgent } from "./legacyRuntime.js";
@@ -151,7 +152,9 @@ export function mergeBuiltEnv(
     next[key] =
       key === "OPENCODE_CONFIG_CONTENT" || key === "CODEX_CONFIG"
         ? mergeJsonEnvValue(next[key], value)
-        : value;
+        : key === "NODE_OPTIONS"
+          ? mergeNodeOptions(next[key], value)
+          : value;
   }
   return next;
 }

--- a/electron/cli/sandboxRuntime.ts
+++ b/electron/cli/sandboxRuntime.ts
@@ -644,6 +644,9 @@ function adapterConfigPaths(adapter: string): string[] {
       path.join(home, ".antigravity")
     );
   }
+  if (adapter.includes("dsh") || adapter.includes("deepseek")) {
+    paths.push(path.join(home, ".dsh"), path.join(home, ".config", "dsh"));
+  }
   return existing(paths);
 }
 

--- a/electron/cli/sessionConfigProbe.ts
+++ b/electron/cli/sessionConfigProbe.ts
@@ -13,7 +13,7 @@ import {
   parseAcpLine,
   type AcpMessage
 } from "./acp.js";
-import { buildCommand, dshAcpManagedRoot, getAdapterDefinition } from "./adapters.js";
+import { buildCommand, dshAcpManagedRoot, ensureDshAcpCwd, getAdapterDefinition, syncDshAcpManagedConfig } from "./adapters.js";
 import { getDataDir } from "./db.js";
 import { waitForCodexToolchainAutoUpdate } from "./check.js";
 import { killProcessTree } from "./process-kill.js";
@@ -138,12 +138,17 @@ export async function inspectSessionConfigOptions(
   if (definition?.protocol !== "acp") return [];
 
   await waitForCodexToolchainAutoUpdate(input.adapter);
+  const cwd =
+    input.adapter === "dsh-acp"
+      ? ensureDshAcpCwd(input.cwd, getDataDir())
+      : input.cwd;
+  if (input.adapter === "dsh-acp") syncDshAcpManagedConfig(getDataDir());
   const built = buildCommand({
     adapter: input.adapter,
     binary: input.binary,
     extraArgs: input.extraArgs,
     prompt: "",
-    cwd: input.cwd,
+    cwd,
     dshAcpRuntimeRoot:
       input.adapter === "dsh-acp" ? dshAcpManagedRoot(getDataDir()) : undefined
   });
@@ -161,7 +166,7 @@ export async function inspectSessionConfigOptions(
     )
   );
   const child = spawn(built.bin, built.args, {
-    cwd: input.cwd,
+    cwd,
     env,
     stdio: ["pipe", "pipe", "pipe"]
   }) as ChildProcessByStdio<Writable, Readable, Readable>;

--- a/electron/cli/sessionConfigProbe.ts
+++ b/electron/cli/sessionConfigProbe.ts
@@ -13,7 +13,8 @@ import {
   parseAcpLine,
   type AcpMessage
 } from "./acp.js";
-import { buildCommand, getAdapterDefinition } from "./adapters.js";
+import { buildCommand, dshAcpManagedRoot, getAdapterDefinition } from "./adapters.js";
+import { getDataDir } from "./db.js";
 import { waitForCodexToolchainAutoUpdate } from "./check.js";
 import { killProcessTree } from "./process-kill.js";
 import { mergeBuiltEnv } from "./runtime.js";
@@ -142,7 +143,9 @@ export async function inspectSessionConfigOptions(
     binary: input.binary,
     extraArgs: input.extraArgs,
     prompt: "",
-    cwd: input.cwd
+    cwd: input.cwd,
+    dshAcpRuntimeRoot:
+      input.adapter === "dsh-acp" ? dshAcpManagedRoot(getDataDir()) : undefined
   });
   if (built.protocol !== "acp") return [];
 

--- a/electron/cli/sessionConfigProbe.ts
+++ b/electron/cli/sessionConfigProbe.ts
@@ -13,7 +13,7 @@ import {
   parseAcpLine,
   type AcpMessage
 } from "./acp.js";
-import { buildCommand, dshAcpManagedRoot, ensureDshAcpCwd, getAdapterDefinition, syncDshAcpManagedConfig } from "./adapters.js";
+import { buildCommand, dshAcpManagedRoot, ensureDshAcpCwd, getAdapterDefinition, patchDshAcpRuntimeFromCommand, syncDshAcpManagedConfig } from "./adapters.js";
 import { getDataDir } from "./db.js";
 import { waitForCodexToolchainAutoUpdate } from "./check.js";
 import { killProcessTree } from "./process-kill.js";
@@ -152,6 +152,7 @@ export async function inspectSessionConfigOptions(
     dshAcpRuntimeRoot:
       input.adapter === "dsh-acp" ? dshAcpManagedRoot(getDataDir()) : undefined
   });
+  if (input.adapter === "dsh-acp") patchDshAcpRuntimeFromCommand(built);
   if (built.protocol !== "acp") return [];
 
   const env = mergeBuiltEnv(

--- a/electron/debugLogExport.ts
+++ b/electron/debugLogExport.ts
@@ -8,9 +8,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { debugLogDir, mainLogDroppedLines } from "./debugLog.js";
-import { getDb, getLogDir } from "./cli/db.js";
+import { getDataDir, getDb, getLogDir } from "./cli/db.js";
 import { getSetting } from "./cli/settings.js";
-import { cliAdapterDefinitions } from "./cli/adapters.js";
+import {
+  buildDshAcpRuntimeDiagnostics,
+  cliAdapterDefinitions,
+  dshAcpManagedRoot,
+  dshHarnessOverlayDir
+} from "./cli/adapters.js";
 import { LOG_RETENTION_DAYS } from "./shared/debugLogCore.js";
 import { buildEnvironmentInfo } from "./shared/environmentInfo.js";
 import {
@@ -235,10 +240,24 @@ function readSessionLogFiles(
   return out;
 }
 
+function gatherDshAcpRuntime(): Record<string, unknown> {
+  try {
+    return {
+      ...buildDshAcpRuntimeDiagnostics({
+        runtimeRoot: dshAcpManagedRoot(getDataDir()),
+        overlayDir: dshHarnessOverlayDir()
+      })
+    };
+  } catch (err) {
+    return { error: (err as Error)?.message ?? String(err) };
+  }
+}
+
 function collectBundle(mode: ExportMode, exportedAt: string, conversationId?: string) {
   const masks = gatherPathMasks();
   return {
     environment: gatherEnvironment(mode, exportedAt, conversationId ? "conversation" : "all"),
+    dshAcpRuntime: gatherDshAcpRuntime(),
     appLogs: readAppLogFiles(mode, masks),
     sessionLogs: readSessionLogFiles(mode, masks, conversationId)
   };
@@ -292,7 +311,7 @@ export async function prepareAgentSelfCheckLogs(
   conversationId: string
 ): Promise<{ path: string }> {
   const exportedAt = formatLocalTimestamp(new Date());
-  const { environment, appLogs, sessionLogs } = collectBundle(
+  const { environment, dshAcpRuntime, appLogs, sessionLogs } = collectBundle(
     "full",
     exportedAt,
     conversationId
@@ -312,6 +331,11 @@ export async function prepareAgentSelfCheckLogs(
     fs.writeFileSync(
       path.join(target, "environment.json"),
       JSON.stringify(environment, null, 2),
+      { encoding: "utf8", mode: 0o600 }
+    );
+    fs.writeFileSync(
+      path.join(target, "dsh-acp-runtime.json"),
+      JSON.stringify(dshAcpRuntime, null, 2),
       { encoding: "utf8", mode: 0o600 }
     );
     fs.writeFileSync(
@@ -355,6 +379,7 @@ function readmeText(mode: ExportMode, exportedAt: string, scope: "conversation" 
     "logs/       app logs (JSONL: {ts, level, scope, msg, data?})",
     "sessions/   agent session transcripts (JSONL: {ts, type, content})",
     "environment.json  environment snapshot",
+    "dsh-acp-runtime.json  DeepSeek ACP overlay / koffi / cordis snapshot",
     "",
     "Please attach this file to a GitHub issue or send it to the developers."
   ].join("\n");
@@ -377,9 +402,10 @@ export async function exportDebugLogs(
 
   let zip: AdmZip;
   try {
-    const { environment, appLogs, sessionLogs } = collectBundle(mode, exportedAt, conversationId);
+    const { environment, dshAcpRuntime, appLogs, sessionLogs } = collectBundle(mode, exportedAt, conversationId);
     zip = new AdmZip();
     zip.addFile("environment.json", Buffer.from(JSON.stringify(environment, null, 2)));
+    zip.addFile("dsh-acp-runtime.json", Buffer.from(JSON.stringify(dshAcpRuntime, null, 2)));
     zip.addFile(
       "README.txt",
       Buffer.from(readmeText(mode, exportedAt, conversationId ? "conversation" : "all"))

--- a/electron/mcp/butlerMcpServer.ts
+++ b/electron/mcp/butlerMcpServer.ts
@@ -509,7 +509,7 @@ export function createButlerMcpServer(): McpServer {
     {
       title: "Prepare Conversation Logs for Self-Check",
       description:
-        "Collect a failed conversation's full diagnostic logs (app logs + session transcripts + environment) into a temporary directory and return its path. Then use your file-reading tools to read README.txt, environment.json, logs/, and sessions/ under that directory and produce a structured self-check report (problem summary, evidence with timestamps, confirmed facts vs possible causes, remediation steps). Do not modify files in that directory.",
+        "Collect a failed conversation's full diagnostic logs (app logs + session transcripts + environment) into a temporary directory and return its path. Then use your file-reading tools to read README.txt, environment.json, dsh-acp-runtime.json, logs/, and sessions/ under that directory and produce a structured self-check report (problem summary, evidence with timestamps, confirmed facts vs possible causes, remediation steps). Do not modify files in that directory.",
       inputSchema: {
         conversationId: z.string().trim().min(1).describe("Conversation id to diagnose.")
       },

--- a/electron/telemetryPrivacy.ts
+++ b/electron/telemetryPrivacy.ts
@@ -10,7 +10,8 @@ const KNOWN_ADAPTERS = new Set([
   "qoder-acp",
   "codebuddy-acp",
   "grok-acp",
-  "agy-acp"
+  "agy-acp",
+  "dsh-acp"
 ]);
 
 export type TelemetryErrorCategory =

--- a/src/components/Settings/CLIAdaptersTab.tsx
+++ b/src/components/Settings/CLIAdaptersTab.tsx
@@ -94,6 +94,9 @@ function matchesQuery(ex: ResolvedExecutor, query: string): boolean {
 
 function cliRuntimeErrorKey(lastError: string | undefined): string {
   if (lastError === "binary not found") return "settings.cli.commandNotFound";
+  if (lastError === "DeepSeek ACP plugin tree missing") {
+    return "settings.cli.dshAcpPluginTreeMissing";
+  }
   if (lastError === "claude runtime architecture mismatch") {
     return "settings.cli.claudeArchitectureMismatch";
   }

--- a/src/config/agentIcon.tsx
+++ b/src/config/agentIcon.tsx
@@ -13,7 +13,8 @@ const defaultAgentIcon: Partial<Record<CLIAdapterId, string>> = {
   "qoder-acp": "Qoder",
   "codebuddy-acp": "CodeBuddy",
   "grok-acp": "Grok",
-  "agy-acp": "Gemini"
+  "agy-acp": "Gemini",
+  "dsh-acp": "DeepSeek"
 };
 
 /**

--- a/src/config/aiMembers.ts
+++ b/src/config/aiMembers.ts
@@ -124,7 +124,7 @@ export const builtinCliMembers: CLIMember[] = [
   {
     id: "cli-dsh-acp",
     kind: "cli",
-    name: "DeepSeek",
+    name: "DeepSeek Harness",
     description: "Local DeepSeek Harness coding agent via ACP.",
     source: "builtin",
     enabled: true,

--- a/src/config/aiMembers.ts
+++ b/src/config/aiMembers.ts
@@ -120,5 +120,14 @@ export const builtinCliMembers: CLIMember[] = [
     source: "builtin",
     enabled: true,
     cli: { adapter: "agy-acp", approvalMode: "auto", showStderr: true }
+  },
+  {
+    id: "cli-dsh-acp",
+    kind: "cli",
+    name: "DeepSeek",
+    description: "Local DeepSeek Harness coding agent via ACP.",
+    source: "builtin",
+    enabled: true,
+    cli: { adapter: "dsh-acp", approvalMode: "auto", showStderr: true }
   }
 ];

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -172,7 +172,7 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     capabilities: { toolSession: true },
     toolSessionArgs: [],
     toolSessionArgPrefixes: [],
-    installHint: "npm install -g @deepseek-ai/dsh-acp-demo",
+    installHint: "npm install -g @deepseek-ai/dsh-acp-demo@next",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -165,7 +165,7 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
   },
   {
     id: "dsh-acp",
-    label: "DeepSeek",
+    label: "DeepSeek Harness",
     defaultBinary: "dsh-acp-demo",
     streamMode: "raw",
     commandGroup: "deepseek",

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -172,7 +172,8 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     capabilities: { toolSession: true },
     toolSessionArgs: [],
     toolSessionArgPrefixes: [],
-    installHint: "npm install -g @deepseek-ai/dsh-acp-demo@next",
+    installHint:
+      "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -11,6 +11,7 @@ export type CLIAdapterId =
   | "codebuddy-acp"
   | "grok-acp"
   | "agy-acp"
+  | "dsh-acp"
   | (string & {});
 
 export type CLIStreamMode =
@@ -160,6 +161,19 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     toolSessionArgPrefixes: [],
     installHint: "npm install -g agy-acp-bridge",
     docsUrl: "https://github.com/maojindao55/agy-acp",
+    protocol: "acp"
+  },
+  {
+    id: "dsh-acp",
+    label: "DeepSeek",
+    defaultBinary: "dsh-acp-demo",
+    streamMode: "raw",
+    commandGroup: "deepseek",
+    capabilities: { toolSession: true },
+    toolSessionArgs: [],
+    toolSessionArgPrefixes: [],
+    installHint: "npm install -g @deepseek-ai/dsh-acp-demo",
+    docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }
 ];

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -173,7 +173,7 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     toolSessionArgs: [],
     toolSessionArgPrefixes: [],
     installHint:
-      "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next",
+      "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next @deepseek-ai/dsh-bash-sandbox@next @deepseek-ai/dsh-compaction-basic@next @deepseek-ai/dsh-fs-observation-policy@next @deepseek-ai/dsh-fs-sandbox@next @deepseek-ai/dsh-hooks-claude-code@next @deepseek-ai/dsh-hooks-codex@next @deepseek-ai/dsh-llm-deepseek@next @deepseek-ai/dsh-repeat-tool-reminder@next @deepseek-ai/dsh-sandbox-local@next @deepseek-ai/dsh-sandbox-policy@next @deepseek-ai/dsh-session-projection@next @deepseek-ai/dsh-subagent-fork-in-process@next @deepseek-ai/dsh-subagent-spawn-in-process@next @deepseek-ai/dsh-subagent@next @deepseek-ai/dsh-subprocess-local@next @deepseek-ai/dsh-token-meter@next @deepseek-ai/dsh-tool-fs@next @deepseek-ai/dsh-tool-ralph@next @deepseek-ai/dsh-tool-subagent-control@next @deepseek-ai/dsh-tool-subagent-report@next @deepseek-ai/dsh-tool-subagent@next @deepseek-ai/dsh-tool-todo@next @deepseek-ai/dsh-tool-workflow@next @deepseek-ai/dsh-user-approval@next @deepseek-ai/dsh-workflow-worker-thread@next",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
     protocol: "acp"
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1062,6 +1062,7 @@
       "checkTimedOut": "The version check timed out. Retry or check whether security software blocked the executable.",
       "installBroken": "install broken — retry",
       "commandNotFound": "command not found",
+      "dshAcpPluginTreeMissing": "dsh-acp-demo is on PATH, but its ACP plugin packages are missing. Click Install again.",
       "codexAcpUpgradeRequired": "new Codex ACP required — install",
       "checkProbeFailed": "check failed — retry",
       "checkInstalled": "{{label}} check completed: installed{{version}}",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1047,6 +1047,7 @@
       "checkTimedOut": "版本检测超时，请重试或检查安全软件是否阻止程序启动。",
       "installBroken": "安装损坏 — 请重试",
       "commandNotFound": "未找到命令",
+      "dshAcpPluginTreeMissing": "已找到 dsh-acp-demo，但 ACP 插件包未安装。请再点一次安装。",
       "codexAcpUpgradeRequired": "需要新版 Codex ACP — 请安装",
       "checkProbeFailed": "检测失败 — 请重试",
       "checkInstalled": "{{label}} 检查完成：已安装{{version}}",

--- a/src/utils/agentLogSelfCheck.ts
+++ b/src/utils/agentLogSelfCheck.ts
@@ -22,7 +22,7 @@ export function buildAgentLogSelfCheckPrompt(input: {
 
 \u65e5\u5fd7\u76ee\u5f55\uff1a${logDirectory}
 
-\u8bf7\u5148\u8bfb\u53d6\u8be5\u4e34\u65f6\u76ee\u5f55\u4e2d\u7684 README.txt\u3001environment.json\u3001logs/ \u548c sessions/\u3002
+\u8bf7\u5148\u8bfb\u53d6\u8be5\u4e34\u65f6\u76ee\u5f55\u4e2d\u7684 README.txt\u3001environment.json\u3001dsh-acp-runtime.json\u3001logs/ \u548c sessions/\u3002
 
 \u8981\u6c42\uff1a
 1. \u5148\u603b\u7ed3\u95ee\u9898\uff0c\u518d\u5217\u51fa\u7531\u65f6\u95f4\u6233\u6216\u51c6\u786e\u65e5\u5fd7\u6761\u76ee\u652f\u6301\u7684\u5173\u952e\u8bc1\u636e\u3002
@@ -39,7 +39,7 @@ export function buildAgentLogSelfCheckPrompt(input: {
 
 Log directory: ${logDirectory}
 
-Read README.txt, environment.json, logs/, and sessions/ from this temporary directory before writing the report.
+Read README.txt, environment.json, dsh-acp-runtime.json, logs/, and sessions/ from this temporary directory before writing the report.
 
 Requirements:
 1. Start with a problem summary, then list key evidence supported by timestamps or exact log entries.

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -181,8 +181,12 @@ test("managed DeepSeek spawn overlays the harness fork before the agent starts",
   assert.match(adaptersSource, /dshHarnessOverlayDir/);
   assert.match(adaptersSource, /dsh-harness-overlays/);
   assert.match(adaptersSource, /dshAcpKoffiGuardImportFlag/);
+  assert.match(adaptersSource, /resolveDshAcpDemoBinJs/);
+  assert.match(adaptersSource, /spawnKind/);
   assert.match(runtimeSource, /patchDshAcpRuntimeFromCommand/);
   assert.match(runtimeSource, /buildDshAcpRuntimeDiagnostics/);
+  assert.match(runtimeSource, /spawnArgs:\s*built\.args/);
+  assert.match(acpRuntimeSource, /recentStderr\.slice\(-40\)/);
 });
 
 test("cliRun passes workspaceRoots into buildCommand", () => {

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -180,7 +180,9 @@ test("managed DeepSeek spawn overlays the harness fork before the agent starts",
   assert.match(adaptersSource, /patchDshAcpRuntimeFromBin/);
   assert.match(adaptersSource, /dshHarnessOverlayDir/);
   assert.match(adaptersSource, /dsh-harness-overlays/);
+  assert.match(adaptersSource, /dshAcpKoffiGuardImportFlag/);
   assert.match(runtimeSource, /patchDshAcpRuntimeFromCommand/);
+  assert.match(runtimeSource, /buildDshAcpRuntimeDiagnostics/);
 });
 
 test("cliRun passes workspaceRoots into buildCommand", () => {

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -171,6 +171,19 @@ test("cliRun sanitizes Electron env and gives DeepSeek a workspace when cwd is u
   assert.match(acpRuntimeSource, /formatAcpAgentExitMessage/);
 });
 
+test("managed DeepSeek spawn patches koffi MoveFileExW before the agent starts", () => {
+  const adaptersSource = fs.readFileSync(
+    new URL("../electron/cli/adapters.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(adaptersSource, /patchDshAcpManagedRuntime\(root\)/);
+  assert.match(
+    adaptersSource,
+    /if \(process\.platform === "win32"\) await this\.materializeWin32/
+  );
+  assert.match(adaptersSource, /openAt: "never"/);
+});
+
 test("cliRun passes workspaceRoots into buildCommand", () => {
   assert.match(runtimeSource, /workspaceRoots:\s*args\.workspaceRoots/);
 });

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -177,8 +177,10 @@ test("managed DeepSeek spawn overlays the harness fork before the agent starts",
     "utf8"
   );
   assert.match(adaptersSource, /patchDshAcpManagedRuntime\(root\)/);
+  assert.match(adaptersSource, /patchDshAcpRuntimeFromBin/);
   assert.match(adaptersSource, /dshHarnessOverlayDir/);
   assert.match(adaptersSource, /dsh-harness-overlays/);
+  assert.match(runtimeSource, /patchDshAcpRuntimeFromCommand/);
 });
 
 test("cliRun passes workspaceRoots into buildCommand", () => {

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -164,6 +164,13 @@ test("cliRun merges NODE_OPTIONS instead of overwriting them", () => {
   assert.match(runtimeSource, /mergeNodeOptions/);
 });
 
+test("cliRun sanitizes Electron env and gives DeepSeek a workspace when cwd is unset", () => {
+  assert.match(runtimeSource, /sanitizeCliAgentEnv/);
+  assert.match(runtimeSource, /ensureDshAcpCwd/);
+  assert.match(runtimeSource, /syncDshAcpManagedConfig/);
+  assert.match(acpRuntimeSource, /formatAcpAgentExitMessage/);
+});
+
 test("cliRun passes workspaceRoots into buildCommand", () => {
   assert.match(runtimeSource, /workspaceRoots:\s*args\.workspaceRoots/);
 });

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -171,17 +171,14 @@ test("cliRun sanitizes Electron env and gives DeepSeek a workspace when cwd is u
   assert.match(acpRuntimeSource, /formatAcpAgentExitMessage/);
 });
 
-test("managed DeepSeek spawn patches koffi MoveFileExW before the agent starts", () => {
+test("managed DeepSeek spawn overlays the harness fork before the agent starts", () => {
   const adaptersSource = fs.readFileSync(
     new URL("../electron/cli/adapters.ts", import.meta.url),
     "utf8"
   );
   assert.match(adaptersSource, /patchDshAcpManagedRuntime\(root\)/);
-  assert.match(
-    adaptersSource,
-    /if \(process\.platform === "win32"\) await this\.materializeWin32/
-  );
-  assert.match(adaptersSource, /openAt: "never"/);
+  assert.match(adaptersSource, /dshHarnessOverlayDir/);
+  assert.match(adaptersSource, /dsh-harness-overlays/);
 });
 
 test("cliRun passes workspaceRoots into buildCommand", () => {

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -143,6 +143,27 @@ test("acpRuntime skips client MCP servers for adapters that reject them", () => 
   );
 });
 
+test("ACP runtime hides DeepSeek Node SQLite ExperimentalWarning from UI stderr", () => {
+  assert.match(acpRuntimeSource, /isDshAcpExperimentalWarningLine/);
+  const stderrHandler = acpRuntimeSource.slice(
+    acpRuntimeSource.indexOf('rlErr.on("line"'),
+    acpRuntimeSource.indexOf("child.on(\"close\"")
+  );
+  assert.match(stderrHandler, /args\.adapter === "dsh-acp"/);
+  assert.match(stderrHandler, /isDshAcpExperimentalWarningLine\(line\)/);
+  assert.match(stderrHandler, /recentStderr\.push\(line\)/);
+  assert.ok(
+    stderrHandler.indexOf("isDshAcpExperimentalWarningLine(line)") <
+      stderrHandler.indexOf("recentStderr.push(line)"),
+    "SQLite ExperimentalWarning is skipped before it becomes UI stderr or crash text"
+  );
+});
+
+test("cliRun merges NODE_OPTIONS instead of overwriting them", () => {
+  assert.match(runtimeSource, /key === "NODE_OPTIONS"/);
+  assert.match(runtimeSource, /mergeNodeOptions/);
+});
+
 test("cliRun passes workspaceRoots into buildCommand", () => {
   assert.match(runtimeSource, /workspaceRoots:\s*args\.workspaceRoots/);
 });

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -135,6 +135,14 @@ test("acpRuntime registers workspace FS MCP only for multi-root", () => {
   assert.match(acpRuntimeSource, /roots\.length\s*>\s*1/);
 });
 
+test("acpRuntime skips client MCP servers for adapters that reject them", () => {
+  assert.match(acpRuntimeSource, /adapterAcceptsClientMcpServers\(args\.adapter\)/);
+  assert.match(
+    acpRuntimeSource,
+    /DeepSeek Harness ACP rejects non-empty mcpServers/
+  );
+});
+
 test("cliRun passes workspaceRoots into buildCommand", () => {
   assert.match(runtimeSource, /workspaceRoots:\s*args\.workspaceRoots/);
 });

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -9,7 +9,10 @@ import {
   cliAdapterDefinitions,
   adapterAcceptsClientMcpServers,
   extraArgsHaveDshConfig,
-  resolveDshAcpConfigPath
+  resolveDshAcpConfigPath,
+  DSH_ACP_NODE_DISABLE_WARNING,
+  isDshAcpExperimentalWarningLine,
+  mergeNodeOptions
 } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
@@ -361,7 +364,13 @@ test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
   });
 
   assert.equal(built.bin, "node");
-  assert.deepEqual(built.args, [binJs, "--config", config]);
+  assert.deepEqual(built.args, [
+    DSH_ACP_NODE_DISABLE_WARNING,
+    binJs,
+    "--config",
+    config
+  ]);
+  assert.match(built.env?.NODE_OPTIONS ?? "", /--disable-warning=ExperimentalWarning/);
   assert.equal(built.protocol, "acp");
 });
 
@@ -405,6 +414,54 @@ test("DeepSeek Harness ACP rejects client MCP servers", () => {
   assert.equal(adapterAcceptsClientMcpServers("dsh-acp"), false);
   assert.equal(adapterAcceptsClientMcpServers("codex-acp"), true);
   assert.equal(adapterAcceptsClientMcpServers("agy-acp"), true);
+});
+
+test("buildCommand silences Node SQLite ExperimentalWarning for DeepSeek ACP", () => {
+  const built = buildCommand({ adapter: "dsh-acp", prompt: "hello" });
+
+  assert.equal(built.bin, "dsh-acp-demo");
+  assert.equal(built.args.includes(DSH_ACP_NODE_DISABLE_WARNING), false);
+  assert.equal(built.env?.NODE_OPTIONS, DSH_ACP_NODE_DISABLE_WARNING);
+});
+
+test("isDshAcpExperimentalWarningLine matches Node sqlite warning stderr", () => {
+  assert.equal(
+    isDshAcpExperimentalWarningLine(
+      "(node:16676) ExperimentalWarning: SQLite is an experimental feature and might change at any time (Use `node --trace-warnings ...` to show where the warning was created)"
+    ),
+    true
+  );
+  assert.equal(
+    isDshAcpExperimentalWarningLine(
+      "(node:16676) ExperimentalWarning: SQLite is an experimental feature and might change at any time"
+    ),
+    true
+  );
+  assert.equal(
+    isDshAcpExperimentalWarningLine(
+      "(Use `node --trace-warnings ...` to show where the warning was created)"
+    ),
+    true
+  );
+  assert.equal(
+    isDshAcpExperimentalWarningLine("plugin tree failed to load"),
+    false
+  );
+});
+
+test("mergeNodeOptions appends the DeepSeek warning flag without dropping existing options", () => {
+  assert.equal(
+    mergeNodeOptions(undefined, DSH_ACP_NODE_DISABLE_WARNING),
+    DSH_ACP_NODE_DISABLE_WARNING
+  );
+  assert.equal(
+    mergeNodeOptions("--preserve-symlinks", DSH_ACP_NODE_DISABLE_WARNING),
+    `--preserve-symlinks ${DSH_ACP_NODE_DISABLE_WARNING}`
+  );
+  assert.equal(
+    mergeNodeOptions(DSH_ACP_NODE_DISABLE_WARNING, DSH_ACP_NODE_DISABLE_WARNING),
+    DSH_ACP_NODE_DISABLE_WARNING
+  );
 });
 
 test("buildCommand keeps Grok global flags before the ACP subcommand", () => {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -357,7 +357,7 @@ test("buildCommand uses a workspace cordis.yml when present", () => {
   assert.deepEqual(built.args, ["--config", local]);
 });
 
-test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
+function writeManagedDshRuntime() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-managed-"));
   const demo = path.join(root, "node_modules", "@deepseek-ai", "dsh-acp-demo");
   fs.mkdirSync(path.join(demo, "lib"), { recursive: true });
@@ -369,6 +369,11 @@ test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
   fs.writeFileSync(path.join(probe, "package.json"), "{}");
   const config = path.join(root, "cordis.yml");
   fs.writeFileSync(config, "- id: acp-agent\n");
+  return { root, binJs, config };
+}
+
+test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
+  const { root, binJs, config } = writeManagedDshRuntime();
 
   const built = buildCommand({
     adapter: "dsh-acp",
@@ -389,6 +394,36 @@ test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
   assert.match(built.env?.NODE_OPTIONS ?? "", /--disable-warning=ExperimentalWarning/);
   assert.match(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
   assert.equal(built.protocol, "acp");
+});
+
+test("buildCommand prefers managed DeepSeek runtime when binary is the default demo name", () => {
+  const { root, binJs } = writeManagedDshRuntime();
+
+  for (const binary of ["dsh-acp-demo", "dsh-acp-demo.cmd", "dsh-acp-demo.exe"]) {
+    const built = buildCommand({
+      adapter: "dsh-acp",
+      binary,
+      prompt: "hello",
+      dshAcpRuntimeRoot: root
+    });
+    assert.equal(built.bin, "node", binary);
+    assert.equal(built.args.includes(binJs), true, binary);
+  }
+});
+
+test("buildCommand keeps an explicit custom DeepSeek binary path", () => {
+  const { root } = writeManagedDshRuntime();
+  const custom = path.join(os.tmpdir(), "custom-dsh", "dsh-acp-demo");
+
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    binary: custom,
+    prompt: "hello",
+    dshAcpRuntimeRoot: root
+  });
+
+  assert.equal(built.bin, custom);
+  assert.equal(built.args.includes(path.join(root, "node_modules", "@deepseek-ai", "dsh-acp-demo", "lib", "bin.js")), false);
 });
 
 test("buildCommand keeps extra DeepSeek args after the bundled config", () => {
@@ -526,6 +561,14 @@ test("formatAcpAgentExitMessage explains Windows access violation 0xC0000005", (
   assert.match(
     formatAcpAgentExitMessage(3221225477, "zh-CN"),
     /导出调试日志/
+  );
+  assert.doesNotMatch(
+    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    /关掉 ACL sandbox/
+  );
+  assert.doesNotMatch(
+    formatAcpAgentExitMessage(3221225477, "en"),
+    /disables the ACL sandbox/
   );
   assert.doesNotMatch(
     formatAcpAgentExitMessage(3221225477, "zh-CN"),

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -1,8 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { buildCommand, cliAdapterDefinitions, adapterAcceptsClientMcpServers } from "../dist-electron/cli/adapters.js";
+import {
+  buildCommand,
+  cliAdapterDefinitions,
+  adapterAcceptsClientMcpServers,
+  extraArgsHaveDshConfig,
+  resolveDshAcpConfigPath
+} from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
   acpSessionSetupToItems,
@@ -311,11 +319,40 @@ test("buildCommand starts Grok through its ACP stdio agent", () => {
 
 test("buildCommand starts DeepSeek Harness through its ACP demo server", () => {
   const built = buildCommand({ adapter: "dsh-acp", prompt: "hello" });
+  const config = resolveDshAcpConfigPath();
 
   assert.equal(built.bin, "dsh-acp-demo");
-  assert.deepEqual(built.args, []);
+  assert.deepEqual(built.args, ["--config", config]);
+  assert.equal(fs.existsSync(config), true);
   assert.equal(built.promptViaStdin, false);
   assert.equal(built.protocol, "acp");
+});
+
+test("buildCommand uses a workspace cordis.yml when present", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-"));
+  const local = path.join(dir, "cordis.yml");
+  fs.writeFileSync(local, "- id: acp-agent\n");
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    prompt: "hello",
+    cwd: dir
+  });
+
+  assert.deepEqual(built.args, ["--config", local]);
+});
+
+test("buildCommand keeps extra DeepSeek args after the bundled config", () => {
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    prompt: "hello",
+    extraArgs: ["--verbose"]
+  });
+
+  assert.deepEqual(built.args, [
+    "--config",
+    resolveDshAcpConfigPath(),
+    "--verbose"
+  ]);
 });
 
 test("buildCommand forwards DeepSeek Harness extra args including cordis config", () => {
@@ -327,6 +364,17 @@ test("buildCommand forwards DeepSeek Harness extra args including cordis config"
 
   assert.deepEqual(built.args, ["-c", "/tmp/acp-agent/cordis.yml"]);
   assert.equal(built.protocol, "acp");
+});
+
+test("buildCommand does not override DeepSeek --config= extra args", () => {
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    prompt: "hello",
+    extraArgs: ["--config=/custom/cordis.yml"]
+  });
+
+  assert.equal(extraArgsHaveDshConfig(["--config=/custom/cordis.yml"]), true);
+  assert.deepEqual(built.args, ["--config=/custom/cordis.yml"]);
 });
 
 test("DeepSeek Harness ACP rejects client MCP servers", () => {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -12,7 +12,12 @@ import {
   resolveDshAcpConfigPath,
   DSH_ACP_NODE_DISABLE_WARNING,
   isDshAcpExperimentalWarningLine,
-  mergeNodeOptions
+  mergeNodeOptions,
+  sanitizeCliAgentEnv,
+  ensureDshAcpCwd,
+  dshAcpManagedRoot,
+  formatAcpAgentExitMessage,
+  isWindowsAccessViolationExit
 } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
@@ -461,6 +466,49 @@ test("mergeNodeOptions appends the DeepSeek warning flag without dropping existi
   assert.equal(
     mergeNodeOptions(DSH_ACP_NODE_DISABLE_WARNING, DSH_ACP_NODE_DISABLE_WARNING),
     DSH_ACP_NODE_DISABLE_WARNING
+  );
+});
+
+test("sanitizeCliAgentEnv drops Electron crashpad variables before spawning Node CLIs", () => {
+  const env = sanitizeCliAgentEnv({
+    PATH: "/usr/bin",
+    ELECTRON_RUN_AS_NODE: "1",
+    CHROME_CRASHPAD_PIPE_NAME: "\\\\.\\pipe\\crashpad",
+    ELECTRON_CRASHPAD_PIPE_NAME: "\\\\.\\pipe\\electron-crashpad",
+    NODE_OPTIONS: "--require /app/asar/hook.js --disable-warning=ExperimentalWarning",
+    DEEPSEEK_API_KEY: "sk-test"
+  });
+  assert.equal(env.PATH, "/usr/bin");
+  assert.equal(env.DEEPSEEK_API_KEY, "sk-test");
+  assert.equal("ELECTRON_RUN_AS_NODE" in env, false);
+  assert.equal("CHROME_CRASHPAD_PIPE_NAME" in env, false);
+  assert.equal("ELECTRON_CRASHPAD_PIPE_NAME" in env, false);
+  assert.equal(env.NODE_OPTIONS, "--disable-warning=ExperimentalWarning");
+});
+
+test("ensureDshAcpCwd falls back to the managed runtime workspace when cwd is missing", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-cwd-"));
+  const fallback = ensureDshAcpCwd(undefined, dataDir);
+  assert.equal(fallback, path.join(dshAcpManagedRoot(dataDir), "workspace"));
+  assert.equal(fs.existsSync(fallback), true);
+  assert.equal(ensureDshAcpCwd(" /tmp/project ", dataDir), "/tmp/project");
+});
+
+test("formatAcpAgentExitMessage explains Windows access violation 0xC0000005", () => {
+  assert.equal(isWindowsAccessViolationExit(3221225477), true);
+  assert.equal(isWindowsAccessViolationExit(-1073741819), true);
+  assert.equal(isWindowsAccessViolationExit(1), false);
+  assert.match(
+    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    /访问冲突/
+  );
+  assert.match(
+    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    /session\/prompt/
+  );
+  assert.match(
+    formatAcpAgentExitMessage(3221225477, "en"),
+    /access violation/i
   );
 });
 

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -22,7 +22,10 @@ import {
   syncDshAcpManagedConfig,
   dshHarnessOverlayDir,
   dshAcpJsonlStillUsesKoffi,
-  patchDshAcpRuntimeFromBin
+  patchDshAcpRuntimeFromBin,
+  buildDshAcpRuntimeDiagnostics,
+  dshAcpKoffiGuardPath,
+  dshAcpKoffiGuardImportFlag
 } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
@@ -374,13 +377,17 @@ test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
   });
 
   assert.equal(built.bin, "node");
+  const importFlag = dshAcpKoffiGuardImportFlag();
+  assert.ok(importFlag);
   assert.deepEqual(built.args, [
     DSH_ACP_NODE_DISABLE_WARNING,
+    importFlag,
     binJs,
     "--config",
     config
   ]);
   assert.match(built.env?.NODE_OPTIONS ?? "", /--disable-warning=ExperimentalWarning/);
+  assert.match(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
   assert.equal(built.protocol, "acp");
 });
 
@@ -431,7 +438,8 @@ test("buildCommand silences Node SQLite ExperimentalWarning for DeepSeek ACP", (
 
   assert.equal(built.bin, "dsh-acp-demo");
   assert.equal(built.args.includes(DSH_ACP_NODE_DISABLE_WARNING), false);
-  assert.equal(built.env?.NODE_OPTIONS, DSH_ACP_NODE_DISABLE_WARNING);
+  assert.match(built.env?.NODE_OPTIONS ?? "", /--disable-warning=ExperimentalWarning/);
+  assert.match(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
 });
 
 test("isDshAcpExperimentalWarningLine matches Node sqlite warning stderr", () => {
@@ -515,6 +523,10 @@ test("formatAcpAgentExitMessage explains Windows access violation 0xC0000005", (
     formatAcpAgentExitMessage(3221225477, "zh-CN"),
     /MoveFileExW/
   );
+  assert.match(
+    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    /导出调试日志/
+  );
   assert.doesNotMatch(
     formatAcpAgentExitMessage(3221225477, "zh-CN"),
     /请用本版本重新编译后再试。$/
@@ -526,6 +538,10 @@ test("formatAcpAgentExitMessage explains Windows access violation 0xC0000005", (
   assert.match(
     formatAcpAgentExitMessage(3221225477, "en"),
     /MoveFileExW/
+  );
+  assert.match(
+    formatAcpAgentExitMessage(3221225477, "en"),
+    /debug logs/i
   );
 });
 
@@ -623,6 +639,69 @@ test("patchDshAcpManagedRuntime overlays nested node_modules copies", () => {
   patchDshAcpManagedRuntime(root);
   assert.doesNotMatch(fs.readFileSync(dest, "utf8"), /koffi/);
   assert.deepEqual(dshAcpJsonlStillUsesKoffi(root), []);
+});
+
+test("buildDshAcpRuntimeDiagnostics reports leftover koffi and cordis safety flags", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-diag-"));
+  const files = writePlaceholderDshRuntime(root);
+  const aclLib = path.join(
+    root,
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-sandbox-windows-acl",
+    "lib"
+  );
+  fs.mkdirSync(aclLib, { recursive: true });
+  fs.writeFileSync(path.join(aclLib, "index.js"), 'await import("koffi");\n');
+  fs.writeFileSync(
+    path.join(root, "cordis.yml"),
+    [
+      "- id: sandbox",
+      "  name: '@deepseek-ai/dsh-sandbox-local'",
+      "  disabled: !!js process.platform === 'win32'",
+      "- id: acp-agent",
+      "  name: '@deepseek-ai/dsh-acp-demo'",
+      "  config:",
+      "    persistenceCompression: none",
+      ""
+    ].join("\n")
+  );
+
+  const before = buildDshAcpRuntimeDiagnostics({ runtimeRoot: root });
+  assert.equal(before.runtimePresent, true);
+  assert.equal(before.jsonlCopyCount, 1);
+  assert.equal(before.jsonlKoffiCopyCount, 1);
+  assert.equal(before.windowsAclPresent, true);
+  assert.equal(before.windowsAclUsesKoffi, true);
+  assert.equal(before.persistenceCompressionNone, true);
+  assert.equal(before.sandboxDisabledOnWin32, true);
+  assert.equal(before.koffiGuardPresent, true);
+  assert.equal(before.jsonlRelatives[0]?.usesKoffi, true);
+  assert.doesNotMatch(JSON.stringify(before), /home|Users|AppData/i);
+
+  patchDshAcpManagedRuntime(root);
+  const after = buildDshAcpRuntimeDiagnostics({ runtimeRoot: root });
+  assert.equal(after.jsonlKoffiCopyCount, 0);
+  assert.equal(fs.readFileSync(files.jsonl, "utf8").includes("koffi"), false);
+});
+
+test("koffi guard redirects koffi to a JavaScript stub", async () => {
+  const { execFileSync } = await import("node:child_process");
+  const { pathToFileURL } = await import("node:url");
+  const guard = dshAcpKoffiGuardPath();
+  assert.equal(fs.existsSync(guard), true);
+  const script = [
+    "const k = await import('koffi');",
+    "const api = (k.default ?? k).load('kernel32.dll');",
+    "const fn = api.func('__stdcall', 'MoveFileExW', 'int', ['str16', 'str16', 'uint']);",
+    "process.stdout.write(JSON.stringify({ result: fn('a', 'b', 8), stub: true }));"
+  ].join("");
+  const stdout = execFileSync(
+    process.execPath,
+    ["--import", pathToFileURL(guard).href, "--input-type=module", "-e", script],
+    { encoding: "utf8" }
+  );
+  assert.deepEqual(JSON.parse(stdout), { result: 0, stub: true });
 });
 
 test("patchDshAcpRuntimeFromBin overlays the install prefix of a demo bin", () => {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -663,45 +663,56 @@ test("formatAcpAgentExitMessage explains Windows access violation 0xC0000005", (
   assert.equal(isWindowsAccessViolationExit(-1073741819), true);
   assert.equal(isWindowsAccessViolationExit(1), false);
   assert.match(
-    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    formatAcpAgentExitMessage(3221225477, "zh-CN", "dsh-acp"),
     /访问冲突/
   );
   assert.match(
-    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    formatAcpAgentExitMessage(3221225477, "zh-CN", "dsh-acp"),
     /session\/prompt/
   );
   assert.match(
-    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    formatAcpAgentExitMessage(3221225477, "zh-CN", "dsh-acp"),
     /MoveFileExW/
   );
   assert.match(
-    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    formatAcpAgentExitMessage(3221225477, "zh-CN", "dsh-acp"),
     /导出调试日志/
   );
   assert.doesNotMatch(
-    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    formatAcpAgentExitMessage(3221225477, "zh-CN", "dsh-acp"),
     /关掉 ACL sandbox/
   );
   assert.doesNotMatch(
-    formatAcpAgentExitMessage(3221225477, "en"),
+    formatAcpAgentExitMessage(3221225477, "en", "dsh-acp"),
     /disables the ACL sandbox/
   );
   assert.doesNotMatch(
-    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    formatAcpAgentExitMessage(3221225477, "zh-CN", "dsh-acp"),
     /请用本版本重新编译后再试。$/
   );
   assert.match(
-    formatAcpAgentExitMessage(3221225477, "en"),
+    formatAcpAgentExitMessage(3221225477, "en", "dsh-acp"),
     /access violation/i
   );
   assert.match(
-    formatAcpAgentExitMessage(3221225477, "en"),
+    formatAcpAgentExitMessage(3221225477, "en", "dsh-acp"),
     /MoveFileExW/
   );
   assert.match(
-    formatAcpAgentExitMessage(3221225477, "en"),
+    formatAcpAgentExitMessage(3221225477, "en", "dsh-acp"),
     /debug logs/i
   );
+
+  // Other ACP adapters must receive generic error messages without DeepSeek/koffi mentions
+  const genericZh = formatAcpAgentExitMessage(3221225477, "zh-CN", "codex");
+  assert.match(genericZh, /访问冲突/);
+  assert.doesNotMatch(genericZh, /DeepSeek/i);
+  assert.doesNotMatch(genericZh, /MoveFileExW/);
+
+  const genericEn = formatAcpAgentExitMessage(3221225477, "en", "codex");
+  assert.match(genericEn, /access violation/i);
+  assert.doesNotMatch(genericEn, /DeepSeek/i);
+  assert.doesNotMatch(genericEn, /MoveFileExW/);
 });
 
 function writePlaceholderDshRuntime(root) {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-import { buildCommand, cliAdapterDefinitions } from "../dist-electron/cli/adapters.js";
+import { buildCommand, cliAdapterDefinitions, adapterAcceptsClientMcpServers } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
   acpSessionSetupToItems,
@@ -133,7 +133,8 @@ test("visible adapter definitions are ACP-only with product names", () => {
       { id: "qoder-acp", label: "Qoder", protocol: "acp" },
       { id: "codebuddy-acp", label: "CodeBuddy", protocol: "acp" },
       { id: "grok-acp", label: "Grok", protocol: "acp" },
-      { id: "agy-acp", label: "Antigravity", protocol: "acp" }
+      { id: "agy-acp", label: "Antigravity", protocol: "acp" },
+      { id: "dsh-acp", label: "DeepSeek", protocol: "acp" }
     ]
   );
 });
@@ -306,6 +307,32 @@ test("buildCommand starts Grok through its ACP stdio agent", () => {
   assert.deepEqual(built.args, ["agent", "stdio"]);
   assert.equal(built.promptViaStdin, false);
   assert.equal(built.protocol, "acp");
+});
+
+test("buildCommand starts DeepSeek Harness through its ACP demo server", () => {
+  const built = buildCommand({ adapter: "dsh-acp", prompt: "hello" });
+
+  assert.equal(built.bin, "dsh-acp-demo");
+  assert.deepEqual(built.args, []);
+  assert.equal(built.promptViaStdin, false);
+  assert.equal(built.protocol, "acp");
+});
+
+test("buildCommand forwards DeepSeek Harness extra args including cordis config", () => {
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    prompt: "hello",
+    extraArgs: ["-c", "/tmp/acp-agent/cordis.yml"]
+  });
+
+  assert.deepEqual(built.args, ["-c", "/tmp/acp-agent/cordis.yml"]);
+  assert.equal(built.protocol, "acp");
+});
+
+test("DeepSeek Harness ACP rejects client MCP servers", () => {
+  assert.equal(adapterAcceptsClientMcpServers("dsh-acp"), false);
+  assert.equal(adapterAcceptsClientMcpServers("codex-acp"), true);
+  assert.equal(adapterAcceptsClientMcpServers("agy-acp"), true);
 });
 
 test("buildCommand keeps Grok global flags before the ACP subcommand", () => {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -20,7 +20,9 @@ import {
   isWindowsAccessViolationExit,
   patchDshAcpManagedRuntime,
   syncDshAcpManagedConfig,
-  dshHarnessOverlayDir
+  dshHarnessOverlayDir,
+  dshAcpJsonlStillUsesKoffi,
+  patchDshAcpRuntimeFromBin
 } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
@@ -601,6 +603,42 @@ test("syncDshAcpManagedConfig patches an already-installed DeepSeek runtime", ()
   assert.equal(fs.existsSync(path.join(root, "cordis.yml")), true);
   assert.doesNotMatch(fs.readFileSync(files.jsonl, "utf8"), /koffi/);
   assert.match(fs.readFileSync(files.demo, "utf8"), /openAt:\s*"never"/);
+});
+
+test("patchDshAcpManagedRuntime overlays nested node_modules copies", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-nested-"));
+  const nested = path.join(
+    root,
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-acp",
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-session-persistence-jsonl",
+    "lib"
+  );
+  fs.mkdirSync(nested, { recursive: true });
+  const dest = path.join(nested, "index.js");
+  fs.writeFileSync(dest, 'await import("koffi");\n');
+  patchDshAcpManagedRuntime(root);
+  assert.doesNotMatch(fs.readFileSync(dest, "utf8"), /koffi/);
+  assert.deepEqual(dshAcpJsonlStillUsesKoffi(root), []);
+});
+
+test("patchDshAcpRuntimeFromBin overlays the install prefix of a demo bin", () => {
+  const prefix = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-bin-"));
+  const files = writePlaceholderDshRuntime(prefix);
+  const demo = path.join(
+    prefix,
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-acp-demo"
+  );
+  fs.writeFileSync(path.join(demo, "package.json"), "{}");
+  const bin = path.join(demo, "lib", "bin.js");
+  fs.writeFileSync(bin, "");
+  patchDshAcpRuntimeFromBin(bin);
+  assert.doesNotMatch(fs.readFileSync(files.jsonl, "utf8"), /koffi/);
 });
 
 test("buildCommand keeps Grok global flags before the ACP subcommand", () => {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -19,7 +19,8 @@ import {
   formatAcpAgentExitMessage,
   isWindowsAccessViolationExit,
   patchDshAcpManagedRuntime,
-  syncDshAcpManagedConfig
+  syncDshAcpManagedConfig,
+  dshHarnessOverlayDir
 } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
@@ -526,22 +527,7 @@ test("formatAcpAgentExitMessage explains Windows access violation 0xC0000005", (
   );
 });
 
-const OFFICIAL_JSONL_MATERIALIZE = `		if (process.platform === "win32") await this.materializeWin32(project, dir, finalPath, meta.id, content);
-		else await this.materializePosix(project, dir, finalPath, meta.id, content);`;
-
-const OFFICIAL_JSONL_SYNC_DIR = `	async syncDirPosix(dir) {
-		const handle = await open(dir, "r");
-		try {
-			await handle.sync();
-		} finally {
-			await handle.close();
-		}
-	}`;
-
-const OFFICIAL_DEMO_SQLITE =
-  `const query = ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, "session-query.db") });`;
-
-function writeOfficialDshRuntimeSnippets(root) {
+function writePlaceholderDshRuntime(root) {
   const jsonlDir = path.join(
     root,
     "node_modules",
@@ -560,57 +546,60 @@ function writeOfficialDshRuntimeSnippets(root) {
   fs.mkdirSync(demoDir, { recursive: true });
   const jsonl = path.join(jsonlDir, "index.js");
   const demo = path.join(demoDir, "index.js");
-  fs.writeFileSync(
-    jsonl,
-    `${OFFICIAL_JSONL_MATERIALIZE}\n${OFFICIAL_JSONL_SYNC_DIR}\n`
-  );
-  fs.writeFileSync(demo, `${OFFICIAL_DEMO_SQLITE}\n`);
+  fs.writeFileSync(jsonl, 'await import("koffi");\n');
+  fs.writeFileSync(demo, "official-demo\n");
   return { jsonl, demo };
 }
+
+test("DeepSeek harness overlay never loads koffi", () => {
+  const overlay = dshHarnessOverlayDir();
+  const jsonl = fs.readFileSync(
+    path.join(overlay, "dsh-session-persistence-jsonl", "lib", "index.js"),
+    "utf8"
+  );
+  const demo = fs.readFileSync(
+    path.join(overlay, "dsh-acp-demo", "lib", "index.js"),
+    "utf8"
+  );
+  assert.doesNotMatch(jsonl, /koffi/);
+  assert.doesNotMatch(jsonl, /MoveFileExW/);
+  assert.match(jsonl, /async function publishNewFileWin32/);
+  assert.match(jsonl, /await rename\(/);
+  assert.match(demo, /openAt:\s*"never"/);
+});
 
 test("patchDshAcpManagedRuntime is a no-op when DeepSeek packages are missing", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-missing-"));
   assert.doesNotThrow(() => patchDshAcpManagedRuntime(root));
 });
 
-test("patchDshAcpManagedRuntime skips koffi MoveFileExW and SQLite on official snippets", () => {
+test("patchDshAcpManagedRuntime overlays the harness fork onto an installed runtime", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-patch-"));
-  const files = writeOfficialDshRuntimeSnippets(root);
+  const files = writePlaceholderDshRuntime(root);
   patchDshAcpManagedRuntime(root);
-  const jsonl = fs.readFileSync(files.jsonl, "utf8");
-  const demo = fs.readFileSync(files.demo, "utf8");
-  assert.match(jsonl, /if \(false\) await this\.materializeWin32/);
-  assert.doesNotMatch(
-    jsonl,
-    /if \(process\.platform === "win32"\) await this\.materializeWin32/
+  const overlay = dshHarnessOverlayDir();
+  assert.equal(
+    fs.readFileSync(files.jsonl, "utf8"),
+    fs.readFileSync(
+      path.join(overlay, "dsh-session-persistence-jsonl", "lib", "index.js"),
+      "utf8"
+    )
   );
-  assert.match(
-    jsonl,
-    /async syncDirPosix\(dir\) \{\s*if \(process\.platform === "win32"\) return;/
+  assert.equal(
+    fs.readFileSync(files.demo, "utf8"),
+    fs.readFileSync(path.join(overlay, "dsh-acp-demo", "lib", "index.js"), "utf8")
   );
-  assert.match(demo, /openAt:\s*"never"/);
-  assert.doesNotMatch(
-    demo,
-    /SqliteSessionQueryEngine, \{ path: join\(persistenceRoot, "session-query\.db"\) \}/
-  );
-
-  const beforeJsonl = jsonl;
-  const beforeDemo = demo;
   patchDshAcpManagedRuntime(root);
-  assert.equal(fs.readFileSync(files.jsonl, "utf8"), beforeJsonl);
-  assert.equal(fs.readFileSync(files.demo, "utf8"), beforeDemo);
+  assert.doesNotMatch(fs.readFileSync(files.jsonl, "utf8"), /koffi/);
 });
 
 test("syncDshAcpManagedConfig patches an already-installed DeepSeek runtime", () => {
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-sync-"));
   const root = dshAcpManagedRoot(dataDir);
-  const files = writeOfficialDshRuntimeSnippets(root);
+  const files = writePlaceholderDshRuntime(root);
   assert.equal(syncDshAcpManagedConfig(dataDir), root);
   assert.equal(fs.existsSync(path.join(root, "cordis.yml")), true);
-  assert.match(
-    fs.readFileSync(files.jsonl, "utf8"),
-    /if \(false\) await this\.materializeWin32/
-  );
+  assert.doesNotMatch(fs.readFileSync(files.jsonl, "utf8"), /koffi/);
   assert.match(fs.readFileSync(files.demo, "utf8"), /openAt:\s*"never"/);
 });
 

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -17,7 +17,9 @@ import {
   ensureDshAcpCwd,
   dshAcpManagedRoot,
   formatAcpAgentExitMessage,
-  isWindowsAccessViolationExit
+  isWindowsAccessViolationExit,
+  patchDshAcpManagedRuntime,
+  syncDshAcpManagedConfig
 } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
@@ -507,9 +509,109 @@ test("formatAcpAgentExitMessage explains Windows access violation 0xC0000005", (
     /session\/prompt/
   );
   assert.match(
+    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    /MoveFileExW/
+  );
+  assert.doesNotMatch(
+    formatAcpAgentExitMessage(3221225477, "zh-CN"),
+    /请用本版本重新编译后再试。$/
+  );
+  assert.match(
     formatAcpAgentExitMessage(3221225477, "en"),
     /access violation/i
   );
+  assert.match(
+    formatAcpAgentExitMessage(3221225477, "en"),
+    /MoveFileExW/
+  );
+});
+
+const OFFICIAL_JSONL_MATERIALIZE = `		if (process.platform === "win32") await this.materializeWin32(project, dir, finalPath, meta.id, content);
+		else await this.materializePosix(project, dir, finalPath, meta.id, content);`;
+
+const OFFICIAL_JSONL_SYNC_DIR = `	async syncDirPosix(dir) {
+		const handle = await open(dir, "r");
+		try {
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	}`;
+
+const OFFICIAL_DEMO_SQLITE =
+  `const query = ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, "session-query.db") });`;
+
+function writeOfficialDshRuntimeSnippets(root) {
+  const jsonlDir = path.join(
+    root,
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-session-persistence-jsonl",
+    "lib"
+  );
+  const demoDir = path.join(
+    root,
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-acp-demo",
+    "lib"
+  );
+  fs.mkdirSync(jsonlDir, { recursive: true });
+  fs.mkdirSync(demoDir, { recursive: true });
+  const jsonl = path.join(jsonlDir, "index.js");
+  const demo = path.join(demoDir, "index.js");
+  fs.writeFileSync(
+    jsonl,
+    `${OFFICIAL_JSONL_MATERIALIZE}\n${OFFICIAL_JSONL_SYNC_DIR}\n`
+  );
+  fs.writeFileSync(demo, `${OFFICIAL_DEMO_SQLITE}\n`);
+  return { jsonl, demo };
+}
+
+test("patchDshAcpManagedRuntime is a no-op when DeepSeek packages are missing", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-missing-"));
+  assert.doesNotThrow(() => patchDshAcpManagedRuntime(root));
+});
+
+test("patchDshAcpManagedRuntime skips koffi MoveFileExW and SQLite on official snippets", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-patch-"));
+  const files = writeOfficialDshRuntimeSnippets(root);
+  patchDshAcpManagedRuntime(root);
+  const jsonl = fs.readFileSync(files.jsonl, "utf8");
+  const demo = fs.readFileSync(files.demo, "utf8");
+  assert.match(jsonl, /if \(false\) await this\.materializeWin32/);
+  assert.doesNotMatch(
+    jsonl,
+    /if \(process\.platform === "win32"\) await this\.materializeWin32/
+  );
+  assert.match(
+    jsonl,
+    /async syncDirPosix\(dir\) \{\s*if \(process\.platform === "win32"\) return;/
+  );
+  assert.match(demo, /openAt:\s*"never"/);
+  assert.doesNotMatch(
+    demo,
+    /SqliteSessionQueryEngine, \{ path: join\(persistenceRoot, "session-query\.db"\) \}/
+  );
+
+  const beforeJsonl = jsonl;
+  const beforeDemo = demo;
+  patchDshAcpManagedRuntime(root);
+  assert.equal(fs.readFileSync(files.jsonl, "utf8"), beforeJsonl);
+  assert.equal(fs.readFileSync(files.demo, "utf8"), beforeDemo);
+});
+
+test("syncDshAcpManagedConfig patches an already-installed DeepSeek runtime", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-sync-"));
+  const root = dshAcpManagedRoot(dataDir);
+  const files = writeOfficialDshRuntimeSnippets(root);
+  assert.equal(syncDshAcpManagedConfig(dataDir), root);
+  assert.equal(fs.existsSync(path.join(root, "cordis.yml")), true);
+  assert.match(
+    fs.readFileSync(files.jsonl, "utf8"),
+    /if \(false\) await this\.materializeWin32/
+  );
+  assert.match(fs.readFileSync(files.demo, "utf8"), /openAt:\s*"never"/);
 });
 
 test("buildCommand keeps Grok global flags before the ACP subcommand", () => {

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -25,7 +25,8 @@ import {
   patchDshAcpRuntimeFromBin,
   buildDshAcpRuntimeDiagnostics,
   dshAcpKoffiGuardPath,
-  dshAcpKoffiGuardImportFlag
+  dshAcpKoffiGuardImportFlag,
+  isDefaultDshAcpBinary
 } from "../dist-electron/cli/adapters.js";
 import {
   acpSessionListToItems,
@@ -426,6 +427,91 @@ test("buildCommand keeps an explicit custom DeepSeek binary path", () => {
   assert.equal(built.args.includes(path.join(root, "node_modules", "@deepseek-ai", "dsh-acp-demo", "lib", "bin.js")), false);
 });
 
+test("isDefaultDshAcpBinary treats npm-global shims as the stock demo", () => {
+  assert.equal(isDefaultDshAcpBinary(undefined), true);
+  assert.equal(isDefaultDshAcpBinary("dsh-acp-demo"), true);
+  assert.equal(isDefaultDshAcpBinary("dsh-acp-demo.cmd"), true);
+  assert.equal(
+    isDefaultDshAcpBinary(
+      "C:/Users/Morefine/AppData/Roaming/npm/dsh-acp-demo.cmd"
+    ),
+    true
+  );
+  assert.equal(
+    isDefaultDshAcpBinary(path.join(os.tmpdir(), "custom-dsh", "dsh-acp-demo")),
+    false
+  );
+});
+
+test("buildCommand launches a PATH npm-global demo through node so koffi --import is on argv", () => {
+  const prefix = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-global-"));
+  const demo = path.join(prefix, "node_modules", "@deepseek-ai", "dsh-acp-demo");
+  fs.mkdirSync(path.join(demo, "lib"), { recursive: true });
+  fs.writeFileSync(path.join(demo, "package.json"), "{}");
+  const binJs = path.join(demo, "lib", "bin.js");
+  fs.writeFileSync(binJs, "");
+  const cmd = path.join(prefix, "dsh-acp-demo.cmd");
+  fs.writeFileSync(
+    cmd,
+    `@ECHO off\r\nnode "%~dp0\\node_modules\\@deepseek-ai\\dsh-acp-demo\\lib\\bin.js" %*\r\n`
+  );
+
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    binary: cmd,
+    prompt: "hello",
+    dshAcpRuntimeRoot: path.join(prefix, "missing-managed")
+  });
+
+  assert.equal(built.bin, "node");
+  assert.equal(built.args.includes(binJs), true);
+  const importFlag = dshAcpKoffiGuardImportFlag();
+  assert.ok(importFlag);
+  assert.equal(built.args.includes(importFlag), true);
+});
+
+test("buildCommand prefers managed runtime over a resolved npm-global demo shim", () => {
+  const { root, binJs } = writeManagedDshRuntime();
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    binary: "C:/Users/Morefine/AppData/Roaming/npm/dsh-acp-demo.cmd",
+    prompt: "hello",
+    dshAcpRuntimeRoot: root
+  });
+  assert.equal(built.bin, "node");
+  assert.equal(built.args.includes(binJs), true);
+});
+
+test("buildCommand uses a well-known npm-global demo when managed runtime is missing", () => {
+  const appdata = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-appdata-"));
+  const demo = path.join(
+    appdata,
+    "npm",
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-acp-demo"
+  );
+  fs.mkdirSync(path.join(demo, "lib"), { recursive: true });
+  fs.writeFileSync(path.join(demo, "package.json"), "{}");
+  const binJs = path.join(demo, "lib", "bin.js");
+  fs.writeFileSync(binJs, "");
+  const previous = process.env.APPDATA;
+  process.env.APPDATA = appdata;
+  try {
+    const built = buildCommand({
+      adapter: "dsh-acp",
+      binary: "dsh-acp-demo",
+      prompt: "hello",
+      dshAcpRuntimeRoot: path.join(appdata, "missing-managed")
+    });
+    assert.equal(built.bin, "node");
+    assert.equal(built.args.includes(binJs), true);
+  } finally {
+    if (previous === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = previous;
+  }
+});
+
 test("buildCommand keeps extra DeepSeek args after the bundled config", () => {
   const built = buildCommand({
     adapter: "dsh-acp",
@@ -719,6 +805,7 @@ test("buildDshAcpRuntimeDiagnostics reports leftover koffi and cordis safety fla
   assert.equal(before.persistenceCompressionNone, true);
   assert.equal(before.sandboxDisabledOnWin32, true);
   assert.equal(before.koffiGuardPresent, true);
+  assert.equal(before.koffiGuardOnArgv, false);
   assert.equal(before.jsonlRelatives[0]?.usesKoffi, true);
   assert.doesNotMatch(JSON.stringify(before), /home|Users|AppData/i);
 

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -341,6 +341,30 @@ test("buildCommand uses a workspace cordis.yml when present", () => {
   assert.deepEqual(built.args, ["--config", local]);
 });
 
+test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-managed-"));
+  const demo = path.join(root, "node_modules", "@deepseek-ai", "dsh-acp-demo");
+  fs.mkdirSync(path.join(demo, "lib"), { recursive: true });
+  fs.writeFileSync(path.join(demo, "package.json"), "{}");
+  const binJs = path.join(demo, "lib", "bin.js");
+  fs.writeFileSync(binJs, "");
+  const probe = path.join(root, "node_modules", "@deepseek-ai", "dsh-llm-deepseek");
+  fs.mkdirSync(probe, { recursive: true });
+  fs.writeFileSync(path.join(probe, "package.json"), "{}");
+  const config = path.join(root, "cordis.yml");
+  fs.writeFileSync(config, "- id: acp-agent\n");
+
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    prompt: "hello",
+    dshAcpRuntimeRoot: root
+  });
+
+  assert.equal(built.bin, "node");
+  assert.deepEqual(built.args, [binJs, "--config", config]);
+  assert.equal(built.protocol, "acp");
+});
+
 test("buildCommand keeps extra DeepSeek args after the bundled config", () => {
   const built = buildCommand({
     adapter: "dsh-acp",

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -159,7 +159,7 @@ test("visible adapter definitions are ACP-only with product names", () => {
       { id: "codebuddy-acp", label: "CodeBuddy", protocol: "acp" },
       { id: "grok-acp", label: "Grok", protocol: "acp" },
       { id: "agy-acp", label: "Antigravity", protocol: "acp" },
-      { id: "dsh-acp", label: "DeepSeek", protocol: "acp" }
+      { id: "dsh-acp", label: "DeepSeek Harness", protocol: "acp" }
     ]
   );
 });
@@ -358,6 +358,22 @@ test("buildCommand uses a workspace cordis.yml when present", () => {
   assert.deepEqual(built.args, ["--config", local]);
 });
 
+function withPlatform(platform, fn) {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true
+  });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, "platform", {
+      value: original,
+      configurable: true
+    });
+  }
+}
+
 function writeManagedDshRuntime() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-managed-"));
   const demo = path.join(root, "node_modules", "@deepseek-ai", "dsh-acp-demo");
@@ -385,15 +401,19 @@ test("buildCommand starts a managed DeepSeek ACP runtime with node", () => {
   assert.equal(built.bin, "node");
   const importFlag = dshAcpKoffiGuardImportFlag();
   assert.ok(importFlag);
+  // The koffi guard is Windows-only; real koffi loads on macOS/Linux.
+  const guardArgs = process.platform === "win32" ? [importFlag] : [];
   assert.deepEqual(built.args, [
     DSH_ACP_NODE_DISABLE_WARNING,
-    importFlag,
+    ...guardArgs,
     binJs,
     "--config",
     config
   ]);
   assert.match(built.env?.NODE_OPTIONS ?? "", /--disable-warning=ExperimentalWarning/);
-  assert.match(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
+  if (process.platform === "win32") {
+    assert.match(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
+  }
   assert.equal(built.protocol, "acp");
 });
 
@@ -443,31 +463,36 @@ test("isDefaultDshAcpBinary treats npm-global shims as the stock demo", () => {
   );
 });
 
-test("buildCommand launches a PATH npm-global demo through node so koffi --import is on argv", () => {
-  const prefix = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-global-"));
-  const demo = path.join(prefix, "node_modules", "@deepseek-ai", "dsh-acp-demo");
-  fs.mkdirSync(path.join(demo, "lib"), { recursive: true });
-  fs.writeFileSync(path.join(demo, "package.json"), "{}");
-  const binJs = path.join(demo, "lib", "bin.js");
-  fs.writeFileSync(binJs, "");
-  const cmd = path.join(prefix, "dsh-acp-demo.cmd");
+test("buildCommand puts koffi --import on argv on Windows when the composition uses the native sandbox", () => {
+  const { root, binJs } = writeManagedDshRuntime();
+  // The managed cordis.yml must mount the native sandbox for the guard to apply.
   fs.writeFileSync(
-    cmd,
-    `@ECHO off\r\nnode "%~dp0\\node_modules\\@deepseek-ai\\dsh-acp-demo\\lib\\bin.js" %*\r\n`
+    path.join(root, "cordis.yml"),
+    "- name: '@deepseek-ai/dsh-sandbox-local'\n"
   );
 
-  const built = buildCommand({
-    adapter: "dsh-acp",
-    binary: cmd,
-    prompt: "hello",
-    dshAcpRuntimeRoot: path.join(prefix, "missing-managed")
+  withPlatform("win32", () => {
+    const built = buildCommand({
+      adapter: "dsh-acp",
+      prompt: "hello",
+      dshAcpRuntimeRoot: root
+    });
+
+    assert.equal(built.bin, "node");
+    assert.equal(built.args.includes(binJs), true);
+    const importFlag = dshAcpKoffiGuardImportFlag();
+    assert.ok(importFlag);
+    assert.equal(built.args.includes(importFlag), true);
   });
 
-  assert.equal(built.bin, "node");
-  assert.equal(built.args.includes(binJs), true);
+  // On the real (non-Windows) host the guard must stay absent.
+  const built = buildCommand({
+    adapter: "dsh-acp",
+    prompt: "hello",
+    dshAcpRuntimeRoot: root
+  });
   const importFlag = dshAcpKoffiGuardImportFlag();
-  assert.ok(importFlag);
-  assert.equal(built.args.includes(importFlag), true);
+  assert.equal(built.args.includes(importFlag), false);
 });
 
 test("buildCommand prefers managed runtime over a resolved npm-global demo shim", () => {
@@ -560,7 +585,12 @@ test("buildCommand silences Node SQLite ExperimentalWarning for DeepSeek ACP", (
   assert.equal(built.bin, "dsh-acp-demo");
   assert.equal(built.args.includes(DSH_ACP_NODE_DISABLE_WARNING), false);
   assert.match(built.env?.NODE_OPTIONS ?? "", /--disable-warning=ExperimentalWarning/);
-  assert.match(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
+  // The koffi guard is Windows-only; real koffi loads on macOS/Linux.
+  if (process.platform === "win32") {
+    assert.match(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
+  } else {
+    assert.doesNotMatch(built.env?.NODE_OPTIONS ?? "", /koffi-guard/);
+  }
 });
 
 test("isDshAcpExperimentalWarningLine matches Node sqlite warning stderr", () => {

--- a/tests/agent-log-self-check.test.mjs
+++ b/tests/agent-log-self-check.test.mjs
@@ -67,7 +67,7 @@ test("diagnostic prompt contains the temporary directory path, not log contents"
   assert.match(dialog, /logDirectory: prepared\.path/);
   assert.match(promptBuilder, /logDirectory: string/);
   assert.match(promptBuilder, /Review the full diagnostic logs/);
-  assert.match(promptBuilder, /Read README\.txt, environment\.json, logs\/, and sessions\//);
+  assert.match(promptBuilder, /Read README\.txt, environment\.json, dsh-acp-runtime\.json, logs\/, and sessions\//);
   assert.match(promptBuilder, /Separate confirmed facts from possible causes/);
   assert.match(promptBuilder, /Do not modify or delete files in the temporary directory/);
   assert.match(promptBuilder, /conversation\.id/);

--- a/tests/agent-usage-core.test.mjs
+++ b/tests/agent-usage-core.test.mjs
@@ -21,6 +21,7 @@ test("usage adapter mapping only includes session-attributable tokscale clients"
   assert.equal(tokscaleClientForAdapter("cursor-agent-acp"), undefined);
   assert.equal(tokscaleClientForAdapter("qoder-acp"), undefined);
   assert.equal(tokscaleClientForAdapter("agy-acp"), undefined);
+  assert.equal(tokscaleClientForAdapter("dsh-acp"), undefined);
 });
 
 test("Codex rollout filenames and ACP UUIDs normalize to the same session key", () => {

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -52,14 +52,14 @@ test("agy-acp checks agy-acp binary probe", () => {
   });
 });
 
-test("dsh-acp checks dsh-acp-demo binary probe", () => {
+test("dsh-acp install uses the next dist-tag because latest peers 404", () => {
   assert.deepEqual(getCliCheckProbe("dsh-acp"), {
     args: ["--version"],
     versionOptional: true
   });
   assert.equal(
     getAdapterDefinition("dsh-acp")?.installHint,
-    "npm install -g @deepseek-ai/dsh-acp-demo"
+    "npm install -g @deepseek-ai/dsh-acp-demo@next"
   );
   assert.equal(getAdapterDefinition("dsh-acp")?.defaultBinary, "dsh-acp-demo");
 });

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -133,7 +133,7 @@ test("dsh-acp composition ready requires llm-deepseek beside the demo", () => {
   fs.mkdirSync(probe, { recursive: true });
   fs.writeFileSync(path.join(probe, "package.json"), "{}");
   assert.equal(dshAcpCompositionReady(bin), true);
-  assert.equal(resolveDshAcpDemoDirFromBinary(bin), demo);
+  assert.equal(resolveDshAcpDemoDirFromBinary(bin), fs.realpathSync(demo));
   assert.equal(
     dshAcpManagedDemoBin("/data"),
     path.join(

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -69,6 +69,15 @@ test("dsh-acp install uses next plus optional koffi prebuilds", () => {
   assert.equal(getAdapterDefinition("dsh-acp")?.defaultBinary, "dsh-acp-demo");
 });
 
+test("bundled DeepSeek ACP config disables zstd persistence on Windows-safe defaults", () => {
+  const yaml = fs.readFileSync(bundledDshAcpConfigPath(), "utf8");
+  assert.match(yaml, /persistenceCompression:\s*none/);
+  assert.doesNotMatch(
+    yaml,
+    /persistenceCompression:\s*!!js "process\.env\.DSH_SNAPSHOT === undefined \? 'zstd'/
+  );
+});
+
 test("dsh-acp install command includes every bundled cordis plugin package", () => {
   const yaml = fs.readFileSync(bundledDshAcpConfigPath(), "utf8");
   const hint = dshAcpInstallCommand();

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -1,7 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 
-import { getAdapterDefinition, getCliCheckProbe, applyDshAcpNpmInstallEnv, dshAcpWindowsResiduePath } from "../dist-electron/cli/adapters.js";
+import { getAdapterDefinition, getCliCheckProbe, applyDshAcpNpmInstallEnv, dshAcpWindowsResiduePath, dshAcpInstallCommand, parseDshAcpCompositionPackages, bundledDshAcpConfigPath } from "../dist-electron/cli/adapters.js";
 
 test("Codex ACP checks the new Agent Client Protocol package version", () => {
   assert.deepEqual(getCliCheckProbe("codex-acp"), {
@@ -58,11 +59,25 @@ test("dsh-acp install uses next plus optional koffi prebuilds", () => {
     versionOptional: true,
     skipSpawn: true
   });
-  assert.equal(
-    getAdapterDefinition("dsh-acp")?.installHint,
-    "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next"
-  );
+  const hint = getAdapterDefinition("dsh-acp")?.installHint;
+  assert.equal(hint, dshAcpInstallCommand());
+  assert.match(hint ?? "", /^npm install -g --include=optional --ignore-scripts /);
+  assert.match(hint ?? "", /@deepseek-ai\/dsh-acp-demo@next/);
+  assert.match(hint ?? "", /@deepseek-ai\/dsh-llm-deepseek@next/);
   assert.equal(getAdapterDefinition("dsh-acp")?.defaultBinary, "dsh-acp-demo");
+});
+
+test("dsh-acp install command includes every bundled cordis plugin package", () => {
+  const yaml = fs.readFileSync(bundledDshAcpConfigPath(), "utf8");
+  const hint = dshAcpInstallCommand();
+  for (const pkg of parseDshAcpCompositionPackages(yaml)) {
+    assert.match(hint, new RegExp(`${pkg.replace("/", "\\/")}@next`));
+  }
+  const renderer = fs.readFileSync(
+    new URL("../src/config/cliAdapters.ts", import.meta.url),
+    "utf8"
+  );
+  assert.equal(renderer.includes(hint), true);
 });
 
 test("dsh-acp npm installs skip koffi rebuild scripts", () => {

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -51,3 +51,15 @@ test("agy-acp checks agy-acp binary probe", () => {
     versionOptional: true
   });
 });
+
+test("dsh-acp checks dsh-acp-demo binary probe", () => {
+  assert.deepEqual(getCliCheckProbe("dsh-acp"), {
+    args: ["--version"],
+    versionOptional: true
+  });
+  assert.equal(
+    getAdapterDefinition("dsh-acp")?.installHint,
+    "npm install -g @deepseek-ai/dsh-acp-demo"
+  );
+  assert.equal(getAdapterDefinition("dsh-acp")?.defaultBinary, "dsh-acp-demo");
+});

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -76,6 +76,10 @@ test("bundled DeepSeek ACP config disables zstd persistence on Windows-safe defa
     yaml,
     /persistenceCompression:\s*!!js "process\.env\.DSH_SNAPSHOT === undefined \? 'zstd'/
   );
+  assert.match(
+    yaml,
+    /name:\s*'@deepseek-ai\/dsh-sandbox-local'[\s\S]*disabled:\s*!!js process\.platform === 'win32'/
+  );
 });
 
 test("dsh-acp install command includes every bundled cordis plugin package", () => {

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -52,14 +52,14 @@ test("agy-acp checks agy-acp binary probe", () => {
   });
 });
 
-test("dsh-acp install uses the next dist-tag because latest peers 404", () => {
+test("dsh-acp install uses next plus optional koffi prebuilds", () => {
   assert.deepEqual(getCliCheckProbe("dsh-acp"), {
     args: ["--version"],
     versionOptional: true
   });
   assert.equal(
     getAdapterDefinition("dsh-acp")?.installHint,
-    "npm install -g @deepseek-ai/dsh-acp-demo@next"
+    "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next"
   );
   assert.equal(getAdapterDefinition("dsh-acp")?.defaultBinary, "dsh-acp-demo");
 });

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -54,8 +54,9 @@ test("agy-acp checks agy-acp binary probe", () => {
 
 test("dsh-acp install uses next plus optional koffi prebuilds", () => {
   assert.deepEqual(getCliCheckProbe("dsh-acp"), {
-    args: ["--version"],
-    versionOptional: true
+    args: [],
+    versionOptional: true,
+    skipSpawn: true
   });
   assert.equal(
     getAdapterDefinition("dsh-acp")?.installHint,

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { getAdapterDefinition, getCliCheckProbe, applyDshAcpNpmInstallEnv, dshAcpWindowsResiduePath, dshAcpInstallCommand, parseDshAcpCompositionPackages, bundledDshAcpConfigPath } from "../dist-electron/cli/adapters.js";
+import { getAdapterDefinition, getCliCheckProbe, applyDshAcpNpmInstallEnv, dshAcpWindowsResiduePath, dshAcpInstallCommand, parseDshAcpCompositionPackages, bundledDshAcpConfigPath, dshAcpCompositionReady, dshAcpManagedDemoBin, resolveDshAcpDemoDirFromBinary } from "../dist-electron/cli/adapters.js";
 
 test("Codex ACP checks the new Agent Client Protocol package version", () => {
   assert.deepEqual(getCliCheckProbe("codex-acp"), {
@@ -78,6 +80,9 @@ test("dsh-acp install command includes every bundled cordis plugin package", () 
     "utf8"
   );
   assert.equal(renderer.includes(hint), true);
+  const prefixed = dshAcpInstallCommand({ prefix: "/tmp/freebuddy-dsh" });
+  assert.match(prefixed, /--prefix /);
+  assert.equal(prefixed.includes(" -g "), false);
 });
 
 test("dsh-acp npm installs skip koffi rebuild scripts", () => {
@@ -100,4 +105,33 @@ test("dsh-acp npm installs skip koffi rebuild scripts", () => {
       undefined
     );
   }
+});
+
+test("dsh-acp composition ready requires llm-deepseek beside the demo", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-acp-ready-"));
+  const demo = path.join(root, "node_modules", "@deepseek-ai", "dsh-acp-demo");
+  fs.mkdirSync(path.join(demo, "lib"), { recursive: true });
+  fs.writeFileSync(path.join(demo, "package.json"), "{}");
+  const bin = path.join(demo, "lib", "bin.js");
+  fs.writeFileSync(bin, "");
+  assert.equal(dshAcpCompositionReady(bin), false);
+
+  const probe = path.join(root, "node_modules", "@deepseek-ai", "dsh-llm-deepseek");
+  fs.mkdirSync(probe, { recursive: true });
+  fs.writeFileSync(path.join(probe, "package.json"), "{}");
+  assert.equal(dshAcpCompositionReady(bin), true);
+  assert.equal(resolveDshAcpDemoDirFromBinary(bin), demo);
+  assert.equal(
+    dshAcpManagedDemoBin("/data"),
+    path.join(
+      "/data",
+      "runtimes",
+      "dsh-acp",
+      "node_modules",
+      "@deepseek-ai",
+      "dsh-acp-demo",
+      "lib",
+      "bin.js"
+    )
+  );
 });

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { getAdapterDefinition, getCliCheckProbe } from "../dist-electron/cli/adapters.js";
+import { getAdapterDefinition, getCliCheckProbe, applyDshAcpNpmInstallEnv, dshAcpWindowsResiduePath } from "../dist-electron/cli/adapters.js";
 
 test("Codex ACP checks the new Agent Client Protocol package version", () => {
   assert.deepEqual(getCliCheckProbe("codex-acp"), {
@@ -62,4 +62,26 @@ test("dsh-acp install uses next plus optional koffi prebuilds", () => {
     "npm install -g --include=optional --ignore-scripts @deepseek-ai/dsh-acp-demo@next"
   );
   assert.equal(getAdapterDefinition("dsh-acp")?.defaultBinary, "dsh-acp-demo");
+});
+
+test("dsh-acp npm installs skip koffi rebuild scripts", () => {
+  const env = applyDshAcpNpmInstallEnv("dsh-acp", { PATH: "/usr/bin" });
+  assert.equal(env.npm_config_ignore_scripts, "true");
+  assert.equal(env.npm_config_include, "optional");
+  assert.equal(env.npm_config_optional, "true");
+  assert.equal(
+    applyDshAcpNpmInstallEnv("codex-acp", { PATH: "/usr/bin" }).npm_config_ignore_scripts,
+    undefined
+  );
+  if (process.platform === "win32") {
+    assert.equal(
+      dshAcpWindowsResiduePath({ APPDATA: "C:\\Users\\x\\AppData\\Roaming" }),
+      "C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\@deepseek-ai"
+    );
+  } else {
+    assert.equal(
+      dshAcpWindowsResiduePath({ APPDATA: "C:\\Users\\x\\AppData\\Roaming" }),
+      undefined
+    );
+  }
 });

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -76,9 +76,9 @@ test("bundled DeepSeek ACP config disables zstd persistence on Windows-safe defa
     yaml,
     /persistenceCompression:\s*!!js "process\.env\.DSH_SNAPSHOT === undefined \? 'zstd'/
   );
-  assert.match(
+  assert.doesNotMatch(
     yaml,
-    /name:\s*'@deepseek-ai\/dsh-sandbox-local'[\s\S]*disabled:\s*!!js process\.platform === 'win32'/
+    /dsh-sandbox-local'[\s\S]*disabled:\s*!!js process\.platform === 'win32'/
   );
 });
 

--- a/tests/cli-install-ui.test.mjs
+++ b/tests/cli-install-ui.test.mjs
@@ -106,6 +106,10 @@ test("DeepSeek ACP install skips koffi source rebuilds and clears Windows residu
   assert.match(checkSource, /removeDshAcpWindowsResidue/);
 });
 
+test("DeepSeek ACP check treats PATH resolution as installed without --version", () => {
+  assert.match(checkSource, /probe\.skipSpawn/);
+});
+
 test("agent version probes preserve actionable failure categories", () => {
   assert.match(checkSource, /timeoutMs = 15_000/);
   assert.match(checkSource, /CPU lacks AVX support/);

--- a/tests/cli-install-ui.test.mjs
+++ b/tests/cli-install-ui.test.mjs
@@ -106,6 +106,22 @@ test("DeepSeek ACP install skips koffi source rebuilds and clears Windows residu
   assert.match(checkSource, /removeDshAcpWindowsResidue/);
 });
 
+test("DeepSeek ACP install patches koffi MoveFileExW after a successful npm install", () => {
+  assert.match(checkSource, /patchDshAcpManagedRuntime/);
+  const installClose = checkSource.slice(checkSource.indexOf("export function cliInstall("));
+  const streamClose = checkSource.slice(
+    checkSource.indexOf("export function cliInstallStream(")
+  );
+  assert.match(
+    installClose,
+    /adapter === "dsh-acp" && code === 0[\s\S]*patchDshAcpManagedRuntime/
+  );
+  assert.match(
+    streamClose,
+    /adapter === "dsh-acp" && code === 0[\s\S]*patchDshAcpManagedRuntime/
+  );
+});
+
 test("DeepSeek ACP check treats PATH resolution as installed without --version", () => {
   assert.match(checkSource, /probe\.skipSpawn/);
   assert.match(checkSource, /DSH_ACP_PLUGIN_TREE_MISSING/);

--- a/tests/cli-install-ui.test.mjs
+++ b/tests/cli-install-ui.test.mjs
@@ -108,6 +108,8 @@ test("DeepSeek ACP install skips koffi source rebuilds and clears Windows residu
 
 test("DeepSeek ACP check treats PATH resolution as installed without --version", () => {
   assert.match(checkSource, /probe\.skipSpawn/);
+  assert.match(checkSource, /DSH_ACP_PLUGIN_TREE_MISSING/);
+  assert.match(checkSource, /prepareDshAcpManagedInstall/);
 });
 
 test("agent version probes preserve actionable failure categories", () => {

--- a/tests/cli-install-ui.test.mjs
+++ b/tests/cli-install-ui.test.mjs
@@ -101,6 +101,11 @@ test("concurrent agent installs keep stream events scoped to their request", () 
   assert.equal(ipcSource.includes("BrowserWindow.getFocusedWindow()?.webContents"), false);
 });
 
+test("DeepSeek ACP install skips koffi source rebuilds and clears Windows residue", () => {
+  assert.match(checkSource, /applyDshAcpNpmInstallEnv/);
+  assert.match(checkSource, /removeDshAcpWindowsResidue/);
+});
+
 test("agent version probes preserve actionable failure categories", () => {
   assert.match(checkSource, /timeoutMs = 15_000/);
   assert.match(checkSource, /CPU lacks AVX support/);

--- a/tests/debug-log-export.test.mjs
+++ b/tests/debug-log-export.test.mjs
@@ -53,6 +53,8 @@ test("export bundle filters by mode and includes sessions", () => {
   assert.match(exporter, /filterOwnLogLine/);
   assert.match(exporter, /sessions\/\$\{f\.name\}/);
   assert.match(exporter, /environment\.json/);
+  assert.match(exporter, /dsh-acp-runtime\.json/);
+  assert.match(exporter, /buildDshAcpRuntimeDiagnostics/);
   assert.match(exporter, /dialog\.showSaveDialog/);
 });
 

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -32,6 +32,10 @@ test("electron-builder config packages FreeBuddy for desktop platforms", () => {
   assert.match(builderConfig, /extraResources:[\s\S]*from:\s+assets\/app-icon\.png[\s\S]*to:\s+app-icon\.png/m);
   assert.match(builderConfig, /beforePack:\s+scripts\/prepare-tokscale-for-pack\.mjs/);
   assert.match(builderConfig, /extraResources:[\s\S]*from:\s+\.build\/tokscale[\s\S]*to:\s+tokscale/m);
+  assert.match(
+    builderConfig,
+    /extraResources:[\s\S]*from:\s+third_party\/deepseek-harness\/overlays[\s\S]*to:\s+dsh-harness-overlays/m
+  );
 });
 
 test("release workflow uploads version-suffixed assets and update metadata for every platform", () => {

--- a/tests/remote-sandbox.test.mjs
+++ b/tests/remote-sandbox.test.mjs
@@ -31,7 +31,7 @@ test("remote runs and ACP terminal commands use the lightweight sandbox", () => 
   );
   assert.match(
     runtime,
-    /await isolateRemoteCwdForCaller\(effectiveArgs\.cwd\)/,
+    /await isolateRemoteCwdForCaller\((?:effectiveArgs|withWorkspace)\.cwd\)/,
     "every remote agent run must map its cwd to a managed clone"
   );
   assert.match(

--- a/tests/settings-ui.test.mjs
+++ b/tests/settings-ui.test.mjs
@@ -236,12 +236,21 @@ test("coding agent settings explain binary lookup failures separately", () => {
   assert.equal(settingsSource.includes("cliRuntimeErrorKey"), true);
   assert.equal(settingsSource.includes("binary not found"), true);
   assert.equal(settingsSource.includes("settings.cli.commandNotFound"), true);
+  assert.equal(settingsSource.includes("settings.cli.dshAcpPluginTreeMissing"), true);
   assert.equal(settingsSource.includes("settings.cli.codexAcpUpgradeRequired"), true);
   assert.equal(settingsSource.includes("settings.cli.checkProbeFailed"), true);
   assert.equal(zhLocale.settings.cli.commandNotFound, "未找到命令");
+  assert.equal(
+    zhLocale.settings.cli.dshAcpPluginTreeMissing,
+    "已找到 dsh-acp-demo，但 ACP 插件包未安装。请再点一次安装。"
+  );
   assert.equal(zhLocale.settings.cli.codexAcpUpgradeRequired, "需要新版 Codex ACP — 请安装");
   assert.equal(zhLocale.settings.cli.checkProbeFailed, "检测失败 — 请重试");
   assert.equal(enLocale.settings.cli.commandNotFound, "command not found");
+  assert.equal(
+    enLocale.settings.cli.dshAcpPluginTreeMissing,
+    "dsh-acp-demo is on PATH, but its ACP plugin packages are missing. Click Install again."
+  );
   assert.equal(enLocale.settings.cli.codexAcpUpgradeRequired, "new Codex ACP required — install");
   assert.equal(enLocale.settings.cli.checkProbeFailed, "check failed — retry");
   assert.equal(

--- a/tests/telemetry-privacy.test.mjs
+++ b/tests/telemetry-privacy.test.mjs
@@ -9,6 +9,7 @@ import {
 
 test("telemetry adapter values are bounded", () => {
   assert.equal(normalizeTelemetryAdapter("codex-acp"), "codex-acp");
+  assert.equal(normalizeTelemetryAdapter("dsh-acp"), "dsh-acp");
   assert.equal(normalizeTelemetryAdapter("private-agent-name"), "custom");
   assert.equal(normalizeTelemetryAdapter(), "custom");
 });

--- a/tests/workflow-ipc-wiring.test.mjs
+++ b/tests/workflow-ipc-wiring.test.mjs
@@ -76,4 +76,5 @@ test("builtin members module exports the ACP agents", () => {
   assert.match(members, /cli-codebuddy-acp/);
   assert.match(members, /cli-grok-acp/);
   assert.match(members, /cli-agy-acp/);
+  assert.match(members, /cli-dsh-acp/);
 });

--- a/third_party/deepseek-harness/0001-fix-windows-jsonl-node-fs.patch
+++ b/third_party/deepseek-harness/0001-fix-windows-jsonl-node-fs.patch
@@ -1,0 +1,472 @@
+From 2c09511d205808de70ee16edb67f8742164f81ef Mon Sep 17 00:00:00 2001
+From: Cursor Agent <cursoragent@cursor.com>
+Date: Thu, 13 Aug 2026 22:08:49 +0000
+Subject: [PATCH] fix: publish Windows JSONL sessions with Node fs
+
+The ACP demo materializes the first session log through a native Win32
+binding (MoveFileExW). On Windows Electron/Node hosts that aborts the
+process with STATUS_ACCESS_VIOLATION (0xC0000005) during session/prompt.
+
+Keep the win32 helper names so the JSONL backend is unchanged. Implement
+them with rename, copy fallback, and mkdir. Close the ACP demo SQLite
+index at startup (openAt: never).
+
+Co-authored-by: maojindao55 <maojindao55@users.noreply.github.com>
+---
+ packages/examples/acp-demo/src/index.ts       |   2 +-
+ .../session-persistence-jsonl/src/win32.ts    | 166 +++-------------
+ .../tests/win32.spec.ts                       | 185 ++++--------------
+ 3 files changed, 66 insertions(+), 287 deletions(-)
+
+diff --git a/packages/examples/acp-demo/src/index.ts b/packages/examples/acp-demo/src/index.ts
+index bd5981a..0a88daa 100644
+--- a/packages/examples/acp-demo/src/index.ts
++++ b/packages/examples/acp-demo/src/index.ts
+@@ -131,7 +131,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
+     const checkpoint = ctx.plugin(sessionCheckpointPolicy)
+     await checkpoint
+     yield checkpoint.dispose
+-    const query = ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, 'session-query.db') })
++    const query = ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, 'session-query.db'), openAt: 'never' })
+     await query
+     yield query.dispose
+     const transport = ctx.plugin(acp, { provider: config.provider, model: config.model })
+diff --git a/packages/session/session-persistence-jsonl/src/win32.ts b/packages/session/session-persistence-jsonl/src/win32.ts
+index c3fa852..c19d40d 100644
+--- a/packages/session/session-persistence-jsonl/src/win32.ts
++++ b/packages/session/session-persistence-jsonl/src/win32.ts
+@@ -1,155 +1,53 @@
+ /**
+- * Windows durable namespace helpers for the JSONL backend.
++ * Windows publish helpers for the JSONL backend.
+  *
+  * POSIX publishes a newly-created log by creating a directory entry and then
+  * fsyncing the parent directory. Windows does not expose that parent-directory
+- * fsync contract through Node, so the Windows path uses the native durable
+- * namespace primitive instead: create a staging object in the target directory
+- * and publish it with `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)` without
+- * replacement or cross-volume copy fallback.
++ * fsync contract through Node. The previous implementation loaded a native
++ * Win32 binding and called `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)`. That
++ * aborts some Windows Electron/Node hosts with STATUS_ACCESS_VIOLATION
++ * (0xC0000005) the first time a session is materialized.
++ *
++ * Keep the exported names so `index.ts` is unchanged. Publish with Node fs:
++ * rename when the volume allows it, copy+remove on EXDEV/EPERM, mkdir for
++ * directories.
+  *
+  * @module dsh-session-persistence-jsonl/win32
+  */
+ 
+-import { mkdtemp, rm, stat } from 'node:fs/promises'
+-import { join, parse, resolve, toNamespacedPath } from 'node:path'
+-
+-type MoveFileExW = (existing: string, replacement: string, flags: number) => number
+-type GetLastError = () => number
++import { copyFile, mkdir, rename, rm, stat } from 'node:fs/promises'
+ 
+-interface Win32Bindings {
+-  moveFileExW: MoveFileExW
+-  getLastError: GetLastError
+-}
+-
+-interface Win32ErrnoException extends NodeJS.ErrnoException {
+-  win32Code: number
+-  dest: string
+-}
+-
+-const MOVEFILE_WRITE_THROUGH = 0x00000008
+-const ERROR_FILE_NOT_FOUND = 2
+-const ERROR_PATH_NOT_FOUND = 3
+-const ERROR_ACCESS_DENIED = 5
+-const ERROR_NOT_SAME_DEVICE = 17
+-const ERROR_FILE_EXISTS = 80
+-const ERROR_INVALID_NAME = 123
+-const ERROR_ALREADY_EXISTS = 183
+-
+-let bindings: Win32Bindings | undefined
+-
+-/** Load the small Win32 API lazily so non-Windows processes never load Koffi. */
+-async function win32(): Promise<Win32Bindings> {
+-  if (bindings !== undefined) return bindings
+-  const koffi = (await import('koffi')).default
+-  const kernel32 = koffi.load('kernel32.dll')
+-  bindings = {
+-    moveFileExW: kernel32.func('__stdcall', 'MoveFileExW', 'int', ['str16', 'str16', 'uint']) as MoveFileExW,
+-    getLastError: kernel32.func('__stdcall', 'GetLastError', 'uint', []) as GetLastError,
+-  }
+-  return bindings
+-}
+-
+-function errnoCode(win32Code: number): string {
+-  switch (win32Code) {
+-    case ERROR_FILE_NOT_FOUND:
+-    case ERROR_PATH_NOT_FOUND:
+-      return 'ENOENT'
+-    case ERROR_ACCESS_DENIED:
+-      return 'EACCES'
+-    case ERROR_NOT_SAME_DEVICE:
+-      return 'EXDEV'
+-    case ERROR_FILE_EXISTS:
+-    case ERROR_ALREADY_EXISTS:
+-      return 'EEXIST'
+-    case ERROR_INVALID_NAME:
+-      return 'EINVAL'
+-    default:
+-      return 'EIO'
+-  }
+-}
+-
+-function win32Error(syscall: string, win32Code: number, path: string, dest: string): Win32ErrnoException {
+-  const code = errnoCode(win32Code)
+-  const error = new Error(`${syscall} ${code} (Win32 ${win32Code}): ${path} -> ${dest}`) as Win32ErrnoException
+-  error.code = code
+-  error.errno = win32Code
+-  error.syscall = syscall
+-  error.path = path
+-  error.dest = dest
+-  error.win32Code = win32Code
+-  return error
+-}
+-
+-function isENOENT(error: unknown): boolean {
+-  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+-}
+-
+-function isEEXIST(error: unknown): boolean {
+-  return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
+-}
+-
+-async function assertDirectory(path: string): Promise<boolean> {
+-  try {
+-    // A bare drive root is already short, and Node rejects its extended-length
+-    // spelling as EISDIR. Descendants retain the namespace for long-path probes.
+-    const probe = path === parse(path).root ? path : toNamespacedPath(path)
+-    const info = await stat(probe)
+-    if (info.isDirectory()) return true
+-    const error = new Error(`path exists but is not a directory: ${path}`) as NodeJS.ErrnoException
+-    error.code = 'ENOTDIR'
+-    error.path = path
+-    throw error
+-  } catch (error) {
+-    if (isENOENT(error)) return false
+-    throw error
+-  }
++function errorCode(error: unknown): string | undefined {
++  return (error as NodeJS.ErrnoException | null)?.code
+ }
+ 
+ /**
+- * Publish `existing` at `replacement` with Windows write-through rename
+- * semantics. The destination must not already exist; the move must stay within
+- * the volume (no copy fallback flag is set).
++ * Publish `existing` at `replacement`. The destination must not already exist
++ * on the happy path; EXDEV/EPERM fall back to copy+remove.
+  * @param existing - the synced staging path to move.
+- * @param replacement - the final path, which must not already exist.
++ * @param replacement - the final path.
+  */
+ export async function publishNewFileWin32(existing: string, replacement: string): Promise<void> {
+-  const api = await win32()
+-  const ok = api.moveFileExW(toNamespacedPath(existing), toNamespacedPath(replacement), MOVEFILE_WRITE_THROUGH)
+-  if (ok === 0) throw win32Error('MoveFileExW', api.getLastError(), existing, replacement)
++  try {
++    await rename(existing, replacement)
++  } catch (error) {
++    const code = errorCode(error)
++    if (code !== 'EXDEV' && code !== 'EPERM') throw error
++    const info = await stat(existing)
++    if (info.isDirectory()) {
++      await mkdir(replacement, { recursive: true })
++      await rm(existing, { recursive: true, force: true })
++      return
++    }
++    await copyFile(existing, replacement)
++    await rm(existing, { force: true })
++  }
+ }
+ 
+ /**
+- * Create `target` and its missing ancestors with durable Windows namespace
+- * publication. Each missing directory is first created as a random staging
+- * sibling, then moved to its final name with `MOVEFILE_WRITE_THROUGH`; races
+- * with another creator are accepted only after verifying the winner is a
+- * directory.
+- * @param target - the absolute directory path to create durably when absent.
++ * Create `target` and its missing ancestors.
++ * @param target - the absolute directory path to create when absent.
+  */
+ export async function ensureDurableDirectoryWin32(target: string): Promise<void> {
+-  const absolute = resolve(target)
+-  const root = parse(absolute).root
+-  await assertDirectory(root)
+-
+-  const segments = absolute.slice(root.length).split(/[\\/]+/).filter(part => part.length > 0)
+-  let current = root
+-  for (const segment of segments) {
+-    const next = join(current, segment)
+-    if (!await assertDirectory(next)) await createLeafDirectoryWin32(current, next)
+-    current = next
+-  }
+-}
+-
+-async function createLeafDirectoryWin32(parent: string, target: string): Promise<void> {
+-  // Keep the staging component independent of the target basename so a legal
+-  // 255-byte target component does not make mkdtemp's sibling name too long.
+-  const staging = await mkdtemp(toNamespacedPath(join(parent, '.dsh-mkdir-')))
+-  try {
+-    await publishNewFileWin32(staging, target)
+-  } catch (error) {
+-    await rm(staging, { recursive: true, force: true })
+-    if (isEEXIST(error) && await assertDirectory(target)) return
+-    throw error
+-  }
++  await mkdir(target, { recursive: true })
+ }
+diff --git a/packages/session/session-persistence-jsonl/tests/win32.spec.ts b/packages/session/session-persistence-jsonl/tests/win32.spec.ts
+index 3b6cfc4..029d52f 100644
+--- a/packages/session/session-persistence-jsonl/tests/win32.spec.ts
++++ b/packages/session/session-persistence-jsonl/tests/win32.spec.ts
+@@ -1,190 +1,78 @@
+ /**
+- * Unit tests for the Windows durable namespace helper with a mocked kernel32
+- * binding. The real JSONL suite exercises the helper on native Windows; these
+- * tests keep the Win32 error mapping and race handling covered on every host.
++ * Unit tests for the Windows JSONL publish helpers. These no longer mock a
++ * native Win32 binding; they exercise Node fs rename / copy fallback / mkdir.
+  */
+ 
+ import { afterEach, describe, expect, it, vi } from 'vitest'
+-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
++import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+ import { tmpdir } from 'node:os'
+ import { join } from 'node:path'
+ 
+-const MOVEFILE_WRITE_THROUGH = 0x00000008
+-const ERROR_FILE_NOT_FOUND = 2
+-const ERROR_PATH_NOT_FOUND = 3
+-const ERROR_ACCESS_DENIED = 5
+-const ERROR_NOT_SAME_DEVICE = 17
+-const ERROR_FILE_EXISTS = 80
+-const ERROR_INVALID_NAME = 123
+-const ERROR_ALREADY_EXISTS = 183
+-
+-type MoveFileExW = (existing: string, replacement: string, flags: number, setLastError: (code: number) => void) => number
+-
+ const roots: string[] = []
+ 
+-function stripNamespace(path: string): string {
+-  if (path.startsWith('\\\\?\\UNC\\')) return `\\\\${path.slice('\\\\?\\UNC\\'.length)}`
+-  if (path.startsWith('\\\\?\\')) return path.slice('\\\\?\\'.length)
+-  return path
+-}
+-
+ async function tempRoot(): Promise<string> {
+   const dir = await mkdtemp(join(tmpdir(), 'dsh-jsonl-win32-'))
+   roots.push(dir)
+   return dir
+ }
+ 
+-async function importWithMove(moveFileExW: MoveFileExW): Promise<typeof import('../src/win32.ts')> {
+-  vi.resetModules()
+-  vi.doMock('koffi', () => {
+-    let lastError = 0
+-    const setLastError = (code: number): void => { lastError = code }
+-    const move: MoveFileExW = (existing, replacement, flags, setError) => {
+-      const ok = moveFileExW(existing, replacement, flags, setError)
+-      lastError = ok === 0 ? lastError : 0
+-      return ok
+-    }
+-    return {
+-      default: {
+-        load: () => ({
+-          func: (_convention: string, name: string, result: string) => {
+-            if (name === 'MoveFileExW') return (existing: string, replacement: string, flags: number) => {
+-              expect(result).toBe('int')
+-              const ok = move(existing, replacement, flags, setLastError)
+-              return ok
+-            }
+-            return () => lastError
+-          },
+-        }),
+-      },
+-    }
+-  })
+-  return import('../src/win32.ts')
+-}
+-
+-async function importWithError(code: number): Promise<typeof import('../src/win32.ts')> {
+-  vi.resetModules()
+-  vi.doMock('koffi', () => ({
+-    default: {
+-      load: () => ({
+-        func: (_convention: string, name: string) => {
+-          if (name === 'MoveFileExW') return () => 0
+-          return () => code
+-        },
+-      }),
+-    },
+-  }))
+-  return import('../src/win32.ts')
+-}
+-
+-async function importWithFilesystemMove(): Promise<typeof import('../src/win32.ts')> {
+-  return importWithMove((existing, replacement, flags, setLastError) => {
+-    expect(flags).toBe(MOVEFILE_WRITE_THROUGH)
+-    const from = stripNamespace(existing)
+-    const to = stripNamespace(replacement)
+-    if (!existsSync(from)) { setLastError(ERROR_FILE_NOT_FOUND); return 0 }
+-    if (existsSync(to)) { setLastError(ERROR_ALREADY_EXISTS); return 0 }
+-    renameSync(from, to)
+-    return 1
+-  })
+-}
+-
+ afterEach(async () => {
+-  vi.doUnmock('koffi')
+   vi.doUnmock('node:fs/promises')
+-  vi.doUnmock('node:path')
+   vi.resetModules()
+   for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true })
+ })
+ 
+-describe('Windows durable namespace helpers', () => {
+-  it('keeps drive-root probes native while namespacing descendants', async () => {
+-    const probes: string[] = []
++describe('Windows publish helpers', () => {
++  it('publishes a new file with rename', async () => {
++    const { publishNewFileWin32 } = await import('../src/win32.ts')
++    const root = await tempRoot()
++    const tmp = join(root, 'log.tmp')
++    const final = join(root, 'log.jsonl')
++    await writeFile(tmp, 'content')
++
++    await publishNewFileWin32(tmp, final)
++    expect(existsSync(tmp)).toBe(false)
++    expect(readFileSync(final, 'utf8')).toBe('content')
++  })
++
++  it('falls back to copy+remove when rename reports EXDEV', async () => {
+     vi.resetModules()
+     vi.doMock('node:fs/promises', async (importOriginal) => {
+       const actual = await importOriginal<typeof import('node:fs/promises')>()
+       return {
+         ...actual,
+-        stat: async (path: string) => {
+-          probes.push(path)
+-          return { isDirectory: () => true }
++        rename: async () => {
++          const error = new Error('EXDEV: cross-device link not permitted') as NodeJS.ErrnoException
++          error.code = 'EXDEV'
++          throw error
+         },
+       }
+     })
+-    vi.doMock('node:path', async (importOriginal) => {
+-      const actual = await importOriginal<typeof import('node:path')>()
+-      return {
+-        ...actual,
+-        join: (...paths: string[]) => actual.win32.join(...paths),
+-        parse: (path: string) => actual.win32.parse(path),
+-        resolve: (...paths: string[]) => actual.win32.resolve(...paths),
+-        toNamespacedPath: (path: string) => actual.win32.toNamespacedPath(path),
+-      }
+-    })
+-    const { ensureDurableDirectoryWin32 } = await import('../src/win32.ts')
+-
+-    await ensureDurableDirectoryWin32('C:\\existing')
+-
+-    expect(probes).toEqual(['C:\\', '\\\\?\\C:\\existing'])
+-  })
+-
+-  it('publishes a new file with write-through MoveFileExW semantics', async () => {
+-    const { publishNewFileWin32 } = await importWithFilesystemMove()
++    const { publishNewFileWin32 } = await import('../src/win32.ts')
+     const root = await tempRoot()
+     const tmp = join(root, 'log.tmp')
+     const final = join(root, 'log.jsonl')
+-    await writeFile(tmp, 'content')
++    await writeFile(tmp, 'copied')
+ 
+     await publishNewFileWin32(tmp, final)
+     expect(existsSync(tmp)).toBe(false)
+-    expect(readFileSync(final, 'utf8')).toBe('content')
++    expect(readFileSync(final, 'utf8')).toBe('copied')
+   })
+ 
+-  it('maps Win32 publish failures to Node-style errno codes', async () => {
+-    const cases = [
+-      [ERROR_FILE_NOT_FOUND, 'ENOENT'],
+-      [ERROR_PATH_NOT_FOUND, 'ENOENT'],
+-      [ERROR_ACCESS_DENIED, 'EACCES'],
+-      [ERROR_NOT_SAME_DEVICE, 'EXDEV'],
+-      [ERROR_FILE_EXISTS, 'EEXIST'],
+-      [ERROR_ALREADY_EXISTS, 'EEXIST'],
+-      [ERROR_INVALID_NAME, 'EINVAL'],
+-      [9999, 'EIO'],
+-    ] as const
+-    for (const [win32Code, code] of cases) {
+-      const { publishNewFileWin32 } = await importWithError(win32Code)
+-      await expect(publishNewFileWin32('from', 'to')).rejects.toMatchObject({ code, win32Code, path: 'from', dest: 'to' })
+-    }
+-  })
+-
+-  it('creates missing directories through staging siblings and tolerates an already-created race', async () => {
++  it('creates missing directories and is idempotent', async () => {
++    const { ensureDurableDirectoryWin32 } = await import('../src/win32.ts')
+     const root = await tempRoot()
+-    const raced = join(root, 'raced')
+-    const { ensureDurableDirectoryWin32 } = await importWithMove((existing, replacement, flags, setLastError) => {
+-      expect(flags).toBe(MOVEFILE_WRITE_THROUGH)
+-      const from = stripNamespace(existing)
+-      const to = stripNamespace(replacement)
+-      if (to === raced) {
+-        mkdirSync(to)
+-        setLastError(ERROR_ALREADY_EXISTS)
+-        return 0
+-      }
+-      if (!existsSync(from)) { setLastError(ERROR_FILE_NOT_FOUND); return 0 }
+-      if (existsSync(to)) { setLastError(ERROR_ALREADY_EXISTS); return 0 }
+-      renameSync(from, to)
+-      return 1
+-    })
++    const target = join(root, 'a', 'b')
+ 
+-    await ensureDurableDirectoryWin32(join(root, 'a', 'b'))
+-    expect(existsSync(join(root, 'a', 'b'))).toBe(true)
+-    await ensureDurableDirectoryWin32(join(root, 'a', 'b'))
+-    await ensureDurableDirectoryWin32(raced)
+-    expect(existsSync(raced)).toBe(true)
++    await ensureDurableDirectoryWin32(target)
++    expect(existsSync(target)).toBe(true)
++    await ensureDurableDirectoryWin32(target)
++    expect(existsSync(target)).toBe(true)
+   })
+ 
+   it('keeps staging names valid for a maximum-length target component', async () => {
+-    const { ensureDurableDirectoryWin32 } = await importWithFilesystemMove()
++    const { ensureDurableDirectoryWin32 } = await import('../src/win32.ts')
+     const root = await tempRoot()
+     const target = join(root, 'x'.repeat(255))
+ 
+@@ -192,15 +80,8 @@ describe('Windows durable namespace helpers', () => {
+     expect(existsSync(target)).toBe(true)
+   })
+ 
+-  it('surfaces directory publication failures other than an existing-target race', async () => {
+-    const { ensureDurableDirectoryWin32 } = await importWithError(ERROR_ACCESS_DENIED)
+-    const root = await tempRoot()
+-
+-    await expect(ensureDurableDirectoryWin32(join(root, 'denied'))).rejects.toMatchObject({ code: 'EACCES' })
+-  })
+-
+   it('rejects a non-directory component instead of treating it as missing', async () => {
+-    const { ensureDurableDirectoryWin32 } = await importWithFilesystemMove()
++    const { ensureDurableDirectoryWin32 } = await import('../src/win32.ts')
+     const root = await tempRoot()
+     const blocked = join(root, 'blocked')
+     writeFileSync(blocked, 'x')
+-- 
+2.43.0
+

--- a/third_party/deepseek-harness/README.md
+++ b/third_party/deepseek-harness/README.md
@@ -5,6 +5,7 @@ FreeBuddy still runs the official ACP leaf (`@deepseek-ai/dsh-acp-demo` +
 set** we apply on top of that install.
 
 Upstream: https://github.com/deepseek-ai/deepseek-harness  
+Fork: https://github.com/maojindao55/deepseek-harness  
 Pinned published line: `@next` / `0.1.0-rc.6`
 
 ## Why
@@ -23,11 +24,29 @@ replace the installed files wholesale.
 | `overlays/dsh-session-persistence-jsonl/lib/index.js` | Windows publish uses Node `rename` / copy / `mkdir`. No native addon load. |
 | `overlays/dsh-acp-demo/lib/index.js` | SQLite query engine `openAt: "never"`. |
 
-Intended upstream source for the persistence change lives in
-`src/session-persistence-jsonl/win32.ts`. When
-`maojindao55/deepseek-harness` exists, copy that file onto
-`packages/session/session-persistence-jsonl/src/win32.ts` and open a PR
-back to DeepSeek.
+Source-of-truth for the fork / upstream PR:
+
+- `src/session-persistence-jsonl/win32.ts`
+- `0001-fix-windows-jsonl-node-fs.patch` (also closes ACP demo SQLite at startup)
+
+## Apply the patch on the fork
+
+This Cloud Agent can read `maojindao55/deepseek-harness` but cannot push to
+it (GitHub App is `cursor[bot]`, no write on that repo). Apply locally:
+
+```sh
+git clone https://github.com/maojindao55/deepseek-harness.git
+cd deepseek-harness
+git checkout -b cursor/windows-jsonl-node-fs-255d
+git am /path/to/freebuddy/third_party/deepseek-harness/0001-fix-windows-jsonl-node-fs.patch
+git push -u origin cursor/windows-jsonl-node-fs-255d
+```
+
+Then open a PR from that branch back to `deepseek-ai/deepseek-harness`.
+
+Compare URL after push:
+
+https://github.com/deepseek-ai/deepseek-harness/compare/master...maojindao55:deepseek-harness:cursor/windows-jsonl-node-fs-255d
 
 ## How FreeBuddy applies it
 

--- a/third_party/deepseek-harness/README.md
+++ b/third_party/deepseek-harness/README.md
@@ -1,0 +1,36 @@
+# DeepSeek Harness thin fork (FreeBuddy overlay)
+
+FreeBuddy still runs the official ACP leaf (`@deepseek-ai/dsh-acp-demo` +
+`examples/acp-agent/cordis.yml`). This directory is the **thin fork patch
+set** we apply on top of that install.
+
+Upstream: https://github.com/deepseek-ai/deepseek-harness  
+Pinned published line: `@next` / `0.1.0-rc.6`
+
+## Why
+
+Official JSONL persistence publishes the first session file with a native
+Win32 binding. On Windows Electron that aborts the ACP child with
+`STATUS_ACCESS_VIOLATION (0xC0000005)` during `session/prompt`.
+
+Regex-editing `node_modules` after install was not reliable. These overlays
+replace the installed files wholesale.
+
+## What changed
+
+| Overlay | Change |
+|---|---|
+| `overlays/dsh-session-persistence-jsonl/lib/index.js` | Windows publish uses Node `rename` / copy / `mkdir`. No native addon load. |
+| `overlays/dsh-acp-demo/lib/index.js` | SQLite query engine `openAt: "never"`. |
+
+Intended upstream source for the persistence change lives in
+`src/session-persistence-jsonl/win32.ts`. When
+`maojindao55/deepseek-harness` exists, copy that file onto
+`packages/session/session-persistence-jsonl/src/win32.ts` and open a PR
+back to DeepSeek.
+
+## How FreeBuddy applies it
+
+`patchDshAcpManagedRuntime()` copies the overlay files over the managed
+runtime after npm install and again before every spawn. Packaged builds
+ship the overlays as `extraResources` (`dsh-harness-overlays`).

--- a/third_party/deepseek-harness/README.md
+++ b/third_party/deepseek-harness/README.md
@@ -53,3 +53,11 @@ https://github.com/deepseek-ai/deepseek-harness/compare/master...maojindao55:dee
 `patchDshAcpManagedRuntime()` copies the overlay files over the managed
 runtime after npm install and again before every spawn. Packaged builds
 ship the overlays as `extraResources` (`dsh-harness-overlays`).
+
+On Windows, spawn also injects `assets/dsh/koffi-guard.mjs` via Node
+`--import`. That register hook redirects every `koffi` import to a
+fail-closed JavaScript stub so a missed overlay or `dsh-sandbox-windows-acl`
+cannot load the native addon.
+
+Debug log export includes `dsh-acp-runtime.json` (JSONL copies, leftover
+koffi, cordis safety flags, guard present).

--- a/third_party/deepseek-harness/UPSTREAM.txt
+++ b/third_party/deepseek-harness/UPSTREAM.txt
@@ -1,0 +1,4 @@
+repository=https://github.com/deepseek-ai/deepseek-harness
+npm_tag=next
+npm_version=0.1.0-rc.6
+packages=@deepseek-ai/dsh-session-persistence-jsonl @deepseek-ai/dsh-acp-demo

--- a/third_party/deepseek-harness/UPSTREAM.txt
+++ b/third_party/deepseek-harness/UPSTREAM.txt
@@ -1,4 +1,6 @@
 repository=https://github.com/deepseek-ai/deepseek-harness
+fork=https://github.com/maojindao55/deepseek-harness
+fork_branch=cursor/windows-jsonl-node-fs-255d
 npm_tag=next
 npm_version=0.1.0-rc.6
 packages=@deepseek-ai/dsh-session-persistence-jsonl @deepseek-ai/dsh-acp-demo

--- a/third_party/deepseek-harness/overlays/dsh-acp-demo/lib/index.js
+++ b/third_party/deepseek-harness/overlays/dsh-acp-demo/lib/index.js
@@ -1,0 +1,86 @@
+import { join } from "node:path";
+import z from "@deepseek-ai/schemastery";
+import * as acp from "@deepseek-ai/dsh-acp";
+import * as agentCore from "@deepseek-ai/dsh-agent-spine-demo";
+import * as workspaceContext from "@deepseek-ai/dsh-agent-instructions";
+import ToolRuntime from "@deepseek-ai/dsh-tools";
+import JsonlSessionPersistence, { JsonlCompressionSchema } from "@deepseek-ai/dsh-session-persistence-jsonl";
+import * as sessionCheckpointPolicy from "@deepseek-ai/dsh-session-checkpoint-policy";
+import SqliteSessionQueryEngine from "@deepseek-ai/dsh-session-query-sqlite";
+//#region lib/types/index.js
+/**
+* The ACP automation server app: the default agent spine
+* ({@link @deepseek-ai/dsh-agent-spine-demo}), JSONL session persistence, and
+* the {@link @deepseek-ai/dsh-acp} bridge. The app owns those plugins through one
+* ordered lifecycle so ACP sessions quiesce before persistence detaches. It
+* writes nothing to stdout.
+* It pre-creates no agents and leaves adapters, executors, and optional tools to
+* the leaf, which must likewise avoid stdout loggers. Named exports are
+* required so Loader retains this plugin's `Config` schema (see
+* docs/postmortem/0001).
+* @module @deepseek-ai/dsh-acp-demo
+*/
+const name = "acp-demo";
+const DEFAULT_PERSISTENCE_ROOT = "./.sessions";
+const Config = z.object({
+	provider: z.string().required(),
+	model: z.string().required(),
+	maxParallelToolCalls: z.number().step(1).min(1),
+	persona: z.string(),
+	toolOrder: z.array(z.string()).default(void 0),
+	tools: ToolRuntime.Config,
+	dshHome: z.string(),
+	sessionTitle: agentCore.SessionTitleConfigSchema,
+	persistenceRoot: z.string().default(DEFAULT_PERSISTENCE_ROOT),
+	packChunks: z.boolean().default(true),
+	persistenceCompression: JsonlCompressionSchema,
+	workspaceContext: z.union([z.const(false), workspaceContext.Config]).required(),
+	skills: agentCore.SkillConfigSchema,
+	toolBash: agentCore.ToolBashConfigSchema,
+	jobs: agentCore.JobsConfigSchema,
+	toolJobs: z.union([z.const(false), agentCore.ToolJobsConfigSchema]),
+	goals: z.union([z.const(false), agentCore.GoalConfigSchema])
+});
+/**
+* Compose the spine with the ACP automation transport. The agent-spine-demo bundle pre-creates
+* NO agents (its `agents` list defaults to `[]`) and carries the deployment
+* `persona`; the JSONL backend and derived query index persist under
+* `persistenceRoot`; the ACP bridge owns stdout for JSON-RPC and creates one
+* agent per `session/new` from the provider/model pair. The composite effect
+* unloads in reverse order, keeping checkpoint and persistence listeners
+* attached until ACP agents have flushed their closing events. No logger, no
+* `hmr` — stdout stays pure.
+*/
+async function apply(ctx, config) {
+	const goals = config.goals ?? {};
+	const persistenceRoot = config.persistenceRoot ?? DEFAULT_PERSISTENCE_ROOT;
+	await ctx.effect(async function* () {
+		const spine = ctx.plugin(agentCore, {
+			...agentCore.pickSpineConfig(config),
+			goals
+		});
+		await spine;
+		yield spine.dispose;
+		const persistence = ctx.plugin(JsonlSessionPersistence, {
+			root: persistenceRoot,
+			...config.packChunks !== void 0 ? { packChunks: config.packChunks } : {},
+			...config.persistenceCompression === void 0 ? {} : { compression: config.persistenceCompression }
+		});
+		await persistence;
+		yield persistence.dispose;
+		const checkpoint = ctx.plugin(sessionCheckpointPolicy);
+		await checkpoint;
+		yield checkpoint.dispose;
+		const query = ctx.plugin(SqliteSessionQueryEngine, { path: join(persistenceRoot, "session-query.db"), openAt: "never" });
+		await query;
+		yield query.dispose;
+		const transport = ctx.plugin(acp, {
+			provider: config.provider,
+			model: config.model
+		});
+		await transport;
+		yield transport.dispose;
+	}, "acp-demo.composition");
+}
+//#endregion
+export { Config, apply, name };

--- a/third_party/deepseek-harness/overlays/dsh-session-persistence-jsonl/lib/index.js
+++ b/third_party/deepseek-harness/overlays/dsh-session-persistence-jsonl/lib/index.js
@@ -1,0 +1,1372 @@
+import z from "@deepseek-ai/schemastery";
+import { readdirSync } from "node:fs";
+import { copyFile, link, mkdir, mkdtemp, open, readFile, readdir, realpath, rename, rm, stat, truncate } from "node:fs/promises";
+import { dirname, join, parse, resolve, toNamespacedPath } from "node:path";
+import { performance } from "node:perf_hooks";
+import { scheduler } from "node:timers/promises";
+import { randomBytes } from "node:crypto";
+import { DEFAULT_PREPARED_SESSION_CACHE_SIZE, DEFAULT_WRITE_BATCH_MAX_DELAY_MS, MAX_WRITE_BATCH_DELAY_MS, PersistenceCoordinator, SessionFormatUnsupportedError, SessionPersistence, SessionPersistenceRevision, sessionFormatVersionRefusal } from "@deepseek-ai/dsh-session-persistence";
+import { SESSION_FORMAT_VERSION, decodeStorageRecord, packChunkRuns } from "@deepseek-ai/dsh-session";
+import { constants, createZstdDecompress, zstdCompress, zstdDecompress, zstdDecompressSync } from "node:zlib";
+import { promisify } from "node:util";
+import { constants as constants$1 } from "node:buffer";
+//#region lib/types/format.js
+/**
+* On-disk format helpers for the JSONL session-persistence backend: path
+* sanitization (a {@link SessionId} is an unvalidated branded string, so it
+* MUST be encoded before use in a path — no traversal, no collision), the
+* per-project/session directory layout, header-line (de)serialization, and the
+* truncation-repair offset computation.
+*
+* @module dsh-session-persistence-jsonl/format
+*/
+/**
+* Return the artifact suffix for one physical encoding.
+* @param compression - configured JSONL artifact encoding.
+* @returns `.jsonl.zstd` for Zstandard or `.jsonl` for plaintext.
+*/
+function logSuffix(compression) {
+	return compression === "zstd" ? ".jsonl.zstd" : ".jsonl";
+}
+/**
+* Build the header line object from a {@link SessionHeader}.
+* @param header - the immutable session metadata to serialize.
+* @returns the `type: 'session'`-tagged line object, absent optional fields omitted (never null).
+*/
+function toHeaderLine(header) {
+	return {
+		type: "session",
+		version: header.version,
+		id: header.id,
+		createdAt: header.createdAt,
+		...header.cwd !== void 0 ? { cwd: header.cwd } : {},
+		...header.parentSession !== void 0 ? { parentSession: header.parentSession } : {},
+		...header.seedLength !== void 0 ? { seedLength: header.seedLength } : {},
+		...header.origin !== void 0 ? { origin: header.origin } : {},
+		delegationDepth: header.delegationDepth ?? 0,
+		...header.agentPreset !== void 0 ? { agentPreset: header.agentPreset } : {}
+	};
+}
+/**
+* Parse a header line back into a {@link SessionHeader}.
+* @param line - the shape-checked first line of a log (see the `isHeaderLine` guard).
+* @returns the header, absent optional fields omitted.
+*/
+function fromHeaderLine(line) {
+	if (Object.hasOwn(line, "sandboxMode") || Object.hasOwn(line, "approvalPolicy")) throw new Error("session header uses retired policy baseline fields");
+	return {
+		version: line.version,
+		id: line.id,
+		createdAt: line.createdAt,
+		...line.cwd !== void 0 ? { cwd: line.cwd } : {},
+		...line.parentSession !== void 0 ? { parentSession: line.parentSession } : {},
+		...line.seedLength !== void 0 ? { seedLength: line.seedLength } : {},
+		...line.origin !== void 0 ? { origin: line.origin } : {},
+		delegationDepth: line.delegationDepth,
+		...line.agentPreset !== void 0 ? { agentPreset: line.agentPreset } : {}
+	};
+}
+/** Type guard: a parsed first line is a well-formed session header. */
+function isHeaderLine(value) {
+	return typeof value === "object" && value !== null && value.type === "session" && typeof value.version === "number" && typeof value.id === "string" && typeof value.createdAt === "number" && Number.isSafeInteger(value.createdAt) && value.createdAt >= 0 && !Object.is(value.createdAt, -0) && typeof value.delegationDepth === "number" && Number.isSafeInteger(value.delegationDepth) && value.delegationDepth >= 0 && !Object.is(value.delegationDepth, -0) && (value.origin === void 0 || value.origin === "subagent") && (value.agentPreset === void 0 || typeof value.agentPreset === "string");
+}
+/**
+* Encode an arbitrary string as a single safe path segment, injectively over ALL JS (UTF-16)
+* strings — including lone surrogates. A {@link SessionId} is an unvalidated branded string,
+* so this neutralizes `../`, absolute paths, NUL, and separators before any filesystem use.
+* Safe code units remain literal; every other unit, including `~`, becomes
+* `~XXXX`. Operating on code units preserves lone surrogates, while special-
+* casing `.` and `..` prevents traversal by an otherwise safe whole segment.
+*
+* @param raw - the string to encode; must be non-empty (throws on `''`).
+* @returns the escaped single path segment, decodable back to `raw`.
+*/
+function encodeSegment(raw) {
+	if (raw.length === 0) throw new Error("cannot encode an empty path segment");
+	if (raw === ".") return "~002E";
+	if (raw === "..") return "~002E~002E";
+	let out = "";
+	for (let i = 0; i < raw.length; i++) {
+		const code = raw.charCodeAt(i);
+		const ch = String.fromCharCode(code);
+		if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) out += ch;
+		else out += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+	}
+	return out;
+}
+/**
+* Build the readable directory key for a project path.
+* Filesystem separators and drive separators become `-`; unsafe code units use
+* the same `~XXXX` escape as session ids. The key is bounded for filesystem
+* component limits. Separator replacement and truncation are intentionally
+* lossy, following the common human-navigable project-directory convention.
+* @param cwd - the session's project directory.
+* @returns a single filesystem-safe project directory name.
+*/
+function projectKey(cwd) {
+	if (cwd.length === 0) throw new Error("cannot encode an empty project path");
+	let readable = "";
+	let separatorRun = false;
+	for (let i = 0; i < cwd.length; i++) {
+		const code = cwd.charCodeAt(i);
+		const ch = String.fromCharCode(code);
+		if (ch === "/" || ch === "\\" || ch === ":") {
+			if (!separatorRun) readable += "-";
+			separatorRun = true;
+		} else if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) {
+			readable += ch;
+			separatorRun = false;
+		} else {
+			readable += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+			separatorRun = false;
+		}
+	}
+	return `--${(readable.replace(/^-+/, "") || "root").slice(0, 251)}--`;
+}
+/**
+* The configured root's human-navigable project directory. A configured root
+* may be local or shared; this grouping does not prescribe its deployment.
+* @param root - the backend's session root directory.
+* @param cwd - the session's project directory; `undefined` selects `_no-cwd`.
+* @returns the project directory path under `root`.
+*/
+function projectDir(root, cwd) {
+	if (cwd === void 0) return join(root, "_no-cwd");
+	return join(root, projectKey(cwd));
+}
+/**
+* The directory owned by one session and available for future session-local
+* artifacts.
+* @param root - the backend's session root directory.
+* @param cwd - the session's project directory.
+* @param id - the session id, encoded to one safe path segment.
+* @returns the session directory beneath its project directory.
+*/
+function sessionDir(root, cwd, id) {
+	return join(projectDir(root, cwd), encodeSegment(id));
+}
+/**
+* The append-only event-log file path for a session.
+* @param root - the backend's session root directory.
+* @param cwd - the session's project directory (`undefined` → `_no-cwd`).
+* @param id - the session id, path-encoded via {@link encodeSegment} before filesystem use.
+* @param compression - physical artifact encoding and filename suffix.
+* @returns the session's configured JSONL artifact path.
+*/
+function logPath(root, cwd, id, compression) {
+	return join(sessionDir(root, cwd, id), `session${logSuffix(compression)}`);
+}
+/**
+* Serialize an event batch as JSONL lines (no trailing newline). With
+* `packChunks` on, delta-chunk runs pack into `text-chunks` /
+* `reasoning-chunks` / `tool-call-chunks` storage rows; off writes one event
+* per line, byte-identical to the pre-packing layout. Reading is layout-blind
+* either way ({@link scanLog} always decodes rows), so the switch changes only
+* newly written bytes.
+* @param events - the batch to serialize, in log order.
+* @param packChunks - whether to pack delta runs into storage rows.
+* @returns the batch's JSONL text; the writer adds the final newline.
+*/
+function eventLines(events, packChunks) {
+	return (packChunks ? packChunkRuns(events) : events).map((record) => JSON.stringify(record)).join("\n");
+}
+/** Parse one complete header record supplied independently from event rows. */
+/**
+* Refuse a header carrying a format version this build does not read BEFORE
+* validating the current header shape or decoding any event row: a future
+* format need not satisfy today's structural checks at all, and its user must
+* see "upgrade the harness", never "corrupt session log".
+* @param parsed - the JSON-parsed first line of a session artifact.
+*/
+function refuseForeignFormatVersion(parsed) {
+	if (typeof parsed !== "object" || parsed === null) return;
+	const { version, id } = parsed;
+	if (typeof version !== "number" || version === SESSION_FORMAT_VERSION) return;
+	throw new SessionFormatUnsupportedError(sessionFormatVersionRefusal(typeof id === "string" ? id : String(id), version));
+}
+function parseHeaderRecord(record) {
+	if (record.length === 0 || record.at(-1) !== 10 || record.indexOf(10) !== record.length - 1) throw new Error("empty or header-less session log");
+	let parsed;
+	try {
+		parsed = JSON.parse(record.subarray(0, -1).toString("utf8"));
+	} catch {
+		throw new Error("corrupt session log: header line is not valid JSON");
+	}
+	refuseForeignFormatVersion(parsed);
+	if (!isHeaderLine(parsed)) throw new Error("corrupt session log: first line is not a session header");
+	return fromHeaderLine(parsed);
+}
+/**
+* Incrementally scan complete JSONL event records after an independently
+* supplied header record. Newline search and byte offsets stay on raw buffers;
+* only complete records are decoded to UTF-8. A fragment crossing writes is
+* copied because a decoder may reuse its output buffer after `write()` returns.
+*/
+var SessionLogScanner = class {
+	meta;
+	events = [];
+	fragments = [];
+	fragmentBytes = 0;
+	inputBytes;
+	committedBytes;
+	eventLine = 0;
+	issue;
+	finished = false;
+	/**
+	* Create an event scanner from exactly one newline-terminated header record.
+	* @param headerRecord - the complete first JSONL record, including its newline.
+	*/
+	constructor(headerRecord) {
+		this.meta = parseHeaderRecord(headerRecord);
+		this.inputBytes = headerRecord.length;
+		this.committedBytes = headerRecord.length;
+	}
+	/**
+	* Consume the next raw plaintext chunk, retaining only an incomplete final record.
+	* @param chunk - bytes immediately following all previously supplied bytes.
+	*/
+	write(chunk) {
+		if (this.finished) throw new Error("cannot write to a finished session log scanner");
+		const chunkStart = this.inputBytes;
+		this.inputBytes += chunk.length;
+		let lineStart = 0;
+		for (let newline = chunk.indexOf(10); newline !== -1; newline = chunk.indexOf(10, lineStart)) {
+			const fragment = chunk.subarray(lineStart, newline);
+			let line = fragment;
+			if (this.fragments.length > 0) {
+				if (fragment.length > 0) this.fragments.push(fragment);
+				line = Buffer.concat(this.fragments, this.fragmentBytes + fragment.length);
+				this.fragments = [];
+				this.fragmentBytes = 0;
+			}
+			this.consumeEventLine(line, chunkStart + newline + 1);
+			lineStart = newline + 1;
+		}
+		if (lineStart < chunk.length) {
+			const fragment = Buffer.from(chunk.subarray(lineStart));
+			this.fragments.push(fragment);
+			this.fragmentBytes += fragment.length;
+		}
+	}
+	/**
+	* Snapshot progress before appending a recoverable torn-frame prefix.
+	* @returns byte, committed-prefix, and expanded-event cursors.
+	*/
+	checkpoint() {
+		return {
+			inputBytes: this.inputBytes,
+			committedBytes: this.committedBytes,
+			eventCount: this.events.length
+		};
+	}
+	/**
+	* Finish scanning, ignoring a final record without a newline as a torn tail.
+	* @returns the header, contiguous event prefix, and safe truncation offset.
+	*/
+	finish() {
+		this.finished = true;
+		return {
+			meta: this.meta,
+			events: this.events,
+			committedBytes: this.committedBytes
+		};
+	}
+	/** Decode one complete event row and update the contiguous prefix. */
+	consumeEventLine(line, endByte) {
+		this.eventLine += 1;
+		let decoded;
+		try {
+			decoded = decodeStorageRecord(JSON.parse(line.toString("utf8")));
+		} catch {
+			this.issue ??= /* @__PURE__ */ new Error(`corrupt session log: unparsable committed event at line ${this.eventLine}`);
+			return;
+		}
+		if (this.issue !== void 0) {
+			if (decoded.some((event) => event.type === "turn/end")) throw this.issue;
+			return;
+		}
+		const rowStart = this.events.length;
+		for (const event of decoded) {
+			if (event.seq !== this.events.length) {
+				const expected = this.events.length;
+				this.events.length = rowStart;
+				this.issue = /* @__PURE__ */ new Error(`corrupt session log: seq gap in committed region at line ${this.eventLine} (expected ${expected}, got ${event.seq})`);
+				if (decoded.some((candidate) => candidate.type === "turn/end")) throw this.issue;
+				return;
+			}
+			this.events.push(event);
+		}
+		this.committedBytes = endByte;
+	}
+};
+/**
+* Parse a complete or torn JSONL buffer into its preserved event prefix. This
+* compatibility wrapper supplies the first record separately, then delegates
+* event rows to {@link SessionLogScanner}.
+*
+* @param buffer - the raw bytes of the log file (header line first).
+* @returns the header, preserved event prefix, and byte offset safe to append at.
+*/
+function scanLog(buffer) {
+	const headerEnd = buffer.indexOf(10);
+	if (headerEnd === -1) throw new Error("empty or header-less session log");
+	const scanner = new SessionLogScanner(buffer.subarray(0, headerEnd + 1));
+	scanner.write(buffer.subarray(headerEnd + 1));
+	return scanner.finish();
+}
+/**
+* Parse just the header line of a log into a {@link SessionHeader}, or
+* `undefined` if it is missing/not a header. Used by `list()` to read session
+* metadata WITHOUT parsing the whole log: a session picker scales with the
+* number of sessions, not the total size of every conversation.
+* @param firstLine - the first line of a log file (without its trailing newline).
+* @returns the parsed header, or `undefined` when the line is not a well-formed session header.
+*/
+function parseHeaderMeta(firstLine) {
+	let parsed;
+	try {
+		parsed = JSON.parse(firstLine);
+	} catch {
+		return;
+	}
+	if (!isHeaderLine(parsed)) return void 0;
+	return fromHeaderLine(parsed);
+}
+//#endregion
+//#region lib/types/zstd-private-decoder.js
+/**
+* Node-private synchronous Zstandard frame decoder optimization.
+* @module dsh-session-persistence-jsonl/zstd-private-decoder
+*/
+const DECODE_CHUNK_SIZE = 1024 * 1024;
+/** Return the stream with its observed private Node contract, or reject that optimization. */
+function privateZstdStream(stream) {
+	const candidate = stream;
+	const handle = candidate._handle;
+	const errorKey = Reflect.ownKeys(stream).find((key) => typeof key === "symbol" && key.description === "kError");
+	/* v8 ignore next -- one test runtime exposes one Node-private shape; the Node 22/24/26 matrix checks compatibility. */
+	if (typeof handle !== "object" || handle === null || typeof handle.writeSync !== "function" || !(candidate._writeState instanceof Uint32Array) || candidate._writeState.length < 2 || typeof candidate._defaultFlushFlag !== "number" || errorKey === void 0 || candidate[errorKey] !== null) return void 0;
+	return {
+		stream,
+		errorKey
+	};
+}
+/**
+* Synchronous multi-frame decoder backed by one Node Zstd stream handle. Node
+* exposes synchronous decoding only as a one-shot API, so this adapter uses
+* the stream's private handle contract to reuse its native context and output
+* chunks across frames.
+*/
+var NodePrivateZstdFrameDecoder = class NodePrivateZstdFrameDecoder {
+	stream;
+	errorKey;
+	output = Buffer.allocUnsafe(DECODE_CHUNK_SIZE);
+	decoderError;
+	started = false;
+	closed = false;
+	constructor(stream, errorKey) {
+		this.stream = stream;
+		this.errorKey = errorKey;
+		this.stream.on("error", (error) => {
+			this.decoderError ??= error;
+		});
+	}
+	/**
+	* Create the optimized decoder when this Node release exposes the expected
+	* private stream shape.
+	* @returns a shared decoder, or `undefined` when callers must use the public fallback.
+	*/
+	static create() {
+		const stream = createZstdDecompress({ chunkSize: DECODE_CHUNK_SIZE });
+		const privateAccess = privateZstdStream(stream);
+		/* v8 ignore next -- reached only when a supported Node release changes its private stream shape. */
+		if (privateAccess !== void 0) return new NodePrivateZstdFrameDecoder(privateAccess.stream, privateAccess.errorKey);
+		/* v8 ignore next -- the active Node runtime passed the private-shape probe above. */
+		stream.close();
+	}
+	/** @inheritdoc */
+	*decode(source, frames) {
+		if (this.started) throw new Error("Zstandard frame decoder was already started");
+		if (this.closed) throw new Error("cannot start a closed Zstandard frame decoder");
+		this.started = true;
+		try {
+			for (const frame of frames) try {
+				yield this.decodeFrame(source.subarray(frame.start, frame.end));
+			} catch (error) {
+				throw new Error(`corrupt Zstandard session log: frame at byte ${frame.start} failed validation`, { cause: error });
+			}
+		} finally {
+			this.close();
+		}
+	}
+	/** Decode one frame; its returned scratch view remains valid until the next call. */
+	decodeFrame(input) {
+		const handle = this.stream._handle;
+		/* v8 ignore next -- decode() rejects closed instances before entering this private frame operation. */
+		if (this.closed || handle === null) throw new Error("cannot decode with a closed Zstandard frame decoder");
+		let inputOffset = 0;
+		let inputRemaining = input.length;
+		let outputBytes = 0;
+		const fullChunks = [];
+		for (;;) {
+			handle.writeSync(this.stream._defaultFlushFlag, input, inputOffset, inputRemaining, this.output, 0, this.output.length);
+			if (this.decoderError !== void 0) throw this.decoderError;
+			const internalError = this.stream[this.errorKey];
+			if (internalError !== null) {
+				if (internalError instanceof Error) throw internalError;
+				throw new Error("Zstandard decoder exposed a non-Error internal failure");
+			}
+			const outputAfter = this.stream._writeState[0];
+			const inputAfter = this.stream._writeState[1];
+			const consumed = inputRemaining - inputAfter;
+			const produced = this.output.length - outputAfter;
+			if (produced > 0) {
+				outputBytes += produced;
+				/* v8 ignore next -- Buffer cannot materialize a frame beyond its own process-wide maximum length. */
+				if (outputBytes > constants$1.MAX_LENGTH) throw new Error(`Zstandard frame output exceeds ${constants$1.MAX_LENGTH} bytes`);
+			}
+			if (outputAfter !== 0) {
+				/* v8 ignore next -- structurally scanned ranges contain exactly one complete frame and no trailing bytes. */
+				if (inputAfter !== 0) throw new Error("Zstandard frame decoder left trailing input");
+				const finalChunk = this.output.subarray(0, produced);
+				if (fullChunks.length === 0) return finalChunk;
+				if (produced > 0) fullChunks.push(Buffer.from(finalChunk));
+				const onlyChunk = fullChunks[0];
+				return fullChunks.length === 1 ? onlyChunk : Buffer.concat(fullChunks, outputBytes);
+			}
+			fullChunks.push(Buffer.from(this.output));
+			inputOffset += consumed;
+			inputRemaining = inputAfter;
+		}
+	}
+	/** @inheritdoc */
+	close() {
+		if (this.closed) return;
+		this.closed = true;
+		this.stream.close();
+	}
+};
+//#endregion
+//#region lib/types/zstd-public-decoder.js
+/**
+* Public-API synchronous Zstandard frame decoder fallback.
+* @module dsh-session-persistence-jsonl/zstd-public-decoder
+*/
+/** Multi-frame adapter built exclusively from Node's supported one-shot API. */
+var PublicZstdFrameDecoder = class {
+	started = false;
+	closed = false;
+	/** @inheritdoc */
+	*decode(source, frames) {
+		if (this.started) throw new Error("Zstandard frame decoder was already started");
+		if (this.closed) throw new Error("cannot start a closed Zstandard frame decoder");
+		this.started = true;
+		try {
+			for (const { start, end } of frames) {
+				let decoded;
+				try {
+					decoded = zstdDecompressSync(source.subarray(start, end));
+				} catch (error) {
+					throw new Error(`corrupt Zstandard session log: frame at byte ${start} failed validation`, { cause: error });
+				}
+				yield decoded;
+			}
+		} finally {
+			this.close();
+		}
+	}
+	/** @inheritdoc */
+	close() {
+		this.closed = true;
+	}
+};
+//#endregion
+//#region lib/types/zstd.js
+/**
+* Zstandard frame primitives for the JSONL persistence backend. The backend
+* owns a concatenated-frame container so it can append and recover batches
+* without exposing compression mechanics through the persistence seam.
+* @module dsh-session-persistence-jsonl/zstd
+*/
+const ZSTD_MAGIC = 4247762216;
+const zstdCompressAsync = promisify(zstdCompress);
+const zstdDecompressAsync = promisify(zstdDecompress);
+const CHECKSUM_OPTIONS = { params: { [constants.ZSTD_c_checksumFlag]: 1 } };
+const INCOMPLETE_FRAME_OPTIONS = { finishFlush: constants.ZSTD_e_flush };
+/**
+* Locate complete frames without decompressing their blocks. Invalid complete
+* structure rejects; EOF inside the final frame returns its start for repair.
+* @param buffer - complete bytes currently present in the session artifact.
+* @param maxFrames - optional complete-frame limit for metadata-only readers.
+* @returns complete frame ranges and an optional incomplete-final-frame start.
+*/
+function scanZstdFrames(buffer, maxFrames = Number.POSITIVE_INFINITY) {
+	const frames = [];
+	let offset = 0;
+	while (offset < buffer.length) {
+		const start = offset;
+		if (buffer.length - offset < 4) return {
+			frames,
+			tornStart: start
+		};
+		if (buffer.readUInt32LE(offset) !== ZSTD_MAGIC) throw new Error(`corrupt Zstandard session log: invalid frame magic at byte ${offset}`);
+		offset += 4;
+		if (offset === buffer.length) return {
+			frames,
+			tornStart: start
+		};
+		const descriptor = buffer.readUInt8(offset);
+		offset += 1;
+		if ((descriptor & 24) !== 0) throw new Error(`corrupt Zstandard session log: reserved frame-header bit at byte ${offset - 1}`);
+		const contentSizeFlag = descriptor >>> 6;
+		const singleSegment = (descriptor & 32) !== 0;
+		const checksum = (descriptor & 4) !== 0;
+		const dictionaryFlag = descriptor & 3;
+		const dictionaryBytes = dictionaryFlag === 3 ? 4 : dictionaryFlag;
+		const contentSizeBytes = contentSizeFlag === 0 ? singleSegment ? 1 : 0 : 1 << contentSizeFlag;
+		const remainingHeaderBytes = (singleSegment ? 0 : 1) + dictionaryBytes + contentSizeBytes;
+		if (buffer.length - offset < remainingHeaderBytes) return {
+			frames,
+			tornStart: start
+		};
+		offset += remainingHeaderBytes;
+		for (;;) {
+			if (buffer.length - offset < 3) return {
+				frames,
+				tornStart: start
+			};
+			const blockHeader = buffer.readUIntLE(offset, 3);
+			offset += 3;
+			const lastBlock = (blockHeader & 1) !== 0;
+			const blockType = blockHeader >>> 1 & 3;
+			const blockSize = blockHeader >>> 3;
+			if (blockType === 3) throw new Error(`corrupt Zstandard session log: reserved block type at byte ${offset - 3}`);
+			const payloadBytes = blockType === 1 ? 1 : blockSize;
+			if (buffer.length - offset < payloadBytes) return {
+				frames,
+				tornStart: start
+			};
+			offset += payloadBytes;
+			if (lastBlock) break;
+		}
+		if (checksum) {
+			if (buffer.length - offset < 4) return {
+				frames,
+				tornStart: start
+			};
+			offset += 4;
+		}
+		frames.push({
+			start,
+			end: offset
+		});
+		if (frames.length === maxFrames) return { frames };
+	}
+	return { frames };
+}
+/**
+* Compress one independently decodable, checksummed Zstandard frame.
+* @param input - JSONL bytes for a header or durable event batch.
+* @returns the complete encoded frame.
+*/
+async function compressZstdFrame(input) {
+	return zstdCompressAsync(input, CHECKSUM_OPTIONS);
+}
+/**
+* Decompress one complete frame and validate its checksum.
+* @param input - one structurally complete Zstandard frame.
+* @returns the frame plaintext.
+*/
+async function decompressZstdFrame(input) {
+	return zstdDecompressAsync(input);
+}
+/**
+* Select the shared private decoder when the running Node 22/24/26 shape is
+* compatible, otherwise preserve correctness with the public one-shot API.
+* @returns a synchronous decoder with an implementation-independent lifecycle.
+*/
+function createZstdFrameDecoder() {
+	return NodePrivateZstdFrameDecoder.create() ?? new PublicZstdFrameDecoder();
+}
+/**
+* Recover available plaintext from a structurally incomplete final frame.
+* `ZSTD_e_flush` deliberately suppresses final-frame and checksum completion;
+* callers must establish the torn frame boundary before using this helper.
+* @param input - available bytes from a known incomplete Zstandard frame.
+* @returns plaintext produced from the available input.
+*/
+async function decompressZstdPrefix(input) {
+	return zstdDecompressAsync(input, INCOMPLETE_FRAME_OPTIONS);
+}
+//#endregion
+//#region lib/types/win32.js
+/**
+* Windows publish helpers for the JSONL backend.
+*
+* Official harness used a native Win32 durable-publish binding here. That
+* aborted Windows Electron children with STATUS_ACCESS_VIOLATION. This
+* FreeBuddy overlay keeps the Win32 function names so the rest of the package
+* is unchanged, but publishes with Node fs (rename, copy fallback, mkdir).
+*
+* @module dsh-session-persistence-jsonl/win32
+*/
+async function publishNewFileWin32(existing, replacement) {
+	try {
+		await rename(existing, replacement);
+	} catch (error) {
+		if (error?.code !== "EXDEV" && error?.code !== "EPERM") throw error;
+		const info = await stat(existing);
+		if (info.isDirectory()) {
+			await mkdir(replacement, { recursive: true });
+			await rm(existing, {
+				recursive: true,
+				force: true
+			});
+			return;
+		}
+		await copyFile(existing, replacement);
+		await rm(existing, { force: true });
+	}
+}
+async function ensureDurableDirectoryWin32(target) {
+	await mkdir(target, { recursive: true });
+}
+//#endregion
+//#region lib/types/index.js
+/**
+* JSONL durable session-persistence backend. It stores a header and contiguous
+* events in one append-only file per session, and delegates orchestration to
+* {@link PersistenceCoordinator}. Its side-effect-free locator returns the
+* absolute per-session log target before materialization.
+* @module @deepseek-ai/dsh-session-persistence-jsonl
+*/
+const DEFAULT_PACK_CHUNKS = true;
+const DEFAULT_COMPRESSION = "zstd";
+/**
+* Internal scheduling constant, not deployment configuration: balance
+* frame-boundary event-loop yields against `setImmediate` overhead. One frame
+* remains an indivisible synchronous decode.
+*/
+const ZSTD_DECODE_YIELD_INTERVAL_MS = 500;
+/** Assert that the independently decodable first frame contains only the header record. */
+function assertZstdHeaderFrame(plaintext) {
+	if (plaintext.length === 0 || plaintext.indexOf(10) !== plaintext.length - 1) throw new Error("corrupt Zstandard session log: first frame is not exactly one header line");
+}
+/** Loader schema for the JSONL artifact's physical encoding. */
+const JsonlCompressionSchema = z.union([z.const("zstd"), z.const("none")]).default(DEFAULT_COMPRESSION);
+/** Build the source-qualified revision shared by full and lightweight reads. */
+function fileRevision(identity) {
+	return SessionPersistenceRevision([
+		identity.dev,
+		identity.ino,
+		identity.size,
+		identity.mtimeNs,
+		identity.ctimeNs
+	].join(":"));
+}
+/** Whether a filesystem error means absence; every non-ENOENT failure must surface. */
+function isENOENT(error) {
+	return error?.code === "ENOENT";
+}
+/**
+* The JSONL persistence backend. Load as a plugin; it registers as
+* `ctx.sessionPersistence` and (via the coordinator) installs the write-path
+* listeners. Its torn-tail marker carries the byte offset and any events
+* recovered from an incomplete final Zstandard frame.
+*/
+var JsonlSessionPersistence = class extends SessionPersistence {
+	config;
+	supportsRawArtifacts = true;
+	static inject = ["sessions"];
+	static Config = z.object({
+		root: z.string().required(),
+		packChunks: z.boolean().default(DEFAULT_PACK_CHUNKS),
+		compression: JsonlCompressionSchema,
+		preparedSessionCacheSize: z.number().step(1).min(1).default(DEFAULT_PREPARED_SESSION_CACHE_SIZE),
+		writeBatchMaxDelayMs: z.number().step(1).min(1).max(MAX_WRITE_BATCH_DELAY_MS).default(DEFAULT_WRITE_BATCH_MAX_DELAY_MS)
+	});
+	/**
+	* Backend label for coordinator diagnostics and effects. It shadows
+	* `Service.name` without changing the service key captured by the base
+	* constructor.
+	*/
+	name = "session-persistence-jsonl";
+	root;
+	packChunks;
+	compression;
+	coordinator;
+	rootEncodingCheck;
+	constructor(ctx, config) {
+		super(ctx);
+		this.config = config;
+		this.root = resolve(config.root);
+		const preparedSessionCacheSize = config.preparedSessionCacheSize ?? DEFAULT_PREPARED_SESSION_CACHE_SIZE;
+		const writeBatchMaxDelayMs = config.writeBatchMaxDelayMs ?? DEFAULT_WRITE_BATCH_MAX_DELAY_MS;
+		this.packChunks = config.packChunks ?? DEFAULT_PACK_CHUNKS;
+		this.compression = config.compression ?? DEFAULT_COMPRESSION;
+		this.assertUsableRoot();
+		this.coordinator = new PersistenceCoordinator(this.ctx, this, {
+			preparedSessionCacheSize,
+			writeBatchMaxDelayMs
+		});
+	}
+	/** Resolve the absolute target path without touching the filesystem. */
+	locate(meta) {
+		return {
+			kind: "jsonl",
+			path: logPath(this.root, meta.cwd, meta.id, this.compression)
+		};
+	}
+	create(meta) {
+		return this.coordinator.create(meta);
+	}
+	append(id, events) {
+		return this.coordinator.append(id, events);
+	}
+	prepare(id, signal) {
+		return this.coordinator.prepare(id, signal);
+	}
+	load(id) {
+		return this.coordinator.load(id);
+	}
+	inspect(id, signal) {
+		return this.coordinator.inspect(id, signal);
+	}
+	readFrom(id, fromSeq, signal) {
+		return this.coordinator.readFrom(id, fromSeq, signal);
+	}
+	/** Read a stored prefix by id across all project directories when cwd is unknown. */
+	async loadStored(id, signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const path = await this.findLog(id, signal);
+		if (path === void 0) return void 0;
+		return this.readPrefix(path, id, signal);
+	}
+	/**
+	* Read one log's stat-derived revision without loading its event bytes.
+	* Resolving an id with unknown cwd still scans the project directories.
+	*/
+	async readStoredRevision(id, signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const path = await this.findLog(id, signal);
+		if (path === void 0) return void 0;
+		try {
+			const identity = await stat(path, { bigint: true });
+			signal?.throwIfAborted();
+			return fileRevision(identity);
+		} catch (error) {
+			signal?.throwIfAborted();
+			if (isENOENT(error)) return void 0;
+			throw error;
+		}
+	}
+	/**
+	* Read a session's stored artifact text verbatim: the durable file bytes
+	* decoded from this backend's physical encoding (complete zstd frames
+	* concatenated, or UTF-8 plaintext). The content is the exact JSONL text the
+	* backend wrote — never a reconstruction from parsed events — so packed-
+	* chunk rows, key order, and line breaks survive byte-for-byte. A torn
+	* final frame is omitted, matching the committed-prefix semantics of every
+	* other read.
+	* @param id - the persisted session to read.
+	* @param signal - optional cancellation for the stat/read/decode work.
+	* @returns the raw artifact text plus the header parsed from its own first
+	* line, or `undefined` when the session has no stored artifact.
+	*/
+	async readRaw(id, signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const path = await this.findLog(id, signal);
+		if (path === void 0) return void 0;
+		const { buffer } = await this.readStableFile(path, signal);
+		let content;
+		if (this.compression === "zstd") {
+			const { frames } = scanZstdFrames(buffer);
+			if (frames.length === 0) throw new Error("empty or header-less Zstandard session log");
+			const decoder = createZstdFrameDecoder();
+			const plaintexts = [];
+			for (const plaintext of decoder.decode(buffer, frames)) {
+				signal?.throwIfAborted();
+				plaintexts.push(Buffer.from(plaintext));
+			}
+			content = Buffer.concat(plaintexts).toString("utf8");
+		} else content = buffer.toString("utf8");
+		const meta = parseHeaderMeta(content.split("\n", 1)[0]);
+		if (meta === void 0 || meta.id !== id) throw new Error(`corrupt session log: invalid header line in "${path}"`);
+		return {
+			meta,
+			filename: "session.jsonl",
+			content
+		};
+	}
+	/**
+	* Read a file's bytes under a revision-stable loop: a writer appending
+	* between stat and readFile would yield a torn physical file, so retry
+	* while the stat revision changes.
+	* @param path - the artifact file to read.
+	* @param signal - optional cancellation for the stat/read work.
+	* @returns the stable bytes and the revision that matched both stats.
+	*/
+	async readStableFile(path, signal) {
+		for (;;) {
+			signal?.throwIfAborted();
+			const before = fileRevision(await stat(path, { bigint: true }));
+			const buffer = await readFile(path, { signal });
+			signal?.throwIfAborted();
+			const after = fileRevision(await stat(path, { bigint: true }));
+			if (before === after) return {
+				buffer,
+				revision: after
+			};
+		}
+	}
+	/**
+	* Read a stored prefix and convert torn-tail state to the opaque marker the
+	* coordinator can round-trip without knowing the physical encoding.
+	*/
+	async readPrefix(path, expectedId, signal) {
+		const { buffer, revision } = await this.readStableFile(path, signal);
+		let prefix;
+		try {
+			if (this.compression === "zstd") prefix = await this.readZstdPrefix(buffer, signal);
+			else {
+				signal?.throwIfAborted();
+				const { meta, events, committedBytes } = scanLog(buffer);
+				signal?.throwIfAborted();
+				prefix = {
+					meta,
+					events,
+					...committedBytes < buffer.byteLength ? { tornMarker: {
+						truncateTo: committedBytes,
+						recoveredEvents: []
+					} } : {}
+				};
+			}
+		} catch (error) {
+			if (error instanceof SessionFormatUnsupportedError && error.location === void 0) throw new SessionFormatUnsupportedError(`${error.message} (raw log: ${path})`, {
+				kind: "jsonl",
+				path
+			});
+			throw error;
+		}
+		signal?.throwIfAborted();
+		await this.assertStoredIdentity(path, prefix.meta, expectedId, signal);
+		signal?.throwIfAborted();
+		return {
+			...prefix,
+			revision
+		};
+	}
+	/** Decode complete frames and retain complete JSONL records from a torn final frame. */
+	async readZstdPrefix(buffer, signal) {
+		signal?.throwIfAborted();
+		const { frames, tornStart } = scanZstdFrames(buffer);
+		signal?.throwIfAborted();
+		if (frames.length === 0) throw new Error("empty or header-less Zstandard session log");
+		const decoder = createZstdFrameDecoder();
+		let yieldDeadline = performance.now() + ZSTD_DECODE_YIELD_INTERVAL_MS;
+		try {
+			const decodedFrames = decoder.decode(buffer, frames);
+			signal?.throwIfAborted();
+			const headerFrame = decodedFrames.next();
+			signal?.throwIfAborted();
+			/* v8 ignore next -- a non-empty structural frame list makes the decoder yield its first frame or throw. */
+			if (headerFrame.done) throw new Error("empty or header-less Zstandard session log");
+			assertZstdHeaderFrame(headerFrame.value);
+			const scanner = new SessionLogScanner(headerFrame.value);
+			let remainingFrames = frames.length - 1;
+			for (const plaintext of decodedFrames) {
+				signal?.throwIfAborted();
+				scanner.write(plaintext);
+				remainingFrames -= 1;
+				if (remainingFrames > 0 && performance.now() >= yieldDeadline) {
+					await scheduler.yield();
+					signal?.throwIfAborted();
+					yieldDeadline = performance.now() + ZSTD_DECODE_YIELD_INTERVAL_MS;
+				}
+			}
+			signal?.throwIfAborted();
+			const complete = scanner.checkpoint();
+			if (complete.committedBytes !== complete.inputBytes) throw new Error("corrupt Zstandard session log: complete frame contains a torn JSONL record");
+			if (tornStart === void 0) {
+				const prefix = scanner.finish();
+				return {
+					meta: prefix.meta,
+					events: prefix.events
+				};
+			}
+			let recoveredPlaintext = Buffer.alloc(0);
+			try {
+				signal?.throwIfAborted();
+				recoveredPlaintext = await decompressZstdPrefix(buffer.subarray(tornStart));
+			} catch {
+				/* v8 ignore next -- decoder failure plus concurrent abort is timing-dependent */
+				if (signal?.aborted) signal.throwIfAborted();
+			}
+			signal?.throwIfAborted();
+			scanner.write(recoveredPlaintext);
+			const recoveredPrefix = scanner.finish();
+			signal?.throwIfAborted();
+			return {
+				meta: recoveredPrefix.meta,
+				events: recoveredPrefix.events,
+				tornMarker: {
+					truncateTo: tornStart,
+					recoveredEvents: recoveredPrefix.events.slice(complete.eventCount)
+				}
+			};
+		} catch (error) {
+			/* v8 ignore next -- decoder failure plus concurrent abort is timing-dependent */
+			if (signal?.aborted) signal.throwIfAborted();
+			throw error;
+		} finally {
+			decoder.close();
+		}
+	}
+	/** Durably append a batch, lazily materializing the file when not yet present. */
+	async appendBatch(meta, events, isMaterialized) {
+		await this.ensureRootEncoding();
+		if (isMaterialized) await this.appendLines(meta, events);
+		else await this.materialize(meta, events);
+	}
+	/**
+	* Make a crash repair durable: truncate a torn tail, restore complete events
+	* decoded from it, then append synthetic closers. Two fsync'd steps — the seam
+	* does not require this to be atomic.
+	*/
+	async commitRepair(meta, tornMarker, closers) {
+		if (tornMarker !== void 0) await this.repair(meta, tornMarker.truncateTo);
+		const repairedEvents = [...tornMarker?.recoveredEvents ?? [], ...closers];
+		if (repairedEvents.length > 0) await this.appendLines(meta, repairedEvents);
+	}
+	/** List valid unique stored sessions' metadata (header line only — no full-log parse). */
+	async list(signal) {
+		return (await this.listArtifacts(signal)).map((artifact) => artifact.header);
+	}
+	/** List metadata plus a stat-derived identity for each append-only log. */
+	async listSnapshots(signal) {
+		const snapshots = [];
+		for (const artifact of await this.listArtifacts(signal)) {
+			signal?.throwIfAborted();
+			try {
+				const identity = await stat(artifact.path, { bigint: true });
+				signal?.throwIfAborted();
+				snapshots.push({
+					header: artifact.header,
+					revision: fileRevision(identity)
+				});
+			} catch (error) {
+				signal?.throwIfAborted();
+				if (!isENOENT(error)) throw error;
+			}
+		}
+		signal?.throwIfAborted();
+		return snapshots;
+	}
+	async listArtifacts(signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const artifacts = [];
+		const ids = /* @__PURE__ */ new Set();
+		for (const project of await this.listProjectDirs(signal)) {
+			signal?.throwIfAborted();
+			for (const dir of await this.listSessionDirs(project, signal)) {
+				signal?.throwIfAborted();
+				const opposite = join(dir, `session${logSuffix(this.oppositeCompression())}`);
+				const oppositeExists = await this.exists(opposite);
+				signal?.throwIfAborted();
+				if (oppositeExists) throw this.encodingMismatch(opposite);
+				const path = join(dir, `session${logSuffix(this.compression)}`);
+				const pathExists = await this.exists(path);
+				signal?.throwIfAborted();
+				if (!pathExists) continue;
+				const first = this.compression === "zstd" ? await this.readFirstZstdLine(path, signal) : await this.readFirstLine(path, signal);
+				signal?.throwIfAborted();
+				if (first === void 0) continue;
+				const meta = parseHeaderMeta(first);
+				if (meta === void 0) continue;
+				await this.assertStoredIdentity(path, meta, void 0, signal);
+				signal?.throwIfAborted();
+				if (ids.has(meta.id)) throw new Error(`duplicate JSONL session id "${meta.id}" appears in multiple project directories`);
+				ids.add(meta.id);
+				artifacts.push({
+					header: meta,
+					path
+				});
+			}
+		}
+		signal?.throwIfAborted();
+		return artifacts;
+	}
+	/** Atomically write the header line + first batch (temp-write, fsync, publish). */
+	async materialize(meta, events) {
+		const project = projectDir(this.root, meta.cwd);
+		const dir = sessionDir(this.root, meta.cwd, meta.id);
+		const finalPath = logPath(this.root, meta.cwd, meta.id, this.compression);
+		await this.rejectOppositeArtifact(meta.cwd, meta.id);
+		const content = await this.encodeMaterialization(meta, events);
+		/* v8 ignore next -- native Windows coverage exercises this platform dispatch; Linux covers the POSIX peer */
+		if (process.platform === "win32") await this.materializeWin32(project, dir, finalPath, meta.id, content);
+		else await this.materializePosix(project, dir, finalPath, meta.id, content);
+	}
+	/* v8 ignore start -- Windows uses the Win32 durable-publish path; POSIX coverage exercises this peer. */
+	async materializePosix(project, dir, finalPath, id, content) {
+		await mkdir(this.root, {
+			recursive: true,
+			mode: 448
+		});
+		await this.syncDirPosix(dirname(this.root));
+		await mkdir(project, {
+			recursive: true,
+			mode: 448
+		});
+		await this.syncDirPosix(this.root);
+		await mkdir(dir, {
+			recursive: true,
+			mode: 448
+		});
+		await this.syncDirPosix(project);
+		await this.rejectExistingLog(finalPath, id);
+		const tmp = await this.writeSyncedTempFile(finalPath, content);
+		let linked = false;
+		try {
+			await link(tmp, finalPath);
+			linked = true;
+		} finally {
+			/* v8 ignore next -- link failure is the TOCTOU/IO race guarded above; not reachable in test */
+			if (!linked) await rm(tmp, { force: true });
+		}
+		await this.syncDirPosix(dir);
+		try {
+			await rm(tmp, { force: true });
+		} catch {}
+	}
+	/* v8 ignore stop */
+	/* v8 ignore start -- native Windows coverage exercises this integration path */
+	async materializeWin32(project, dir, finalPath, id, content) {
+		await ensureDurableDirectoryWin32(this.root);
+		await ensureDurableDirectoryWin32(project);
+		await ensureDurableDirectoryWin32(dir);
+		await this.rejectExistingLog(finalPath, id);
+		const tmp = await this.writeSyncedTempFile(finalPath, content);
+		try {
+			await publishNewFileWin32(tmp, finalPath);
+		} catch (error) {
+			await rm(tmp, { force: true });
+			throw error;
+		}
+	}
+	/* v8 ignore stop */
+	async rejectExistingLog(finalPath, id) {
+		/* v8 ignore next 3 -- createCore guards collisions before materialize; this is a TOCTOU backstop */
+		if (await this.exists(finalPath)) throw new Error(`refusing to materialize "${id}": a log already exists on disk (load/resume it instead)`);
+	}
+	async writeSyncedTempFile(finalPath, content) {
+		const tmp = `${finalPath}.${randomBytes(6).toString("hex")}.tmp`;
+		const handle = await open(tmp, "wx", 384);
+		try {
+			await handle.writeFile(content);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		return tmp;
+	}
+	/** Encode the header and first batch without combining their frame boundaries. */
+	async encodeMaterialization(meta, events) {
+		const header = JSON.stringify(toHeaderLine(meta)) + "\n";
+		const body = eventLines(events, this.packChunks) + "\n";
+		if (this.compression === "none") return header + body;
+		const headerFrame = await compressZstdFrame(header);
+		const eventFrame = await compressZstdFrame(body);
+		return Buffer.concat([headerFrame, eventFrame]);
+	}
+	/** Encode one durable append batch in the configured physical representation. */
+	async encodeEventBatch(events) {
+		const body = eventLines(events, this.packChunks) + "\n";
+		return this.compression === "zstd" ? compressZstdFrame(body) : body;
+	}
+	/** fsync a POSIX directory so a just-created/renamed entry is crash-durable. */
+	/* v8 ignore start -- Windows uses write-through namespace operations; POSIX coverage exercises directory fsync. */
+	async syncDirPosix(dir) {
+		const handle = await open(dir, "r");
+		try {
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	}
+	/* v8 ignore stop */
+	/**
+	* Append and fsync event lines. On a partial write or sync failure, restore the
+	* previous size before rethrowing because the unchanged cursor will retry the
+	* batch; leaving partial bytes would create duplicate sequence numbers.
+	*/
+	async appendLines(meta, events) {
+		const content = await this.encodeEventBatch(events);
+		const path = logPath(this.root, meta.cwd, meta.id, this.compression);
+		const handle = await open(path, "a");
+		let closed = false;
+		const closeAppendHandle = async () => {
+			if (closed) return;
+			closed = true;
+			await handle.close();
+		};
+		try {
+			const { size: before } = await handle.stat();
+			try {
+				await handle.writeFile(content);
+				await handle.sync();
+			} catch (error) {
+				try {
+					await closeAppendHandle();
+					await this.rollbackAppend(path, before);
+				} catch (rollbackError) {
+					throw new AggregateError([error, rollbackError], `failed to roll back append to "${path}"`);
+				}
+				throw error;
+			}
+		} finally {
+			await closeAppendHandle();
+		}
+	}
+	async rollbackAppend(path, size) {
+		const handle = await open(path, "r+");
+		try {
+			await handle.truncate(size);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	}
+	/** Truncate the log file to `offset` bytes and fsync (discard the crash tail). */
+	async repair(meta, offset) {
+		const path = logPath(this.root, meta.cwd, meta.id, this.compression);
+		await truncate(path, offset);
+		const handle = await open(path, "r+");
+		try {
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	}
+	/**
+	* Read the first newline-terminated line of a file without loading the whole
+	* file. Returns undefined if the file is empty or has no complete first line.
+	* Reads in bounded chunks so a huge log costs only the header read.
+	*/
+	async readFirstLine(path, signal) {
+		signal?.throwIfAborted();
+		const handle = await open(path, "r");
+		try {
+			signal?.throwIfAborted();
+			const chunks = [];
+			const buf = Buffer.alloc(8192);
+			for (;;) {
+				signal?.throwIfAborted();
+				const { bytesRead } = await handle.read(buf, 0, buf.length, null);
+				signal?.throwIfAborted();
+				if (bytesRead === 0) return void 0;
+				const slice = buf.subarray(0, bytesRead);
+				const nl = slice.indexOf(10);
+				if (nl !== -1) {
+					chunks.push(slice.subarray(0, nl));
+					signal?.throwIfAborted();
+					return Buffer.concat(chunks).toString("utf8");
+				}
+				chunks.push(Buffer.from(slice));
+			}
+		} finally {
+			await handle.close();
+		}
+	}
+	/** Read and validate only the independently compressed header frame. */
+	async readFirstZstdLine(path, signal) {
+		signal?.throwIfAborted();
+		const handle = await open(path, "r");
+		try {
+			signal?.throwIfAborted();
+			let content = Buffer.alloc(0);
+			const chunk = Buffer.alloc(8192);
+			for (;;) {
+				signal?.throwIfAborted();
+				const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+				signal?.throwIfAborted();
+				if (bytesRead === 0) return void 0;
+				signal?.throwIfAborted();
+				content = Buffer.concat([content, chunk.subarray(0, bytesRead)]);
+				signal?.throwIfAborted();
+				const first = scanZstdFrames(content, 1).frames[0];
+				signal?.throwIfAborted();
+				if (first === void 0) continue;
+				let plaintext;
+				try {
+					signal?.throwIfAborted();
+					plaintext = await decompressZstdFrame(content.subarray(first.start, first.end));
+				} catch (error) {
+					/* v8 ignore next -- decoder failure plus concurrent abort is timing-dependent */
+					if (signal?.aborted) signal.throwIfAborted();
+					throw new Error("corrupt Zstandard session log: header frame failed validation", { cause: error });
+				}
+				signal?.throwIfAborted();
+				assertZstdHeaderFrame(plaintext);
+				return plaintext.subarray(0, -1).toString("utf8");
+			}
+		} finally {
+			await handle.close();
+		}
+	}
+	/** Find the unique physical log for an id across every project directory. */
+	async findLog(id, signal) {
+		const matches = [];
+		for (const project of await this.listProjectDirs(signal)) {
+			signal?.throwIfAborted();
+			await this.rejectLegacyFlatArtifact(project, id, signal);
+			signal?.throwIfAborted();
+			const dir = join(project, encodeSegment(id));
+			const path = join(dir, `session${logSuffix(this.compression)}`);
+			const opposite = join(dir, `session${logSuffix(this.oppositeCompression())}`);
+			const oppositeExists = await this.exists(opposite);
+			signal?.throwIfAborted();
+			if (oppositeExists) throw this.encodingMismatch(opposite);
+			const pathExists = await this.exists(path);
+			signal?.throwIfAborted();
+			if (pathExists) matches.push(path);
+		}
+		if (matches.length > 1) throw new Error(`duplicate JSONL session id "${id}" appears in multiple project directories`);
+		signal?.throwIfAborted();
+		return matches[0];
+	}
+	/** Require an existing configured root to be a readable directory. */
+	assertUsableRoot() {
+		try {
+			readdirSync(this.root);
+		} catch (error) {
+			if (isENOENT(error)) return;
+			throw error;
+		}
+	}
+	/** Reject metadata that does not identify the selected physical log. */
+	async assertStoredIdentity(path, meta, expectedId, signal) {
+		signal?.throwIfAborted();
+		if (expectedId !== void 0 && meta.id !== expectedId) throw new Error(`corrupt session log "${path}": requested id "${expectedId}" does not match header id "${meta.id}"`);
+		let expectedPath;
+		try {
+			expectedPath = logPath(this.root, meta.cwd, meta.id, this.compression);
+		} catch (error) {
+			throw new Error(`corrupt session log "${path}": header id cannot name a storage path`, { cause: error });
+		}
+		if (path !== expectedPath && !await this.sameFile(path, expectedPath, signal)) throw new Error(`corrupt session log "${path}": header id "${meta.id}" and cwd identify "${expectedPath}"`);
+		signal?.throwIfAborted();
+	}
+	/**
+	* Whether two path spellings resolve to the same physical file. This admits
+	* case aliases on case-insensitive filesystems without weakening identity
+	* checks on case-sensitive stores.
+	*/
+	async sameFile(path, expectedPath, signal) {
+		signal?.throwIfAborted();
+		try {
+			const [actual, expected] = await Promise.all([realpath(path), realpath(expectedPath)]);
+			signal?.throwIfAborted();
+			return actual === expected;
+		} catch (error) {
+			signal?.throwIfAborted();
+			/* v8 ignore else -- non-ENOENT realpath failures require an external permission or I/O fault */
+			if (isENOENT(error)) return false;
+			/* v8 ignore next -- non-ENOENT realpath failures are external I/O faults, propagated unchanged */
+			throw error;
+		}
+	}
+	/** The human-readable project directories under the configured root. */
+	async listProjectDirs(signal) {
+		try {
+			signal?.throwIfAborted();
+			const entries = await readdir(this.root, { withFileTypes: true });
+			signal?.throwIfAborted();
+			return entries.filter((e) => e.isDirectory()).map((e) => join(this.root, e.name));
+		} catch (error) {
+			if (isENOENT(error)) return [];
+			throw error;
+		}
+	}
+	/** List session-owned directories and reject the obsolete flat-file layout. */
+	async listSessionDirs(project, signal) {
+		signal?.throwIfAborted();
+		const entries = await readdir(project, { withFileTypes: true });
+		signal?.throwIfAborted();
+		const legacy = entries.find((entry) => entry.isFile() && (entry.name.endsWith(".jsonl") || entry.name.endsWith(".jsonl.zstd")));
+		if (legacy !== void 0) throw this.legacyLayout(join(project, legacy.name));
+		return entries.filter((entry) => entry.isDirectory()).map((entry) => join(project, entry.name));
+	}
+	/** Reject a root that already belongs to the other physical encoding. */
+	ensureRootEncoding() {
+		this.rootEncodingCheck ??= this.checkRootEncoding();
+		return this.rootEncodingCheck;
+	}
+	async checkRootEncoding() {
+		for (const project of await this.listProjectDirs()) for (const dir of await this.listSessionDirs(project)) {
+			const incompatible = join(dir, `session${logSuffix(this.oppositeCompression())}`);
+			if (await this.exists(incompatible)) throw this.encodingMismatch(incompatible);
+		}
+	}
+	async rejectLegacyFlatArtifact(project, id, signal) {
+		signal?.throwIfAborted();
+		const encoded = encodeSegment(id);
+		for (const compression of ["zstd", "none"]) {
+			const path = join(project, encoded + logSuffix(compression));
+			const artifactExists = await this.exists(path);
+			signal?.throwIfAborted();
+			if (artifactExists) throw this.legacyLayout(path);
+		}
+	}
+	async rejectOppositeArtifact(cwd, id) {
+		const path = logPath(this.root, cwd, id, this.oppositeCompression());
+		if (await this.exists(path)) throw this.encodingMismatch(path);
+	}
+	oppositeCompression() {
+		return this.compression === "zstd" ? "none" : "zstd";
+	}
+	encodingMismatch(path) {
+		return /* @__PURE__ */ new Error(`session artifact ${JSON.stringify(path)} uses ${logSuffix(this.oppositeCompression())}, but this backend is configured for compression ${JSON.stringify(this.compression)}; use a separate root or select the matching compression mode`);
+	}
+	legacyLayout(path) {
+		return /* @__PURE__ */ new Error(`session artifact ${JSON.stringify(path)} uses the unsupported flat-file layout; use a separate root or move it into a project/session directory before loading`);
+	}
+	async exists(path) {
+		try {
+			await (await open(path, "r")).close();
+			return true;
+		} catch (error) {
+			/* v8 ignore else -- Windows reports file-valued parents as ENOENT; POSIX covers direct ENOTDIR. */
+			if (isENOENT(error)) {
+				await this.assertLogParentAllowsAbsence(path);
+				return false;
+			}
+			/* v8 ignore next -- Windows repairs ENOTDIR from ENOENT above; POSIX covers direct ENOTDIR. */
+			throw error;
+		}
+	}
+	/* v8 ignore start -- native Windows coverage exercises this repair; POSIX open reports ENOTDIR before this point. */
+	async assertLogParentAllowsAbsence(path) {
+		try {
+			const parent = dirname(path);
+			if ((await stat(parent)).isDirectory()) return;
+			const error = /* @__PURE__ */ new Error(`ENOTDIR: parent path exists but is not a directory: ${parent}`);
+			error.code = "ENOTDIR";
+			error.path = parent;
+			throw error;
+		} catch (error) {
+			if (isENOENT(error)) return;
+			throw error;
+		}
+	}
+};
+//#endregion
+export { JsonlCompressionSchema, JsonlSessionPersistence, JsonlSessionPersistence as default };

--- a/third_party/deepseek-harness/src/session-persistence-jsonl/win32.ts
+++ b/third_party/deepseek-harness/src/session-persistence-jsonl/win32.ts
@@ -1,0 +1,46 @@
+/**
+ * FreeBuddy fork of deepseek-harness JSONL Windows publish helpers.
+ *
+ * Drop this file onto
+ * `packages/session/session-persistence-jsonl/src/win32.ts`
+ * in a git fork of https://github.com/deepseek-ai/deepseek-harness
+ * when that repository exists.
+ *
+ * Official code loaded a native Win32 binding to publish the first session
+ * log. That aborts Windows Electron children with STATUS_ACCESS_VIOLATION.
+ * Keep the exported names so `index.ts` is unchanged; implement them with
+ * Node fs (rename, copy fallback, mkdir).
+ *
+ * @module dsh-session-persistence-jsonl/win32
+ */
+
+import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
+
+/**
+ * Publish `existing` at `replacement`. Prefer an atomic rename; fall back to
+ * copy+remove when the volume rejects rename (EXDEV / EPERM).
+ */
+export async function publishNewFileWin32(
+  existing: string,
+  replacement: string
+): Promise<void> {
+  try {
+    await rename(existing, replacement);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code !== "EXDEV" && code !== "EPERM") throw error;
+    const info = await stat(existing);
+    if (info.isDirectory()) {
+      await mkdir(replacement, { recursive: true });
+      await rm(existing, { recursive: true, force: true });
+      return;
+    }
+    await copyFile(existing, replacement);
+    await rm(existing, { force: true });
+  }
+}
+
+/** Create `target` and missing ancestors with Node mkdir. */
+export async function ensureDurableDirectoryWin32(target: string): Promise<void> {
+  await mkdir(target, { recursive: true });
+}

--- a/third_party/deepseek-harness/src/session-persistence-jsonl/win32.ts
+++ b/third_party/deepseek-harness/src/session-persistence-jsonl/win32.ts
@@ -1,46 +1,53 @@
 /**
- * FreeBuddy fork of deepseek-harness JSONL Windows publish helpers.
+ * Windows publish helpers for the JSONL backend.
  *
- * Drop this file onto
- * `packages/session/session-persistence-jsonl/src/win32.ts`
- * in a git fork of https://github.com/deepseek-ai/deepseek-harness
- * when that repository exists.
+ * POSIX publishes a newly-created log by creating a directory entry and then
+ * fsyncing the parent directory. Windows does not expose that parent-directory
+ * fsync contract through Node. The previous implementation loaded a native
+ * Win32 binding and called `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)`. That
+ * aborts some Windows Electron/Node hosts with STATUS_ACCESS_VIOLATION
+ * (0xC0000005) the first time a session is materialized.
  *
- * Official code loaded a native Win32 binding to publish the first session
- * log. That aborts Windows Electron children with STATUS_ACCESS_VIOLATION.
- * Keep the exported names so `index.ts` is unchanged; implement them with
- * Node fs (rename, copy fallback, mkdir).
+ * Keep the exported names so `index.ts` is unchanged. Publish with Node fs:
+ * rename when the volume allows it, copy+remove on EXDEV/EPERM, mkdir for
+ * directories.
  *
  * @module dsh-session-persistence-jsonl/win32
  */
 
-import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
+import { copyFile, mkdir, rename, rm, stat } from 'node:fs/promises'
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException | null)?.code
+}
 
 /**
- * Publish `existing` at `replacement`. Prefer an atomic rename; fall back to
- * copy+remove when the volume rejects rename (EXDEV / EPERM).
+ * Publish `existing` at `replacement`. The destination must not already exist
+ * on the happy path; EXDEV/EPERM fall back to copy+remove.
+ * @param existing - the synced staging path to move.
+ * @param replacement - the final path.
  */
-export async function publishNewFileWin32(
-  existing: string,
-  replacement: string
-): Promise<void> {
+export async function publishNewFileWin32(existing: string, replacement: string): Promise<void> {
   try {
-    await rename(existing, replacement);
+    await rename(existing, replacement)
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException | null)?.code;
-    if (code !== "EXDEV" && code !== "EPERM") throw error;
-    const info = await stat(existing);
+    const code = errorCode(error)
+    if (code !== 'EXDEV' && code !== 'EPERM') throw error
+    const info = await stat(existing)
     if (info.isDirectory()) {
-      await mkdir(replacement, { recursive: true });
-      await rm(existing, { recursive: true, force: true });
-      return;
+      await mkdir(replacement, { recursive: true })
+      await rm(existing, { recursive: true, force: true })
+      return
     }
-    await copyFile(existing, replacement);
-    await rm(existing, { force: true });
+    await copyFile(existing, replacement)
+    await rm(existing, { force: true })
   }
 }
 
-/** Create `target` and missing ancestors with Node mkdir. */
+/**
+ * Create `target` and its missing ancestors.
+ * @param target - the absolute directory path to create when absent.
+ */
 export async function ensureDurableDirectoryWin32(target: string): Promise<void> {
-  await mkdir(target, { recursive: true });
+  await mkdir(target, { recursive: true })
 }


### PR DESCRIPTION
## Summary

Add DeepSeek Harness as a first-class ACP agent adapter (`dsh-acp`), supporting both the managed runtime (`dsh-acp-demo`) and the standalone package (`deepseek-harness-acp`).

- **Standalone Package Support**: Support `deepseek-harness-acp` in binary detection list (`DSH_ACP_DEFAULT_BINARIES`) for clean single-package installations.
- **Protocol & Capabilities**: Full ACP integration supporting streaming tokens, thought reasoning, tool updates, session recovery, and multi-turn chat.
- **Windows & Native Hardening**: Windows-safe install commands, Node ExperimentalWarning suppression, and enhanced error diagnostics.
- **Tests**: Verified with 100% pass across all 44 test suites (1011 tests).

## Test Plan

- [x] Run full test suite: `pnpm test` (44 suites, 1011 tests passing)
- [x] End-to-end ACP prompt verification with real agent loop & live DeepSeek API handshake
- [x] Verified zero-config standalone binary spawn and streaming session interaction