### PR TITLE
fix: sub-user web UI conversation list, image rendering, and remote workspace grouping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .superpowers/
 .worktrees/
 .sessions/
+.agents/

--- a/electron/cli/attachments.ts
+++ b/electron/cli/attachments.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import {
@@ -240,12 +241,44 @@ export function isManagedAttachmentPath(filePath: string): boolean {
   return resolved === managedDir || resolved.startsWith(`${managedDir}${path.sep}`);
 }
 
-/** Managed uploads plus paths inside the caller's remote workspace roots. */
+const SERVEABLE_MEDIA_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+  "gif",
+  "svg",
+  "bmp",
+  "avif",
+  "heic",
+  "heif",
+  "ico",
+  "mp3",
+  "wav",
+  "m4a",
+  "ogg",
+  "mp4",
+  "webm"
+]);
+
+/** Managed uploads plus paths inside the caller's remote workspace roots and temp-generated media. */
 export function canServeAttachmentPath(
   filePath: string,
   roots: string[]
 ): boolean {
   if (isManagedAttachmentPath(filePath)) return true;
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  if (SERVEABLE_MEDIA_EXTENSIONS.has(ext)) {
+    const allowedMediaDirs = [
+      os.homedir(),
+      os.tmpdir(),
+      "/tmp",
+      "/private/tmp",
+      "/var/folders",
+      "/private/var/folders"
+    ];
+    if (isPathWithinRoots(filePath, allowedMediaDirs)) return true;
+  }
   return isPathWithinRoots(filePath, roots);
 }
 

--- a/electron/cli/ipc.ts
+++ b/electron/cli/ipc.ts
@@ -69,6 +69,7 @@ import {
 import {
   createProject,
   deleteProject,
+  findProjectByCwd,
   getProject,
   listProjects,
   resolveWorkspaceRootsForConversation,
@@ -1010,8 +1011,15 @@ export function registerCliIpc() {
   registerHandler(
     "cli:createConversation",
     async (_e, input: CreateConversationInput) => {
+      const matchedProjectId =
+        input.projectId ||
+        (input.cwd ? findProjectByCwd(input.cwd)?.id : undefined);
       const isolatedCwd = await isolateRemoteCwdForCaller(input.cwd);
-      const conversation = createConversation({ ...input, cwd: isolatedCwd });
+      const conversation = createConversation({
+        ...input,
+        cwd: isolatedCwd,
+        projectId: matchedProjectId ?? input.projectId
+      });
       trackTelemetryEvent("conversation_created", {
         adapter: normalizeTelemetryAdapter(input.adapter),
         has_workspace: Boolean(isolatedCwd),

--- a/electron/cli/projects.ts
+++ b/electron/cli/projects.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { getDb } from "./db.js";
 import { getSetting, setSetting } from "./settings.js";
+import { sourcePathForManagedWorkspace } from "./remoteWorkspaces.js";
 
 const CWD_MIGRATION_KEY = "projects.cwdMigration.v1";
 
@@ -143,22 +144,28 @@ export function getProject(id: string): Project | null {
 export function findProjectByCwd(cwd: string): Project | null {
   const trimmed = (cwd || "").trim();
   if (!trimmed) return null;
-  let normalized: string;
-  try {
-    normalized = path.resolve(trimmed).toLowerCase();
-  } catch {
-    return null;
-  }
+  const candidates: string[] = [trimmed];
+  const source = sourcePathForManagedWorkspace(trimmed);
+  if (source && source !== trimmed) candidates.push(source);
+
   const all = listProjects();
-  for (const project of all) {
-    for (const folder of project.folders) {
-      let folderNormalized: string;
-      try {
-        folderNormalized = path.resolve(folder.trim()).toLowerCase();
-      } catch {
-        continue;
+  for (const candidate of candidates) {
+    let normalized: string;
+    try {
+      normalized = path.resolve(candidate).toLowerCase();
+    } catch {
+      continue;
+    }
+    for (const project of all) {
+      for (const folder of project.folders) {
+        let folderNormalized: string;
+        try {
+          folderNormalized = path.resolve(folder.trim()).toLowerCase();
+        } catch {
+          continue;
+        }
+        if (folderNormalized === normalized) return project;
       }
-      if (folderNormalized === normalized) return project;
     }
   }
   return null;

--- a/electron/cli/remoteWorkspaces.ts
+++ b/electron/cli/remoteWorkspaces.ts
@@ -70,12 +70,29 @@ export function listRemoteWorkspacePaths(userId: string): string[] {
     });
 }
 
+export function listAllRemoteWorkspaces(): RemoteWorkspace[] {
+  try {
+    return (
+      getDb()
+        .prepare(
+          `SELECT id, owner_id, source_path, workspace_path, created_at, updated_at
+           FROM remote_workspaces
+           ORDER BY created_at ASC`
+        )
+        .all() as any[]
+    ).map(rowToWorkspace);
+  } catch {
+    return [];
+  }
+}
+
 export function sourcePathForManagedWorkspace(
   workspacePath: string,
-  workspaces: RemoteWorkspace[]
+  workspaces?: RemoteWorkspace[]
 ): string | undefined {
+  const wsList = workspaces ?? listAllRemoteWorkspaces();
   const requested = path.resolve(workspacePath);
-  for (const workspace of workspaces) {
+  for (const workspace of wsList) {
     const managedRoot = path.resolve(workspace.workspacePath);
     const relativePath = path.relative(managedRoot, requested);
     if (

--- a/electron/shared/remoteChannelPolicy.ts
+++ b/electron/shared/remoteChannelPolicy.ts
@@ -312,7 +312,8 @@ export function listRemoteChannels(access: RemoteChannelAccess): string[] {
 export const REMOTE_READABLE_SETTING_KEYS: readonly string[] = [
   "language",
   "theme",
-  "telemetry.enabled"
+  "telemetry.enabled",
+  "member.runtimeOverrides"
 ];
 
 /** Telemetry is a host-level privacy decision, so it is read-only remotely. */

--- a/electron/webUIServer.ts
+++ b/electron/webUIServer.ts
@@ -89,7 +89,17 @@ const MIME_TYPES: Record<string, string> = {
   ".gif": "image/gif",
   ".svg": "image/svg+xml",
   ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".avif": "image/avif",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
   ".ico": "image/x-icon",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".m4a": "audio/mp4",
+  ".ogg": "audio/ogg",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
   ".woff": "font/woff",
   ".woff2": "font/woff2",
   ".ttf": "font/ttf",
@@ -402,10 +412,17 @@ function handleAttachment(req: IncomingMessage, res: ServerResponse): boolean {
     sendJson(res, 401, { ok: false, error: "unauthorized" });
     return true;
   }
-  const filePath = url.searchParams.get("path");
+  let filePath = url.searchParams.get("path");
   if (!filePath) {
     sendJson(res, 400, { ok: false, error: "missing_path" });
     return true;
+  }
+  if (filePath.startsWith("file://")) {
+    try {
+      filePath = decodeURIComponent(new URL(filePath).pathname);
+    } catch {
+      filePath = filePath.replace(/^file:\/\//, "");
+    }
   }
   const roots = remoteRootsForUser(callerUserIdFromMediaRequest(req));
   if (!canServeAttachmentPath(filePath, roots)) {

--- a/public/web-preload.js
+++ b/public/web-preload.js
@@ -193,6 +193,13 @@
       getToolSession: function (agentId, workspacePath) { return invoke("cli:getToolSession", { agentId: agentId, workspacePath: workspacePath }); },
       saveToolSession: function (args) { return invoke("cli:saveToolSession", args); },
 
+      listProjects: function () { return invoke("cli:listProjects"); },
+      getProject: function (id) { return invoke("cli:getProject", id); },
+      createProject: function (input) { return invoke("cli:createProject", input); },
+      updateProject: function (input) { return invoke("cli:updateProject", input); },
+      deleteProject: function (id) { return invoke("cli:deleteProject", id); },
+      importCodexSession: function () { return Promise.resolve({ created: false, turns: 0, messages: 0 }); },
+
       listConversations: function (args) { return invoke("cli:listConversations", args); },
       getConversation: function (id) { return invoke("cli:getConversation", id); },
       createConversation: function (input) { return invoke("cli:createConversation", input); },
@@ -325,6 +332,25 @@
       onChanged: function (cb) { return subscribe("infoCards://changed", cb); }
     },
 
+    delegation: {
+      listTeams: function () { return invoke("delegation:listTeams"); },
+      getTeam: function (id) { return invoke("delegation:getTeam", id); },
+      createTeam: function (input) { return invoke("delegation:createTeam", input); },
+      updateTeam: function (id, patch) { return invoke("delegation:updateTeam", { id: id, patch: patch }); },
+      deleteTeam: function (id) { return invoke("delegation:deleteTeam", id); },
+      getRun: function (id) { return invoke("delegation:getRun", id); },
+      getRunByConversation: function (conversationId) { return invoke("delegation:getRunByConversation", conversationId); },
+      listEvents: function (runId) { return invoke("delegation:listEvents", runId); },
+      listPendingApprovals: function (runId) { return invoke("delegation:listPendingApprovals", runId); },
+      stopRun: function (runId) { return invoke("delegation:stopRun", runId); },
+      pauseRun: function () { return Promise.resolve(false); },
+      resumeRun: function () { return Promise.resolve(false); },
+      hasRunForConversation: function (conversationId) { return invoke("delegation:hasRunForConversation", conversationId); },
+      followUp: function (input) { return invoke("delegation:followUp", input); },
+      onChanged: function (cb) { return subscribe("delegationTeams://changed", cb); },
+      onRunFinished: function (cb) { return subscribe("delegation://finished", cb); }
+    },
+
     workflow: {
       validate: function (plan) { return invoke("workflow:validate", plan); },
       previewReviewLoop: function (input) { return invoke("workflow:previewReviewLoop", input); },
@@ -344,7 +370,9 @@
       listRuns: function (conversationId) { return invoke("workflow:listRuns", conversationId); },
       previewTeamRun: function (input) { return invoke("workflow:previewTeamRun", input); },
       createTeamRun: function (input) { return invoke("workflow:createTeamRun", input); },
-      onStepMessage: function (conversationId, cb) { return subscribe("workflow://message/" + conversationId, cb); }
+      onStepMessage: function (conversationId, cb) { return subscribe("workflow://message/" + conversationId, cb); },
+      onStepEvent: function (conversationId, cb) { return subscribe("workflow://event/" + conversationId, cb); },
+      onRunFinished: function (cb) { return subscribe("workflow://finished", cb); }
     },
 
     workflowTeams: {
@@ -353,7 +381,8 @@
       create: function (input) { return invoke("workflowTeams:create", input); },
       update: function (args) { return invoke("workflowTeams:update", args); },
       delete: function (id) { return invoke("workflowTeams:delete", id); },
-      seedBuiltins: function () { return invoke("workflowTeams:seedBuiltins"); }
+      seedBuiltins: function () { return invoke("workflowTeams:seedBuiltins"); },
+      onChanged: function (cb) { return subscribe("workflowTeams://changed", cb); }
     },
 
     skills: {
@@ -372,7 +401,8 @@
       searchMarket: function (args) { return invoke("skills:searchMarket", args); },
       installFromMarket: function () { return Promise.resolve({ ok: false, error: "not_supported_remotely" }); },
       openMarketUrl: function () { return Promise.resolve(true); },
-      resolveMarketHomepage: function (args) { return invoke("skills:resolveMarketHomepage", args); }
+      resolveMarketHomepage: function (args) { return invoke("skills:resolveMarketHomepage", args); },
+      onChanged: function (cb) { return subscribe("skills://changed", cb); }
     },
 
     plugins: {
@@ -406,6 +436,19 @@
 
     shell: {
       showItemInFolder: function () { return Promise.resolve(false); }
+    },
+
+    debugLogs: {
+      write: function () { return Promise.resolve(); },
+      preview: function () { return Promise.resolve(""); },
+      prepareSelfCheck: function () { return Promise.resolve({ path: "" }); },
+      export: function () { return Promise.resolve({ canceled: true }); }
+    },
+
+    butlerBuddy: {
+      reportTaskResult: function () {},
+      updatePreferences: function () { return Promise.resolve(); },
+      onPreferencesChanged: function () { return noopUnsub(); }
     },
 
     remote: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { useSkillStore } from "./store/skillStore";
 import { useUpdaterStore } from "./store/updaterStore";
 import { useDetailLayoutStore, selectDetailWidth, DETAIL_MIN_WIDTH } from "./store/detailLayoutStore";
 import { useNewTaskUiStore } from "./store/newTaskUiStore";
+import { useProjectStore } from "./store/projectStore";
 import { useWorkflowStore } from "./store/workflowStore";
 import { useTaskReceiptStore } from "./store/taskReceiptStore";
 import {
@@ -90,12 +91,13 @@ function App() {
   const loadExecutors = useCliExecutorStore((s) => s.load);
   const loadConversations = useConversationStore((s) => s.load);
   const refreshConversationList = useConversationStore((s) => s.refreshList);
+  const refreshProjects = useProjectStore((s) => s.refresh);
   useEffect(() => {
     void (async () => {
       await loadExecutors();
-      await loadConversations();
+      await Promise.all([loadConversations(), refreshProjects()]);
     })();
-  }, [loadExecutors, loadConversations]);
+  }, [loadExecutors, loadConversations, refreshProjects]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;

--- a/src/components/CLI/ChatView.tsx
+++ b/src/components/CLI/ChatView.tsx
@@ -2185,6 +2185,7 @@ export function ChatView({
                 agentIconKey={messageMember?.avatar}
                 blockLimit={partial?.blockLimit}
                 typingChars={partial?.typingChars}
+                cwd={conv?.cwd || conv?.sourceCwd}
                 afterContent={
                   shareReferences && shareReferences.length > 0 ? (
                     <SharedConversationReferences

--- a/src/components/CLI/ConversationList.tsx
+++ b/src/components/CLI/ConversationList.tsx
@@ -433,6 +433,7 @@ export function ConversationList({
     left: number;
   } | null>(null);
   const hoverCloseTimerRef = useRef<number | null>(null);
+  const userCollapsedProjectsRef = useRef<Set<string>>(new Set());
   const [formOpen, setFormOpen] = useState(false);
   const [formMode, setFormMode] = useState<"create" | "edit">("create");
   const [editingProject, setEditingProject] = useState<Project | null>(null);
@@ -515,6 +516,9 @@ export function ConversationList({
       const bPinned = bPin >= 0;
       if (aPinned !== bPinned) return aPinned ? -1 : 1;
       if (aPinned && bPinned && aPin !== bPin) return aPin - bPin;
+      const aHasItems = a.items.length > 0 ? 1 : 0;
+      const bHasItems = b.items.length > 0 ? 1 : 0;
+      if (aHasItems !== bHasItems) return bHasItems - aHasItems;
       return b.latestAt - a.latestAt || a.label.localeCompare(b.label);
     });
   }, [conversations, apiProjects, pinnedKeys, projectsLoaded]);
@@ -529,22 +533,38 @@ export function ConversationList({
 
   const activeProjectKey = useMemo(() => {
     const active = conversations.find((c) => c.id === activeId);
-    return active?.projectId?.trim() || undefined;
-  }, [activeId, conversations]);
+    if (active?.projectId?.trim()) return active.projectId.trim();
+    if (active) {
+      const matched = projects.find((p) => p.items.some((item) => item.id === active.id));
+      if (matched) return matched.key;
+    }
+    return undefined;
+  }, [activeId, conversations, projects]);
+
+  const currentUser = useConversationStore((s) => s.currentUser);
 
   const visibleProjects = useMemo(() => {
-    if (showAllProjects || projects.length <= PROJECT_LIST_LIMIT) {
-      return projects;
+    const relevantProjects =
+      currentUser && !currentUser.isOwner
+        ? projects.filter(
+            (p) =>
+              p.items.length > 0 ||
+              pinnedKeys.includes(p.key) ||
+              p.key === activeProjectKey
+          )
+        : projects;
+    if (showAllProjects || relevantProjects.length <= PROJECT_LIST_LIMIT) {
+      return relevantProjects;
     }
     const visibleKeys = new Set<string>();
     const result: ConversationProjectGroup[] = [];
     // Always keep pinned projects visible.
-    for (const project of projects) {
+    for (const project of relevantProjects) {
       if (!pinnedKeys.includes(project.key)) continue;
       result.push(project);
       visibleKeys.add(project.key);
     }
-    for (const project of projects) {
+    for (const project of relevantProjects) {
       if (result.length >= PROJECT_LIST_LIMIT) break;
       if (visibleKeys.has(project.key)) continue;
       result.push(project);
@@ -552,31 +572,48 @@ export function ConversationList({
     }
     // Keep the active project visible even if it would be truncated.
     if (activeProjectKey && !visibleKeys.has(activeProjectKey)) {
-      const active = projects.find((project) => project.key === activeProjectKey);
+      const active = relevantProjects.find((project) => project.key === activeProjectKey);
       if (active) result.push(active);
     }
     return result;
-  }, [projects, showAllProjects, pinnedKeys, activeProjectKey]);
+  }, [projects, showAllProjects, pinnedKeys, activeProjectKey, currentUser]);
 
   const hiddenProjectCount = Math.max(0, projects.length - visibleProjects.length);
 
   useEffect(() => {
-    if (!activeProjectKey) return;
-    setExpandedProjects(new Set([activeProjectKey]));
-  }, [activeProjectKey]);
-
-  useEffect(() => {
     if (projects.length === 0) return;
     setExpandedProjects((current) => {
-      if (current.size > 0) return current;
-      return new Set([projects[0].key]);
+      const next = new Set(current);
+      if (activeProjectKey) {
+        next.add(activeProjectKey);
+      }
+      for (const p of projects) {
+        if (p.items.length > 0 && !userCollapsedProjectsRef.current.has(p.key)) {
+          next.add(p.key);
+        }
+      }
+      if (
+        next.size === 0 &&
+        projects[0] &&
+        !userCollapsedProjectsRef.current.has(projects[0].key)
+      ) {
+        next.add(projects[0].key);
+      }
+      return next;
     });
-  }, [projects]);
+  }, [projects, activeProjectKey]);
 
   const toggleProject = (key: string) => {
     setExpandedProjects((current) => {
-      if (current.has(key)) return new Set();
-      return new Set([key]);
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+        userCollapsedProjectsRef.current.add(key);
+      } else {
+        next.add(key);
+        userCollapsedProjectsRef.current.delete(key);
+      }
+      return next;
     });
   };
 

--- a/src/components/CLI/MessageBubble.tsx
+++ b/src/components/CLI/MessageBubble.tsx
@@ -760,7 +760,8 @@ export const MessageBubble = memo(function MessageBubble({
   agentIconKey,
   blockLimit,
   typingChars,
-  afterContent
+  afterContent,
+  cwd
 }: {
   message: ConversationMessage;
   adapter?: string;
@@ -769,6 +770,7 @@ export const MessageBubble = memo(function MessageBubble({
   blockLimit?: number;
   typingChars?: number;
   afterContent?: ReactNode;
+  cwd?: string;
 }) {
   const { t } = useTranslation();
   const currentUser = useConversationStore((s) => s.currentUser);

--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -29,21 +29,43 @@ import { prepareToolResultText } from "@/utils/streamMedia";
 import {
   attachmentPreviewUrl,
   formatBytes,
-  resolveLocalFilePath
+  resolveLocalFilePath,
+  withWebMediaAuth
 } from "@/utils/chatAttachments";
 import { useImageLightbox } from "./ImageLightbox";
 
 const IMAGE_PATH_EXTENSIONS = "png|jpe?g|webp|gif|bmp|svg|avif|heic|heif";
+const IMAGE_EXTENSIONS_SET = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+  "gif",
+  "bmp",
+  "svg",
+  "avif",
+  "heic",
+  "heif"
+]);
 const IMAGE_PATH_REGEX = new RegExp(
-  // Absolute POSIX path or Windows drive path ending in a known image extension.
-  `(?:/[^\\s)\\]\`'"<>]+|[A-Za-z]:[\\\\/][^\\s)\\]\`'"<>]+)\\.(?:${IMAGE_PATH_EXTENSIONS})`,
+  // Absolute POSIX path, file:/// URI, or Windows drive path ending in a known image extension.
+  `(?:file:\\/\\/\\/[^\\s)\\]\`'"<>]+|\\/[^\\s)\\]\`'"<>]+|[A-Za-z]:[\\\\/][^\\s)\\]\`'"<>]+)\\.(?:${IMAGE_PATH_EXTENSIONS})`,
   "gi"
 );
-const IMAGE_PATH_FULL_REGEX = new RegExp(`^${IMAGE_PATH_REGEX.source}$`, "i");
-const MARKDOWN_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+const MARKDOWN_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/g;
 
 function isImagePath(value: string): boolean {
-  return IMAGE_PATH_FULL_REGEX.test(value.trim());
+  const trimmed = value.trim().replace(/^`+|`+$/g, "");
+  if (!trimmed) return false;
+  if (/^data:image\//i.test(trimmed) || /^\/api\/attachment\?path=/i.test(trimmed)) {
+    return true;
+  }
+  const cleanUrl = trimmed.replace(/^file:\/\//i, "");
+  const match = cleanUrl.match(/\.([a-z0-9]+)(?:[?#].*)?$/i);
+  if (match && IMAGE_EXTENSIONS_SET.has(match[1].toLowerCase())) {
+    return true;
+  }
+  return false;
 }
 
 function isHttpUrl(value: string): boolean {
@@ -54,6 +76,27 @@ function resolveImageSrc(raw: string, cwd = ""): string {
   const value = raw.trim();
   if (!value) return "";
   if (isHttpUrl(value)) return value;
+  if (value.startsWith("/api/")) {
+    return withWebMediaAuth(value);
+  }
+  if (value.startsWith("freebuddy-file://open?path=")) {
+    try {
+      const url = new URL(value);
+      const filePath = url.searchParams.get("path");
+      if (filePath) return attachmentPreviewUrl(filePath);
+    } catch {
+      /* ignore */
+    }
+  }
+  if (value.startsWith("file://")) {
+    try {
+      const url = new URL(value);
+      const filePath = decodeURIComponent(url.pathname);
+      if (filePath) return attachmentPreviewUrl(filePath);
+    } catch {
+      /* ignore */
+    }
+  }
   const abs = resolveLocalFilePath(value, cwd);
   return abs ? attachmentPreviewUrl(abs) : "";
 }
@@ -151,11 +194,17 @@ function resolveLinkHref(raw: string, cwd = ""): string {
   const value = raw.trim();
   if (!value) return "";
   if (isHttpUrl(value)) return value;
+  if (value.startsWith("file://")) {
+    try {
+      const url = new URL(value);
+      const filePath = decodeURIComponent(url.pathname);
+      if (filePath) return attachmentPreviewUrl(filePath);
+    } catch {
+      /* ignore */
+    }
+  }
   const abs = resolveLocalFilePath(value, cwd);
   if (abs) return attachmentPreviewUrl(abs);
-  if (/^file:\/\//i.test(value)) {
-    return value;
-  }
   return value;
 }
 
@@ -179,30 +228,67 @@ interface InlineImageRef {
   src: string;
 }
 
-/** Collect image references from a chunk of text: markdown ![alt](src) and bare absolute paths. */
+/** Collect image references from a chunk of text: markdown images/links and bare absolute/file paths. */
 function collectInlineImages(text: string, cwd = ""): InlineImageRef[] {
   const seen = new Set<string>();
   const refs: InlineImageRef[] = [];
-  let stripped = text;
 
-  stripped = stripped.replace(MARKDOWN_IMAGE_REGEX, (_match, alt: string, src: string) => {
-    const resolved = resolveImageSrc(src, cwd) || (isHttpUrl(src) ? src : "");
+  const addImage = (srcRaw: string, alt = "") => {
+    const trimmed = srcRaw.trim().replace(/^`+|`+$/g, "");
+    if (!trimmed) return;
+    const resolved = resolveImageSrc(trimmed, cwd) || (isHttpUrl(trimmed) ? trimmed : "");
     if (resolved && !seen.has(resolved)) {
       seen.add(resolved);
-      refs.push({ alt: (alt || "").trim(), src: resolved });
+      refs.push({ alt: alt.trim(), src: resolved });
     }
-    return " ";
-  });
+  };
 
-  const matches = stripped.match(IMAGE_PATH_REGEX);
-  if (matches) {
-    for (const raw of matches) {
-      const resolved = resolveImageSrc(raw, cwd);
-      if (!resolved || seen.has(resolved)) continue;
-      seen.add(resolved);
-      refs.push({ alt: "", src: resolved });
+  // 1. Markdown image syntax: ![alt](src)
+  let stripped = text.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    (_match, alt: string, src: string) => {
+      addImage(src, alt);
+      return " ";
+    }
+  );
+
+  // 2. Markdown link syntax pointing to an image: [alt](src.png) or [alt](file:///...png)
+  stripped = stripped.replace(
+    /\[([^\]]*)\]\(([^)]+)\)/g,
+    (_match, alt: string, src: string) => {
+      if (isImagePath(src)) {
+        addImage(src, alt);
+      }
+      return " ";
+    }
+  );
+
+  // 3. Backtick-enclosed paths ending in image extensions
+  stripped = stripped.replace(
+    /`([^`]+?\.(?:png|jpe?g|webp|gif|bmp|svg|avif|heic|heif)(?:[?#][^`]*)?)`/gi,
+    (_match, src: string) => {
+      addImage(src);
+      return " ";
+    }
+  );
+
+  // 4. File URI paths: file:///path/to/image.png
+  stripped = stripped.replace(
+    /file:\/\/\/[^\s\`'"<>]+?\.(?:png|jpe?g|webp|gif|bmp|svg|avif|heic|heif)/gi,
+    (src: string) => {
+      addImage(src);
+      return " ";
+    }
+  );
+
+  // 5. Bare absolute POSIX or Windows paths ending in image extension
+  const pathMatches = stripped.match(IMAGE_PATH_REGEX);
+  if (pathMatches) {
+    for (const raw of pathMatches) {
+      addImage(raw);
     }
   }
+
   return refs;
 }
 
@@ -722,16 +808,21 @@ export function StreamToolInvocation({
   const input = formatValue(call.input);
   const { t } = useTranslation();
   const statusMeta = toolStatusMeta(call, t);
+  const toolImages = collectInlineImages(
+    [input, ...visibleResults.map((r) => r.content)].join("\n")
+  );
   const hasBody =
     Boolean(input) ||
     visibleCommands.length > 0 ||
     visibleResults.length > 0 ||
-    visibleExtras.length > 0;
+    visibleExtras.length > 0 ||
+    toolImages.length > 0;
   const showDoneMeta =
     call.status === "completed" &&
     !visibleResults.some((result) => hasVisibleContent(result.content)) &&
     visibleCommands.length === 0 &&
-    visibleExtras.length === 0;
+    visibleExtras.length === 0 &&
+    toolImages.length === 0;
 
   return (
     <details
@@ -778,7 +869,8 @@ export function StreamToolInvocation({
           <span className="stream-tool-summary-meta">
             {visibleResults.some((result) => hasVisibleContent(result.content)) ||
             visibleCommands.length > 0 ||
-            visibleExtras.length > 0
+            visibleExtras.length > 0 ||
+            toolImages.length > 0
               ? t("stream.summaryResult")
               : showDoneMeta
                 ? t("stream.summaryDone")
@@ -805,6 +897,17 @@ export function StreamToolInvocation({
             <StreamItem item={extra} />
           </div>
         ))}
+        {toolImages.length > 0 && (
+          <div className="stream-tool-section stream-tool-images">
+            {toolImages.map((image, imageIndex) => (
+              <MessageImage
+                key={`tool-img-${imageIndex}`}
+                src={image.src}
+                alt={image.alt}
+              />
+            ))}
+          </div>
+        )}
         {visibleResults.map((result, index) => (
           <div className="stream-tool-section" key={`${result.id ?? "result"}-${index}`}>
             <span className="stream-label">
@@ -859,13 +962,13 @@ function TerminalEmbed({
   );
 }
 
-export function StreamItem({ item }: { item: CliStreamItem }) {
+export function StreamItem({ item, cwd }: { item: CliStreamItem; cwd?: string }) {
   const { t } = useTranslation();
   switch (item.kind) {
     case "text":
       return (
         <div className={`stream-text role-${item.role}`}>
-          <MarkdownText content={item.content} />
+          <MarkdownText content={item.content} cwd={cwd} />
         </div>
       );
     case "thinking":
@@ -875,7 +978,7 @@ export function StreamItem({ item }: { item: CliStreamItem }) {
             <ToolKindIcon toolKind="think" />
             <span>{t("stream.thinking")}</span>
           </summary>
-          <MarkdownText content={item.content} />
+          <MarkdownText content={item.content} cwd={cwd} />
         </details>
       );
     case "content-block":

--- a/src/components/CLI/WorkspacePanel.tsx
+++ b/src/components/CLI/WorkspacePanel.tsx
@@ -123,8 +123,12 @@ export function WorkspacePanel({
 
   const [isDelegationConv, setIsDelegationConv] = useState(false);
   useEffect(() => {
-    if (!activeId) { setIsDelegationConv(false); return; }
-    delegationClient.getRunByConversation(activeId)
+    if (!activeId || !delegationClient.isAvailable()) {
+      setIsDelegationConv(false);
+      return;
+    }
+    delegationClient
+      .getRunByConversation(activeId)
       .then((r) => setIsDelegationConv(!!r))
       .catch(() => setIsDelegationConv(false));
   }, [activeId]);

--- a/src/components/CLI/conversationProjectGrouping.ts
+++ b/src/components/CLI/conversationProjectGrouping.ts
@@ -86,8 +86,22 @@ export function groupConversationsByProjects(
   projects: Project[]
 ): ConversationProjectGroup[] {
   const byProjectId = new Map<string, Conversation[]>();
+
+  const folderToProjectId = new Map<string, string>();
+  for (const project of projects) {
+    for (const folder of project.folders) {
+      folderToProjectId.set(projectKeyFromCwd(folder), project.id);
+    }
+  }
+
   for (const conversation of items) {
-    const projectId = conversation.projectId?.trim();
+    let projectId = conversation.projectId?.trim();
+    if (!projectId) {
+      const cwd = conversationDisplayCwd(conversation);
+      if (cwd) {
+        projectId = folderToProjectId.get(projectKeyFromCwd(cwd));
+      }
+    }
     if (!projectId) continue;
     const bucket = byProjectId.get(projectId);
     if (bucket) bucket.push(conversation);

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,193 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import i18next from "i18next";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
+import { debugLogClient } from "@/services/debugLog";
+import { useConversationStore } from "@/store/conversationStore";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, errorInfo: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error, errorInfo: null };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.setState({ errorInfo: info });
+    console.error("[ErrorBoundary]", error, info.componentStack);
+    debugLogClient.error("react_error_boundary", error.message, {
+      stack: error.stack?.slice(0, 2000),
+      componentStack: info.componentStack?.slice(0, 2000)
+    });
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  handleReset = () => {
+    try {
+      useConversationStore.getState().setActive(undefined);
+    } catch {
+      /* ignore */
+    }
+    this.setState({ error: null, errorInfo: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          className="app-error-boundary"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            padding: "24px",
+            background: "var(--bg-app, #18181b)",
+            color: "var(--text-primary, #f4f4f5)",
+            fontFamily: "var(--font-sans, system-ui, -apple-system, sans-serif)",
+            textAlign: "center"
+          }}
+          role="alert"
+        >
+          <div
+            style={{
+              maxWidth: "520px",
+              width: "100%",
+              padding: "32px",
+              background: "var(--bg-card, #27272a)",
+              border: "1px solid var(--border-color, #3f3f46)",
+              borderRadius: "12px",
+              boxShadow: "0 12px 32px rgba(0,0,0,0.36)"
+            }}
+          >
+            <div
+              style={{
+                display: "inline-flex",
+                padding: "12px",
+                borderRadius: "50%",
+                background: "rgba(239, 68, 68, 0.15)",
+                color: "#ef4444",
+                marginBottom: "16px"
+              }}
+            >
+              <AlertTriangle size={32} strokeWidth={2} />
+            </div>
+            <h2
+              style={{
+                fontSize: "18px",
+                fontWeight: 600,
+                marginBottom: "8px"
+              }}
+            >
+              {i18next.t("errors.somethingWentWrong", {
+                defaultValue: "Something went wrong"
+              })}
+            </h2>
+            <p
+              style={{
+                fontSize: "14px",
+                color: "var(--text-muted, #a1a1aa)",
+                marginBottom: "20px",
+                wordBreak: "break-word"
+              }}
+            >
+              {this.state.error.message || String(this.state.error)}
+            </p>
+            <div
+              style={{
+                display: "flex",
+                gap: "12px",
+                justifyContent: "center",
+                flexWrap: "wrap",
+                marginBottom: "16px"
+              }}
+            >
+              <button
+                type="button"
+                onClick={this.handleReset}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  padding: "8px 16px",
+                  borderRadius: "6px",
+                  background: "var(--primary, #3b82f6)",
+                  color: "#fff",
+                  border: "none",
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  cursor: "pointer"
+                }}
+              >
+                <Home size={16} />
+                {i18next.t("errors.backToHome", { defaultValue: "Return Home" })}
+              </button>
+              <button
+                type="button"
+                onClick={this.handleReload}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  padding: "8px 16px",
+                  borderRadius: "6px",
+                  background: "var(--bg-hover, #3f3f46)",
+                  color: "var(--text-primary, #f4f4f5)",
+                  border: "1px solid var(--border-color, #52525b)",
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  cursor: "pointer"
+                }}
+              >
+                <RefreshCw size={16} />
+                {i18next.t("errors.reload", { defaultValue: "Reload" })}
+              </button>
+            </div>
+            {this.state.error.stack ? (
+              <details
+                style={{
+                  textAlign: "left",
+                  marginTop: "16px",
+                  fontSize: "12px",
+                  color: "var(--text-muted, #a1a1aa)"
+                }}
+              >
+                <summary style={{ cursor: "pointer", userSelect: "none" }}>
+                  {i18next.t("errors.details", { defaultValue: "Error Details" })}
+                </summary>
+                <pre
+                  style={{
+                    marginTop: "8px",
+                    padding: "10px",
+                    borderRadius: "6px",
+                    background: "rgba(0,0,0,0.3)",
+                    overflowX: "auto",
+                    maxHeight: "180px",
+                    fontSize: "11px",
+                    lineHeight: "1.4"
+                  }}
+                >
+                  {this.state.error.stack}
+                </pre>
+              </details>
+            ) : null}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import App from "./App";
 import { ButlerBuddyChat } from "./components/ButlerBuddy/ButlerBuddyChat";
 import { ButlerBuddyPet } from "./components/ButlerBuddy/ButlerBuddyPet";
 import { ButlerBuddyScreenBall } from "./components/ButlerBuddy/ButlerBuddyScreenBall";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./i18n";
 import "../styles.css";
 import { installDebugLogClient } from "./services/debugLog";
@@ -25,5 +26,7 @@ const content =
   );
 
 createRoot(document.getElementById("root") as HTMLElement).render(
-  <StrictMode>{content}</StrictMode>
+  <StrictMode>
+    <ErrorBoundary>{content}</ErrorBoundary>
+  </StrictMode>
 );

--- a/src/services/cli/client.ts
+++ b/src/services/cli/client.ts
@@ -212,19 +212,21 @@ export const cliClient = {
     return api().saveToolSession(args);
   },
 
-  listProjects(): Promise<Project[]> {
+  async listProjects(): Promise<Project[]> {
+    if (!this.isAvailable() || typeof api().listProjects !== "function") return [];
     return api().listProjects();
   },
-  getProject(id: string): Promise<Project | null> {
+  async getProject(id: string): Promise<Project | null> {
+    if (!this.isAvailable() || typeof api().getProject !== "function") return null;
     return api().getProject(id);
   },
-  createProject(input: ProjectInput): Promise<Project> {
+  async createProject(input: ProjectInput): Promise<Project> {
     return api().createProject(input);
   },
-  updateProject(input: ProjectInput & { id: string }): Promise<Project> {
+  async updateProject(input: ProjectInput & { id: string }): Promise<Project> {
     return api().updateProject(input);
   },
-  deleteProject(id: string): Promise<{ ok: true }> {
+  async deleteProject(id: string): Promise<{ ok: true }> {
     return api().deleteProject(id);
   },
 

--- a/src/services/delegation/client.ts
+++ b/src/services/delegation/client.ts
@@ -108,30 +108,32 @@ export const delegationClient = {
     return Boolean(window.freebuddy?.delegation);
   },
 
-  list(): Promise<DelegationTeam[]> {
+  async list(): Promise<DelegationTeam[]> {
+    if (!this.isAvailable()) return [];
     return api().listTeams();
   },
 
-  get(id: string): Promise<DelegationTeam | undefined> {
+  async get(id: string): Promise<DelegationTeam | undefined> {
+    if (!this.isAvailable()) return undefined;
     return api().getTeam(id);
   },
 
-  create(input: UpsertDelegationTeamInput): Promise<DelegationTeam> {
+  async create(input: UpsertDelegationTeamInput): Promise<DelegationTeam> {
     return api().createTeam(input);
   },
 
-  update(
+  async update(
     id: string,
     patch: UpdateDelegationTeamPatch
   ): Promise<DelegationTeam | undefined> {
     return api().updateTeam(id, patch);
   },
 
-  delete(id: string): Promise<boolean> {
+  async delete(id: string): Promise<boolean> {
     return api().deleteTeam(id);
   },
 
-  createRun(input: {
+  async createRun(input: {
     teamId: string;
     goal: string;
     cwd?: string;
@@ -143,7 +145,7 @@ export const delegationClient = {
     return wfApi().createDelegationRun(input);
   },
 
-  approveWrite(input: {
+  async approveWrite(input: {
     runId: string;
     approvalId: string;
     approved: boolean;
@@ -151,43 +153,51 @@ export const delegationClient = {
     return wfApi().approveDelegateWrite(input);
   },
 
-  getRun(id: string): Promise<unknown> {
+  async getRun(id: string): Promise<unknown> {
+    if (!this.isAvailable()) return undefined;
     return api().getRun(id);
   },
 
-  getRunByConversation(
+  async getRunByConversation(
     conversationId: string
   ): Promise<DelegationRunRow | undefined> {
+    if (!this.isAvailable()) return undefined;
     return api().getRunByConversation(conversationId);
   },
 
-  listEvents(runId: string): Promise<DelegationEventRow[]> {
+  async listEvents(runId: string): Promise<DelegationEventRow[]> {
+    if (!this.isAvailable()) return [];
     return api().listEvents(runId);
   },
 
-  listPendingApprovals(
+  async listPendingApprovals(
     runId: string
   ): Promise<Array<{ approvalId: string; runId: string }>> {
+    if (!this.isAvailable()) return [];
     return api().listPendingApprovals(runId);
   },
 
-  stopRun(runId: string): Promise<boolean> {
+  async stopRun(runId: string): Promise<boolean> {
+    if (!this.isAvailable()) return false;
     return api().stopRun(runId);
   },
 
-  pauseRun(runId: string): Promise<boolean> {
+  async pauseRun(runId: string): Promise<boolean> {
+    if (!this.isAvailable()) return false;
     return api().pauseRun(runId);
   },
 
-  resumeRun(runId: string): Promise<boolean> {
+  async resumeRun(runId: string): Promise<boolean> {
+    if (!this.isAvailable()) return false;
     return api().resumeRun(runId);
   },
 
-  hasRunForConversation(conversationId: string): Promise<boolean> {
+  async hasRunForConversation(conversationId: string): Promise<boolean> {
+    if (!this.isAvailable()) return false;
     return api().hasRunForConversation(conversationId);
   },
 
-  followUp(input: {
+  async followUp(input: {
     conversationId: string;
     prompt: string;
   }): Promise<

--- a/src/services/scheduledTasks/client.ts
+++ b/src/services/scheduledTasks/client.ts
@@ -37,7 +37,7 @@ export const scheduledTasksClient = {
   run(id: string): Promise<boolean> {
     return api().run(id);
   },
-  onChanged(cb: (task?: ScheduledTask) => void): () => void {
-    return api().onChanged(cb);
+  onChanged(cb: (task?: ScheduledTask) => void): (() => void) | undefined {
+    return window.freebuddy?.scheduledTasks?.onChanged?.(cb);
   }
 };

--- a/src/services/skills/client.ts
+++ b/src/services/skills/client.ts
@@ -47,7 +47,7 @@ export const skillsClient = {
     version?: string;
     downloadsHint?: number;
   }): Promise<string | null> => api().resolveMarketHomepage(args),
-  onChanged(cb: () => void): () => void {
-    return api().onChanged(cb);
+  onChanged(cb: () => void): (() => void) | undefined {
+    return window.freebuddy?.skills?.onChanged?.(cb);
   }
 };

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -376,9 +376,9 @@ const MEMBER_RUNTIME_OVERRIDES_KEY = "member.runtimeOverrides";
 async function loadMemberOverrideMap(
   key: string
 ): Promise<Record<string, string>> {
-  const raw = await cliClient.getSetting(key);
-  if (!raw) return {};
   try {
+    const raw = await cliClient.getSetting(key);
+    if (!raw) return {};
     const parsed = JSON.parse(raw) as unknown;
     if (parsed && typeof parsed === "object") {
       const result: Record<string, string> = {};
@@ -390,7 +390,7 @@ async function loadMemberOverrideMap(
       return result;
     }
   } catch {
-    // ignore malformed override payload
+    // non-fatal
   }
   return {};
 }
@@ -581,6 +581,32 @@ async function workflowFollowupContextForRun(
   return buildWorkflowFollowupContext(run, steps);
 }
 
+const ACTIVE_CONV_STORAGE_KEY = "fb_last_active_conversation";
+
+function getStoredActiveId(): string | undefined {
+  try {
+    if (typeof window === "undefined") return undefined;
+    const fromUrl = new URLSearchParams(window.location.search).get("c");
+    if (fromUrl) return fromUrl;
+    return sessionStorage.getItem(ACTIVE_CONV_STORAGE_KEY) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function setStoredActiveId(id: string | undefined): void {
+  try {
+    if (typeof window === "undefined") return;
+    if (id) {
+      sessionStorage.setItem(ACTIVE_CONV_STORAGE_KEY, id);
+    } else {
+      sessionStorage.removeItem(ACTIVE_CONV_STORAGE_KEY);
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
 export const useConversationStore = create<ConversationState>((set, get) => ({
   members: buildConversationMembers(),
   memberRuntimeOverrides: {},
@@ -609,17 +635,16 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     } catch {
       // current user unavailable; non-fatal
     }
+    const stored = getStoredActiveId();
+    const cur = get().activeId || stored;
+    const matchedCur =
+      cur && synced.conversations.some((c) => c.id === cur) ? cur : undefined;
     set({
       members,
       memberRuntimeOverrides,
-      conversations: synced.conversations
+      conversations: synced.conversations,
+      activeId: matchedCur
     });
-    const cur = get().activeId;
-    // Keep startup on the new-task page: do not auto-open the latest conversation.
-    // Only clear activeId when a previously selected conversation no longer exists.
-    if (cur && !list.find((c) => c.id === cur)) {
-      set({ activeId: undefined });
-    }
     const active = get().activeId;
     if (active) get().markConversationRead(active);
     if (active && !get().messages[active]) {
@@ -685,6 +710,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
   },
 
   async setActive(id) {
+    setStoredActiveId(id);
     if (id && get().unreadConversations[id]) {
       const unreadConversations = { ...get().unreadConversations };
       delete unreadConversations[id];
@@ -840,6 +866,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       ),
       titleSource: title ? "prompt" : "default"
     });
+    setStoredActiveId(conv.id);
     set((s) => ({
       conversations: [conv, ...s.conversations.filter((c) => c.id !== conv.id)],
       activeId: conv.id,

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -107,9 +107,10 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     const resolved = resolveLanguagePreference(preference, systemLanguage);
     const storedTheme = await cliClient.getSetting("theme");
     const storedTelemetryEnabled = await cliClient.getSetting("telemetry.enabled");
-    const butlerPreferences = await window.freebuddy?.butlerBuddy
-      ?.getPreferences()
-      .catch(() => undefined);
+    const butlerPreferences =
+      typeof window.freebuddy?.butlerBuddy?.getPreferences === "function"
+        ? await window.freebuddy.butlerBuddy.getPreferences().catch(() => undefined)
+        : undefined;
     const themePreference = normalizeThemePreference(storedTheme);
     const resolvedTheme = resolveThemePreference(themePreference, systemTheme);
     await i18next.changeLanguage(resolved);


### PR DESCRIPTION
### Summary of Changes

1. **Sub-user Conversation List Loading**:
   - Whitelisted `member.runtimeOverrides` under `REMOTE_READABLE_SETTING_KEYS` in `electron/shared/remoteChannelPolicy.ts`.
   - Added `try-catch` error boundary around `loadMemberOverrideMap` in `src/store/conversationStore.ts` to prevent non-admin setting reads from failing the entire conversation hydration.
   - Fixed `settingsStore.ts` to safely check `butlerBuddy.getPreferences` on WebUI.

2. **Generated Image Rendering**:
   - Allowed authenticated sub-users to view generated artifacts under user home directories and temporary directories in `electron/cli/attachments.ts`.
   - Enhanced image detection regex and tool invocation image preview in `src/components/CLI/StreamItem.tsx`.

3. **Remote Workspace Project Grouping & Sidebar Display**:
   - Mapped isolated remote workspace paths back to canonical host project IDs in `electron/cli/projects.ts` and `electron/cli/ipc.ts`.
   - Filtered out empty host projects for remote sub-users in `src/components/CLI/ConversationList.tsx`.
   - Added `sessionStorage` persistence for active conversation ID so refreshes preserve active conversation context without force-opening unintended chats.

4. **Reliability & Crash Protection**:
   - Added React `ErrorBoundary` to prevent full-app blank screens on uncaught component errors.

### Testing
- `npm run typecheck`: Passed
- `npm test`: 126 pass, 0 fail
- Headless Chrome E2E verification: Verified sub-user conversation loading, rendering, and refresh persistence.