### PR TITLE
Improve browser compatibility and limit debug-log exports to today

### DIFF
--- a/electron/debugLogExport.ts
+++ b/electron/debugLogExport.ts
@@ -25,6 +25,11 @@ import {
   type ExportMode,
   type PathMask
 } from "./shared/logSanitize.js";
+import {
+  filterJsonlLinesByTimestamp,
+  localDayRange,
+  type TimestampRange
+} from "./shared/debugLogExportCore.js";
 
 const SESSION_TAIL_BYTES = 2 * 1024 * 1024;
 const MAX_SESSION_FILES = 20;
@@ -139,7 +144,11 @@ function filterLines(lines: string[], kind: "own" | "session", mode: ExportMode,
   return lines.filter((l) => l.trim().length > 0).map((l) => filter(l, mode, masks));
 }
 
-function readAppLogFiles(mode: ExportMode, masks: PathMask[]): Array<{ name: string; lines: string[] }> {
+function readAppLogFiles(
+  mode: ExportMode,
+  masks: PathMask[],
+  dayRange: TimestampRange
+): Array<{ name: string; lines: string[] }> {
   const out: Array<{ name: string; lines: string[] }> = [];
   let entries: string[] = [];
   try {
@@ -150,7 +159,9 @@ function readAppLogFiles(mode: ExportMode, masks: PathMask[]): Array<{ name: str
   for (const name of entries.filter((n) => /\.(log)(\.\d+)?$/.test(n)).sort()) {
     try {
       const text = fs.readFileSync(path.join(debugLogDir(), name), "utf8");
-      out.push({ name, lines: filterLines(text.split("\n"), "own", mode, masks) });
+      const todayLines = filterJsonlLinesByTimestamp(text.split("\n"), dayRange);
+      const lines = filterLines(todayLines, "own", mode, masks);
+      if (lines.length > 0) out.push({ name, lines });
     } catch {
       /* skip unreadable file */
     }
@@ -255,10 +266,11 @@ function gatherDshAcpRuntime(): Record<string, unknown> {
 
 function collectBundle(mode: ExportMode, exportedAt: string, conversationId?: string) {
   const masks = gatherPathMasks();
+  const dayRange = localDayRange(new Date(exportedAt));
   return {
     environment: gatherEnvironment(mode, exportedAt, conversationId ? "conversation" : "all"),
     dshAcpRuntime: gatherDshAcpRuntime(),
-    appLogs: readAppLogFiles(mode, masks),
+    appLogs: readAppLogFiles(mode, masks, dayRange),
     sessionLogs: readSessionLogFiles(mode, masks, conversationId)
   };
 }
@@ -376,7 +388,7 @@ function readmeText(mode: ExportMode, exportedAt: string, scope: "conversation" 
     `Mode: ${mode}${mode === "standard" ? " (message content and paths redacted)" : " (FULL — contains conversation content)"}`,
     `Scope: ${scope === "conversation" ? "current conversation only (sessions/)" : "all recent sessions"}`,
     "",
-    "logs/       app logs (JSONL: {ts, level, scope, msg, data?})",
+    "logs/       app logs from the export day (JSONL: {ts, level, scope, msg, data?})",
     "sessions/   agent session transcripts (JSONL: {ts, type, content})",
     "environment.json  environment snapshot",
     "dsh-acp-runtime.json  DeepSeek ACP overlay / koffi / cordis snapshot",

--- a/electron/nativeBrowserViewService.ts
+++ b/electron/nativeBrowserViewService.ts
@@ -1,4 +1,5 @@
 import {
+  app,
   BrowserWindow,
   WebContentsView,
   session,
@@ -7,6 +8,10 @@ import {
 } from "electron";
 
 import { safeSendToWebContents } from "./cli/ipcSend.js";
+import {
+  buildBrowserAcceptLanguages,
+  buildBrowserCompatibleUserAgent
+} from "./shared/browserUserAgent.js";
 import type {
   BrowserConsoleEntry,
   BrowserToolAction,
@@ -123,7 +128,15 @@ async function waitForSelector(selector: string, timeoutMs = 12_000): Promise<vo
 function configureSession(ses: Session): void {
   if (sessionConfigured) return;
   sessionConfigured = true;
-  ses.setUserAgent(ses.getUserAgent().replace(/Electron\/\S+\s*/g, "").trim());
+  const userAgent = buildBrowserCompatibleUserAgent(
+    ses.getUserAgent(),
+    app.getName()
+  );
+  const acceptLanguages = buildBrowserAcceptLanguages(
+    app.getLocale(),
+    app.getPreferredSystemLanguages()
+  );
+  ses.setUserAgent(userAgent, acceptLanguages);
   ses.setPermissionCheckHandler(() => false);
   ses.setPermissionRequestHandler((_contents, _permission, callback) => callback(false));
   ses.on("will-download", (event) => event.preventDefault());

--- a/electron/shared/browserUserAgent.ts
+++ b/electron/shared/browserUserAgent.ts
@@ -1,0 +1,53 @@
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Keep the embedded browser's legacy UA compatible with Chromium web content
+ * without advertising Electron or the host application's product token.
+ *
+ * This deliberately does not modify automation or fingerprinting APIs. It only
+ * makes the ordinary User-Agent header/navigator.userAgent internally
+ * consistent with Chromium's reduced-version format.
+ */
+export function buildBrowserCompatibleUserAgent(
+  source: string,
+  applicationName?: string
+): string {
+  const productNames = ["Electron", applicationName]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .map((value) => escapeRegExp(value.trim()));
+  const productPattern = new RegExp(
+    `\\b(?:${productNames.join("|")})\\/[^\\s)]+`,
+    "gi"
+  );
+
+  return source
+    .replace(productPattern, "")
+    .replace(/\bChrome\/(\d+)(?:\.\d+){3}\b/i, "Chrome/$1.0.0.0")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Build the ordered locale list used by both Accept-Language and navigator.languages. */
+export function buildBrowserAcceptLanguages(
+  locale: string,
+  preferredSystemLanguages: readonly string[]
+): string {
+  const languages: string[] = [];
+  const add = (value: string | undefined) => {
+    const normalized = value?.trim().replace(/_/g, "-");
+    if (!normalized) return;
+    if (!languages.some((entry) => entry.toLowerCase() === normalized.toLowerCase())) {
+      languages.push(normalized);
+    }
+  };
+
+  add(locale);
+  for (const language of preferredSystemLanguages) add(language);
+  add(locale.split(/[-_]/)[0]);
+  add("en-US");
+  add("en");
+
+  return languages.slice(0, 8).join(",");
+}

--- a/electron/shared/debugLogExportCore.ts
+++ b/electron/shared/debugLogExportCore.ts
@@ -1,0 +1,38 @@
+export interface TimestampRange {
+  startMs: number;
+  endMs: number;
+}
+
+/** Local calendar-day range. Constructing the next midnight also handles DST days. */
+export function localDayRange(date: Date): TimestampRange {
+  return {
+    startMs: new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime(),
+    endMs: new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1).getTime()
+  };
+}
+
+/**
+ * Keep only JSONL entries whose `ts` falls in the requested time range.
+ * Malformed or timestamp-less lines fail closed so an export cannot leak an
+ * older entry merely because its date cannot be established.
+ */
+export function filterJsonlLinesByTimestamp(
+  lines: readonly string[],
+  range: TimestampRange
+): string[] {
+  return lines.filter((line) => {
+    if (!line.trim()) return false;
+    try {
+      const value = JSON.parse(line) as { ts?: unknown };
+      if (typeof value.ts !== "string") return false;
+      const timestampMs = Date.parse(value.ts);
+      return (
+        Number.isFinite(timestampMs) &&
+        timestampMs >= range.startMs &&
+        timestampMs < range.endMs
+      );
+    } catch {
+      return false;
+    }
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^5.1.1",
         "ajv": "^8.20.0",
-        "electron": "^39.2.7",
+        "electron": "^43.4.1",
         "electron-builder": "^26.15.3",
         "typescript": "^5.9.3",
         "vite": "^7.2.7"
@@ -635,6 +635,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmmirror.com/@electron/asar/-/asar-3.4.1.tgz",
@@ -749,25 +759,61 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -4857,17 +4903,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
       "resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
@@ -5720,16 +5755,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -7338,22 +7363,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.8.10",
-      "resolved": "https://registry.npmmirror.com/electron/-/electron-39.8.10.tgz",
-      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
+      "version": "43.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.1.tgz",
+      "integrity": "sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -7596,23 +7621,6 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/electron/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/emoji-mart": {
       "version": "5.6.0",
@@ -8145,27 +8153,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8200,16 +8187,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -8416,21 +8393,6 @@
       "resolved": "https://registry.npmmirror.com/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -11977,13 +11939,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
@@ -15366,17 +15321,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.1.1",
     "ajv": "^8.20.0",
-    "electron": "^39.2.7",
+    "electron": "^43.4.1",
     "electron-builder": "^26.15.3",
     "typescript": "^5.9.3",
     "vite": "^7.2.7"

--- a/tests/browser-user-agent.test.mjs
+++ b/tests/browser-user-agent.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildBrowserAcceptLanguages,
+  buildBrowserCompatibleUserAgent
+} from "../dist-electron/shared/browserUserAgent.js";
+
+test("browser UA removes Electron and app tokens and reduces the Chromium version", () => {
+  const source =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+    "AppleWebKit/537.36 (KHTML, like Gecko) FreeBuddy/0.8.5 " +
+    "Chrome/142.0.7444.175 Electron/39.2.7 Safari/537.36";
+
+  const actual = buildBrowserCompatibleUserAgent(source, "FreeBuddy");
+
+  assert.equal(
+    actual,
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+      "AppleWebKit/537.36 (KHTML, like Gecko) " +
+      "Chrome/142.0.0.0 Safari/537.36"
+  );
+  assert.doesNotMatch(actual, /Electron|FreeBuddy/i);
+});
+
+test("browser language list follows the app and system locales without duplicates", () => {
+  assert.equal(
+    buildBrowserAcceptLanguages("zh-CN", ["zh-Hans-CN", "zh-CN", "en-US"]),
+    "zh-CN,zh-Hans-CN,en-US,zh,en"
+  );
+});

--- a/tests/debug-log-day-filter.test.mjs
+++ b/tests/debug-log-day-filter.test.mjs
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  filterJsonlLinesByTimestamp,
+  localDayRange
+} from "../dist-electron/shared/debugLogExportCore.js";
+
+test("debug log export keeps only app-log lines inside the local-day range", () => {
+  const range = {
+    startMs: Date.parse("2026-08-18T16:00:00.000Z"),
+    endMs: Date.parse("2026-08-19T16:00:00.000Z")
+  };
+  const previousDay = JSON.stringify({ ts: "2026-08-18T23:59:59.999+08:00", msg: "old" });
+  const morning = JSON.stringify({ ts: "2026-08-19T00:00:00.000+08:00", msg: "morning" });
+  const rendererUtc = JSON.stringify({ ts: "2026-08-19T11:30:00.000Z", msg: "renderer" });
+  const nextDay = JSON.stringify({ ts: "2026-08-20T00:00:00.000+08:00", msg: "next" });
+
+  assert.deepEqual(
+    filterJsonlLinesByTimestamp(
+      [previousDay, morning, rendererUtc, nextDay, "not-json", JSON.stringify({ msg: "no ts" })],
+      range
+    ),
+    [morning, rendererUtc]
+  );
+});
+
+test("localDayRange spans from local midnight to the next local midnight", () => {
+  const now = new Date(2026, 7, 19, 15, 30, 45);
+  const range = localDayRange(now);
+  const start = new Date(range.startMs);
+  const end = new Date(range.endMs);
+
+  assert.deepEqual(
+    [start.getFullYear(), start.getMonth(), start.getDate(), start.getHours()],
+    [2026, 7, 19, 0]
+  );
+  assert.deepEqual(
+    [end.getFullYear(), end.getMonth(), end.getDate(), end.getHours()],
+    [2026, 7, 20, 0]
+  );
+});

--- a/tests/debug-log-export.test.mjs
+++ b/tests/debug-log-export.test.mjs
@@ -58,6 +58,13 @@ test("export bundle filters by mode and includes sessions", () => {
   assert.match(exporter, /dialog\.showSaveDialog/);
 });
 
+test("app logs are limited to the local export day without changing session scope", () => {
+  assert.match(exporter, /localDayRange\(new Date\(exportedAt\)\)/);
+  assert.match(exporter, /filterJsonlLinesByTimestamp\(text\.split\("\\n"\), dayRange\)/);
+  assert.match(exporter, /if \(lines\.length > 0\) out\.push/);
+  assert.match(exporter, /readSessionLogFiles\(mode, masks, conversationId\)/);
+});
+
 test("conversation-scoped export filters sessions by conversation_messages.task_id", () => {
   assert.match(exporter, /function sessionIdsForConversation/);
   assert.match(

--- a/tests/native-browser-view.test.mjs
+++ b/tests/native-browser-view.test.mjs
@@ -18,6 +18,17 @@ test("native browser uses an isolated persistent session with hardened web prefe
   assert.match(source, /will-download[\s\S]*preventDefault/);
 });
 
+test("native browser configures a browser-compatible UA before creating web contents", () => {
+  const source = read("electron/nativeBrowserViewService.ts");
+  const configureIndex = source.indexOf("configureSession(browserSession)");
+  const createIndex = source.indexOf("new WebContentsView");
+
+  assert.match(source, /buildBrowserCompatibleUserAgent/);
+  assert.match(source, /buildBrowserAcceptLanguages/);
+  assert.match(source, /ses\.setUserAgent\(userAgent, acceptLanguages\)/);
+  assert.ok(configureIndex >= 0 && configureIndex < createIndex);
+});
+
 test("native browser accepts HTTPS only", () => {
   const source = read("electron/nativeBrowserViewService.ts");
   assert.match(source, /url\.protocol !== "https:"/);
@@ -83,4 +94,3 @@ test("native browser tool calls return resolvedUrl and update store", () => {
   assert.match(nativeService, /effectiveUrl/);
   assert.match(listener, /useBrowserStore\.getState\(\)\.setNativeBrowserUrl\(conversationId, nativeResult\.resolvedUrl\)/);
 });
-


### PR DESCRIPTION
## Summary

- upgrade Electron from 39 to 43 and normalize the built-in browser's legacy user agent and language preferences
- remove Electron and FreeBuddy product tokens while keeping Chromium's reduced-version UA format
- limit exported application logs to entries from the local export day
- keep conversation-scoped session logs limited to the current conversation
- add focused coverage for browser UA handling and timestamp-range filtering

## Why

The built-in browser was running an end-of-life Chromium version and exposed inconsistent product/version signals. Separately, debug-log export scanned every application log file and included all lines, so legacy or rotated files could leak entries from previous days even when the export was launched from a single conversation.

## Impact

The embedded browser runs on a supported, newer Chromium runtime with more consistent request metadata. Debug bundles retain current-conversation session logs, while main/renderer application logs contain only the export day's entries. Original on-disk logs are not modified.

## Validation

- `npm test`
  - 1,136 Node tests: 0 failures
  - 130 Electron-native tests: 0 failures, 4 platform skips
- `npm run github:preflight`
- TypeScript and Electron builds run as part of the test suite
