### PR TITLE
fix: sync workflow progress when switching team tasks

### DIFF
--- a/src/components/CLI/WorkspacePanel.tsx
+++ b/src/components/CLI/WorkspacePanel.tsx
@@ -62,6 +62,9 @@ export function WorkspacePanel({
   const [resetCreditsExpanded, setResetCreditsExpanded] = useState(false);
   const [copiedSession, setCopiedSession] = useState(false);
   const loadWorkflowForConversation = useWorkflowStore((s) => s.loadForConversation);
+  const clearActiveWorkflowConversation = useWorkflowStore(
+    (s) => s.clearActiveConversation
+  );
   const activeRun = useWorkflowStore((s) => s.activeRun);
   const workflowSteps = useWorkflowStore((s) => s.steps);
   const replayConvId = useReplayStore((s) => s.conversationId);
@@ -69,9 +72,12 @@ export function WorkspacePanel({
   const replayFrames = useReplayStore((s) => s.frames);
 
   useEffect(() => {
-    if (!activeId) return;
+    if (!activeId) {
+      clearActiveWorkflowConversation();
+      return;
+    }
     void loadWorkflowForConversation(activeId);
-  }, [activeId, loadWorkflowForConversation]);
+  }, [activeId, clearActiveWorkflowConversation, loadWorkflowForConversation]);
 
   const replayFrame =
     replayConvId === activeId && replayIndex >= 0
@@ -82,7 +88,9 @@ export function WorkspacePanel({
     ? messages.slice(0, replayFrame.messageIndex + 1)
     : messages;
   const displayLive = replayFrame ? undefined : live;
-  const displayRun = replayWorkflow?.run ?? activeRun;
+  const currentWorkflowRun =
+    activeRun?.conversationId === activeId ? activeRun : undefined;
+  const displayRun = replayWorkflow?.run ?? currentWorkflowRun;
 
   const active = conversations.find((c) => c.id === activeId);
   const activeAgentName = displayAgentName(active?.agentName, active?.adapter);

--- a/src/components/Workflows/WorkflowRunPanel.tsx
+++ b/src/components/Workflows/WorkflowRunPanel.tsx
@@ -90,8 +90,12 @@ export function WorkflowRunPanel() {
     replayConvId === activeId && replayIndex >= 0
       ? replayFrames[replayIndex]?.workflow
       : undefined;
-  const activeRun = replaySnapshot?.run ?? storeActiveRun;
-  const steps = replaySnapshot?.steps ?? storeSteps;
+  const currentStoreRun =
+    activeId && storeActiveRun?.conversationId === activeId
+      ? storeActiveRun
+      : undefined;
+  const activeRun = replaySnapshot?.run ?? currentStoreRun;
+  const steps = replaySnapshot?.steps ?? (currentStoreRun ? storeSteps : []);
   const replayingWorkflow = Boolean(replaySnapshot);
 
   let plan: WorkflowPlan | null = null;
@@ -113,6 +117,10 @@ export function WorkflowRunPanel() {
     const id = window.setInterval(() => void refresh(activeRun.id), 1500);
     return () => window.clearInterval(id);
   }, [activeRun?.id, isLive, refresh, replayingWorkflow]);
+
+  useEffect(() => {
+    setSelectedId(undefined);
+  }, [activeRun?.id]);
 
   const progress = useMemo(() => {
     if (!steps.length) return { done: 0, total: 0, percent: 0 };

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { workflowClient } from "@/services/workflows/client";
 import { workflowTeamsClient } from "@/services/workflowTeams/client";
 import { useConversationStore } from "@/store/conversationStore";
+import { WorkflowViewGuard } from "@/store/workflowViewGuard";
 import type {
   WorkflowPlan,
   WorkflowRunRow,
@@ -11,15 +12,18 @@ import type {
 } from "@/services/workflows/types";
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const workflowViewGuard = new WorkflowViewGuard();
 
 interface State {
   pendingPlan: WorkflowPlan | null;
   pendingErrors: string[];
+  activeConversationId: string | null;
   activeRun: WorkflowRunRow | null;
   activeRuns: WorkflowRunRow[];
   steps: WorkflowStepRow[];
 
   loadForConversation(conversationId: string): Promise<void>;
+  clearActiveConversation(): void;
   loadActiveRuns(): Promise<void>;
   previewReviewLoop(input: {
     goal: string;
@@ -56,19 +60,31 @@ interface State {
 export const useWorkflowStore = create<State>((set, get) => ({
   pendingPlan: null,
   pendingErrors: [],
+  activeConversationId: null,
   activeRun: null,
   activeRuns: [],
   steps: [],
 
   async loadForConversation(conversationId) {
+    const viewToken = workflowViewGuard.select(conversationId);
+    set((state) => {
+      const keepCurrent = state.activeRun?.conversationId === conversationId;
+      return {
+        activeConversationId: conversationId,
+        activeRun: keepCurrent ? state.activeRun : null,
+        steps: keepCurrent ? state.steps : []
+      };
+    });
     if (!workflowClient.isAvailable()) return;
     const runs = await workflowClient.listRuns(conversationId);
+    if (!workflowViewGuard.isCurrent(viewToken)) return;
     const latest =
       runs.find((r) =>
         ["running", "paused", "blocked", "pending_approval"].includes(r.status)
       ) ?? runs[0];
     if (latest) {
       const steps = await workflowClient.getSteps(latest.id);
+      if (!workflowViewGuard.isCurrent(viewToken)) return;
       set({
         activeRun: latest,
         steps
@@ -80,6 +96,11 @@ export const useWorkflowStore = create<State>((set, get) => ({
       });
     }
     void get().loadActiveRuns();
+  },
+
+  clearActiveConversation() {
+    workflowViewGuard.select(null);
+    set({ activeConversationId: null, activeRun: null, steps: [] });
   },
 
   async loadActiveRuns() {
@@ -109,7 +130,14 @@ export const useWorkflowStore = create<State>((set, get) => ({
       set({ pendingErrors: res.errors });
       return false;
     }
-    set({ pendingPlan: null, pendingErrors: [], activeRun: res.run, steps: [] });
+    workflowViewGuard.select(res.run.conversationId ?? input.conversationId ?? null);
+    set({
+      pendingPlan: null,
+      pendingErrors: [],
+      activeConversationId: res.run.conversationId ?? input.conversationId ?? null,
+      activeRun: res.run,
+      steps: []
+    });
     await get().loadActiveRuns();
     await workflowClient.start(res.run.id);
     await get().refresh(res.run.id);
@@ -123,7 +151,14 @@ export const useWorkflowStore = create<State>((set, get) => ({
       set({ pendingErrors: res.errors });
       return false;
     }
-    set({ pendingPlan: null, pendingErrors: [], activeRun: res.run, steps: [] });
+    workflowViewGuard.select(res.run.conversationId ?? input.conversationId ?? null);
+    set({
+      pendingPlan: null,
+      pendingErrors: [],
+      activeConversationId: res.run.conversationId ?? input.conversationId ?? null,
+      activeRun: res.run,
+      steps: []
+    });
     await get().loadActiveRuns();
     await workflowClient.start(res.run.id);
     await get().refresh(res.run.id);
@@ -132,13 +167,26 @@ export const useWorkflowStore = create<State>((set, get) => ({
 
   async refresh(runId) {
     if (!workflowClient.isAvailable()) return;
+    const viewToken = workflowViewGuard.snapshot();
     const previousRun = get().activeRun?.id === runId ? get().activeRun : undefined;
     const [run, steps] = await Promise.all([
       workflowClient.getRun(runId),
       workflowClient.getSteps(runId)
     ]);
     if (run) {
-      set({ activeRun: run, steps });
+      const current = get();
+      const runBelongsToView = run.conversationId
+        ? run.conversationId === current.activeConversationId
+        : current.activeRun?.id === runId;
+      const runIsStillSelected =
+        current.activeRun === null || current.activeRun.id === runId;
+      if (
+        workflowViewGuard.isCurrent(viewToken) &&
+        runBelongsToView &&
+        runIsStillSelected
+      ) {
+        set({ activeRun: run, steps });
+      }
       const wasLive =
         previousRun &&
         ["running", "paused", "blocked", "pending_approval"].includes(previousRun.status);

--- a/src/store/workflowViewGuard.ts
+++ b/src/store/workflowViewGuard.ts
@@ -1,0 +1,34 @@
+export interface WorkflowViewToken {
+  conversationId: string | null;
+  revision: number;
+}
+
+/**
+ * Invalidates async workflow reads whenever the selected conversation changes
+ * (including A -> B -> A). This prevents an older request from restoring a
+ * workflow run that no longer owns the right-hand panel.
+ */
+export class WorkflowViewGuard {
+  private conversationId: string | null = null;
+  private revision = 0;
+
+  select(conversationId: string | null): WorkflowViewToken {
+    this.conversationId = conversationId;
+    this.revision += 1;
+    return this.snapshot();
+  }
+
+  snapshot(): WorkflowViewToken {
+    return {
+      conversationId: this.conversationId,
+      revision: this.revision
+    };
+  }
+
+  isCurrent(token: WorkflowViewToken): boolean {
+    return (
+      token.revision === this.revision &&
+      token.conversationId === this.conversationId
+    );
+  }
+}

--- a/tests/workflow-ui.test.mjs
+++ b/tests/workflow-ui.test.mjs
@@ -29,8 +29,12 @@ test("WorkflowRunPanel uses replay workflow snapshots as read-only state", () =>
   const src = read("../src/components/Workflows/WorkflowRunPanel.tsx");
   assert.match(src, /useReplayStore/);
   assert.match(src, /replayFrames\[replayIndex\]\?\.workflow/);
-  assert.match(src, /const activeRun = replaySnapshot\?\.run \?\? storeActiveRun/);
-  assert.match(src, /const steps = replaySnapshot\?\.steps \?\? storeSteps/);
+  assert.match(src, /storeActiveRun\?\.conversationId === activeId/);
+  assert.match(src, /const activeRun = replaySnapshot\?\.run \?\? currentStoreRun/);
+  assert.match(
+    src,
+    /const steps = replaySnapshot\?\.steps \?\? \(currentStoreRun \? storeSteps : \[\]\)/
+  );
   assert.match(src, /!replayingWorkflow && \(isLive \|\| gatingPhaseId \|\| canContinueImplementReview\)/);
   assert.match(src, /replayingWorkflow[\s\S]*\? undefined[\s\S]*: \(step\) => void retryStep/);
 });
@@ -100,7 +104,8 @@ test("WorkspacePanel syncs the run-state card with replay frames", () => {
   assert.match(src, /const replayFrame =[\s\S]*?replayFrames\[replayIndex\]/);
   assert.match(src, /const displayMessages = replayFrame[\s\S]*?messages\.slice\(0, replayFrame\.messageIndex \+ 1\)[\s\S]*?: messages/);
   assert.match(src, /const displayLive = replayFrame \? undefined : live/);
-  assert.match(src, /const displayRun = replayWorkflow\?\.run \?\? activeRun/);
+  assert.match(src, /activeRun\?\.conversationId === activeId/);
+  assert.match(src, /const displayRun = replayWorkflow\?\.run \?\? currentWorkflowRun/);
   assert.match(src, /!replayFrame &&[\s\S]*?isTeamRun/);
   assert.match(src, /const end = replayWorkflow\?\.at[\s\S]*?Date\.parse\(replayWorkflow\.at\)/);
 });

--- a/tests/workflow-view-guard.test.mjs
+++ b/tests/workflow-view-guard.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import ts from "typescript";
+
+const read = (path) => fs.readFileSync(new URL(path, import.meta.url), "utf8");
+
+async function loadGuard() {
+  const output = ts.transpileModule(read("../src/store/workflowViewGuard.ts"), {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+
+  return import(
+    `data:text/javascript;base64,${Buffer.from(output).toString("base64")}`
+  );
+}
+
+test("switching conversations invalidates an earlier workflow request", async () => {
+  const { WorkflowViewGuard } = await loadGuard();
+  const guard = new WorkflowViewGuard();
+  const conversationA = guard.select("conversation-a");
+  const conversationB = guard.select("conversation-b");
+
+  assert.equal(guard.isCurrent(conversationA), false);
+  assert.equal(guard.isCurrent(conversationB), true);
+});
+
+test("switching A to B to A still rejects the first A request", async () => {
+  const { WorkflowViewGuard } = await loadGuard();
+  const guard = new WorkflowViewGuard();
+  const firstA = guard.select("conversation-a");
+  guard.select("conversation-b");
+  const latestA = guard.select("conversation-a");
+
+  assert.equal(guard.isCurrent(firstA), false);
+  assert.equal(guard.isCurrent(latestA), true);
+});
+
+test("clearing the selected conversation invalidates in-flight requests", async () => {
+  const { WorkflowViewGuard } = await loadGuard();
+  const guard = new WorkflowViewGuard();
+  const selected = guard.select("conversation-a");
+
+  guard.select(null);
+
+  assert.equal(guard.isCurrent(selected), false);
+  assert.deepEqual(guard.snapshot(), { conversationId: null, revision: 2 });
+});
+
+test("workflow UI only displays state owned by the selected conversation", () => {
+  const store = read("../src/store/workflowStore.ts");
+  const runPanel = read("../src/components/Workflows/WorkflowRunPanel.tsx");
+  const workspacePanel = read("../src/components/CLI/WorkspacePanel.tsx");
+
+  assert.match(store, /workflowViewGuard\.isCurrent\(viewToken\)/);
+  assert.match(runPanel, /storeActiveRun\?\.conversationId === activeId/);
+  assert.match(workspacePanel, /activeRun\?\.conversationId === activeId/);
+  assert.match(workspacePanel, /clearActiveWorkflowConversation\(\)/);
+});


### PR DESCRIPTION
## What changed

- Track the conversation that owns the active workflow view.
- Invalidate stale workflow loads and polling responses when the selected conversation changes.
- Clear the previous workflow immediately and render progress only when the run belongs to the active conversation.
- Reset selected step details when switching runs.
- Add regression coverage for A → B and A → B → A switching races.

## Why

When several team workflows ran concurrently, they shared a singleton workflow state. An asynchronous load or polling response from the previously selected conversation could arrive after a switch and overwrite the right-side progress panel, leaving it stuck on the wrong task.

## Impact

Switching between concurrent team-task conversations now updates the workflow progress panel immediately and prevents stale background responses from restoring another conversation's progress.

## Validation

- `npm run typecheck`
- `npm run build:renderer`
- `node --test --test-force-exit tests/*.mjs` — 1000 passed, 117 skipped
- `npm run test:handoff-db` — 126 passed, 4 skipped
- `npm run github:preflight`
