### PR TITLE
feat(game): 对战大厅新增五子棋与中国象棋支持 (Game Arena)

### DIFF
--- a/assets/skills/game-arena/SKILL.md
+++ b/assets/skills/game-arena/SKILL.md
@@ -10,9 +10,10 @@ You are playing a turn-based board or card game with the user inside FreeBuddy.
 ## Available Game Tools (MCP)
 
 You have access to the `freebuddy-game` MCP toolset:
-- `game_get_state`: Query current board matrix, active turn, and legal candidate moves.
-- `game_make_move`: Execute a piece placement or card move by providing `actionId` (e.g. `"H8"`, `"E11"`).
+- `game_get_state`: Query current board matrix, active turn, last move, and legal candidate moves (lean token footprint).
+- `game_make_move`: Execute a piece placement or card move by providing `actionId` (e.g. `"H8"`, `"b2e2"`).
 - `game_send_chat`: Send in-game psychological chat/dialogue to the player.
+- `game_get_history`: Query historical moves and dialogue records for post-game review or tactical recap (optional).
 - `game_resign`: Resign/surrender if the match is lost.
 
 ## Playing Instructions

--- a/assets/skills/game-arena/SKILL.md
+++ b/assets/skills/game-arena/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: game-arena
+description: Play board and card games (such as Gomoku, Chinese Chess) with the user using the freebuddy-game MCP tools.
+---
+
+# Game Arena
+
+You are playing a turn-based board or card game with the user inside FreeBuddy.
+
+## Available Game Tools (MCP)
+
+You have access to the `freebuddy-game` MCP toolset:
+- `game_get_state`: Query current board matrix, active turn, and legal candidate moves.
+- `game_make_move`: Execute a piece placement or card move by providing `actionId` (e.g. `"H8"`, `"E11"`).
+- `game_send_chat`: Send in-game psychological chat/dialogue to the player.
+- `game_resign`: Resign/surrender if the match is lost.
+
+## Playing Instructions
+
+1. Whenever you are prompted that it is your turn to act:
+   - Call `game_make_move` with the chosen `actionId` (e.g. `actionId: "H8"`).
+   - Call `game_send_chat` to send an in-game personality reaction or dialogue to the opponent.
+2. Do NOT run system terminal commands (PowerShell/Bash) to search for games or processes. All game interactions are handled purely via the MCP tools.

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -64,6 +64,10 @@ import {
   unregisterBrowserToolSession
 } from "../browserToolService.js";
 import {
+  registerGameToolSession,
+  unregisterGameToolSession
+} from "../gameToolService.js";
+import {
   registerSkillToolSession,
   unregisterSkillToolSession
 } from "../skillToolService.js";
@@ -84,6 +88,7 @@ import {
   registerWorkspaceFsToolSession,
   unregisterWorkspaceFsToolSession
 } from "../workspaceFsToolService.js";
+import { getConversation } from "./conversations.js";
 import type { AcpStdioMcpServer } from "../shared/browserToolProtocol.js";
 import {
   clearAuthenticationTerminalsForSession,
@@ -385,6 +390,7 @@ export async function runAcpAgent({
     terminalManager.dispose();
     running.delete(args.sessionId);
     unregisterBrowserToolSession(args.sessionId);
+    unregisterGameToolSession(args.sessionId);
     unregisterSkillToolSession(args.sessionId);
     unregisterButlerToolSession(args.sessionId);
     unregisterDelegateToolSession(args.sessionId);
@@ -1254,6 +1260,21 @@ export async function runAcpAgent({
             webContents
           })
         );
+        const conv = args.conversationId ? getConversation(args.conversationId) : undefined;
+        const isGameSession =
+          conv?.kind === "game" ||
+          args.skills?.some((s) => s.id === "game-arena" || s.name === "game-arena");
+        if (isGameSession) {
+          const gameType = (conv?.metadata?.gameType as any) || "gomoku";
+          mcpServers.push(
+            await registerGameToolSession({
+              taskSessionId: args.sessionId,
+              conversationId: args.conversationId,
+              gameType,
+              webContents
+            })
+          );
+        }
       }
       if (args.skills?.length) {
         mcpServers.push(registerSkillToolSession(args.sessionId, args.skills));

--- a/electron/cli/conversations.ts
+++ b/electron/cli/conversations.ts
@@ -46,6 +46,7 @@ export interface ChatAttachment {
 }
 
 export type ConversationTitleSource = "default" | "prompt" | "agent" | "user";
+export type ConversationKind = "default" | "game" | "workflow" | "scheduled" | string;
 
 export interface Conversation {
   id: string;
@@ -53,6 +54,8 @@ export interface Conversation {
   agentId: string;
   agentName: string;
   adapter: string;
+  kind?: ConversationKind;
+  metadata?: Record<string, unknown>;
   cwd?: string;
   /** Assigned source path shown to remote users; cwd remains the execution path. */
   sourceCwd?: string;
@@ -149,12 +152,22 @@ function rowToConversation(
     }
     sourceCwd = sourcePathForManagedWorkspace(cwd, workspaces);
   }
+  let metadata: Record<string, unknown> | undefined;
+  if (r.metadata) {
+    try {
+      metadata = typeof r.metadata === "string" ? JSON.parse(r.metadata) : r.metadata;
+    } catch {
+      /* ignore invalid json */
+    }
+  }
   return {
     id: r.id,
     title: r.title,
     agentId: r.agent_id,
     agentName: r.agent_name,
     adapter: r.adapter,
+    kind: (r.kind as ConversationKind) || "default",
+    metadata,
     cwd,
     sourceCwd,
     projectId: r.project_id ?? undefined,
@@ -237,6 +250,8 @@ export interface CreateConversationInput {
   agentId: string;
   agentName: string;
   adapter: string;
+  kind?: ConversationKind;
+  metadata?: Record<string, unknown>;
   cwd?: string;
   projectId?: string;
   approvalMode?: "auto" | "ask";
@@ -262,12 +277,12 @@ export function createConversation(input: CreateConversationInput): Conversation
   getDb()
     .prepare(
       `INSERT INTO conversations
-         (id, title, agent_id, agent_name, adapter, cwd, project_id, approval_mode,
+         (id, title, agent_id, agent_name, adapter, kind, metadata, cwd, project_id, approval_mode,
           config_option_overrides, skill_snapshot, title_source, archived,
           source_conversation_id, source_agent_id, source_agent_name,
           source_adapter, source_brief_id, owner_id,
           created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       input.id,
@@ -275,6 +290,8 @@ export function createConversation(input: CreateConversationInput): Conversation
       input.agentId,
       input.agentName,
       input.adapter,
+      input.kind || "default",
+      input.metadata ? JSON.stringify(input.metadata) : null,
       input.cwd ?? null,
       projectId ?? null,
       input.approvalMode ?? null,
@@ -321,6 +338,18 @@ export function setConversationSkills(
       id
     );
   return getConversation(id);
+}
+
+export function updateConversationMetadata(
+  id: string,
+  patch: Record<string, unknown>
+): void {
+  const conv = getConversation(id);
+  if (!conv) return;
+  const merged = { ...(conv.metadata || {}), ...patch };
+  getDb()
+    .prepare("UPDATE conversations SET metadata = ?, updated_at = ? WHERE id = ?")
+    .run(JSON.stringify(merged), new Date().toISOString(), id);
 }
 
 export function setConversationApprovalMode(

--- a/electron/cli/db.ts
+++ b/electron/cli/db.ts
@@ -278,7 +278,9 @@ export function migrate(db: DB) {
       source_adapter TEXT,
       source_brief_id TEXT,
       owner_id TEXT,
-      project_id TEXT
+      project_id TEXT,
+      kind TEXT NOT NULL DEFAULT 'default',
+      metadata TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_conversations_updated
       ON conversations(archived, updated_at DESC);
@@ -815,6 +817,12 @@ export function migrate(db: DB) {
   }
   if (!conversationCols.some((c) => c.name === "project_id")) {
     db.exec("ALTER TABLE conversations ADD COLUMN project_id TEXT");
+  }
+  if (!conversationCols.some((c) => c.name === "kind")) {
+    db.exec("ALTER TABLE conversations ADD COLUMN kind TEXT NOT NULL DEFAULT 'default'");
+  }
+  if (!conversationCols.some((c) => c.name === "metadata")) {
+    db.exec("ALTER TABLE conversations ADD COLUMN metadata TEXT");
   }
 
   const scheduledTaskOwnerCols = db

--- a/electron/cli/skills.ts
+++ b/electron/cli/skills.ts
@@ -444,7 +444,15 @@ export function getSkill(id: string): SkillRecord | undefined {
 export function resolveSkillSnapshots(ids: readonly string[]): SkillSnapshot[] {
   const unique = [...new Set(ids.filter(Boolean))];
   return unique.flatMap((id) => {
-    const skill = getSkill(id);
+    let skill = getSkill(id);
+    if (!skill) {
+      try {
+        seedBuiltinSkills();
+        skill = getSkill(id);
+      } catch (err) {
+        console.warn(`[skills] failed to seed builtin skills for ${id}:`, err);
+      }
+    }
     if (!skill?.enabled || !skill.trusted) return [];
     return [{
       id: skill.id,

--- a/electron/gameToolService.ts
+++ b/electron/gameToolService.ts
@@ -10,6 +10,7 @@ import { XiangqiGameInstance, PLAYER_RED as XIANGQI_RED, PLAYER_BLACK as XIANGQI
 import type {
   GameAction,
   GameChatMessage,
+  GameMoveRecord,
   GameStateSnapshot,
   GameStatus,
   GameToolBinding,
@@ -26,7 +27,9 @@ export interface GameInstance {
   status: GameStatus;
   turn: number;
   winner: number | null;
-  getSnapshot(): GameStateSnapshot;
+  moveHistory: GameMoveRecord[];
+  chatHistory: GameChatMessage[];
+  getSnapshot(options?: { includeHistory?: boolean }): GameStateSnapshot;
   applyMove(actionId: string, player: number, reason?: string): { ok: boolean; error?: string; winner?: number | null; chineseMove?: string };
   addChat(sender: "player" | "agent" | "system", message: string, mood?: any): GameChatMessage;
   resign(player: number, reason?: string): { ok: boolean; winner: number };
@@ -66,7 +69,7 @@ export function persistGameState(conversationId: string, game: GameInstance): vo
   if (!updateMetadataFn) return;
   try {
     updateMetadataFn(conversationId, {
-      gameState: game.getSnapshot()
+      gameState: game.getSnapshot({ includeHistory: true })
     });
   } catch (err) {
     console.warn(`[FreeBuddy] Failed to persist game state for ${conversationId}:`, err);
@@ -136,6 +139,20 @@ export async function dispatchGameAction(
       ok: true,
       gameId: game.gameId,
       gameState: game.getSnapshot()
+    };
+  }
+
+  if (action === "get_history") {
+    const limit = typeof params.limit === "number" && params.limit > 0 ? params.limit : undefined;
+    const moves = limit ? game.moveHistory.slice(-limit) : [...game.moveHistory];
+    const chats = limit ? game.chatHistory.slice(-limit) : [...game.chatHistory];
+    return {
+      ok: true,
+      gameId: game.gameId,
+      gameType: game.getSnapshot().gameType,
+      stepCount: game.moveHistory.length,
+      moveHistory: moves,
+      chatHistory: chats
     };
   }
 

--- a/electron/gameToolService.ts
+++ b/electron/gameToolService.ts
@@ -1,0 +1,408 @@
+import { randomBytes } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+import type { WebContents } from "electron";
+
+import { waitForActiveBridgePort } from "./agentBridge.js";
+import { safeSendToWebContents } from "./cli/ipcSend.js";
+import { GomokuGameInstance, PLAYER_BLACK as GOMOKU_BLACK, PLAYER_WHITE as GOMOKU_WHITE } from "./games/gomokuEngine.js";
+import { XiangqiGameInstance, PLAYER_RED as XIANGQI_RED, PLAYER_BLACK as XIANGQI_BLACK } from "./games/xiangqiEngine.js";
+import type {
+  GameAction,
+  GameChatMessage,
+  GameStateSnapshot,
+  GameStatus,
+  GameToolBinding,
+  GameToolResult,
+  GameType
+} from "./shared/gameToolProtocol.js";
+import type { AcpStdioMcpServer } from "./shared/browserToolProtocol.js";
+
+const GAME_TOOL_PATH = "/freebuddy/game-tool";
+const MAX_REQUEST_BYTES = 256 * 1024;
+
+export interface GameInstance {
+  gameId: string;
+  status: GameStatus;
+  turn: number;
+  winner: number | null;
+  getSnapshot(): GameStateSnapshot;
+  applyMove(actionId: string, player: number, reason?: string): { ok: boolean; error?: string; winner?: number | null; chineseMove?: string };
+  addChat(sender: "player" | "agent" | "system", message: string, mood?: any): GameChatMessage;
+  resign(player: number, reason?: string): { ok: boolean; winner: number };
+}
+
+interface GameSessionBinding extends GameToolBinding {
+  taskSessionId: string;
+  conversationId: string;
+  gameType: GameType;
+  webContents?: WebContents;
+}
+
+let getConversationFn: ((id: string) => any) | null = null;
+let updateMetadataFn: ((id: string, patch: Record<string, unknown>) => void) | null = null;
+
+export function initGamePersistence(
+  getConv: (id: string) => any,
+  updateMeta: (id: string, patch: Record<string, unknown>) => void
+): void {
+  getConversationFn = getConv;
+  updateMetadataFn = updateMeta;
+}
+
+const bindingsByToken = new Map<string, GameSessionBinding>();
+const tokensByTaskSession = new Map<string, string>();
+const activeGamesByConversation = new Map<string, GameInstance>();
+
+function gameMcpServerPath(): string {
+  return fileURLToPath(new URL("./mcp/gameMcpServer.js", import.meta.url));
+}
+
+function createCapabilityToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function persistGameState(conversationId: string, game: GameInstance): void {
+  if (!updateMetadataFn) return;
+  try {
+    updateMetadataFn(conversationId, {
+      gameState: game.getSnapshot()
+    });
+  } catch (err) {
+    console.warn(`[FreeBuddy] Failed to persist game state for ${conversationId}:`, err);
+  }
+}
+
+export function getOrCreateGame(conversationId: string, gameType: GameType = "gomoku"): GameInstance {
+  let game = activeGamesByConversation.get(conversationId);
+  if (!game) {
+    const conv = getConversationFn ? getConversationFn(conversationId) : undefined;
+    const saved = conv?.metadata?.gameState as GameStateSnapshot | undefined;
+    const effectiveType = (saved?.gameType || conv?.metadata?.gameType || gameType) as GameType;
+
+    if (effectiveType === "xiangqi") {
+      if (saved && saved.board && Array.isArray(saved.board) && saved.board.length === 10) {
+        game = XiangqiGameInstance.fromSnapshot(saved);
+      } else {
+        game = new XiangqiGameInstance(conversationId);
+      }
+    } else {
+      if (saved && saved.board && Array.isArray(saved.board) && saved.board.length === 15) {
+        game = GomokuGameInstance.fromSnapshot(saved);
+      } else {
+        game = new GomokuGameInstance(conversationId);
+      }
+    }
+    activeGamesByConversation.set(conversationId, game);
+  }
+  return game;
+}
+
+export function broadcastGameUpdate(webContents: WebContents | undefined, snapshot: GameStateSnapshot): void {
+  if (webContents && !webContents.isDestroyed()) {
+    safeSendToWebContents(webContents, "freebuddy://game-event", {
+      type: "GAME_STATE_UPDATE",
+      payload: snapshot
+    });
+  }
+  try {
+    // Dynamic require so tests outside electron don't fail
+    const electron = require("electron");
+    const BrowserWindow = electron?.BrowserWindow;
+    if (BrowserWindow && typeof BrowserWindow.getAllWindows === "function") {
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.isDestroyed() && (!webContents || win.webContents !== webContents)) {
+          safeSendToWebContents(win.webContents, "freebuddy://game-event", {
+            type: "GAME_STATE_UPDATE",
+            payload: snapshot
+          });
+        }
+      }
+    }
+  } catch {
+    /* best effort */
+  }
+}
+
+export async function dispatchGameAction(
+  binding: GameSessionBinding,
+  action: GameAction,
+  params: Record<string, unknown>
+): Promise<GameToolResult> {
+  const game = getOrCreateGame(binding.conversationId, binding.gameType);
+
+  if (action === "get_state") {
+    return {
+      ok: true,
+      gameId: game.gameId,
+      gameState: game.getSnapshot()
+    };
+  }
+
+  if (action === "make_move") {
+    const actionId = String(params.actionId || "").trim();
+    const reason = typeof params.reason === "string" ? params.reason : undefined;
+    if (!actionId) {
+      return { ok: false, error: "Missing required 'actionId'." };
+    }
+
+    // Agent is player 2
+    const res = game.applyMove(actionId, 2, reason);
+    if (!res.ok) {
+      return { ok: false, error: res.error };
+    }
+
+    persistGameState(binding.conversationId, game);
+    const snapshot = game.getSnapshot();
+    broadcastGameUpdate(binding.webContents, snapshot);
+
+    const moveLabel = res.chineseMove ? `${res.chineseMove} (${actionId})` : actionId;
+    return {
+      ok: true,
+      actionId,
+      gameId: game.gameId,
+      gameState: snapshot,
+      message: res.winner
+        ? `落子 ${moveLabel} 成功，并获得胜利！`
+        : `落子 ${moveLabel} 成功，轮到玩家行动。`
+    };
+  }
+
+  if (action === "send_chat") {
+    const message = String(params.message || "").trim();
+    const mood = params.mood as any;
+    if (!message) {
+      return { ok: false, error: "Missing required 'message'." };
+    }
+
+    const chat = game.addChat("agent", message, mood);
+    persistGameState(binding.conversationId, game);
+    const snapshot = game.getSnapshot();
+    broadcastGameUpdate(binding.webContents, snapshot);
+
+    return {
+      ok: true,
+      chat,
+      gameState: snapshot
+    };
+  }
+
+  if (action === "resign") {
+    const reason = typeof params.reason === "string" ? params.reason : undefined;
+    const res = game.resign(2, reason);
+    persistGameState(binding.conversationId, game);
+    const snapshot = game.getSnapshot();
+    broadcastGameUpdate(binding.webContents, snapshot);
+
+    return {
+      ok: true,
+      gameState: snapshot,
+      message: "你已认输，本局游戏结束。"
+    };
+  }
+
+  if (action === "reset") {
+    const newGame =
+      binding.gameType === "xiangqi"
+        ? new XiangqiGameInstance(binding.conversationId)
+        : new GomokuGameInstance(binding.conversationId);
+    activeGamesByConversation.set(binding.conversationId, newGame);
+    persistGameState(binding.conversationId, newGame);
+    const snapshot = newGame.getSnapshot();
+    broadcastGameUpdate(binding.webContents, snapshot);
+
+    return {
+      ok: true,
+      gameState: snapshot,
+      message: "对局已重置。"
+    };
+  }
+
+  return { ok: false, error: `Unknown game action '${action}'.` };
+}
+
+export function handlePlayerMove(
+  conversationId: string,
+  actionId: string,
+  webContents?: WebContents
+): GameToolResult {
+  const game = getOrCreateGame(conversationId);
+  if (game.turn === 2 && game.status === "playing") {
+    game.turn = 1;
+  }
+  const res = game.applyMove(actionId, 1);
+  if (!res.ok) {
+    return { ok: false, error: res.error };
+  }
+  persistGameState(conversationId, game);
+  const snapshot = game.getSnapshot();
+  broadcastGameUpdate(webContents, snapshot);
+  return {
+    ok: true,
+    actionId,
+    gameId: game.gameId,
+    gameState: snapshot
+  };
+}
+
+export function handleAgentMove(
+  conversationId: string,
+  actionId: string,
+  reason?: string,
+  speech?: string,
+  mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring",
+  webContents?: WebContents
+): GameToolResult {
+  const game = getOrCreateGame(conversationId);
+  const res = game.applyMove(actionId, 2, reason);
+  if (!res.ok) {
+    return { ok: false, error: res.error };
+  }
+  if (speech) {
+    game.addChat("agent", speech, mood);
+  }
+  persistGameState(conversationId, game);
+  const snapshot = game.getSnapshot();
+  broadcastGameUpdate(webContents, snapshot);
+  return {
+    ok: true,
+    actionId,
+    gameId: game.gameId,
+    gameState: snapshot
+  };
+}
+
+export function handleResetGame(
+  conversationId: string,
+  webContents?: WebContents
+): GameToolResult {
+  const existing = activeGamesByConversation.get(conversationId);
+  const isXiangqi = existing?.getSnapshot().gameType === "xiangqi";
+  const newGame = isXiangqi
+    ? new XiangqiGameInstance(conversationId)
+    : new GomokuGameInstance(conversationId);
+  activeGamesByConversation.set(conversationId, newGame);
+  persistGameState(conversationId, newGame);
+  const snapshot = newGame.getSnapshot();
+  broadcastGameUpdate(webContents, snapshot);
+  return {
+    ok: true,
+    gameId: newGame.gameId,
+    gameState: snapshot
+  };
+}
+
+export async function registerGameToolSession(input: {
+  taskSessionId: string;
+  conversationId: string;
+  gameType?: GameType;
+  webContents?: WebContents;
+}): Promise<AcpStdioMcpServer> {
+  const { taskSessionId, conversationId, gameType = "gomoku", webContents } = input;
+  unregisterGameToolSession(taskSessionId);
+
+  const token = createCapabilityToken();
+  const binding: GameSessionBinding = {
+    token,
+    taskSessionId,
+    conversationId,
+    gameType,
+    webContents
+  };
+
+  bindingsByToken.set(token, binding);
+  tokensByTaskSession.set(taskSessionId, token);
+
+  const port = await waitForActiveBridgePort();
+  return {
+    name: "freebuddy-game",
+    command: process.execPath,
+    args: [gameMcpServerPath()],
+    env: [
+      { name: "ELECTRON_RUN_AS_NODE", value: "1" },
+      { name: "FREEBUDDY_GAME_ENDPOINT", value: `http://127.0.0.1:${port}${GAME_TOOL_PATH}` },
+      { name: "FREEBUDDY_GAME_TOKEN", value: token },
+      { name: "FB_APP_VERSION", value: process.env.FB_APP_VERSION || "0.8.7" }
+    ]
+  };
+}
+
+export function unregisterGameToolSession(taskSessionId: string): void {
+  const token = tokensByTaskSession.get(taskSessionId);
+  if (!token) return;
+  tokensByTaskSession.delete(taskSessionId);
+  bindingsByToken.delete(token);
+}
+
+export async function handleGameToolHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<boolean> {
+  const url = req.url || "";
+  if (!url.startsWith(GAME_TOOL_PATH)) {
+    return false;
+  }
+
+  if (req.method !== "POST") {
+    res.writeHead(405, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: false, error: "Method Not Allowed" }));
+    return true;
+  }
+
+  const authHeader = req.headers.authorization || "";
+  const token = authHeader.startsWith("Bearer ")
+    ? authHeader.slice(7).trim()
+    : "";
+
+  const binding = bindingsByToken.get(token);
+  if (!binding) {
+    res.writeHead(401, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: false, error: "Unauthorized game tool session token" }));
+    return true;
+  }
+
+  const chunks: Buffer[] = [];
+  let bytesRead = 0;
+
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    bytesRead += buffer.length;
+    if (bytesRead > MAX_REQUEST_BYTES) {
+      res.writeHead(413, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+      return true;
+    }
+    chunks.push(buffer);
+  }
+
+  let body: { action?: unknown; params?: unknown } = {};
+  try {
+    const raw = Buffer.concat(chunks).toString("utf8");
+    body = raw ? JSON.parse(raw) : {};
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: false, error: "Invalid JSON payload" }));
+    return true;
+  }
+
+  const action = String(body.action || "") as GameAction;
+  const params = (body.params && typeof body.params === "object"
+    ? body.params
+    : {}) as Record<string, unknown>;
+
+  try {
+    const result = await dispatchGameAction(binding, action, params);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result));
+  } catch (error) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        ok: false,
+        error: (error as Error)?.message || String(error)
+      })
+    );
+  }
+
+  return true;
+}

--- a/electron/games/gomokuEngine.ts
+++ b/electron/games/gomokuEngine.ts
@@ -1,0 +1,336 @@
+import type {
+  GameChatMessage,
+  GameMoveRecord,
+  GameStateSnapshot,
+  GameStatus,
+  LegalGameMove
+} from "../shared/gameToolProtocol.js";
+
+export const BOARD_SIZE = 15;
+export const PLAYER_BLACK = 1; // Human / Player
+export const PLAYER_WHITE = 2; // AI / Agent
+
+const COLS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"];
+
+export function coordToString(x: number, y: number): string {
+  const col = COLS[x] || `${x}`;
+  const row = BOARD_SIZE - y; // 1 to 15
+  return `${col}${row}`;
+}
+
+export function stringToCoord(coord: string): { x: number; y: number } | null {
+  const match = coord.trim().toUpperCase().match(/^([A-O])(\d{1,2})$/);
+  if (!match) return null;
+  const colLetter = match[1];
+  const rowNum = parseInt(match[2], 10);
+  const x = COLS.indexOf(colLetter);
+  const y = BOARD_SIZE - rowNum;
+  if (x >= 0 && x < BOARD_SIZE && y >= 0 && y < BOARD_SIZE) {
+    return { x, y };
+  }
+  return null;
+}
+
+export function createEmptyBoard(): number[][] {
+  return Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(0));
+}
+
+export function checkWin(board: number[][], x: number, y: number, player: number): boolean {
+  const directions = [
+    [1, 0],  // Horizontal
+    [0, 1],  // Vertical
+    [1, 1],  // Diagonal \
+    [1, -1]  // Diagonal /
+  ];
+
+  for (const [dx, dy] of directions) {
+    let count = 1;
+
+    // Positive direction
+    let nx = x + dx;
+    let ny = y + dy;
+    while (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE && board[ny][nx] === player) {
+      count++;
+      nx += dx;
+      ny += dy;
+    }
+
+    // Negative direction
+    nx = x - dx;
+    ny = y - dy;
+    while (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE && board[ny][nx] === player) {
+      count++;
+      nx -= dx;
+      ny -= dy;
+    }
+
+    if (count >= 5) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function countConsecutive(board: number[][], x: number, y: number, player: number): number {
+  const directions = [
+    [1, 0],
+    [0, 1],
+    [1, 1],
+    [1, -1]
+  ];
+  let maxCount = 0;
+  for (const [dx, dy] of directions) {
+    let count = 1;
+    let nx = x + dx;
+    let ny = y + dy;
+    while (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE && board[ny][nx] === player) {
+      count++;
+      nx += dx;
+      ny += dy;
+    }
+    nx = x - dx;
+    ny = y - dy;
+    while (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE && board[ny][nx] === player) {
+      count++;
+      nx -= dx;
+      ny -= dy;
+    }
+    if (count > maxCount) maxCount = count;
+  }
+  return maxCount;
+}
+
+export function evaluateThreat(
+  board: number[][],
+  x: number,
+  y: number,
+  turnPlayer: number
+): "winning" | "critical_block" | "attack" | "normal" {
+  const opponent = turnPlayer === PLAYER_BLACK ? PLAYER_WHITE : PLAYER_BLACK;
+
+  // If this move completes 5 for current player -> winning move
+  if (checkWin(board, x, y, turnPlayer)) {
+    return "winning";
+  }
+
+  // If this move blocks an opponent's 5 -> critical block
+  if (checkWin(board, x, y, opponent)) {
+    return "critical_block";
+  }
+
+  // If this move forms 4 consecutive stones -> attack
+  const selfCount = countConsecutive(board, x, y, turnPlayer);
+  const oppCount = countConsecutive(board, x, y, opponent);
+  if (selfCount >= 4 || oppCount >= 4) {
+    return "attack";
+  }
+
+  return "normal";
+}
+
+export function getCandidateMoves(board: number[][], turnPlayer: number): LegalGameMove[] {
+  const hasStones = board.some((row) => row.some((cell) => cell !== 0));
+  if (!hasStones) {
+    // Opening move: Center (H8)
+    const center = Math.floor(BOARD_SIZE / 2);
+    return [
+      {
+        actionId: coordToString(center, center),
+        x: center,
+        y: center,
+        coord: coordToString(center, center),
+        description: "天元落子 (首步开局最优位)",
+        threatLevel: "normal"
+      }
+    ];
+  }
+
+  const occupied = new Set<string>();
+  const candidates = new Map<string, { x: number; y: number; priority: number; threatLevel: "winning" | "critical_block" | "attack" | "normal" }>();
+
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    for (let x = 0; x < BOARD_SIZE; x++) {
+      if (board[y][x] !== 0) {
+        occupied.add(`${x},${y}`);
+      }
+    }
+  }
+
+  // Search neighbors within distance 2 of any existing stone
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    for (let x = 0; x < BOARD_SIZE; x++) {
+      if (board[y][x] === 0) continue;
+
+      for (let dy = -2; dy <= 2; dy++) {
+        for (let dx = -2; dx <= 2; dx++) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE && board[ny][nx] === 0) {
+            const key = `${nx},${ny}`;
+            if (!candidates.has(key)) {
+              const threat = evaluateThreat(board, nx, ny, turnPlayer);
+              let priority = 10;
+              if (threat === "winning") priority = 1000;
+              else if (threat === "critical_block") priority = 800;
+              else if (threat === "attack") priority = 200;
+              else if (Math.abs(dx) <= 1 && Math.abs(dy) <= 1) priority = 30;
+
+              candidates.set(key, { x: nx, y: ny, priority, threatLevel: threat });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const sorted = Array.from(candidates.values())
+    .sort((a, b) => b.priority - a.priority)
+    .slice(0, 30); // Top 30 candidate moves to keep token footprint ultra-clean
+
+  return sorted.map((c) => {
+    const coord = coordToString(c.x, c.y);
+    let desc = `落子 ${coord}`;
+    if (c.threatLevel === "winning") desc = `绝杀胜手 ${coord} (形成五连珠)`;
+    else if (c.threatLevel === "critical_block") desc = `关键封堵 ${coord} (拦截对方活四/连五)`;
+    else if (c.threatLevel === "attack") desc = `进攻落子 ${coord} (形成活三/冲四)`;
+
+    return {
+      actionId: coord,
+      x: c.x,
+      y: c.y,
+      coord,
+      description: desc,
+      threatLevel: c.threatLevel
+    };
+  });
+}
+
+export class GomokuGameInstance {
+  public gameId: string;
+  public status: GameStatus = "playing";
+  public turn: number = PLAYER_BLACK; // Black moves first
+  public board: number[][];
+  public moveHistory: GameMoveRecord[] = [];
+  public chatHistory: GameChatMessage[] = [];
+  public winner: number | null = null;
+  public updatedAt: number = Date.now();
+
+  constructor(gameId: string) {
+    this.gameId = gameId;
+    this.board = createEmptyBoard();
+  }
+
+  public static fromSnapshot(snapshot: GameStateSnapshot): GomokuGameInstance {
+    const inst = new GomokuGameInstance(snapshot.gameId);
+    inst.status = snapshot.status;
+    inst.turn = snapshot.turn;
+    inst.winner = snapshot.winner ?? null;
+    inst.board = snapshot.board ? snapshot.board.map((row) => [...row]) : createEmptyBoard();
+    inst.moveHistory = [...(snapshot.moveHistory || [])];
+    inst.chatHistory = [...(snapshot.chatHistory || [])];
+    inst.updatedAt = snapshot.updatedAt || Date.now();
+    return inst;
+  }
+
+  public getSnapshot(): GameStateSnapshot {
+    return {
+      gameType: "gomoku",
+      gameId: this.gameId,
+      status: this.status,
+      turn: this.turn,
+      stepCount: this.moveHistory.length,
+      winner: this.winner,
+      board: this.board.map((row) => [...row]),
+      lastMove: this.moveHistory.length > 0 ? this.moveHistory[this.moveHistory.length - 1] : null,
+      moveHistory: [...this.moveHistory],
+      legalMoves: this.status === "playing" ? getCandidateMoves(this.board, this.turn) : [],
+      chatHistory: [...this.chatHistory],
+      updatedAt: this.updatedAt
+    };
+  }
+
+  public applyMove(
+    actionId: string,
+    player: number,
+    reason?: string
+  ): { ok: boolean; error?: string; winner?: number | null } {
+    if (this.status !== "playing") {
+      return { ok: false, error: `Game is already over with status '${this.status}'.` };
+    }
+
+    if (this.turn !== player) {
+      return { ok: false, error: `Not player ${player}'s turn. Current turn: ${this.turn}` };
+    }
+
+    const coord = stringToCoord(actionId);
+    if (!coord) {
+      return { ok: false, error: `Invalid coordinate actionId '${actionId}'. Format should be like 'H8' or 'D4'.` };
+    }
+
+    const { x, y } = coord;
+    if (this.board[y][x] !== 0) {
+      return { ok: false, error: `Position ${actionId} (${x}, ${y}) is already occupied.` };
+    }
+
+    // Apply move
+    this.board[y][x] = player;
+    const moveRecord: GameMoveRecord = {
+      actionId,
+      x,
+      y,
+      player,
+      stepIndex: this.moveHistory.length + 1,
+      timestamp: Date.now(),
+      reason
+    };
+    this.moveHistory.push(moveRecord);
+    this.updatedAt = Date.now();
+
+    // Check win
+    if (checkWin(this.board, x, y, player)) {
+      this.status = player === PLAYER_BLACK ? "player_won" : "agent_won";
+      this.winner = player;
+      return { ok: true, winner: player };
+    }
+
+    // Check draw
+    if (this.moveHistory.length >= BOARD_SIZE * BOARD_SIZE) {
+      this.status = "draw";
+      this.winner = null;
+      return { ok: true, winner: null };
+    }
+
+    // Switch turn
+    this.turn = player === PLAYER_BLACK ? PLAYER_WHITE : PLAYER_BLACK;
+    return { ok: true };
+  }
+
+  public addChat(sender: "player" | "agent" | "system", message: string, mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring"): GameChatMessage {
+    const chat: GameChatMessage = {
+      sender,
+      message: message.trim(),
+      mood,
+      timestamp: Date.now()
+    };
+    this.chatHistory.push(chat);
+    this.updatedAt = Date.now();
+    return chat;
+  }
+
+  public resign(player: number, reason?: string): { ok: boolean; winner: number } {
+    if (this.status !== "playing") {
+      return { ok: false, winner: this.winner || 0 };
+    }
+    const winningPlayer = player === PLAYER_BLACK ? PLAYER_WHITE : PLAYER_BLACK;
+    this.status = winningPlayer === PLAYER_BLACK ? "player_won" : "agent_won";
+    this.winner = winningPlayer;
+    this.updatedAt = Date.now();
+    this.addChat(
+      player === PLAYER_BLACK ? "player" : "agent",
+      reason ? `认输: ${reason}` : "我认输了，这一局你下得漂亮！",
+      "calm"
+    );
+    return { ok: true, winner: winningPlayer };
+  }
+}

--- a/electron/games/gomokuEngine.ts
+++ b/electron/games/gomokuEngine.ts
@@ -233,7 +233,8 @@ export class GomokuGameInstance {
     return inst;
   }
 
-  public getSnapshot(): GameStateSnapshot {
+  public getSnapshot(options?: { includeHistory?: boolean }): GameStateSnapshot {
+    const includeHistory = options?.includeHistory ?? false;
     return {
       gameType: "gomoku",
       gameId: this.gameId,
@@ -243,9 +244,10 @@ export class GomokuGameInstance {
       winner: this.winner,
       board: this.board.map((row) => [...row]),
       lastMove: this.moveHistory.length > 0 ? this.moveHistory[this.moveHistory.length - 1] : null,
-      moveHistory: [...this.moveHistory],
+      moveHistory: includeHistory ? [...this.moveHistory] : undefined,
+      recentMoves: this.moveHistory.slice(-3),
       legalMoves: this.status === "playing" ? getCandidateMoves(this.board, this.turn) : [],
-      chatHistory: [...this.chatHistory],
+      chatHistory: includeHistory ? [...this.chatHistory] : this.chatHistory.slice(-3),
       updatedAt: this.updatedAt
     };
   }

--- a/electron/games/xiangqiEngine.ts
+++ b/electron/games/xiangqiEngine.ts
@@ -559,7 +559,8 @@ export class XiangqiGameInstance {
     return inst;
   }
 
-  public getSnapshot(): GameStateSnapshot {
+  public getSnapshot(options?: { includeHistory?: boolean }): GameStateSnapshot {
+    const includeHistory = options?.includeHistory ?? false;
     return {
       gameType: "xiangqi",
       gameId: this.gameId,
@@ -569,9 +570,10 @@ export class XiangqiGameInstance {
       winner: this.winner,
       board: this.board.map((row) => [...row]),
       lastMove: this.moveHistory.length > 0 ? this.moveHistory[this.moveHistory.length - 1] : null,
-      moveHistory: [...this.moveHistory],
+      moveHistory: includeHistory ? [...this.moveHistory] : undefined,
+      recentMoves: this.moveHistory.slice(-3),
       legalMoves: this.status === "playing" ? getCandidateMoves(this.board, this.turn) : [],
-      chatHistory: [...this.chatHistory],
+      chatHistory: includeHistory ? [...this.chatHistory] : this.chatHistory.slice(-3),
       updatedAt: this.updatedAt
     };
   }

--- a/electron/games/xiangqiEngine.ts
+++ b/electron/games/xiangqiEngine.ts
@@ -1,0 +1,686 @@
+import type {
+  GameChatMessage,
+  GameMoveRecord,
+  GameStateSnapshot,
+  GameStatus,
+  LegalGameMove
+} from "../shared/gameToolProtocol.js";
+
+export const BOARD_COLS = 9;
+export const BOARD_ROWS = 10;
+
+export const PLAYER_RED = 1;   // Red side (moves first by default)
+export const PLAYER_BLACK = 2; // Black side
+
+// Piece Definitions
+// Red pieces > 0, Black pieces < 0, Empty = 0
+export const PIECE_KING = 1;     // 帥 (Red: 1), 將 (Black: -1)
+export const PIECE_ADVISOR = 2;  // 仕 (Red: 2), 士 (Black: -2)
+export const PIECE_BISHOP = 3;   // 相 (Red: 3), 象 (Black: -3)
+export const PIECE_KNIGHT = 4;   // 傌 (Red: 4), 馬 (Black: -4)
+export const PIECE_ROOK = 5;     // 俥 (Red: 5), 車 (Black: -5)
+export const PIECE_CANNON = 6;   // 炮 (Red: 6), 砲 (Black: -6)
+export const PIECE_PAWN = 7;     // 兵 (Red: 7), 卒 (Black: -7)
+
+const COL_LETTERS = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+const CHINESE_DIGITS_RED = ["九", "八", "七", "六", "五", "四", "三", "二", "一"];
+const CHINESE_DIGITS_BLACK = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
+
+export interface RawXiangqiMove {
+  fromX: number;
+  fromY: number;
+  toX: number;
+  toY: number;
+  piece: number;
+  captured?: number;
+}
+
+export function coordToString(x: number, y: number): string {
+  const col = COL_LETTERS[x] || `${x}`;
+  return `${col}${y}`;
+}
+
+export function moveToString(fromX: number, fromY: number, toX: number, toY: number): string {
+  return `${coordToString(fromX, fromY)}${coordToString(toX, toY)}`;
+}
+
+export function stringToMove(moveStr: string): { fromX: number; fromY: number; toX: number; toY: number } | null {
+  const clean = moveStr.trim().toLowerCase();
+  const match = clean.match(/^([a-i])(\d)([a-i])(\d)$/);
+  if (!match) return null;
+
+  const fromX = COL_LETTERS.indexOf(match[1]);
+  const fromY = parseInt(match[2], 10);
+  const toX = COL_LETTERS.indexOf(match[3]);
+  const toY = parseInt(match[4], 10);
+
+  if (
+    fromX >= 0 && fromX < BOARD_COLS &&
+    fromY >= 0 && fromY < BOARD_ROWS &&
+    toX >= 0 && toX < BOARD_COLS &&
+    toY >= 0 && toY < BOARD_ROWS
+  ) {
+    return { fromX, fromY, toX, toY };
+  }
+  return null;
+}
+
+export function createInitialBoard(): number[][] {
+  const board: number[][] = Array.from({ length: BOARD_ROWS }, () => Array(BOARD_COLS).fill(0));
+
+  // Red Side (y = 0..3)
+  board[0][0] = PIECE_ROOK;
+  board[0][1] = PIECE_KNIGHT;
+  board[0][2] = PIECE_BISHOP;
+  board[0][3] = PIECE_ADVISOR;
+  board[0][4] = PIECE_KING;
+  board[0][5] = PIECE_ADVISOR;
+  board[0][6] = PIECE_BISHOP;
+  board[0][7] = PIECE_KNIGHT;
+  board[0][8] = PIECE_ROOK;
+
+  board[2][1] = PIECE_CANNON;
+  board[2][7] = PIECE_CANNON;
+
+  board[3][0] = PIECE_PAWN;
+  board[3][2] = PIECE_PAWN;
+  board[3][4] = PIECE_PAWN;
+  board[3][6] = PIECE_PAWN;
+  board[3][8] = PIECE_PAWN;
+
+  // Black Side (y = 6..9)
+  board[9][0] = -PIECE_ROOK;
+  board[9][1] = -PIECE_KNIGHT;
+  board[9][2] = -PIECE_BISHOP;
+  board[9][3] = -PIECE_ADVISOR;
+  board[9][4] = -PIECE_KING;
+  board[9][5] = -PIECE_ADVISOR;
+  board[9][6] = -PIECE_BISHOP;
+  board[9][7] = -PIECE_KNIGHT;
+  board[9][8] = -PIECE_ROOK;
+
+  board[7][1] = -PIECE_CANNON;
+  board[7][7] = -PIECE_CANNON;
+
+  board[6][0] = -PIECE_PAWN;
+  board[6][2] = -PIECE_PAWN;
+  board[6][4] = -PIECE_PAWN;
+  board[6][6] = -PIECE_PAWN;
+  board[6][8] = -PIECE_PAWN;
+
+  return board;
+}
+
+export function isRedPiece(val: number): boolean {
+  return val > 0;
+}
+
+export function isBlackPiece(val: number): boolean {
+  return val < 0;
+}
+
+export function isOwnPiece(val: number, player: number): boolean {
+  if (val === 0) return false;
+  return player === PLAYER_RED ? isRedPiece(val) : isBlackPiece(val);
+}
+
+export function isOpponentPiece(val: number, player: number): boolean {
+  if (val === 0) return false;
+  return player === PLAYER_RED ? isBlackPiece(val) : isRedPiece(val);
+}
+
+export function getPieceName(piece: number): string {
+  switch (piece) {
+    case PIECE_KING: return "帥";
+    case PIECE_ADVISOR: return "仕";
+    case PIECE_BISHOP: return "相";
+    case PIECE_KNIGHT: return "傌";
+    case PIECE_ROOK: return "俥";
+    case PIECE_CANNON: return "炮";
+    case PIECE_PAWN: return "兵";
+    case -PIECE_KING: return "將";
+    case -PIECE_ADVISOR: return "士";
+    case -PIECE_BISHOP: return "象";
+    case -PIECE_KNIGHT: return "馬";
+    case -PIECE_ROOK: return "車";
+    case -PIECE_CANNON: return "砲";
+    case -PIECE_PAWN: return "卒";
+    default: return "";
+  }
+}
+
+// Pseudo-legal moves generation without king safety check
+export function getPseudoLegalMoves(board: number[][], x: number, y: number): { toX: number; toY: number }[] {
+  const piece = board[y][x];
+  if (piece === 0) return [];
+  const player = isRedPiece(piece) ? PLAYER_RED : PLAYER_BLACK;
+  const absPiece = Math.abs(piece);
+  const moves: { toX: number; toY: number }[] = [];
+
+  const addIfValid = (tx: number, ty: number) => {
+    if (tx < 0 || tx >= BOARD_COLS || ty < 0 || ty >= BOARD_ROWS) return;
+    if (isOwnPiece(board[ty][tx], player)) return;
+    moves.push({ toX: tx, toY: ty });
+  };
+
+  switch (absPiece) {
+    case PIECE_KING: {
+      // Palace check: Red (x: 3..5, y: 0..2), Black (x: 3..5, y: 7..9)
+      const minX = 3, maxX = 5;
+      const minY = player === PLAYER_RED ? 0 : 7;
+      const maxY = player === PLAYER_RED ? 2 : 9;
+
+      const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+      for (const [dx, dy] of dirs) {
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= minX && nx <= maxX && ny >= minY && ny <= maxY) {
+          addIfValid(nx, ny);
+        }
+      }
+
+      // Flying General (飞将 / King faces King)
+      const stepY = player === PLAYER_RED ? 1 : -1;
+      let checkY = y + stepY;
+      while (checkY >= 0 && checkY < BOARD_ROWS) {
+        const target = board[checkY][x];
+        if (target !== 0) {
+          if (target === (player === PLAYER_RED ? -PIECE_KING : PIECE_KING)) {
+            moves.push({ toX: x, toY: checkY });
+          }
+          break;
+        }
+        checkY += stepY;
+      }
+      break;
+    }
+
+    case PIECE_ADVISOR: {
+      // Palace diagonal steps
+      const minX = 3, maxX = 5;
+      const minY = player === PLAYER_RED ? 0 : 7;
+      const maxY = player === PLAYER_RED ? 2 : 9;
+
+      const dirs = [[1, 1], [1, -1], [-1, 1], [-1, -1]];
+      for (const [dx, dy] of dirs) {
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= minX && nx <= maxX && ny >= minY && ny <= maxY) {
+          addIfValid(nx, ny);
+        }
+      }
+      break;
+    }
+
+    case PIECE_BISHOP: {
+      // Diagonal 2 steps, cannot cross river, elephant eye check
+      const minY = player === PLAYER_RED ? 0 : 5;
+      const maxY = player === PLAYER_RED ? 4 : 9;
+
+      const dirs = [[2, 2], [2, -2], [-2, 2], [-2, -2]];
+      for (const [dx, dy] of dirs) {
+        const nx = x + dx;
+        const ny = y + dy;
+        const eyeX = x + dx / 2;
+        const eyeY = y + dy / 2;
+        if (nx >= 0 && nx < BOARD_COLS && ny >= minY && ny <= maxY) {
+          if (board[eyeY][eyeX] === 0) {
+            addIfValid(nx, ny);
+          }
+        }
+      }
+      break;
+    }
+
+    case PIECE_KNIGHT: {
+      // 8 horse directions with horse leg check (蹩马腿)
+      const knightMoves = [
+        { dx: 1, dy: 2, legX: 0, legY: 1 },
+        { dx: -1, dy: 2, legX: 0, legY: 1 },
+        { dx: 1, dy: -2, legX: 0, legY: -1 },
+        { dx: -1, dy: -2, legX: 0, legY: -1 },
+        { dx: 2, dy: 1, legX: 1, legY: 0 },
+        { dx: 2, dy: -1, legX: 1, legY: 0 },
+        { dx: -2, dy: 1, legX: -1, legY: 0 },
+        { dx: -2, dy: -1, legX: -1, legY: 0 }
+      ];
+
+      for (const m of knightMoves) {
+        const nx = x + m.dx;
+        const ny = y + m.dy;
+        const lx = x + m.legX;
+        const ly = y + m.legY;
+        if (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny < BOARD_ROWS) {
+          if (board[ly][lx] === 0) {
+            addIfValid(nx, ny);
+          }
+        }
+      }
+      break;
+    }
+
+    case PIECE_ROOK: {
+      // 4 orthogonal straight lines
+      const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+      for (const [dx, dy] of dirs) {
+        let nx = x + dx;
+        let ny = y + dy;
+        while (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny < BOARD_ROWS) {
+          const target = board[ny][nx];
+          if (target === 0) {
+            moves.push({ toX: nx, toY: ny });
+          } else {
+            if (isOpponentPiece(target, player)) {
+              moves.push({ toX: nx, toY: ny });
+            }
+            break;
+          }
+          nx += dx;
+          ny += dy;
+        }
+      }
+      break;
+    }
+
+    case PIECE_CANNON: {
+      // 4 orthogonal lines: move like rook before obstacle, jump over 1 screen to capture
+      const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+      for (const [dx, dy] of dirs) {
+        let nx = x + dx;
+        let ny = y + dy;
+        let jumped = false;
+
+        while (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny < BOARD_ROWS) {
+          const target = board[ny][nx];
+          if (!jumped) {
+            if (target === 0) {
+              moves.push({ toX: nx, toY: ny });
+            } else {
+              jumped = true; // Screen found!
+            }
+          } else {
+            if (target !== 0) {
+              if (isOpponentPiece(target, player)) {
+                moves.push({ toX: nx, toY: ny });
+              }
+              break; // Second obstacle reached, stop
+            }
+          }
+          nx += dx;
+          ny += dy;
+        }
+      }
+      break;
+    }
+
+    case PIECE_PAWN: {
+      // Red: moves up (y+1). After river (y >= 5), can also move left/right (x±1)
+      // Black: moves down (y-1). After river (y <= 4), can also move left/right (x±1)
+      const forwardY = player === PLAYER_RED ? 1 : -1;
+      const crossedRiver = player === PLAYER_RED ? y >= 5 : y <= 4;
+
+      addIfValid(x, y + forwardY);
+      if (crossedRiver) {
+        addIfValid(x - 1, y);
+        addIfValid(x + 1, y);
+      }
+      break;
+    }
+  }
+
+  return moves;
+}
+
+// Find king coordinate
+export function findKing(board: number[][], player: number): { x: number; y: number } | null {
+  const target = player === PLAYER_RED ? PIECE_KING : -PIECE_KING;
+  for (let y = 0; y < BOARD_ROWS; y++) {
+    for (let x = 0; x < BOARD_COLS; x++) {
+      if (board[y][x] === target) {
+        return { x, y };
+      }
+    }
+  }
+  return null;
+}
+
+// Check if King is attacked or facing opponent King directly
+export function isKingInCheck(board: number[][], player: number): boolean {
+  const king = findKing(board, player);
+  if (!king) return true; // No king means king was captured
+
+  // Check Flying General (对将)
+  const oppKingVal = player === PLAYER_RED ? -PIECE_KING : PIECE_KING;
+  const stepY = player === PLAYER_RED ? 1 : -1;
+  let cy = king.y + stepY;
+  while (cy >= 0 && cy < BOARD_ROWS) {
+    const p = board[cy][king.x];
+    if (p !== 0) {
+      if (p === oppKingVal) return true; // Direct line of sight!
+      break;
+    }
+    cy += stepY;
+  }
+
+  // Check if any opponent piece attacks the King
+  for (let y = 0; y < BOARD_ROWS; y++) {
+    for (let x = 0; x < BOARD_COLS; x++) {
+      const piece = board[y][x];
+      if (isOpponentPiece(piece, player)) {
+        const moves = getPseudoLegalMoves(board, x, y);
+        if (moves.some((m) => m.toX === king.x && m.toY === king.y)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+// Generate fully verified legal moves for player
+export function getLegalMoves(board: number[][], player: number): RawXiangqiMove[] {
+  const legalMoves: RawXiangqiMove[] = [];
+
+  for (let y = 0; y < BOARD_ROWS; y++) {
+    for (let x = 0; x < BOARD_COLS; x++) {
+      const piece = board[y][x];
+      if (isOwnPiece(piece, player)) {
+        const pseudo = getPseudoLegalMoves(board, x, y);
+        for (const m of pseudo) {
+          // Clone and simulate move
+          const nextBoard = board.map((row) => [...row]);
+          const captured = nextBoard[m.toY][m.toX];
+          nextBoard[m.toY][m.toX] = piece;
+          nextBoard[y][x] = 0;
+
+          if (!isKingInCheck(nextBoard, player)) {
+            legalMoves.push({
+              fromX: x,
+              fromY: y,
+              toX: m.toX,
+              toY: m.toY,
+              piece,
+              captured: captured !== 0 ? captured : undefined
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return legalMoves;
+}
+
+// Convert move to traditional Chinese notation (e.g. 炮二平五, 马八进七, 车1进3)
+export function toChineseNotation(board: number[][], move: RawXiangqiMove, player: number): string {
+  const piece = move.piece;
+  const name = getPieceName(piece);
+  const isRed = player === PLAYER_RED;
+  const digits = isRed ? CHINESE_DIGITS_RED : CHINESE_DIGITS_BLACK;
+
+  const fromCol = isRed ? digits[move.fromX] : digits[move.fromX];
+  const toCol = isRed ? digits[move.toX] : digits[move.toX];
+
+  const dx = move.toX - move.fromX;
+  const dy = move.toY - move.fromY;
+
+  // Straight line pieces vs diagonal pieces
+  const absPiece = Math.abs(piece);
+
+  if (absPiece === PIECE_ROOK || absPiece === PIECE_CANNON || absPiece === PIECE_PAWN || absPiece === PIECE_KING) {
+    if (dy === 0) {
+      // Horizontal move
+      return `${name}${fromCol}平${toCol}`;
+    }
+    const stepCount = Math.abs(dy);
+    const stepDigit = isRed ? digits[9 - stepCount] : digits[stepCount - 1];
+    const isAdvancing = isRed ? dy > 0 : dy < 0;
+    const action = isAdvancing ? "进" : "退";
+    return `${name}${fromCol}${action}${stepDigit}`;
+  } else {
+    // Diagonal pieces (Knight, Advisor, Bishop)
+    const isAdvancing = isRed ? dy > 0 : dy < 0;
+    const action = isAdvancing ? "进" : "退";
+    return `${name}${fromCol}${action}${toCol}`;
+  }
+}
+
+// Piece value for tactical threat evaluation
+const PIECE_VALUES: Record<number, number> = {
+  [PIECE_KING]: 10000,
+  [PIECE_ROOK]: 1000,
+  [PIECE_CANNON]: 450,
+  [PIECE_KNIGHT]: 400,
+  [PIECE_ADVISOR]: 200,
+  [PIECE_BISHOP]: 200,
+  [PIECE_PAWN]: 100
+};
+
+export function getCandidateMoves(board: number[][], player: number): LegalGameMove[] {
+  const legal = getLegalMoves(board, player);
+  if (legal.length === 0) return [];
+
+  const opponent = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+
+  const scored = legal.map((move) => {
+    const actionId = moveToString(move.fromX, move.fromY, move.toX, move.toY);
+    const chineseDesc = toChineseNotation(board, move, player);
+
+    // Simulate move
+    const nextBoard = board.map((row) => [...row]);
+    nextBoard[move.toY][move.toX] = move.piece;
+    nextBoard[move.fromY][move.fromX] = 0;
+
+    const oppInCheck = isKingInCheck(nextBoard, opponent);
+    const oppLegalCount = oppInCheck ? getLegalMoves(nextBoard, opponent).length : 10;
+
+    let priority = 10;
+    let threatLevel: "winning" | "critical_block" | "attack" | "normal" = "normal";
+
+    if (oppInCheck && oppLegalCount === 0) {
+      threatLevel = "winning";
+      priority = 10000;
+    } else if (move.captured) {
+      const capVal = PIECE_VALUES[Math.abs(move.captured)] || 100;
+      priority = 200 + capVal;
+      threatLevel = capVal >= 400 ? "attack" : "normal";
+    } else if (oppInCheck) {
+      threatLevel = "attack";
+      priority = 300;
+    } else {
+      // Positional preference: develop Knights, Rooks and central control
+      const absPiece = Math.abs(move.piece);
+      if (absPiece === PIECE_CANNON && (move.toX === 4 || move.toX === 2 || move.toX === 6)) priority += 50;
+      if (absPiece === PIECE_KNIGHT && (move.toY >= 2 && move.toY <= 7)) priority += 40;
+      if (absPiece === PIECE_ROOK && (move.toY === 0 || move.toY === 9 || move.toX === 1 || move.toX === 7)) priority += 60;
+    }
+
+    let fullDesc = `${chineseDesc} (${coordToString(move.fromX, move.fromY)}->${coordToString(move.toX, move.toY)})`;
+    if (threatLevel === "winning") fullDesc += " [绝杀将军]";
+    else if (move.captured) fullDesc += ` [吃${getPieceName(move.captured)}]`;
+    else if (oppInCheck) fullDesc += " [将军]";
+
+    return {
+      actionId,
+      x: move.toX,
+      y: move.toY,
+      fromX: move.fromX,
+      fromY: move.fromY,
+      toX: move.toX,
+      toY: move.toY,
+      coord: actionId,
+      description: fullDesc,
+      threatLevel,
+      priority
+    };
+  });
+
+  scored.sort((a, b) => b.priority - a.priority);
+
+  return scored.slice(0, 30).map((s) => ({
+    actionId: s.actionId,
+    x: s.x,
+    y: s.y,
+    fromX: s.fromX,
+    fromY: s.fromY,
+    toX: s.toX,
+    toY: s.toY,
+    coord: s.coord,
+    description: s.description,
+    threatLevel: s.threatLevel
+  }));
+}
+
+export class XiangqiGameInstance {
+  public gameId: string;
+  public status: GameStatus = "playing";
+  public turn: number = PLAYER_RED; // Red moves first
+  public board: number[][];
+  public moveHistory: GameMoveRecord[] = [];
+  public chatHistory: GameChatMessage[] = [];
+  public winner: number | null = null;
+  public updatedAt: number = Date.now();
+
+  constructor(gameId: string) {
+    this.gameId = gameId;
+    this.board = createInitialBoard();
+  }
+
+  public static fromSnapshot(snapshot: GameStateSnapshot): XiangqiGameInstance {
+    const inst = new XiangqiGameInstance(snapshot.gameId);
+    inst.status = snapshot.status;
+    inst.turn = snapshot.turn;
+    inst.winner = snapshot.winner ?? null;
+    inst.board = snapshot.board ? snapshot.board.map((row) => [...row]) : createInitialBoard();
+    inst.moveHistory = [...(snapshot.moveHistory || [])];
+    inst.chatHistory = [...(snapshot.chatHistory || [])];
+    inst.updatedAt = snapshot.updatedAt || Date.now();
+    return inst;
+  }
+
+  public getSnapshot(): GameStateSnapshot {
+    return {
+      gameType: "xiangqi",
+      gameId: this.gameId,
+      status: this.status,
+      turn: this.turn,
+      stepCount: this.moveHistory.length,
+      winner: this.winner,
+      board: this.board.map((row) => [...row]),
+      lastMove: this.moveHistory.length > 0 ? this.moveHistory[this.moveHistory.length - 1] : null,
+      moveHistory: [...this.moveHistory],
+      legalMoves: this.status === "playing" ? getCandidateMoves(this.board, this.turn) : [],
+      chatHistory: [...this.chatHistory],
+      updatedAt: this.updatedAt
+    };
+  }
+
+  public applyMove(
+    actionId: string,
+    player: number,
+    reason?: string
+  ): { ok: boolean; error?: string; winner?: number | null; chineseMove?: string } {
+    if (this.status !== "playing") {
+      return { ok: false, error: `Game is already over with status '${this.status}'.` };
+    }
+
+    if (this.turn !== player) {
+      return { ok: false, error: `Not player ${player}'s turn. Current turn: ${this.turn}` };
+    }
+
+    const moveCoords = stringToMove(actionId);
+    if (!moveCoords) {
+      return { ok: false, error: `Invalid Xiangqi actionId '${actionId}'. Format should be like 'b2e2' or 'h0g2'.` };
+    }
+
+    const { fromX, fromY, toX, toY } = moveCoords;
+    const piece = this.board[fromY][fromX];
+
+    if (!isOwnPiece(piece, player)) {
+      return { ok: false, error: `No valid piece belonging to player ${player} at (${fromX}, ${fromY}). Found: ${piece}` };
+    }
+
+    // Validate legality
+    const legalMoves = getLegalMoves(this.board, player);
+    const match = legalMoves.find(
+      (m) => m.fromX === fromX && m.fromY === fromY && m.toX === toX && m.toY === toY
+    );
+
+    if (!match) {
+      return { ok: false, error: `Move '${actionId}' (${getPieceName(piece)}) is illegal according to Xiangqi rules or leaves King in check.` };
+    }
+
+    const chineseMove = toChineseNotation(this.board, match, player);
+    const capturedPiece = this.board[toY][toX] !== 0 ? this.board[toY][toX] : undefined;
+
+    // Apply move
+    this.board[toY][toX] = piece;
+    this.board[fromY][fromX] = 0;
+
+    const moveRecord: GameMoveRecord = {
+      actionId,
+      x: toX,
+      y: toY,
+      fromX,
+      fromY,
+      toX,
+      toY,
+      piece,
+      capturedPiece,
+      player,
+      stepIndex: this.moveHistory.length + 1,
+      timestamp: Date.now(),
+      reason
+    };
+    this.moveHistory.push(moveRecord);
+    this.updatedAt = Date.now();
+
+    // Check opponent status
+    const opponent = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+    const opponentLegalMoves = getLegalMoves(this.board, opponent);
+
+    if (opponentLegalMoves.length === 0) {
+      // Opponent is checkmated or stalemated
+      this.status = player === PLAYER_RED ? "player_won" : "agent_won";
+      this.winner = player;
+      return { ok: true, winner: player, chineseMove };
+    }
+
+    // Switch turn
+    this.turn = opponent;
+    return { ok: true, chineseMove };
+  }
+
+  public addChat(
+    sender: "player" | "agent" | "system",
+    message: string,
+    mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring"
+  ): GameChatMessage {
+    const chat: GameChatMessage = {
+      sender,
+      message: message.trim(),
+      mood,
+      timestamp: Date.now()
+    };
+    this.chatHistory.push(chat);
+    this.updatedAt = Date.now();
+    return chat;
+  }
+
+  public resign(player: number, reason?: string): { ok: boolean; winner: number } {
+    if (this.status !== "playing") {
+      return { ok: false, winner: this.winner || 0 };
+    }
+    const winningPlayer = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+    this.status = winningPlayer === PLAYER_RED ? "player_won" : "agent_won";
+    this.winner = winningPlayer;
+    this.updatedAt = Date.now();
+    this.addChat(
+      player === PLAYER_RED ? "player" : "agent",
+      reason ? `认输: ${reason}` : "我认输了，这一局你下得漂亮！",
+      "calm"
+    );
+    return { ok: true, winner: winningPlayer };
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,12 +15,19 @@ import { startWebUIServer } from "./webUIServer.js";
 import { setLocalInvokeWindowGetter } from "./invokeRegistry.js";
 import { setButlerAppWindowGetter } from "./butlerToolService.js";
 import { ensureOwnerUser, getOwnerUser } from "./cli/users.js";
-import { bindConversationNotifier } from "./cli/conversations.js";
+import { bindConversationNotifier, getConversation, updateConversationMetadata } from "./cli/conversations.js";
 import { bindDelegationRunFinishedNotifier } from "./cli/delegationRuns.js";
 import { applyOwnerBackfill } from "./cli/ownerBackfill.js";
 import { initFileBridge } from "./fileBridge.js";
 import { getDb } from "./cli/db.js";
 import { getSetting, setSetting } from "./cli/settings.js";
+import {
+  getOrCreateGame,
+  handlePlayerMove,
+  handleAgentMove,
+  handleResetGame,
+  initGamePersistence
+} from "./gameToolService.js";
 import {
   initRemoteControl,
   getConfiguredBindMode,
@@ -1227,6 +1234,40 @@ function registerButlerBuddyWindowIpc() {
     if (!isButlerBuddyTaskResultSender(event.sender)) return;
     butlerBuddyStateCoordinator.reportTaskResult(result);
   });
+  ipcMain.handle("game:getState", (_event, conversationId: string) => {
+    return getOrCreateGame(conversationId).getSnapshot();
+  });
+  ipcMain.handle(
+    "game:playerMove",
+    (event, payload: { conversationId: string; actionId: string }) => {
+      return handlePlayerMove(payload.conversationId, payload.actionId, event.sender);
+    }
+  );
+  ipcMain.handle(
+    "game:agentMove",
+    (
+      event,
+      payload: {
+        conversationId: string;
+        actionId: string;
+        reason?: string;
+        speech?: string;
+        mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring";
+      }
+    ) => {
+      return handleAgentMove(
+        payload.conversationId,
+        payload.actionId,
+        payload.reason,
+        payload.speech,
+        payload.mood,
+        event.sender
+      );
+    }
+  );
+  ipcMain.handle("game:resetGame", (event, conversationId: string) => {
+    return handleResetGame(conversationId, event.sender);
+  });
   ipcMain.handle(
     "butlerBuddy:updatePreferences",
     (
@@ -1567,6 +1608,7 @@ app.whenReady().then(async () => {
   initializeAgentUsageReconciler();
   initializeTelemetry();
   cleanupOrphanManagedAttachments();
+  initGamePersistence(getConversation, updateConversationMetadata);
   seedBuiltinSkills();
   seedBuiltinWorkflowTeams();
   seedBuiltinDelegationTeams();

--- a/electron/mcp/gameMcpServer.ts
+++ b/electron/mcp/gameMcpServer.ts
@@ -181,6 +181,37 @@ export function createGameMcpServer(): McpServer {
     }
   );
 
+  // Tool 5: Get full move and chat history
+  server.registerTool(
+    "game_get_history",
+    {
+      title: "Get Move History",
+      description:
+        "获取本局对弈的历史走法记录 (moveHistory) 与对白记录。用于复盘、分析过往招法或推演棋谱。",
+      inputSchema: {
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(200)
+          .optional()
+          .describe("获取最近 N 步历史，默认返回全部历史")
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true
+      }
+    },
+    async ({ limit }) => {
+      try {
+        return toolResult(await invokeGameBridge("get_history", { limit }));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
   return server;
 }
 

--- a/electron/mcp/gameMcpServer.ts
+++ b/electron/mcp/gameMcpServer.ts
@@ -1,0 +1,203 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+import type { GameAction, GameToolResult } from "../shared/gameToolProtocol.js";
+
+function bridgeEnvironment(): { endpoint: string; token: string } {
+  const endpoint = process.env.FREEBUDDY_GAME_ENDPOINT?.trim();
+  const token = process.env.FREEBUDDY_GAME_TOKEN?.trim();
+  if (!endpoint || !token) {
+    throw new Error("FreeBuddy Game tool environment is incomplete. Missing FREEBUDDY_GAME_ENDPOINT or TOKEN.");
+  }
+  return { endpoint, token };
+}
+
+export async function invokeGameBridge(
+  action: GameAction,
+  params: Record<string, unknown>
+): Promise<GameToolResult> {
+  const { endpoint, token } = bridgeEnvironment();
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ action, params }),
+    signal: AbortSignal.timeout(20_000)
+  });
+
+  const result = (await response.json().catch(() => ({
+    ok: false,
+    error: `Game bridge returned HTTP ${response.status}`
+  }))) as GameToolResult;
+
+  if (!response.ok) {
+    throw new Error(result.error || `Game bridge returned HTTP ${response.status}`);
+  }
+  return result;
+}
+
+function toolResult(result: GameToolResult) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2)
+      }
+    ],
+    structuredContent: result,
+    ...(result.ok === false ? { isError: true } : {})
+  };
+}
+
+function toolError(error: unknown) {
+  return toolResult({
+    ok: false,
+    error: (error as Error)?.message || String(error)
+  });
+}
+
+export function createGameMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "freebuddy-game",
+    version: process.env.FB_APP_VERSION || "0.8.7"
+  });
+
+  // Tool 1: Get live board state & legal moves
+  server.registerTool(
+    "game_get_state",
+    {
+      title: "Get Board State",
+      description:
+        "获取当前棋盘/牌局最新局势。返回当前执子方、手牌/棋盘矩阵、上一步着法，以及按战术威胁排序的合法候选走法列表 (legalMoves)。",
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true
+      }
+    },
+    async () => {
+      try {
+        return toolResult(await invokeGameBridge("get_state", {}));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
+  // Tool 2: Submit a move
+  server.registerTool(
+    "game_make_move",
+    {
+      title: "Make Game Move",
+      description:
+        "在当前对局中执行落子或出牌。必须传入合法的 actionId (如 'H8'、'E5' 等)。若落子非法将返回错误信息供你调整。",
+      inputSchema: {
+        actionId: z
+          .string()
+          .trim()
+          .min(1)
+          .describe("合法候选走法列表中的唯一 ID/坐标，如 'H8', 'D4'"),
+        reason: z
+          .string()
+          .trim()
+          .optional()
+          .describe("简要阐明本步落子的战术意图（进攻/防守/封堵）")
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false
+      }
+    },
+    async ({ actionId, reason }) => {
+      try {
+        return toolResult(await invokeGameBridge("make_move", { actionId, reason }));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
+  // Tool 3: In-game trash talk & roleplay chat
+  server.registerTool(
+    "game_send_chat",
+    {
+      title: "Send In-Game Chat",
+      description:
+        "在棋盘上方和聊天流中向对手发送一句心理战垃圾话、性格台词或局势评价，增加对局趣味性。",
+      inputSchema: {
+        message: z
+          .string()
+          .trim()
+          .min(1)
+          .max(300)
+          .describe("要对玩家说的台词内容（短小精炼，符合你的人设）"),
+        mood: z
+          .enum(["confident", "mocking", "nervous", "calm", "admiring"])
+          .optional()
+          .describe("台词对应的情绪基调")
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false
+      }
+    },
+    async ({ message, mood }) => {
+      try {
+        return toolResult(await invokeGameBridge("send_chat", { message, mood }));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
+  // Tool 4: Resign
+  server.registerTool(
+    "game_resign",
+    {
+      title: "Resign Match",
+      description: "当确定大势已去无法挽回时，主动认输投降，体面结束本局对弈。",
+      inputSchema: {
+        reason: z.string().trim().optional().describe("认输感言或局势说明")
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true
+      }
+    },
+    async ({ reason }) => {
+      try {
+        return toolResult(await invokeGameBridge("resign", { reason }));
+      } catch (error) {
+        return toolError(error);
+      }
+    }
+  );
+
+  return server;
+}
+
+export async function runGameMcpServer(): Promise<void> {
+  const server = createGameMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+const isDirectEntry =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url).toLowerCase() ===
+    path.resolve(process.argv[1]).toLowerCase();
+
+if (isDirectEntry) {
+  runGameMcpServer().catch((error) => {
+    console.error("[FreeBuddy] Game MCP server failed:", error);
+    process.exit(1);
+  });
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -833,6 +833,33 @@ const remote = {
   listAuditLog: (limit?: number) => ipcRenderer.invoke("remote:listAuditLog", limit)
 };
 
+const game = {
+  getState: (conversationId: string) => ipcRenderer.invoke("game:getState", conversationId),
+  playerMove: (conversationId: string, actionId: string) =>
+    ipcRenderer.invoke("game:playerMove", { conversationId, actionId }),
+  agentMove: (
+    conversationId: string,
+    actionId: string,
+    reason?: string,
+    speech?: string,
+    mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring"
+  ) =>
+    ipcRenderer.invoke("game:agentMove", {
+      conversationId,
+      actionId,
+      reason,
+      speech,
+      mood
+    }),
+  resetGame: (conversationId: string) => ipcRenderer.invoke("game:resetGame", conversationId),
+  onGameEvent: (cb: (event: unknown) => void): (() => void) => {
+    const channel = "freebuddy://game-event";
+    const handler = (_e: IpcRendererEvent, payload: unknown) => cb(payload);
+    ipcRenderer.on(channel, handler);
+    return () => ipcRenderer.off(channel, handler);
+  }
+};
+
 contextBridge.exposeInMainWorld("freebuddy", {
   platform: process.platform,
   arch: process.arch,
@@ -857,5 +884,6 @@ contextBridge.exposeInMainWorld("freebuddy", {
   debugLogs,
   shell: shellApi,
   remote,
-  butlerBuddy
+  butlerBuddy,
+  game
 });

--- a/electron/previewServer.ts
+++ b/electron/previewServer.ts
@@ -12,6 +12,7 @@ import { handleBrowserToolHttpRequest } from "./browserToolService.js";
 import { handleWorkspaceFsToolHttpRequest } from "./workspaceFsToolService.js";
 import { handleButlerToolHttpRequest } from "./butlerToolService.js";
 import { handleDelegateToolHttpRequest } from "./delegationToolService.js";
+import { handleGameToolHttpRequest } from "./gameToolService.js";
 
 let previewServer: http.Server | null = null;
 
@@ -35,6 +36,7 @@ export function startPreviewServer(
         if (await handleWorkspaceFsToolHttpRequest(req, res)) return;
         if (await handleButlerToolHttpRequest(req, res)) return;
         if (await handleDelegateToolHttpRequest(req, res)) return;
+        if (await handleGameToolHttpRequest(req, res)) return;
         const parsed = parseBridgeRequest(req.url || "");
         if (parsed && isKnownBridgeAction(parsed.action)) {
           safeSendToWebContents(getWebContents(), "freebuddy://bridge", parsed);

--- a/electron/shared/gameToolProtocol.ts
+++ b/electron/shared/gameToolProtocol.ts
@@ -1,0 +1,92 @@
+export type GameType = "gomoku" | "xiangqi" | "doudizhu";
+
+export type GameAction =
+  | "get_state"
+  | "make_move"
+  | "send_chat"
+  | "resign"
+  | "reset";
+
+export type GameStatus =
+  | "waiting"
+  | "playing"
+  | "player_won"
+  | "agent_won"
+  | "draw"
+  | "resigned";
+
+export interface GameMoveRecord {
+  actionId: string;
+  x: number;
+  y: number;
+  fromX?: number;
+  fromY?: number;
+  toX?: number;
+  toY?: number;
+  piece?: number;
+  capturedPiece?: number;
+  player: number; // 1: Player, 2: Agent
+  stepIndex: number;
+  timestamp: number;
+  reason?: string;
+}
+
+export interface LegalGameMove {
+  actionId: string;
+  x: number;
+  y: number;
+  fromX?: number;
+  fromY?: number;
+  toX?: number;
+  toY?: number;
+  coord: string; // e.g. "H8" or "b2e2"
+  description?: string;
+  threatLevel?: "winning" | "critical_block" | "attack" | "normal";
+}
+
+export interface GameChatMessage {
+  sender: "player" | "agent" | "system";
+  message: string;
+  mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring";
+  timestamp: number;
+}
+
+export interface GameStateSnapshot {
+  gameType: GameType;
+  gameId: string;
+  status: GameStatus;
+  turn: number; // 1: Player, 2: Agent
+  stepCount: number;
+  winner?: number | null;
+  board: number[][]; // 15x15 for Gomoku (0: empty, 1: player, 2: agent)
+  lastMove?: GameMoveRecord | null;
+  moveHistory: GameMoveRecord[];
+  legalMoves: LegalGameMove[];
+  chatHistory: GameChatMessage[];
+  updatedAt: number;
+}
+
+export interface GameToolEvent {
+  conversationId: string;
+  gameType: GameType;
+  action: GameAction;
+  params: Record<string, unknown>;
+}
+
+export interface GameToolResult {
+  ok: boolean;
+  gameId?: string;
+  gameState?: GameStateSnapshot;
+  message?: string;
+  error?: string;
+  actionId?: string;
+  chat?: GameChatMessage;
+  [key: string]: unknown;
+}
+
+export interface GameToolBinding {
+  token: string;
+  taskSessionId: string;
+  conversationId?: string;
+  gameType: GameType;
+}

--- a/electron/shared/gameToolProtocol.ts
+++ b/electron/shared/gameToolProtocol.ts
@@ -5,7 +5,8 @@ export type GameAction =
   | "make_move"
   | "send_chat"
   | "resign"
-  | "reset";
+  | "reset"
+  | "get_history";
 
 export type GameStatus =
   | "waiting"
@@ -58,9 +59,10 @@ export interface GameStateSnapshot {
   turn: number; // 1: Player, 2: Agent
   stepCount: number;
   winner?: number | null;
-  board: number[][]; // 15x15 for Gomoku (0: empty, 1: player, 2: agent)
+  board: number[][]; // 15x15 for Gomoku, 10x9 for Xiangqi
   lastMove?: GameMoveRecord | null;
-  moveHistory: GameMoveRecord[];
+  moveHistory?: GameMoveRecord[];
+  recentMoves?: GameMoveRecord[];
   legalMoves: LegalGameMove[];
   chatHistory: GameChatMessage[];
   updatedAt: number;
@@ -76,11 +78,15 @@ export interface GameToolEvent {
 export interface GameToolResult {
   ok: boolean;
   gameId?: string;
+  gameType?: GameType;
   gameState?: GameStateSnapshot;
   message?: string;
   error?: string;
   actionId?: string;
   chat?: GameChatMessage;
+  moveHistory?: GameMoveRecord[];
+  chatHistory?: GameChatMessage[];
+  stepCount?: number;
   [key: string]: unknown;
 }
 

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -11,7 +11,6 @@
   let status = "playing";
   let lastMove = null;
   let hoverCoord = null;
-  let audioCtx = null;
 
   // DOM Elements
   const canvas = document.getElementById("gomoku-canvas");

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -61,11 +61,11 @@
   function updateMuteButtonUI() {
     if (!muteBtn) return;
     if (isMuted) {
-      muteBtn.textContent = "🔇";
+      muteBtn.textContent = "🔇 静音";
       muteBtn.classList.add("muted");
       muteBtn.title = "音效已静音（点击开启）";
     } else {
-      muteBtn.textContent = "🔊";
+      muteBtn.textContent = "🔊 音效";
       muteBtn.classList.remove("muted");
       muteBtn.title = "音效已开启（点击静音）";
     }

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -48,26 +48,41 @@
     });
   }
 
-  function getAudioContext() {
-    if (isMuted) return null;
+  function withAudio(callback) {
+    if (isMuted) return;
     try {
       if (!audioCtx) {
         audioCtx = new (window.AudioContext || window.webkitAudioContext)();
       }
       if (audioCtx.state === "suspended") {
+        audioCtx.resume().then(() => {
+          if (audioCtx && audioCtx.state === "running") {
+            callback(audioCtx);
+          }
+        }).catch(() => {});
+      } else if (audioCtx.state === "running") {
+        callback(audioCtx);
+      }
+    } catch {}
+  }
+
+  // Global user interaction unlock
+  const unlockAudio = () => {
+    try {
+      if (!audioCtx) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      if (audioCtx && audioCtx.state === "suspended") {
         audioCtx.resume();
       }
-      return audioCtx;
-    } catch {
-      return null;
-    }
-  }
+    } catch {}
+  };
+  window.addEventListener("pointerdown", unlockAudio, { passive: true });
+  window.addEventListener("keydown", unlockAudio, { passive: true });
 
   // 1. Crisp Stone Placement Click (云子落盘)
   function playStoneSound() {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const now = ctx.currentTime;
       // High-pitch stone snap
       const osc1 = ctx.createOscillator();
@@ -75,7 +90,7 @@
       osc1.type = "sine";
       osc1.frequency.setValueAtTime(620, now);
       osc1.frequency.exponentialRampToValueAtTime(220, now + 0.05);
-      gain1.gain.setValueAtTime(0.35, now);
+      gain1.gain.setValueAtTime(0.4, now);
       gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.05);
       osc1.connect(gain1);
       gain1.connect(ctx.destination);
@@ -88,20 +103,18 @@
       osc2.type = "triangle";
       osc2.frequency.setValueAtTime(240, now);
       osc2.frequency.exponentialRampToValueAtTime(90, now + 0.08);
-      gain2.gain.setValueAtTime(0.25, now);
+      gain2.gain.setValueAtTime(0.28, now);
       gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
       osc2.connect(gain2);
       gain2.connect(ctx.destination);
       osc2.start(now);
       osc2.stop(now + 0.08);
-    } catch {}
+    });
   }
 
   // 2. Victory Arpeggio (旗开得胜和弦)
   function playVictorySound() {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const notes = [523.25, 659.25, 783.99, 1046.5]; // C5, E5, G5, C6
       const now = ctx.currentTime;
       notes.forEach((freq, idx) => {
@@ -110,21 +123,19 @@
         const gain = ctx.createGain();
         osc.type = "triangle";
         osc.frequency.setValueAtTime(freq, start);
-        gain.gain.setValueAtTime(0.28, start);
+        gain.gain.setValueAtTime(0.3, start);
         gain.gain.exponentialRampToValueAtTime(0.001, start + 0.35);
         osc.connect(gain);
         gain.connect(ctx.destination);
         osc.start(start);
         osc.stop(start + 0.35);
       });
-    } catch {}
+    });
   }
 
   // 3. Defeat Tone (惜败音效)
   function playDefeatSound() {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const notes = [392.0, 349.23, 311.13, 261.63]; // G4, F4, Eb4, C4
       const now = ctx.currentTime;
       notes.forEach((freq, idx) => {
@@ -133,14 +144,14 @@
         const gain = ctx.createGain();
         osc.type = "sine";
         osc.frequency.setValueAtTime(freq, start);
-        gain.gain.setValueAtTime(0.22, start);
+        gain.gain.setValueAtTime(0.24, start);
         gain.gain.exponentialRampToValueAtTime(0.001, start + 0.28);
         osc.connect(gain);
         gain.connect(ctx.destination);
         osc.start(start);
         osc.stop(start + 0.28);
       });
-    } catch {}
+    });
   }
 
   function coordToString(x, y) {

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -277,9 +277,9 @@
     }
     ctx.stroke();
 
-    // Coordinates labels
-    ctx.fillStyle = "#6b4423";
-    ctx.font = `600 ${Math.max(10, cellSize * 0.34)}px -apple-system, BlinkMacSystemFont, sans-serif`;
+    // Coordinates labels (Subtle left & bottom)
+    ctx.fillStyle = "rgba(107, 68, 35, 0.45)";
+    ctx.font = `500 ${Math.max(9, cellSize * 0.28)}px -apple-system, BlinkMacSystemFont, sans-serif`;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
 

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -1,0 +1,431 @@
+(function () {
+  const BOARD_SIZE = 15;
+  const COLS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"];
+  const STAR_POINTS = [
+    [3, 3], [11, 3], [7, 7], [3, 11], [11, 11]
+  ];
+
+  // State
+  let board = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(0));
+  let turn = 1; // 1: Player (Black), 2: Agent (White)
+  let status = "playing";
+  let lastMove = null;
+  let hoverCoord = null;
+  let audioCtx = null;
+
+  // DOM Elements
+  const canvas = document.getElementById("gomoku-canvas");
+  const ctx = canvas.getContext("2d");
+  const turnBadge = document.getElementById("turn-badge");
+  const speechText = document.getElementById("speech-text");
+  const statusText = document.getElementById("status-text");
+  const modal = document.getElementById("game-over-modal");
+  const modalTitle = document.getElementById("modal-title");
+  const modalDesc = document.getElementById("modal-desc");
+  const restartBtn = document.getElementById("restart-btn");
+  const resignBtn = document.getElementById("resign-btn");
+  const modalRestartBtn = document.getElementById("modal-restart-btn");
+  const retryAgentBtn = document.getElementById("retry-agent-btn");
+
+  // Web Audio Synth for crisp stone placement click
+  function playStoneSound() {
+    try {
+      if (!audioCtx) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      if (audioCtx.state === "suspended") {
+        audioCtx.resume();
+      }
+      const osc = audioCtx.createOscillator();
+      const gain = audioCtx.createGain();
+      osc.type = "triangle";
+      osc.frequency.setValueAtTime(440, audioCtx.currentTime);
+      osc.frequency.exponentialRampToValueAtTime(120, audioCtx.currentTime + 0.08);
+
+      gain.gain.setValueAtTime(0.35, audioCtx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.08);
+
+      osc.connect(gain);
+      gain.connect(audioCtx.destination);
+      osc.start();
+      osc.stop(audioCtx.currentTime + 0.08);
+    } catch (e) {
+      // Audio not permitted or supported
+    }
+  }
+
+  function coordToString(x, y) {
+    const col = COLS[x] || `${x}`;
+    const row = BOARD_SIZE - y;
+    return `${col}${row}`;
+  }
+
+  let currentGridSize = 0;
+  let currentPadding = 0;
+  let currentCellSize = 0;
+
+  function resizeCanvas() {
+    const parent = canvas.parentElement || document.body;
+    const parentRect = parent.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const availWidth = Math.max(0, parentRect.width - 12);
+    const availHeight = Math.max(0, parentRect.height - 12);
+    const size = Math.floor(Math.min(availWidth, availHeight));
+    if (size <= 0) return;
+
+    currentGridSize = size;
+    currentPadding = Math.max(22, Math.round(size * 0.08));
+    currentCellSize = (size - currentPadding * 2) / (BOARD_SIZE - 1);
+
+    canvas.style.width = `${size}px`;
+    canvas.style.height = `${size}px`;
+    canvas.width = Math.round(size * dpr);
+    canvas.height = Math.round(size * dpr);
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(dpr, dpr);
+    drawBoard();
+  }
+
+  function getMouseGridCoord(e) {
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0 || currentGridSize <= 0) return null;
+
+    const mouseX = (e.clientX - rect.left) * (currentGridSize / rect.width);
+    const mouseY = (e.clientY - rect.top) * (currentGridSize / rect.height);
+
+    const x = Math.round((mouseX - currentPadding) / currentCellSize);
+    const y = Math.round((mouseY - currentPadding) / currentCellSize);
+
+    if (x >= 0 && x < BOARD_SIZE && y >= 0 && y < BOARD_SIZE) {
+      return { x, y };
+    }
+    return null;
+  }
+
+  function drawStone(x, y, radius, player) {
+    ctx.save();
+    // Drop shadow
+    ctx.shadowColor = "rgba(0, 0, 0, 0.45)";
+    ctx.shadowBlur = 6;
+    ctx.shadowOffsetX = 2;
+    ctx.shadowOffsetY = 3;
+
+    ctx.beginPath();
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+
+    if (player === 1) {
+      // Black stone (3D gradient)
+      const grad = ctx.createRadialGradient(
+        x - radius * 0.3,
+        y - radius * 0.3,
+        radius * 0.1,
+        x,
+        y,
+        radius
+      );
+      grad.addColorStop(0, "#666666");
+      grad.addColorStop(0.4, "#222222");
+      grad.addColorStop(1, "#0a0a0a");
+      ctx.fillStyle = grad;
+    } else {
+      // White stone (3D gradient)
+      const grad = ctx.createRadialGradient(
+        x - radius * 0.3,
+        y - radius * 0.3,
+        radius * 0.1,
+        x,
+        y,
+        radius
+      );
+      grad.addColorStop(0, "#ffffff");
+      grad.addColorStop(0.7, "#eeeeee");
+      grad.addColorStop(1, "#cccccc");
+      ctx.fillStyle = grad;
+    }
+    ctx.fill();
+    ctx.restore();
+  }
+
+  function drawBoard() {
+    if (currentGridSize <= 0) {
+      resizeCanvas();
+      return;
+    }
+
+    const size = currentGridSize;
+    const padding = currentPadding;
+    const cellSize = currentCellSize;
+    const stoneRadius = cellSize * 0.43;
+
+    ctx.clearRect(0, 0, size, size);
+
+    // Board background texture
+    ctx.fillStyle = "#deb887";
+    ctx.fillRect(0, 0, size, size);
+
+    // Grid lines
+    ctx.strokeStyle = "#5c3a21";
+    ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    for (let i = 0; i < BOARD_SIZE; i++) {
+      // Horizontal
+      ctx.moveTo(padding, padding + i * cellSize);
+      ctx.lineTo(size - padding, padding + i * cellSize);
+      // Vertical
+      ctx.moveTo(padding + i * cellSize, padding);
+      ctx.lineTo(padding + i * cellSize, size - padding);
+    }
+    ctx.stroke();
+
+    // Coordinates labels
+    ctx.fillStyle = "#6b4423";
+    ctx.font = `600 ${Math.max(10, cellSize * 0.34)}px -apple-system, BlinkMacSystemFont, sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    for (let i = 0; i < BOARD_SIZE; i++) {
+      // Letters along bottom
+      ctx.fillText(COLS[i], padding + i * cellSize, size - padding * 0.42);
+      // Numbers along left
+      ctx.fillText(`${BOARD_SIZE - i}`, padding * 0.45, padding + i * cellSize);
+    }
+
+    // Star points
+    ctx.fillStyle = "#5c3a21";
+    for (const [sx, sy] of STAR_POINTS) {
+      ctx.beginPath();
+      ctx.arc(padding + sx * cellSize, padding + sy * cellSize, cellSize * 0.1, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Stones
+    for (let y = 0; y < BOARD_SIZE; y++) {
+      for (let x = 0; x < BOARD_SIZE; x++) {
+        const val = board[y][x];
+        if (val !== 0) {
+          drawStone(padding + x * cellSize, padding + y * cellSize, stoneRadius, val);
+        }
+      }
+    }
+
+    // Last Move Indicator
+    if (lastMove) {
+      const lx = padding + lastMove.x * cellSize;
+      const ly = padding + lastMove.y * cellSize;
+      ctx.strokeStyle = lastMove.player === 1 ? "#ef4444" : "#3b82f6";
+      ctx.lineWidth = 2.5;
+      ctx.strokeRect(lx - stoneRadius * 0.4, ly - stoneRadius * 0.4, stoneRadius * 0.8, stoneRadius * 0.8);
+    }
+
+    // Hover stone preview & crosshair snap circle
+    if (hoverCoord && status === "playing" && turn === 1 && board[hoverCoord.y][hoverCoord.x] === 0) {
+      const hx = padding + hoverCoord.x * cellSize;
+      const hy = padding + hoverCoord.y * cellSize;
+
+      // Small target ring at the exact intersection point
+      ctx.strokeStyle = "rgba(59, 130, 246, 0.8)";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(hx, hy, stoneRadius * 0.35, 0, Math.PI * 2);
+      ctx.stroke();
+
+      ctx.save();
+      ctx.globalAlpha = 0.55;
+      drawStone(hx, hy, stoneRadius, 1);
+      ctx.restore();
+    }
+  }
+
+  function handleCanvasClick(e) {
+    if (status !== "playing") {
+      statusText.textContent = "本局已结束，请点击下方【重新开局】发起新一轮对战。";
+      return;
+    }
+
+    if (turn !== 1) {
+      statusText.textContent = "当前轮到 AI Agent (白子) 行动，请稍候或点击下方【催促 Agent】。";
+      return;
+    }
+
+    const coord = getMouseGridCoord(e);
+    if (!coord) return;
+
+    const { x, y } = coord;
+    if (board[y][x] !== 0) {
+      statusText.textContent = `坐标 ${coordToString(x, y)} 已有棋子，请在空白交叉点落子。`;
+      return;
+    }
+
+    const actionId = coordToString(x, y);
+
+    // Local optimistic update
+    board[y][x] = 1;
+    lastMove = { x, y, player: 1, actionId };
+    turn = 2;
+    hoverCoord = null;
+    playStoneSound();
+    updateUI();
+    drawBoard();
+
+    // Post message to FreeBuddy host
+    window.parent.postMessage({
+      type: "PLAYER_MOVE",
+      payload: { actionId, x, y }
+    }, "*");
+  }
+
+  function handleMouseMove(e) {
+    if (status !== "playing") {
+      if (hoverCoord) {
+        hoverCoord = null;
+        drawBoard();
+      }
+      return;
+    }
+
+    const coord = getMouseGridCoord(e);
+    if (coord && board[coord.y][coord.x] === 0) {
+      if (!hoverCoord || hoverCoord.x !== coord.x || hoverCoord.y !== coord.y) {
+        hoverCoord = coord;
+        drawBoard();
+      }
+    } else if (hoverCoord) {
+      hoverCoord = null;
+      drawBoard();
+    }
+  }
+
+  function updateUI() {
+    if (status === "player_won") {
+      turnBadge.className = "turn-indicator win";
+      turnBadge.textContent = "🏆 旗开得胜！你赢了";
+      statusText.textContent = "🎉 恭喜你完成五连珠！棋盘已完整保留供复盘截图。";
+      restartBtn.className = "btn primary";
+      restartBtn.textContent = "再来一局";
+      resignBtn.style.display = "none";
+      if (retryAgentBtn) retryAgentBtn.style.display = "none";
+    } else if (status === "agent_won") {
+      turnBadge.className = "turn-indicator lose";
+      turnBadge.textContent = "🤖 Agent 抢先连珠获胜";
+      statusText.textContent = "本局对战结束，棋盘已完整保留供复盘截图。";
+      restartBtn.className = "btn primary";
+      restartBtn.textContent = "再来一局";
+      resignBtn.style.display = "none";
+      if (retryAgentBtn) retryAgentBtn.style.display = "none";
+    } else if (status === "draw") {
+      turnBadge.className = "turn-indicator draw";
+      turnBadge.textContent = "🤝 双方握手言和 (平局)";
+      statusText.textContent = "棋盘已满走满 225 步。点击【再来一局】开启新对决。";
+      restartBtn.className = "btn primary";
+      restartBtn.textContent = "再来一局";
+      resignBtn.style.display = "none";
+      if (retryAgentBtn) retryAgentBtn.style.display = "none";
+    } else {
+      restartBtn.className = "btn";
+      restartBtn.textContent = "重新开局";
+      resignBtn.style.display = "inline-block";
+      if (turn === 1) {
+        turnBadge.className = "turn-indicator active-player";
+        turnBadge.textContent = "轮到你行动 (黑子)";
+        statusText.textContent = "请在棋盘上点击落子";
+        if (retryAgentBtn) retryAgentBtn.style.display = "none";
+      } else {
+        turnBadge.className = "turn-indicator active-agent";
+        turnBadge.textContent = "Agent 正在思考中... (白子)";
+        statusText.textContent = "AI Agent 正在思考并落子中...";
+      }
+    }
+  }
+
+  let initialized = false;
+
+  function syncState(snapshot) {
+    if (!snapshot) return;
+    const prevMove = lastMove;
+    board = snapshot.board || board;
+    turn = snapshot.turn ?? turn;
+    status = snapshot.status || status;
+    lastMove = snapshot.lastMove || null;
+
+    if (snapshot.chatHistory && snapshot.chatHistory.length > 0) {
+      const latestAgentChat = [...snapshot.chatHistory].reverse().find(c => c.sender === "agent");
+      if (latestAgentChat) {
+        speechText.textContent = latestAgentChat.message;
+      }
+    }
+
+    // Only play sound if this is a new move arriving after initialization
+    if (initialized && lastMove && (!prevMove || prevMove.actionId !== lastMove.actionId)) {
+      playStoneSound();
+    }
+    initialized = true;
+
+    updateUI();
+    drawBoard();
+  }
+
+  // Host Message Listener
+  window.addEventListener("message", (event) => {
+    const data = event.data;
+    if (!data || typeof data !== "object") return;
+
+    if (data.type === "FREEBUDDY_GAME_SYNC" || data.type === "GAME_STATE_UPDATE") {
+      syncState(data.payload);
+    } else if (data.type === "AGENT_CHAT") {
+      speechText.textContent = data.payload?.message || "";
+    } else if (data.type === "AGENT_STALLED") {
+      const isStalled = Boolean(data.payload?.stalled);
+      if (isStalled && turn === 2 && status === "playing") {
+        if (retryAgentBtn) retryAgentBtn.style.display = "inline-block";
+        statusText.textContent = "AI 回复结束但未落子，请点击【重试】";
+      } else {
+        if (retryAgentBtn) retryAgentBtn.style.display = "none";
+      }
+    }
+  });
+
+  // Action Buttons
+  restartBtn.addEventListener("click", () => {
+    window.parent.postMessage({ type: "GAME_RESET" }, "*");
+  });
+
+  modalRestartBtn.addEventListener("click", () => {
+    window.parent.postMessage({ type: "GAME_RESET" }, "*");
+  });
+
+  resignBtn.addEventListener("click", () => {
+    if (confirm("确定要认输吗？")) {
+      window.parent.postMessage({ type: "GAME_RESIGN" }, "*");
+    }
+  });
+
+  if (retryAgentBtn) {
+    retryAgentBtn.addEventListener("click", () => {
+      window.parent.postMessage({ type: "REMIND_AGENT" }, "*");
+      retryAgentBtn.style.display = "none";
+      statusText.textContent = "已向 AI 重新发送落子请求...";
+    });
+  }
+
+  canvas.addEventListener("click", handleCanvasClick);
+  canvas.addEventListener("mousemove", handleMouseMove);
+  canvas.addEventListener("mouseleave", () => {
+    hoverCoord = null;
+    drawBoard();
+  });
+
+  window.addEventListener("resize", resizeCanvas);
+  if (window.ResizeObserver) {
+    const ro = new ResizeObserver(() => {
+      resizeCanvas();
+    });
+    ro.observe(canvas);
+  }
+
+  // Initialize
+  resizeCanvas();
+  updateUI();
+
+  // Notify host that canvas is ready
+  window.parent.postMessage({ type: "GAME_CANVAS_READY" }, "*");
+})();

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -19,12 +19,8 @@
   const turnBadge = document.getElementById("turn-badge");
   const speechText = document.getElementById("speech-text");
   const statusText = document.getElementById("status-text");
-  const modal = document.getElementById("game-over-modal");
-  const modalTitle = document.getElementById("modal-title");
-  const modalDesc = document.getElementById("modal-desc");
   const restartBtn = document.getElementById("restart-btn");
   const resignBtn = document.getElementById("resign-btn");
-  const modalRestartBtn = document.getElementById("modal-restart-btn");
   const retryAgentBtn = document.getElementById("retry-agent-btn");
 
   // Web Audio Synth for crisp stone placement click
@@ -389,10 +385,6 @@
     window.parent.postMessage({ type: "GAME_RESET" }, "*");
   });
 
-  modalRestartBtn.addEventListener("click", () => {
-    window.parent.postMessage({ type: "GAME_RESET" }, "*");
-  });
-
   resignBtn.addEventListener("click", () => {
     if (confirm("确定要认输吗？")) {
       window.parent.postMessage({ type: "GAME_RESIGN" }, "*");
@@ -420,6 +412,192 @@
       resizeCanvas();
     });
     ro.observe(canvas);
+  }
+
+  // Share Card Generation
+  const shareBtn = document.getElementById("share-btn");
+  const shareModal = document.getElementById("share-modal");
+  const closeShareBtn = document.getElementById("close-share-btn");
+  const shareImagePreview = document.getElementById("share-image-preview");
+  const copyShareBtn = document.getElementById("copy-share-btn");
+  const downloadShareBtn = document.getElementById("download-share-btn");
+  const shareToast = document.getElementById("share-toast");
+
+  function showToast(msg) {
+    if (!shareToast) return;
+    shareToast.textContent = msg;
+    shareToast.style.display = "block";
+    setTimeout(() => {
+      shareToast.style.display = "none";
+    }, 2000);
+  }
+
+  function generateShareImageCanvas() {
+    const cardCanvas = document.createElement("canvas");
+    const cardWidth = 720;
+    const cardHeight = 880;
+    cardCanvas.width = cardWidth;
+    cardCanvas.height = cardHeight;
+    const sCtx = cardCanvas.getContext("2d");
+
+    // 1. Background Gradient
+    const bgGrad = sCtx.createLinearGradient(0, 0, 0, cardHeight);
+    bgGrad.addColorStop(0, "#0f172a");
+    bgGrad.addColorStop(0.5, "#1e293b");
+    bgGrad.addColorStop(1, "#090d16");
+    sCtx.fillStyle = bgGrad;
+    sCtx.fillRect(0, 0, cardWidth, cardHeight);
+
+    // Decorative aura
+    sCtx.save();
+    const aura = sCtx.createRadialGradient(cardWidth / 2, 220, 10, cardWidth / 2, 220, 360);
+    aura.addColorStop(0, "rgba(59, 130, 246, 0.15)");
+    aura.addColorStop(1, "rgba(0, 0, 0, 0)");
+    sCtx.fillStyle = aura;
+    sCtx.fillRect(0, 0, cardWidth, cardHeight);
+    sCtx.restore();
+
+    // 2. Card Header
+    sCtx.font = "bold 20px -apple-system, BlinkMacSystemFont, 'PingFang SC', sans-serif";
+    sCtx.fillStyle = "#38bdf8";
+    sCtx.fillText("FreeBuddy 对战大厅", 40, 52);
+
+    const now = new Date();
+    const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")} ${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+    sCtx.font = "14px -apple-system, sans-serif";
+    sCtx.fillStyle = "#94a3b8";
+    sCtx.textAlign = "right";
+    sCtx.fillText(dateStr, cardWidth - 40, 52);
+    sCtx.textAlign = "left";
+
+    // 3. Match Title & Status Badge
+    sCtx.font = "bold 28px -apple-system, BlinkMacSystemFont, 'PingFang SC', sans-serif";
+    sCtx.fillStyle = "#ffffff";
+    sCtx.fillText("五子棋 · 赛后复盘战报", 40, 98);
+
+    // Outcome Badge
+    let outcomeText = "对局进行中";
+    let badgeColor = "#3b82f6";
+    if (status === "player_won") {
+      outcomeText = "🏆 玩家胜出 (五连珠)";
+      badgeColor = "#10b981";
+    } else if (status === "agent_won") {
+      outcomeText = "🤖 AI Agent 获胜";
+      badgeColor = "#ef4444";
+    } else if (status === "draw") {
+      outcomeText = "🤝 双方握手言和 (平局)";
+      badgeColor = "#94a3b8";
+    }
+
+    sCtx.font = "bold 15px -apple-system, sans-serif";
+    const textWidth = sCtx.measureText(outcomeText).width;
+    const badgeX = 40;
+    const badgeY = 118;
+    sCtx.fillStyle = "rgba(255, 255, 255, 0.08)";
+    sCtx.strokeStyle = badgeColor;
+    sCtx.lineWidth = 1.5;
+    sCtx.beginPath();
+    if (typeof sCtx.roundRect === "function") {
+      sCtx.roundRect(badgeX, badgeY, textWidth + 24, 30, 15);
+    } else {
+      sCtx.rect(badgeX, badgeY, textWidth + 24, 30);
+    }
+    sCtx.fill();
+    sCtx.stroke();
+
+    sCtx.fillStyle = badgeColor;
+    sCtx.fillText(outcomeText, badgeX + 12, badgeY + 20);
+
+    // Players Info
+    sCtx.font = "15px -apple-system, sans-serif";
+    sCtx.fillStyle = "#e2e8f0";
+    sCtx.textAlign = "right";
+    sCtx.fillText("⚫ 你 (黑先)  VS  ⚪ AI Agent (白后)", cardWidth - 40, 138);
+    sCtx.textAlign = "left";
+
+    // 4. Draw Chessboard
+    const boardSize = 580;
+    const boardX = (cardWidth - boardSize) / 2;
+    const boardY = 175;
+
+    sCtx.save();
+    sCtx.shadowColor = "rgba(0, 0, 0, 0.6)";
+    sCtx.shadowBlur = 24;
+    sCtx.shadowOffsetY = 12;
+    sCtx.drawImage(canvas, boardX, boardY, boardSize, boardSize);
+    sCtx.restore();
+
+    // 5. Footer Watermark
+    sCtx.font = "13px -apple-system, sans-serif";
+    sCtx.fillStyle = "#64748b";
+    sCtx.textAlign = "center";
+    sCtx.fillText("由 FreeBuddy AI 智能体对战引擎驱动 · Powered by FreeBuddy", cardWidth / 2, cardHeight - 36);
+
+    return cardCanvas;
+  }
+
+  function openShareModal() {
+    const shareCanvas = generateShareImageCanvas();
+    const dataUrl = shareCanvas.toDataURL("image/png");
+    if (shareImagePreview) {
+      shareImagePreview.src = dataUrl;
+    }
+    if (shareModal) {
+      shareModal.style.display = "flex";
+    }
+  }
+
+  function closeShareModal() {
+    if (shareModal) {
+      shareModal.style.display = "none";
+    }
+  }
+
+  if (shareBtn) {
+    shareBtn.addEventListener("click", openShareModal);
+  }
+
+  if (closeShareBtn) {
+    closeShareBtn.addEventListener("click", closeShareModal);
+  }
+
+  if (shareModal) {
+    shareModal.addEventListener("click", (e) => {
+      if (e.target === shareModal) closeShareModal();
+    });
+  }
+
+  if (copyShareBtn) {
+    copyShareBtn.addEventListener("click", async () => {
+      try {
+        const shareCanvas = generateShareImageCanvas();
+        shareCanvas.toBlob(async (blob) => {
+          if (!blob) return;
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob })
+            ]);
+            showToast("✓ 图片已复制到剪贴板！");
+          } catch {
+            showToast("复制失败，请使用保存图片");
+          }
+        }, "image/png");
+      } catch {
+        showToast("复制失败，请使用保存图片");
+      }
+    });
+  }
+
+  if (downloadShareBtn) {
+    downloadShareBtn.addEventListener("click", () => {
+      const shareCanvas = generateShareImageCanvas();
+      const link = document.createElement("a");
+      const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+      link.download = `FreeBuddy_五子棋战报_${timestamp}.png`;
+      link.href = shareCanvas.toDataURL("image/png");
+      link.click();
+      showToast("✓ 战报图片已下载！");
+    });
   }
 
   // Initialize

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -21,6 +21,37 @@
   const restartBtn = document.getElementById("restart-btn");
   const resignBtn = document.getElementById("resign-btn");
   const retryAgentBtn = document.getElementById("retry-agent-btn");
+  const agentNameLabel = document.getElementById("agent-name-label");
+  const agentModelBadge = document.getElementById("agent-model-badge");
+  const agentAvatarIcon = document.getElementById("agent-avatar-icon");
+  const speechAvatar = document.getElementById("speech-avatar");
+
+  function updateAgentInfo(info) {
+    if (!info) return;
+    if (info.agentName && agentNameLabel) {
+      agentNameLabel.textContent = info.agentName;
+    }
+    if (agentModelBadge) {
+      if (info.modelName) {
+        agentModelBadge.textContent = info.modelName;
+        agentModelBadge.style.display = "inline-flex";
+        agentModelBadge.title = `运行模型: ${info.modelName}`;
+      } else {
+        agentModelBadge.style.display = "none";
+      }
+    }
+    if (info.avatarUrl) {
+      if (agentAvatarIcon) {
+        agentAvatarIcon.innerHTML = `<img src="${info.avatarUrl}" alt="agent" class="agent-avatar-img" />`;
+      }
+      if (speechAvatar) {
+        speechAvatar.innerHTML = `<img src="${info.avatarUrl}" alt="agent" class="speech-avatar-img" />`;
+      }
+    } else {
+      if (agentAvatarIcon) agentAvatarIcon.textContent = "🤖";
+      if (speechAvatar) speechAvatar.textContent = "🤖";
+    }
+  }
 
   let isMuted = localStorage.getItem("freebuddy_game_muted") === "true";
   let audioCtx = null;
@@ -480,6 +511,11 @@
 
     if (data.type === "FREEBUDDY_GAME_SYNC" || data.type === "GAME_STATE_UPDATE") {
       syncState(data.payload);
+      if (data.payload?.agentInfo) {
+        updateAgentInfo(data.payload.agentInfo);
+      }
+    } else if (data.type === "AGENT_INFO_UPDATE") {
+      updateAgentInfo(data.payload);
     } else if (data.type === "AGENT_CHAT") {
       speechText.textContent = data.payload?.message || "";
     } else if (data.type === "AGENT_STALLED") {
@@ -622,10 +658,12 @@
     sCtx.fillText(outcomeText, badgeX + 12, badgeY + 20);
 
     // Players Info
-    sCtx.font = "15px -apple-system, sans-serif";
+    const agentName = agentNameLabel?.textContent || "AI Agent";
+    const modelName = agentModelBadge?.style.display !== "none" && agentModelBadge?.textContent ? ` [${agentModelBadge.textContent}]` : "";
+    sCtx.font = "14px -apple-system, sans-serif";
     sCtx.fillStyle = "#e2e8f0";
     sCtx.textAlign = "right";
-    sCtx.fillText("⚫ 你 (黑先)  VS  ⚪ AI Agent (白后)", cardWidth - 40, 138);
+    sCtx.fillText(`⚫ 玩家 (黑)  VS  ⚪ ${agentName}${modelName} (白)`, cardWidth - 40, 138);
     sCtx.textAlign = "left";
 
     // 4. Draw Chessboard

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -23,8 +23,34 @@
   const resignBtn = document.getElementById("resign-btn");
   const retryAgentBtn = document.getElementById("retry-agent-btn");
 
-  // Web Audio Synth for crisp stone placement click
-  function playStoneSound() {
+  let isMuted = localStorage.getItem("freebuddy_game_muted") === "true";
+  let audioCtx = null;
+  let gameOverSoundPlayed = false;
+
+  const muteBtn = document.getElementById("mute-btn");
+  function updateMuteButtonUI() {
+    if (!muteBtn) return;
+    if (isMuted) {
+      muteBtn.textContent = "🔇";
+      muteBtn.classList.add("muted");
+      muteBtn.title = "音效已静音（点击开启）";
+    } else {
+      muteBtn.textContent = "🔊";
+      muteBtn.classList.remove("muted");
+      muteBtn.title = "音效已开启（点击静音）";
+    }
+  }
+  if (muteBtn) {
+    updateMuteButtonUI();
+    muteBtn.addEventListener("click", () => {
+      isMuted = !isMuted;
+      localStorage.setItem("freebuddy_game_muted", String(isMuted));
+      updateMuteButtonUI();
+    });
+  }
+
+  function getAudioContext() {
+    if (isMuted) return null;
     try {
       if (!audioCtx) {
         audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -32,22 +58,90 @@
       if (audioCtx.state === "suspended") {
         audioCtx.resume();
       }
-      const osc = audioCtx.createOscillator();
-      const gain = audioCtx.createGain();
-      osc.type = "triangle";
-      osc.frequency.setValueAtTime(440, audioCtx.currentTime);
-      osc.frequency.exponentialRampToValueAtTime(120, audioCtx.currentTime + 0.08);
-
-      gain.gain.setValueAtTime(0.35, audioCtx.currentTime);
-      gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.08);
-
-      osc.connect(gain);
-      gain.connect(audioCtx.destination);
-      osc.start();
-      osc.stop(audioCtx.currentTime + 0.08);
-    } catch (e) {
-      // Audio not permitted or supported
+      return audioCtx;
+    } catch {
+      return null;
     }
+  }
+
+  // 1. Crisp Stone Placement Click (云子落盘)
+  function playStoneSound() {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const now = ctx.currentTime;
+      // High-pitch stone snap
+      const osc1 = ctx.createOscillator();
+      const gain1 = ctx.createGain();
+      osc1.type = "sine";
+      osc1.frequency.setValueAtTime(620, now);
+      osc1.frequency.exponentialRampToValueAtTime(220, now + 0.05);
+      gain1.gain.setValueAtTime(0.35, now);
+      gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.05);
+      osc1.connect(gain1);
+      gain1.connect(ctx.destination);
+      osc1.start(now);
+      osc1.stop(now + 0.05);
+
+      // Wood board resonance
+      const osc2 = ctx.createOscillator();
+      const gain2 = ctx.createGain();
+      osc2.type = "triangle";
+      osc2.frequency.setValueAtTime(240, now);
+      osc2.frequency.exponentialRampToValueAtTime(90, now + 0.08);
+      gain2.gain.setValueAtTime(0.25, now);
+      gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+      osc2.connect(gain2);
+      gain2.connect(ctx.destination);
+      osc2.start(now);
+      osc2.stop(now + 0.08);
+    } catch {}
+  }
+
+  // 2. Victory Arpeggio (旗开得胜和弦)
+  function playVictorySound() {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const notes = [523.25, 659.25, 783.99, 1046.5]; // C5, E5, G5, C6
+      const now = ctx.currentTime;
+      notes.forEach((freq, idx) => {
+        const start = now + idx * 0.1;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "triangle";
+        osc.frequency.setValueAtTime(freq, start);
+        gain.gain.setValueAtTime(0.28, start);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.35);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(start);
+        osc.stop(start + 0.35);
+      });
+    } catch {}
+  }
+
+  // 3. Defeat Tone (惜败音效)
+  function playDefeatSound() {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const notes = [392.0, 349.23, 311.13, 261.63]; // G4, F4, Eb4, C4
+      const now = ctx.currentTime;
+      notes.forEach((freq, idx) => {
+        const start = now + idx * 0.14;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(freq, start);
+        gain.gain.setValueAtTime(0.22, start);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.28);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(start);
+        osc.stop(start + 0.28);
+      });
+    } catch {}
   }
 
   function coordToString(x, y) {
@@ -293,6 +387,10 @@
 
   function updateUI() {
     if (status === "player_won") {
+      if (!gameOverSoundPlayed) {
+        gameOverSoundPlayed = true;
+        playVictorySound();
+      }
       turnBadge.className = "turn-indicator win";
       turnBadge.textContent = "🏆 旗开得胜！你赢了";
       statusText.textContent = "🎉 恭喜你完成五连珠！棋盘已完整保留供复盘截图。";
@@ -301,6 +399,10 @@
       resignBtn.style.display = "none";
       if (retryAgentBtn) retryAgentBtn.style.display = "none";
     } else if (status === "agent_won") {
+      if (!gameOverSoundPlayed) {
+        gameOverSoundPlayed = true;
+        playDefeatSound();
+      }
       turnBadge.className = "turn-indicator lose";
       turnBadge.textContent = "🤖 Agent 抢先连珠获胜";
       statusText.textContent = "本局对战结束，棋盘已完整保留供复盘截图。";
@@ -317,6 +419,7 @@
       resignBtn.style.display = "none";
       if (retryAgentBtn) retryAgentBtn.style.display = "none";
     } else {
+      gameOverSoundPlayed = false;
       restartBtn.className = "btn";
       restartBtn.textContent = "重新开局";
       resignBtn.style.display = "inline-block";

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -22,23 +22,15 @@
   const resignBtn = document.getElementById("resign-btn");
   const retryAgentBtn = document.getElementById("retry-agent-btn");
   const agentNameLabel = document.getElementById("agent-name-label");
-  const agentModelBadge = document.getElementById("agent-model-badge");
   const agentAvatarIcon = document.getElementById("agent-avatar-icon");
   const speechAvatar = document.getElementById("speech-avatar");
 
   function updateAgentInfo(info) {
     if (!info) return;
-    if (info.agentName && agentNameLabel) {
-      agentNameLabel.textContent = info.agentName;
-    }
-    if (agentModelBadge) {
-      if (info.modelName) {
-        agentModelBadge.textContent = info.modelName;
-        agentModelBadge.style.display = "inline-flex";
-        agentModelBadge.title = `运行模型: ${info.modelName}`;
-      } else {
-        agentModelBadge.style.display = "none";
-      }
+    const displayName = info.modelName || info.agentName || "AI Agent";
+    if (agentNameLabel) {
+      agentNameLabel.textContent = displayName;
+      agentNameLabel.title = info.agentName ? `${info.agentName} (${info.modelName || "AI"})` : displayName;
     }
     if (info.avatarUrl) {
       if (agentAvatarIcon) {
@@ -658,12 +650,11 @@
     sCtx.fillText(outcomeText, badgeX + 12, badgeY + 20);
 
     // Players Info
-    const agentName = agentNameLabel?.textContent || "AI Agent";
-    const modelName = agentModelBadge?.style.display !== "none" && agentModelBadge?.textContent ? ` [${agentModelBadge.textContent}]` : "";
+    const agentDisplay = agentNameLabel?.textContent || "AI Agent";
     sCtx.font = "14px -apple-system, sans-serif";
     sCtx.fillStyle = "#e2e8f0";
     sCtx.textAlign = "right";
-    sCtx.fillText(`⚫ 玩家 (黑)  VS  ⚪ ${agentName}${modelName} (白)`, cardWidth - 40, 138);
+    sCtx.fillText(`⚫ 玩家 (黑)  VS  ⚪ ${agentDisplay} (白)`, cardWidth - 40, 138);
     sCtx.textAlign = "left";
 
     // 4. Draw Chessboard

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -39,10 +39,29 @@
       <div id="status-text" class="status-text">请在棋盘上点击落子</div>
       <div class="btn-group">
         <button id="retry-agent-btn" class="btn warning" style="display: none;">⚠️ AI 遗漏落子，点击重试</button>
+        <button id="share-btn" class="btn" title="生成并分享战报长图">📸 分享</button>
         <button id="resign-btn" class="btn danger">认输</button>
         <button id="restart-btn" class="btn">重新开局</button>
       </div>
     </footer>
+  </div>
+
+  <!-- Share Card Modal -->
+  <div id="share-modal" class="share-modal-backdrop" style="display: none;">
+    <div class="share-modal-card">
+      <div class="share-modal-header">
+        <div class="share-modal-title">📸 对弈战报分享</div>
+        <button id="close-share-btn" class="icon-close-btn" aria-label="关闭">✕</button>
+      </div>
+      <div class="share-preview-wrap">
+        <img id="share-image-preview" class="share-preview-img" alt="战报预览" />
+      </div>
+      <div class="share-modal-actions">
+        <button id="copy-share-btn" class="btn primary">📋 复制图片</button>
+        <button id="download-share-btn" class="btn">💾 保存图片</button>
+      </div>
+      <div id="share-toast" class="share-toast" style="display: none;">已复制到剪贴板！</div>
+    </div>
   </div>
 
   <script src="./game.js"></script>

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -17,9 +17,12 @@
       <div id="turn-badge" class="turn-indicator active-player">
         轮到你行动 (黑子)
       </div>
-      <div class="player-badge">
-        <span>AI Agent (白棋)</span>
-        <span class="stone-dot white"></span>
+      <div class="header-right">
+        <div class="player-badge">
+          <span>AI Agent (白棋)</span>
+          <span class="stone-dot white"></span>
+        </div>
+        <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>
     </header>
 

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -29,7 +29,6 @@
             <span class="stone-dot white"></span>
           </div>
         </div>
-        <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>
     </header>
 
@@ -49,6 +48,7 @@
       <div id="status-text" class="status-text">请在棋盘上点击落子</div>
       <div class="btn-group">
         <button id="retry-agent-btn" class="btn warning" style="display: none;">⚠️ AI 遗漏落子，点击重试</button>
+        <button id="mute-btn" class="btn" title="开启/关闭音效" aria-label="音效开关">🔊 音效</button>
         <button id="share-btn" class="btn" title="生成并分享战报长图">📸 分享</button>
         <button id="resign-btn" class="btn danger">认输</button>
         <button id="restart-btn" class="btn">重新开局</button>

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <title>FreeBuddy Agent Gomoku</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="game-container">
+    <!-- Header -->
+    <header class="game-header">
+      <div class="player-badge">
+        <span class="stone-dot black"></span>
+        <span>你 (黑棋)</span>
+      </div>
+      <div id="turn-badge" class="turn-indicator active-player">
+        轮到你行动 (黑子)
+      </div>
+      <div class="player-badge">
+        <span>AI Agent (白棋)</span>
+        <span class="stone-dot white"></span>
+      </div>
+    </header>
+
+    <!-- Agent Dialogue Banner -->
+    <div class="agent-speech-banner">
+      <div class="avatar">🤖</div>
+      <div id="speech-text" class="content">准备好了吗？我已经接入了 Game MCP 工具，请赐教！</div>
+    </div>
+
+    <!-- Board Area (100% Unobstructed for Screenshot & Analysis) -->
+    <div class="board-wrapper">
+      <canvas id="gomoku-canvas"></canvas>
+    </div>
+
+    <!-- Footer Controls -->
+    <footer class="game-footer">
+      <div id="status-text" class="status-text">请在棋盘上点击落子</div>
+      <div class="btn-group">
+        <button id="retry-agent-btn" class="btn warning" style="display: none;">⚠️ AI 遗漏落子，点击重试</button>
+        <button id="resign-btn" class="btn danger">认输</button>
+        <button id="restart-btn" class="btn">重新开局</button>
+      </div>
+    </footer>
+  </div>
+
+  <script src="./game.js"></script>
+</body>
+</html>

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -24,7 +24,6 @@
           <div class="player-badge">
             <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
             <span id="agent-name-label">AI Agent</span>
-            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
             <span class="side-tag">(白棋)</span>
             <span class="stone-dot white"></span>
           </div>

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -10,17 +10,26 @@
   <div class="game-container">
     <!-- Header -->
     <header class="game-header">
-      <div class="player-badge">
-        <span class="stone-dot black"></span>
-        <span>你 (黑棋)</span>
+      <div class="player-col left">
+        <div class="player-badge">
+          <span class="stone-dot black"></span>
+          <span>你 (黑棋)</span>
+        </div>
       </div>
       <div id="turn-badge" class="turn-indicator active-player">
         轮到你行动 (黑子)
       </div>
       <div class="header-right">
-        <div class="player-badge">
-          <span>AI Agent (白棋)</span>
-          <span class="stone-dot white"></span>
+        <div class="player-col right">
+          <div class="player-badge">
+            <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
+            <span id="agent-name-label">AI Agent</span>
+            <span class="side-tag">(白棋)</span>
+            <span class="stone-dot white"></span>
+          </div>
+          <div class="agent-meta-row">
+            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
+          </div>
         </div>
         <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>
@@ -28,7 +37,7 @@
 
     <!-- Agent Dialogue Banner -->
     <div class="agent-speech-banner">
-      <div class="avatar">🤖</div>
+      <div id="speech-avatar" class="avatar">🤖</div>
       <div id="speech-text" class="content">准备好了吗？我已经接入了 Game MCP 工具，请赐教！</div>
     </div>
 

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -24,11 +24,9 @@
           <div class="player-badge">
             <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
             <span id="agent-name-label">AI Agent</span>
+            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
             <span class="side-tag">(白棋)</span>
             <span class="stone-dot white"></span>
-          </div>
-          <div class="agent-meta-row">
-            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
           </div>
         </div>
         <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -105,46 +105,26 @@ body {
   font-weight: normal;
 }
 
-.agent-model-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0 5px;
-  background: rgba(99, 102, 241, 0.16);
-  color: #a5b4fc;
-  border: 1px solid rgba(99, 102, 241, 0.32);
-  border-radius: 4px;
-  font-size: 9.5px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-weight: 500;
-  max-width: 110px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 16px;
-  height: 16px;
-  vertical-align: middle;
-}
-
 .agent-avatar-mini {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  max-width: 20px;
-  max-height: 20px;
+  width: 18px;
+  height: 18px;
+  max-width: 18px;
+  max-height: 18px;
   border-radius: 50%;
   overflow: hidden;
   background: rgba(255, 255, 255, 0.08);
-  font-size: 12px;
+  font-size: 11px;
   flex-shrink: 0;
 }
 
 .agent-avatar-img {
-  width: 20px;
-  height: 20px;
-  max-width: 20px;
-  max-height: 20px;
+  width: 18px;
+  height: 18px;
+  max-width: 18px;
+  max-height: 18px;
   object-fit: cover;
   border-radius: 50%;
   display: block;

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -236,3 +236,108 @@ body {
   }
 }
 
+/* Share Modal */
+.share-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 16px;
+  animation: fadeIn 0.2s ease;
+}
+
+.share-modal-card {
+  background: #181b22;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  padding: 16px;
+  max-width: 440px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.6);
+  position: relative;
+}
+
+.share-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.share-modal-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.icon-close-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 14px;
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+
+.icon-close-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-main);
+}
+
+.share-preview-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: auto;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 8px;
+}
+
+.share-preview-img {
+  max-width: 100%;
+  max-height: 52vh;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.share-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.share-toast {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(16, 185, 129, 0.95);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -81,12 +81,81 @@ body {
   filter: grayscale(1);
 }
 
+.player-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.player-col.right {
+  align-items: flex-end;
+}
+
 .player-badge {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   font-size: 13px;
   font-weight: 500;
+}
+
+.side-tag {
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: normal;
+}
+
+.agent-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  margin-top: 2px;
+}
+
+.agent-model-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  background: rgba(99, 102, 241, 0.18);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: 6px;
+  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-weight: 500;
+  max-width: 140px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 14px;
+}
+
+.agent-avatar-mini {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.agent-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.speech-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
 }
 
 .stone-dot {

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -135,27 +135,35 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
+  max-width: 20px;
+  max-height: 20px;
   border-radius: 50%;
   overflow: hidden;
   background: rgba(255, 255, 255, 0.08);
-  font-size: 13px;
+  font-size: 12px;
   flex-shrink: 0;
 }
 
 .agent-avatar-img {
-  width: 100%;
-  height: 100%;
+  width: 20px;
+  height: 20px;
+  max-width: 20px;
+  max-height: 20px;
   object-fit: cover;
   border-radius: 50%;
+  display: block;
 }
 
 .speech-avatar-img {
-  width: 100%;
-  height: 100%;
+  width: 24px;
+  height: 24px;
+  max-width: 24px;
+  max-height: 24px;
   object-fit: cover;
   border-radius: 50%;
+  display: block;
 }
 
 .stone-dot {
@@ -212,8 +220,29 @@ body {
 }
 
 .agent-speech-banner .avatar {
-  font-size: 20px;
+  width: 24px;
+  height: 24px;
+  max-width: 24px;
+  max-height: 24px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
   line-height: 1;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.agent-speech-banner .avatar img {
+  width: 24px;
+  height: 24px;
+  max-width: 24px;
+  max-height: 24px;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
 }
 
 .agent-speech-banner .content {

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -39,52 +39,23 @@ body {
   gap: 12px;
 }
 
-/* Header & Status */
 .game-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: var(--panel-bg);
-  padding: 10px 16px;
+  padding: 8px 12px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.icon-btn-sound {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 13px;
-  padding: 3px 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-  line-height: 1;
-}
-
-.icon-btn-sound:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.icon-btn-sound.muted {
-  opacity: 0.6;
-  filter: grayscale(1);
+  gap: 8px;
 }
 
 .player-col {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
 }
 
 .player-col.right {

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -176,27 +176,39 @@ body {
 }
 
 .turn-indicator {
-  padding: 4px 12px;
-  border-radius: 20px;
-  font-size: 12px;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.06);
+  padding: 3px 12px;
+  border-radius: 12px;
+  font-size: 11.5px;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.05);
   color: var(--text-muted);
   transition: all 0.3s ease;
+  border: 1px solid transparent;
+  white-space: nowrap;
 }
 
 .turn-indicator.active-player {
-  background: #1e3a8a;
+  background: rgba(59, 130, 246, 0.14);
   color: #93c5fd;
-  border: 1px solid #3b82f6;
-  box-shadow: 0 0 10px var(--accent-glow);
+  border-color: rgba(59, 130, 246, 0.35);
 }
 
 .turn-indicator.active-agent {
-  background: #4c1d95;
+  background: rgba(139, 92, 246, 0.14);
   color: #c4b5fd;
-  border: 1px solid #8b5cf6;
-  box-shadow: 0 0 10px rgba(139, 92, 246, 0.4);
+  border-color: rgba(139, 92, 246, 0.35);
+}
+
+.turn-indicator.win {
+  background: rgba(16, 185, 129, 0.14);
+  color: #6ee7b7;
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.turn-indicator.lose {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fca5a5;
+  border-color: rgba(239, 68, 68, 0.35);
 }
 
 /* Agent Dialogue Bubble Overlay */

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -302,6 +302,11 @@ body {
   border-color: rgba(255, 255, 255, 0.25);
 }
 
+.btn.muted {
+  opacity: 0.65;
+  color: var(--text-muted);
+}
+
 .btn.primary {
   background: var(--accent);
   border-color: var(--accent);

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -176,39 +176,27 @@ body {
 }
 
 .turn-indicator {
-  padding: 3px 12px;
-  border-radius: 12px;
-  font-size: 11.5px;
-  font-weight: 500;
-  background: rgba(255, 255, 255, 0.05);
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
   color: var(--text-muted);
   transition: all 0.3s ease;
-  border: 1px solid transparent;
-  white-space: nowrap;
 }
 
 .turn-indicator.active-player {
-  background: rgba(59, 130, 246, 0.14);
+  background: #1e3a8a;
   color: #93c5fd;
-  border-color: rgba(59, 130, 246, 0.35);
+  border: 1px solid #3b82f6;
+  box-shadow: 0 0 10px var(--accent-glow);
 }
 
 .turn-indicator.active-agent {
-  background: rgba(139, 92, 246, 0.14);
+  background: #4c1d95;
   color: #c4b5fd;
-  border-color: rgba(139, 92, 246, 0.35);
-}
-
-.turn-indicator.win {
-  background: rgba(16, 185, 129, 0.14);
-  color: #6ee7b7;
-  border-color: rgba(16, 185, 129, 0.35);
-}
-
-.turn-indicator.lose {
-  background: rgba(239, 68, 68, 0.14);
-  color: #fca5a5;
-  border-color: rgba(239, 68, 68, 0.35);
+  border: 1px solid #8b5cf6;
+  box-shadow: 0 0 10px rgba(139, 92, 246, 0.4);
 }
 
 /* Agent Dialogue Bubble Overlay */

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -51,6 +51,36 @@ body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.icon-btn-sound {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 3px 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  line-height: 1;
+}
+
+.icon-btn-sound:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.icon-btn-sound.muted {
+  opacity: 0.6;
+  filter: grayscale(1);
+}
+
 .player-badge {
   display: flex;
   align-items: center;

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -105,30 +105,24 @@ body {
   font-weight: normal;
 }
 
-.agent-meta-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  justify-content: flex-end;
-  margin-top: 2px;
-}
-
 .agent-model-badge {
   display: inline-flex;
   align-items: center;
-  padding: 1px 7px;
-  background: rgba(99, 102, 241, 0.18);
+  padding: 0 5px;
+  background: rgba(99, 102, 241, 0.16);
   color: #a5b4fc;
-  border: 1px solid rgba(99, 102, 241, 0.35);
-  border-radius: 6px;
-  font-size: 10px;
+  border: 1px solid rgba(99, 102, 241, 0.32);
+  border-radius: 4px;
+  font-size: 9.5px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-weight: 500;
-  max-width: 140px;
+  max-width: 110px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 14px;
+  line-height: 16px;
+  height: 16px;
+  vertical-align: middle;
 }
 
 .agent-avatar-mini {

--- a/public/games/gomoku/style.css
+++ b/public/games/gomoku/style.css
@@ -1,0 +1,238 @@
+:root {
+  --bg-color: #18191c;
+  --panel-bg: rgba(30, 32, 38, 0.95);
+  --board-bg: #deb887;
+  --board-grid: #5c3a21;
+  --text-main: #f0f2f5;
+  --text-muted: #9ba1ad;
+  --accent: #3b82f6;
+  --accent-glow: rgba(59, 130, 246, 0.4);
+  --danger: #ef4444;
+  --success: #10b981;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  user-select: none;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.game-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 12px;
+  gap: 12px;
+}
+
+/* Header & Status */
+.game-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--panel-bg);
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.player-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.stone-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.stone-dot.black {
+  background: radial-gradient(circle at 35% 35%, #555, #111);
+}
+
+.stone-dot.white {
+  background: radial-gradient(circle at 35% 35%, #fff, #bbb);
+}
+
+.turn-indicator {
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-muted);
+  transition: all 0.3s ease;
+}
+
+.turn-indicator.active-player {
+  background: #1e3a8a;
+  color: #93c5fd;
+  border: 1px solid #3b82f6;
+  box-shadow: 0 0 10px var(--accent-glow);
+}
+
+.turn-indicator.active-agent {
+  background: #4c1d95;
+  color: #c4b5fd;
+  border: 1px solid #8b5cf6;
+  box-shadow: 0 0 10px rgba(139, 92, 246, 0.4);
+}
+
+/* Agent Dialogue Bubble Overlay */
+.agent-speech-banner {
+  position: relative;
+  background: linear-gradient(135deg, rgba(67, 56, 202, 0.25), rgba(124, 58, 237, 0.2));
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  padding: 10px 14px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.agent-speech-banner .avatar {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.agent-speech-banner .content {
+  font-size: 13px;
+  color: #e0e7ff;
+  line-height: 1.4;
+  flex: 1;
+}
+
+/* Board Wrapper */
+.board-wrapper {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 4px;
+}
+
+#gomoku-canvas {
+  aspect-ratio: 1 / 1;
+  background-color: var(--board-bg);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5), inset 0 0 40px rgba(0, 0, 0, 0.2);
+  cursor: crosshair;
+}
+
+/* Footer / Controls */
+.game-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-text {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.btn-group {
+  display: flex;
+  gap: 8px;
+}
+
+.btn {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-main);
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.btn.primary:hover {
+  background: #2563eb;
+}
+
+.btn.danger:hover {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: #ef4444;
+}
+
+.btn.warning {
+  background: rgba(245, 158, 11, 0.2);
+  border: 1px solid #f59e0b;
+  color: #fbbf24;
+  font-weight: 600;
+  animation: pulse-glow 2s infinite;
+}
+
+.btn.warning:hover {
+  background: rgba(245, 158, 11, 0.35);
+  border-color: #fbbf24;
+}
+
+.turn-indicator.win {
+  background: rgba(16, 185, 129, 0.2);
+  color: #34d399;
+  border: 1px solid #10b981;
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.35);
+}
+
+.turn-indicator.lose {
+  background: rgba(239, 68, 68, 0.2);
+  color: #fca5a5;
+  border: 1px solid #ef4444;
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.35);
+}
+
+.turn-indicator.draw {
+  background: rgba(148, 163, 184, 0.2);
+  color: #cbd5e1;
+  border: 1px solid #94a3b8;
+}
+
+@keyframes pulse-glow {
+  0%, 100% {
+    box-shadow: 0 0 0 rgba(245, 158, 11, 0);
+  }
+  50% {
+    box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
+  }
+}
+

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -87,24 +87,12 @@
       const init = INITIAL_BLACK_COUNTS[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
-      if (capturedCount > 0) {
-        const item = document.createElement("span");
-        item.className = "captured-item";
-
+      for (let i = 0; i < capturedCount; i++) {
         const badge = document.createElement("span");
         badge.className = "mini-piece-badge black";
         badge.textContent = PIECE_NAMES[p] || "";
-        badge.title = `${PIECE_NAMES[p]} ×${capturedCount}`;
-        item.appendChild(badge);
-
-        if (capturedCount > 1) {
-          const countText = document.createElement("span");
-          countText.className = "captured-count";
-          countText.textContent = `×${capturedCount}`;
-          item.appendChild(countText);
-        }
-
-        playerCapturedContainer.appendChild(item);
+        badge.title = PIECE_NAMES[p] || "";
+        playerCapturedContainer.appendChild(badge);
       }
     }
 
@@ -114,24 +102,12 @@
       const init = INITIAL_RED_COUNTS[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
-      if (capturedCount > 0) {
-        const item = document.createElement("span");
-        item.className = "captured-item";
-
+      for (let i = 0; i < capturedCount; i++) {
         const badge = document.createElement("span");
         badge.className = "mini-piece-badge red";
         badge.textContent = PIECE_NAMES[p] || "";
-        badge.title = `${PIECE_NAMES[p]} ×${capturedCount}`;
-        item.appendChild(badge);
-
-        if (capturedCount > 1) {
-          const countText = document.createElement("span");
-          countText.className = "captured-count";
-          countText.textContent = `×${capturedCount}`;
-          item.appendChild(countText);
-        }
-
-        agentCapturedContainer.appendChild(item);
+        badge.title = PIECE_NAMES[p] || "";
+        agentCapturedContainer.appendChild(badge);
       }
     }
   }

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -278,8 +278,8 @@
     height = Math.floor(height);
     if (width <= 0 || height <= 0) return;
 
-    paddingX = Math.round(width * 0.07);
-    paddingY = Math.round(height * 0.065);
+    paddingX = Math.max(22, Math.round(width * 0.08));
+    paddingY = Math.max(22, Math.round(height * 0.075));
     cellWidth = (width - paddingX * 2) / (BOARD_COLS - 1);
     cellHeight = (height - paddingY * 2) / (BOARD_ROWS - 1);
     pieceRadius = Math.min(cellWidth, cellHeight) * 0.46;
@@ -491,6 +491,32 @@
 
     ctx.fillText("楚  河", paddingX + 2 * cellWidth, riverY);
     ctx.fillText("漢  界", paddingX + 6 * cellWidth, riverY);
+
+    // 4.5 Coordinate Labels (a-i along top/bottom, 0-9 along left/right)
+    ctx.fillStyle = "rgba(120, 53, 15, 0.85)";
+    ctx.font = `600 ${Math.max(10, Math.round(cellWidth * 0.28))}px "Segoe UI", "PingFang SC", -apple-system, sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    // Column Letters (a - i)
+    for (let c = 0; c < BOARD_COLS; c++) {
+      const x = paddingX + c * cellWidth;
+      const colChar = COL_LETTERS[c];
+      // Bottom (below Red baseline)
+      ctx.fillText(colChar, x, height - paddingY * 0.42);
+      // Top (above Black baseline)
+      ctx.fillText(colChar, x, paddingY * 0.42);
+    }
+
+    // Row Numbers (0 - 9, UCCI algebraic notation: 0 at Red bottom, 9 at Black top)
+    for (let r = 0; r < BOARD_ROWS; r++) {
+      const y = paddingY + r * cellHeight;
+      const rowNum = `${BOARD_ROWS - 1 - r}`;
+      // Left
+      ctx.fillText(rowNum, paddingX * 0.45, y);
+      // Right
+      ctx.fillText(rowNum, width - paddingX * 0.45, y);
+    }
 
     // 5. Star / Cross Markers (兵/炮位十字花)
     const starMarkers = [

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -31,23 +31,15 @@
   const playerCapturedContainer = document.getElementById("player-captured");
   const agentCapturedContainer = document.getElementById("agent-captured");
   const agentNameLabel = document.getElementById("agent-name-label");
-  const agentModelBadge = document.getElementById("agent-model-badge");
   const agentAvatarIcon = document.getElementById("agent-avatar-icon");
   const speechAvatar = document.getElementById("speech-avatar");
 
   function updateAgentInfo(info) {
     if (!info) return;
-    if (info.agentName && agentNameLabel) {
-      agentNameLabel.textContent = info.agentName;
-    }
-    if (agentModelBadge) {
-      if (info.modelName) {
-        agentModelBadge.textContent = info.modelName;
-        agentModelBadge.style.display = "inline-flex";
-        agentModelBadge.title = `运行模型: ${info.modelName}`;
-      } else {
-        agentModelBadge.style.display = "none";
-      }
+    const displayName = info.modelName || info.agentName || "AI Agent";
+    if (agentNameLabel) {
+      agentNameLabel.textContent = displayName;
+      agentNameLabel.title = info.agentName ? `${info.agentName} (${info.modelName || "AI"})` : displayName;
     }
     if (info.avatarUrl) {
       if (agentAvatarIcon) {
@@ -1075,12 +1067,11 @@
     sCtx.fillText(outcomeText, badgeX + 12, badgeY + 20);
 
     // Players Info
-    const agentName = agentNameLabel?.textContent || "AI Agent";
-    const modelName = agentModelBadge?.style.display !== "none" && agentModelBadge?.textContent ? ` [${agentModelBadge.textContent}]` : "";
+    const agentDisplay = agentNameLabel?.textContent || "AI Agent";
     sCtx.font = "14px -apple-system, sans-serif";
     sCtx.fillStyle = "#e2e8f0";
     sCtx.textAlign = "right";
-    sCtx.fillText(`🔴 玩家 (红)  VS  ⚫ ${agentName}${modelName} (黑)`, cardWidth - 40, 138);
+    sCtx.fillText(`🔴 玩家 (红)  VS  ⚫ ${agentDisplay} (黑)`, cardWidth - 40, 138);
     sCtx.textAlign = "left";
 
     // 4. Draw Chessboard (9:10 ratio)

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -17,7 +17,6 @@
   let selectedCoord = null;
   let legalTargets = [];
   let hoverCoord = null;
-  let audioCtx = null;
   let initialized = false;
 
   // DOM Elements

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -703,6 +703,193 @@
     ro.observe(canvas);
   }
 
+  // Share Card Generation
+  const shareBtn = document.getElementById("share-btn");
+  const shareModal = document.getElementById("share-modal");
+  const closeShareBtn = document.getElementById("close-share-btn");
+  const shareImagePreview = document.getElementById("share-image-preview");
+  const copyShareBtn = document.getElementById("copy-share-btn");
+  const downloadShareBtn = document.getElementById("download-share-btn");
+  const shareToast = document.getElementById("share-toast");
+
+  function showToast(msg) {
+    if (!shareToast) return;
+    shareToast.textContent = msg;
+    shareToast.style.display = "block";
+    setTimeout(() => {
+      shareToast.style.display = "none";
+    }, 2000);
+  }
+
+  function generateShareImageCanvas() {
+    const cardCanvas = document.createElement("canvas");
+    const cardWidth = 720;
+    const cardHeight = 920;
+    cardCanvas.width = cardWidth;
+    cardCanvas.height = cardHeight;
+    const sCtx = cardCanvas.getContext("2d");
+
+    // 1. Background Gradient
+    const bgGrad = sCtx.createLinearGradient(0, 0, 0, cardHeight);
+    bgGrad.addColorStop(0, "#0f172a");
+    bgGrad.addColorStop(0.5, "#1e293b");
+    bgGrad.addColorStop(1, "#090d16");
+    sCtx.fillStyle = bgGrad;
+    sCtx.fillRect(0, 0, cardWidth, cardHeight);
+
+    // Decorative aura
+    sCtx.save();
+    const aura = sCtx.createRadialGradient(cardWidth / 2, 240, 10, cardWidth / 2, 240, 380);
+    aura.addColorStop(0, "rgba(220, 38, 38, 0.15)");
+    aura.addColorStop(1, "rgba(0, 0, 0, 0)");
+    sCtx.fillStyle = aura;
+    sCtx.fillRect(0, 0, cardWidth, cardHeight);
+    sCtx.restore();
+
+    // 2. Card Header
+    sCtx.font = "bold 20px -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', sans-serif";
+    sCtx.fillStyle = "#f87171";
+    sCtx.fillText("FreeBuddy 对战大厅", 40, 52);
+
+    const now = new Date();
+    const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")} ${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+    sCtx.font = "14px -apple-system, sans-serif";
+    sCtx.fillStyle = "#94a3b8";
+    sCtx.textAlign = "right";
+    sCtx.fillText(dateStr, cardWidth - 40, 52);
+    sCtx.textAlign = "left";
+
+    // 3. Match Title & Status Badge
+    sCtx.font = "bold 28px -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', sans-serif";
+    sCtx.fillStyle = "#ffffff";
+    sCtx.fillText("中国象棋 · 赛后复盘战报", 40, 98);
+
+    // Outcome Badge
+    let outcomeText = "对局进行中";
+    let badgeColor = "#3b82f6";
+    if (status === "player_won") {
+      outcomeText = "🏆 玩家绝杀胜出";
+      badgeColor = "#10b981";
+    } else if (status === "agent_won") {
+      outcomeText = "🤖 AI Agent 绝杀获胜";
+      badgeColor = "#ef4444";
+    } else if (status === "draw") {
+      outcomeText = "🤝 双方握手言和 (平局)";
+      badgeColor = "#94a3b8";
+    }
+
+    sCtx.font = "bold 15px -apple-system, sans-serif";
+    const textWidth = sCtx.measureText(outcomeText).width;
+    const badgeX = 40;
+    const badgeY = 118;
+    sCtx.fillStyle = "rgba(255, 255, 255, 0.08)";
+    sCtx.strokeStyle = badgeColor;
+    sCtx.lineWidth = 1.5;
+    sCtx.beginPath();
+    if (typeof sCtx.roundRect === "function") {
+      sCtx.roundRect(badgeX, badgeY, textWidth + 24, 30, 15);
+    } else {
+      sCtx.rect(badgeX, badgeY, textWidth + 24, 30);
+    }
+    sCtx.fill();
+    sCtx.stroke();
+
+    sCtx.fillStyle = badgeColor;
+    sCtx.fillText(outcomeText, badgeX + 12, badgeY + 20);
+
+    // Players Info
+    sCtx.font = "15px -apple-system, sans-serif";
+    sCtx.fillStyle = "#e2e8f0";
+    sCtx.textAlign = "right";
+    sCtx.fillText("🔴 你 (红先)  VS  ⚫ AI Agent (黑后)", cardWidth - 40, 138);
+    sCtx.textAlign = "left";
+
+    // 4. Draw Chessboard (9:10 ratio)
+    const boardW = 540;
+    const boardH = 600;
+    const boardX = (cardWidth - boardW) / 2;
+    const boardY = 175;
+
+    sCtx.save();
+    sCtx.shadowColor = "rgba(0, 0, 0, 0.6)";
+    sCtx.shadowBlur = 24;
+    sCtx.shadowOffsetY = 12;
+    sCtx.drawImage(canvas, boardX, boardY, boardW, boardH);
+    sCtx.restore();
+
+    // 5. Footer Watermark
+    sCtx.font = "13px -apple-system, sans-serif";
+    sCtx.fillStyle = "#64748b";
+    sCtx.textAlign = "center";
+    sCtx.fillText("由 FreeBuddy AI 智能体对战引擎驱动 · Powered by FreeBuddy", cardWidth / 2, cardHeight - 36);
+
+    return cardCanvas;
+  }
+
+  function openShareModal() {
+    const shareCanvas = generateShareImageCanvas();
+    const dataUrl = shareCanvas.toDataURL("image/png");
+    if (shareImagePreview) {
+      shareImagePreview.src = dataUrl;
+    }
+    if (shareModal) {
+      shareModal.style.display = "flex";
+    }
+  }
+
+  function closeShareModal() {
+    if (shareModal) {
+      shareModal.style.display = "none";
+    }
+  }
+
+  if (shareBtn) {
+    shareBtn.addEventListener("click", openShareModal);
+  }
+
+  if (closeShareBtn) {
+    closeShareBtn.addEventListener("click", closeShareModal);
+  }
+
+  if (shareModal) {
+    shareModal.addEventListener("click", (e) => {
+      if (e.target === shareModal) closeShareModal();
+    });
+  }
+
+  if (copyShareBtn) {
+    copyShareBtn.addEventListener("click", async () => {
+      try {
+        const shareCanvas = generateShareImageCanvas();
+        shareCanvas.toBlob(async (blob) => {
+          if (!blob) return;
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob })
+            ]);
+            showToast("✓ 图片已复制到剪贴板！");
+          } catch {
+            showToast("复制失败，请使用保存图片");
+          }
+        }, "image/png");
+      } catch {
+        showToast("复制失败，请使用保存图片");
+      }
+    });
+  }
+
+  if (downloadShareBtn) {
+    downloadShareBtn.addEventListener("click", () => {
+      const shareCanvas = generateShareImageCanvas();
+      const link = document.createElement("a");
+      const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+      link.download = `FreeBuddy_象棋战报_${timestamp}.png`;
+      link.href = shareCanvas.toDataURL("image/png");
+      link.click();
+      showToast("✓ 战报图片已下载！");
+    });
+  }
+
   // Initialize
   resizeCanvas();
   updateUI();

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -87,12 +87,24 @@
       const init = INITIAL_BLACK_COUNTS[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
-      for (let i = 0; i < capturedCount; i++) {
+      if (capturedCount > 0) {
+        const item = document.createElement("span");
+        item.className = "captured-item";
+
         const badge = document.createElement("span");
         badge.className = "mini-piece-badge black";
         badge.textContent = PIECE_NAMES[p] || "";
-        badge.title = PIECE_NAMES[p] || "";
-        playerCapturedContainer.appendChild(badge);
+        badge.title = `${PIECE_NAMES[p]} ×${capturedCount}`;
+        item.appendChild(badge);
+
+        if (capturedCount > 1) {
+          const countText = document.createElement("span");
+          countText.className = "captured-count";
+          countText.textContent = `×${capturedCount}`;
+          item.appendChild(countText);
+        }
+
+        playerCapturedContainer.appendChild(item);
       }
     }
 
@@ -102,12 +114,24 @@
       const init = INITIAL_RED_COUNTS[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
-      for (let i = 0; i < capturedCount; i++) {
+      if (capturedCount > 0) {
+        const item = document.createElement("span");
+        item.className = "captured-item";
+
         const badge = document.createElement("span");
         badge.className = "mini-piece-badge red";
         badge.textContent = PIECE_NAMES[p] || "";
-        badge.title = PIECE_NAMES[p] || "";
-        agentCapturedContainer.appendChild(badge);
+        badge.title = `${PIECE_NAMES[p]} ×${capturedCount}`;
+        item.appendChild(badge);
+
+        if (capturedCount > 1) {
+          const countText = document.createElement("span");
+          countText.className = "captured-count";
+          countText.textContent = `×${capturedCount}`;
+          item.appendChild(countText);
+        }
+
+        agentCapturedContainer.appendChild(item);
       }
     }
   }

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -46,8 +46,34 @@
     return b;
   }
 
-  // Audio Synth for crisp wooden piece placement
-  function playPieceSound(isCapture = false) {
+  let isMuted = localStorage.getItem("freebuddy_game_muted") === "true";
+  let audioCtx = null;
+  let gameOverSoundPlayed = false;
+
+  const muteBtn = document.getElementById("mute-btn");
+  function updateMuteButtonUI() {
+    if (!muteBtn) return;
+    if (isMuted) {
+      muteBtn.textContent = "🔇";
+      muteBtn.classList.add("muted");
+      muteBtn.title = "音效已静音（点击开启）";
+    } else {
+      muteBtn.textContent = "🔊";
+      muteBtn.classList.remove("muted");
+      muteBtn.title = "音效已开启（点击静音）";
+    }
+  }
+  if (muteBtn) {
+    updateMuteButtonUI();
+    muteBtn.addEventListener("click", () => {
+      isMuted = !isMuted;
+      localStorage.setItem("freebuddy_game_muted", String(isMuted));
+      updateMuteButtonUI();
+    });
+  }
+
+  function getAudioContext() {
+    if (isMuted) return null;
     try {
       if (!audioCtx) {
         audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -55,33 +81,159 @@
       if (audioCtx.state === "suspended") {
         audioCtx.resume();
       }
-      const osc = audioCtx.createOscillator();
-      const gain = audioCtx.createGain();
-
-      if (isCapture) {
-        osc.type = "sawtooth";
-        osc.frequency.setValueAtTime(220, audioCtx.currentTime);
-        osc.frequency.exponentialRampToValueAtTime(60, audioCtx.currentTime + 0.12);
-        gain.gain.setValueAtTime(0.45, audioCtx.currentTime);
-        gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.12);
-        osc.connect(gain);
-        gain.connect(audioCtx.destination);
-        osc.start();
-        osc.stop(audioCtx.currentTime + 0.12);
-      } else {
-        osc.type = "triangle";
-        osc.frequency.setValueAtTime(360, audioCtx.currentTime);
-        osc.frequency.exponentialRampToValueAtTime(100, audioCtx.currentTime + 0.09);
-        gain.gain.setValueAtTime(0.4, audioCtx.currentTime);
-        gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.09);
-        osc.connect(gain);
-        gain.connect(audioCtx.destination);
-        osc.start();
-        osc.stop(audioCtx.currentTime + 0.09);
-      }
-    } catch (e) {
-      /* Audio not supported */
+      return audioCtx;
+    } catch {
+      return null;
     }
+  }
+
+  // 1. Move Sound: Solid Wood Strike (实木落子)
+  function playPieceSound(isCapture = false) {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const now = ctx.currentTime;
+      if (isCapture) {
+        // Heavy impact capture
+        const osc1 = ctx.createOscillator();
+        const gain1 = ctx.createGain();
+        osc1.type = "sawtooth";
+        osc1.frequency.setValueAtTime(260, now);
+        osc1.frequency.exponentialRampToValueAtTime(45, now + 0.14);
+        gain1.gain.setValueAtTime(0.48, now);
+        gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.14);
+        osc1.connect(gain1);
+        gain1.connect(ctx.destination);
+        osc1.start(now);
+        osc1.stop(now + 0.14);
+
+        const osc2 = ctx.createOscillator();
+        const gain2 = ctx.createGain();
+        osc2.type = "triangle";
+        osc2.frequency.setValueAtTime(140, now);
+        osc2.frequency.exponentialRampToValueAtTime(30, now + 0.12);
+        gain2.gain.setValueAtTime(0.35, now);
+        gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.12);
+        osc2.connect(gain2);
+        gain2.connect(ctx.destination);
+        osc2.start(now);
+        osc2.stop(now + 0.12);
+      } else {
+        // Solid wood placement
+        const osc1 = ctx.createOscillator();
+        const gain1 = ctx.createGain();
+        osc1.type = "triangle";
+        osc1.frequency.setValueAtTime(340, now);
+        osc1.frequency.exponentialRampToValueAtTime(80, now + 0.08);
+        gain1.gain.setValueAtTime(0.38, now);
+        gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+        osc1.connect(gain1);
+        gain1.connect(ctx.destination);
+        osc1.start(now);
+        osc1.stop(now + 0.08);
+
+        const osc2 = ctx.createOscillator();
+        const gain2 = ctx.createGain();
+        osc2.type = "sine";
+        osc2.frequency.setValueAtTime(120, now);
+        osc2.frequency.exponentialRampToValueAtTime(45, now + 0.09);
+        gain2.gain.setValueAtTime(0.25, now);
+        gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
+        osc2.connect(gain2);
+        gain2.connect(ctx.destination);
+        osc2.start(now);
+        osc2.stop(now + 0.09);
+      }
+    } catch {}
+  }
+
+  // 2. Select Piece Sound: Soft wood tap (选子轻触)
+  function playSelectSound() {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const now = ctx.currentTime;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(560, now);
+      osc.frequency.exponentialRampToValueAtTime(320, now + 0.035);
+      gain.gain.setValueAtTime(0.18, now);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.035);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(now);
+      osc.stop(now + 0.035);
+    } catch {}
+  }
+
+  // 3. Check Sound: Ancient East Asian Zither / Chime Strike (将军！金石之声)
+  function playCheckSound() {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const freqs = [440.0, 554.37, 659.25, 880.0]; // A4, C#5, E5, A5
+      const now = ctx.currentTime;
+      freqs.forEach((freq, i) => {
+        const start = now + i * 0.04;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "triangle";
+        osc.frequency.setValueAtTime(freq, start);
+        gain.gain.setValueAtTime(0.26, start);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.45);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(start);
+        osc.stop(start + 0.45);
+      });
+    } catch {}
+  }
+
+  // 4. Victory Sound (旗开得胜)
+  function playVictorySound() {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const notes = [523.25, 659.25, 783.99, 1046.5]; // C5, E5, G5, C6
+      const now = ctx.currentTime;
+      notes.forEach((freq, idx) => {
+        const start = now + idx * 0.1;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "triangle";
+        osc.frequency.setValueAtTime(freq, start);
+        gain.gain.setValueAtTime(0.28, start);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.35);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(start);
+        osc.stop(start + 0.35);
+      });
+    } catch {}
+  }
+
+  // 5. Defeat Sound (惜败)
+  function playDefeatSound() {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+    try {
+      const notes = [392.0, 349.23, 311.13, 261.63]; // G4, F4, Eb4, C4
+      const now = ctx.currentTime;
+      notes.forEach((freq, idx) => {
+        const start = now + idx * 0.14;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(freq, start);
+        gain.gain.setValueAtTime(0.22, start);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.28);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(start);
+        osc.stop(start + 0.28);
+      });
+    } catch {}
   }
 
   function coordToString(x, y) {
@@ -547,6 +699,7 @@
       selectedCoord = { x, y };
       legalTargets = getClientLegalMoves(x, y);
       statusText.textContent = `已选择【${PIECE_NAMES[clickedPiece]}】，点击绿色标记点移动。`;
+      playSelectSound();
       drawBoard();
       return;
     }
@@ -588,6 +741,10 @@
 
   function updateUI() {
     if (status === "player_won") {
+      if (!gameOverSoundPlayed) {
+        gameOverSoundPlayed = true;
+        playVictorySound();
+      }
       turnBadge.className = "turn-indicator win";
       turnBadge.textContent = "🏆 旗开得胜！你赢了";
       statusText.textContent = "🎉 恭喜你绝杀获胜！棋局已完整保留供复盘截图。";
@@ -596,6 +753,10 @@
       resignBtn.style.display = "none";
       if (retryAgentBtn) retryAgentBtn.style.display = "none";
     } else if (status === "agent_won") {
+      if (!gameOverSoundPlayed) {
+        gameOverSoundPlayed = true;
+        playDefeatSound();
+      }
       turnBadge.className = "turn-indicator lose";
       turnBadge.textContent = "🤖 Agent 绝杀获胜";
       statusText.textContent = "本局对战结束，棋局已完整保留供复盘截图。";
@@ -612,6 +773,7 @@
       resignBtn.style.display = "none";
       if (retryAgentBtn) retryAgentBtn.style.display = "none";
     } else {
+      gameOverSoundPlayed = false;
       restartBtn.className = "btn";
       restartBtn.textContent = "重新开局";
       resignBtn.style.display = "inline-block";

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -1,0 +1,712 @@
+(function () {
+  const BOARD_COLS = 9;
+  const BOARD_ROWS = 10;
+  const COL_LETTERS = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+
+  // Piece Definitions
+  const PIECE_NAMES = {
+    1: "帥", 2: "仕", 3: "相", 4: "傌", 5: "俥", 6: "炮", 7: "兵",
+    "-1": "將", "-2": "士", "-3": "象", "-4": "馬", "-5": "車", "-6": "砲", "-7": "卒"
+  };
+
+  // State
+  let board = createInitialBoard();
+  let turn = 1; // 1: Player (Red), 2: Agent (Black)
+  let status = "playing";
+  let lastMove = null;
+  let selectedCoord = null;
+  let legalTargets = [];
+  let hoverCoord = null;
+  let audioCtx = null;
+  let initialized = false;
+
+  // DOM Elements
+  const canvas = document.getElementById("xiangqi-canvas");
+  const ctx = canvas.getContext("2d");
+  const turnBadge = document.getElementById("turn-badge");
+  const speechText = document.getElementById("speech-text");
+  const statusText = document.getElementById("status-text");
+  const restartBtn = document.getElementById("restart-btn");
+  const resignBtn = document.getElementById("resign-btn");
+  const retryAgentBtn = document.getElementById("retry-agent-btn");
+
+  function createInitialBoard() {
+    const b = Array.from({ length: BOARD_ROWS }, () => Array(BOARD_COLS).fill(0));
+    // Red Side (bottom, y = 0..3)
+    b[0][0] = 5; b[0][1] = 4; b[0][2] = 3; b[0][3] = 2; b[0][4] = 1;
+    b[0][5] = 2; b[0][6] = 3; b[0][7] = 4; b[0][8] = 5;
+    b[2][1] = 6; b[2][7] = 6;
+    b[3][0] = 7; b[3][2] = 7; b[3][4] = 7; b[3][6] = 7; b[3][8] = 7;
+
+    // Black Side (top, y = 6..9)
+    b[9][0] = -5; b[9][1] = -4; b[9][2] = -3; b[9][3] = -2; b[9][4] = -1;
+    b[9][5] = -2; b[9][6] = -3; b[9][7] = -4; b[9][8] = -5;
+    b[7][1] = -6; b[7][7] = -6;
+    b[6][0] = -7; b[6][2] = -7; b[6][4] = -7; b[6][6] = -7; b[6][8] = -7;
+    return b;
+  }
+
+  // Audio Synth for crisp wooden piece placement
+  function playPieceSound(isCapture = false) {
+    try {
+      if (!audioCtx) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      if (audioCtx.state === "suspended") {
+        audioCtx.resume();
+      }
+      const osc = audioCtx.createOscillator();
+      const gain = audioCtx.createGain();
+
+      if (isCapture) {
+        osc.type = "sawtooth";
+        osc.frequency.setValueAtTime(220, audioCtx.currentTime);
+        osc.frequency.exponentialRampToValueAtTime(60, audioCtx.currentTime + 0.12);
+        gain.gain.setValueAtTime(0.45, audioCtx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.12);
+        osc.connect(gain);
+        gain.connect(audioCtx.destination);
+        osc.start();
+        osc.stop(audioCtx.currentTime + 0.12);
+      } else {
+        osc.type = "triangle";
+        osc.frequency.setValueAtTime(360, audioCtx.currentTime);
+        osc.frequency.exponentialRampToValueAtTime(100, audioCtx.currentTime + 0.09);
+        gain.gain.setValueAtTime(0.4, audioCtx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.09);
+        osc.connect(gain);
+        gain.connect(audioCtx.destination);
+        osc.start();
+        osc.stop(audioCtx.currentTime + 0.09);
+      }
+    } catch (e) {
+      /* Audio not supported */
+    }
+  }
+
+  function coordToString(x, y) {
+    const col = COL_LETTERS[x] || `${x}`;
+    return `${col}${y}`;
+  }
+
+  function moveToString(fromX, fromY, toX, toY) {
+    return `${coordToString(fromX, fromY)}${coordToString(toX, toY)}`;
+  }
+
+  let cellWidth = 0;
+  let cellHeight = 0;
+  let paddingX = 0;
+  let paddingY = 0;
+  let pieceRadius = 0;
+
+  function resizeCanvas() {
+    const parent = canvas.parentElement || document.body;
+    const parentRect = parent.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+
+    const availWidth = Math.max(0, parentRect.width - 12);
+    const availHeight = Math.max(0, parentRect.height - 12);
+
+    // 9:10 aspect ratio
+    let width = availWidth;
+    let height = (width * 10) / 9;
+
+    if (height > availHeight) {
+      height = availHeight;
+      width = (height * 9) / 10;
+    }
+
+    width = Math.floor(width);
+    height = Math.floor(height);
+    if (width <= 0 || height <= 0) return;
+
+    paddingX = Math.round(width * 0.07);
+    paddingY = Math.round(height * 0.065);
+    cellWidth = (width - paddingX * 2) / (BOARD_COLS - 1);
+    cellHeight = (height - paddingY * 2) / (BOARD_ROWS - 1);
+    pieceRadius = Math.min(cellWidth, cellHeight) * 0.46;
+
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    canvas.width = Math.round(width * dpr);
+    canvas.height = Math.round(height * dpr);
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(dpr, dpr);
+
+    drawBoard();
+  }
+
+  function getMouseGridCoord(e) {
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+
+    const mouseX = (e.clientX - rect.left) * (canvas.width / (window.devicePixelRatio || 1) / rect.width);
+    const mouseY = (e.clientY - rect.top) * (canvas.height / (window.devicePixelRatio || 1) / rect.height);
+
+    // Find closest intersection
+    const x = Math.round((mouseX - paddingX) / cellWidth);
+    const y = Math.round((mouseY - paddingY) / cellHeight);
+
+    // Invert display Y so Red (y=0) is visually at the bottom
+    const gridY = BOARD_ROWS - 1 - y;
+
+    if (x >= 0 && x < BOARD_COLS && gridY >= 0 && gridY < BOARD_ROWS) {
+      return { x, y: gridY };
+    }
+    return null;
+  }
+
+  function getPixelCoord(gridX, gridY) {
+    const displayY = BOARD_ROWS - 1 - gridY;
+    const px = paddingX + gridX * cellWidth;
+    const py = paddingY + displayY * cellHeight;
+    return { px, py };
+  }
+
+  // Draw corner markers (折角)
+  function drawCornerMarker(gx, gy) {
+    const { px, py } = getPixelCoord(gx, gy);
+    const len = cellWidth * 0.16;
+    const dist = cellWidth * 0.08;
+
+    ctx.strokeStyle = "rgba(92, 58, 33, 0.75)";
+    ctx.lineWidth = 1.5;
+
+    const drawCorner = (dirX, dirY) => {
+      ctx.beginPath();
+      ctx.moveTo(px + dirX * dist, py + dirY * (dist + len));
+      ctx.lineTo(px + dirX * dist, py + dirY * dist);
+      ctx.lineTo(px + dirX * (dist + len), py + dirY * dist);
+      ctx.stroke();
+    };
+
+    if (gx > 0) {
+      drawCorner(-1, -1);
+      drawCorner(-1, 1);
+    }
+    if (gx < BOARD_COLS - 1) {
+      drawCorner(1, -1);
+      drawCorner(1, 1);
+    }
+  }
+
+  // Draw 3D Wooden Chinese Chess Piece
+  function drawPiece(gx, gy, piece, isSelected = false) {
+    const { px, py } = getPixelCoord(gx, gy);
+    const isRed = piece > 0;
+    const name = PIECE_NAMES[piece] || "";
+    const radius = pieceRadius;
+
+    ctx.save();
+
+    // 1. Drop Shadow
+    ctx.shadowColor = isSelected ? "rgba(245, 158, 11, 0.7)" : "rgba(0, 0, 0, 0.4)";
+    ctx.shadowBlur = isSelected ? 12 : 6;
+    ctx.shadowOffsetX = 2;
+    ctx.shadowOffsetY = 3;
+
+    // 2. Outer Wood Circle with Radial Gradient
+    ctx.beginPath();
+    ctx.arc(px, py, radius, 0, Math.PI * 2);
+    const woodGrad = ctx.createRadialGradient(
+      px - radius * 0.3,
+      py - radius * 0.3,
+      radius * 0.1,
+      px,
+      py,
+      radius
+    );
+    woodGrad.addColorStop(0, "#fef3c7");
+    woodGrad.addColorStop(0.7, "#fde68a");
+    woodGrad.addColorStop(1, "#d97706");
+    ctx.fillStyle = woodGrad;
+    ctx.fill();
+
+    // 3. Outer Rim Border
+    ctx.strokeStyle = isSelected ? "#f59e0b" : "#92400e";
+    ctx.lineWidth = isSelected ? 3 : 2;
+    ctx.stroke();
+
+    // 4. Inset Ring Line
+    ctx.beginPath();
+    ctx.arc(px, py, radius * 0.82, 0, Math.PI * 2);
+    ctx.strokeStyle = isRed ? "rgba(220, 38, 38, 0.4)" : "rgba(30, 41, 59, 0.4)";
+    ctx.lineWidth = 1.2;
+    ctx.stroke();
+
+    // 5. Piece Calligraphic Character
+    ctx.font = `bold ${Math.round(radius * 1.05)}px "Kaiti", "STKaiti", "KaiTi_GB2312", "SimSun", "Microsoft YaHei", sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = isRed ? "#b91c1c" : "#0f172a";
+    ctx.shadowColor = isRed ? "rgba(254, 202, 202, 0.8)" : "rgba(226, 232, 240, 0.6)";
+    ctx.shadowBlur = 1;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 1;
+
+    ctx.fillText(name, px, py + 1);
+
+    ctx.restore();
+  }
+
+  // Render complete Xiangqi Canvas
+  function drawBoard() {
+    const dpr = window.devicePixelRatio || 1;
+    const width = canvas.width / dpr;
+    const height = canvas.height / dpr;
+    if (width <= 0 || height <= 0) return;
+
+    ctx.clearRect(0, 0, width, height);
+
+    // 1. Board Background Texture
+    const bgGrad = ctx.createLinearGradient(0, 0, width, height);
+    bgGrad.addColorStop(0, "#f5dfb8");
+    bgGrad.addColorStop(1, "#e6c896");
+    ctx.fillStyle = bgGrad;
+    ctx.fillRect(0, 0, width, height);
+
+    // Outer double wooden frame
+    ctx.strokeStyle = "#5c3a21";
+    ctx.lineWidth = 2.5;
+    ctx.strokeRect(paddingX - 6, paddingY - 6, (BOARD_COLS - 1) * cellWidth + 12, (BOARD_ROWS - 1) * cellHeight + 12);
+    ctx.lineWidth = 1;
+    ctx.strokeRect(paddingX - 10, paddingY - 10, (BOARD_COLS - 1) * cellWidth + 20, (BOARD_ROWS - 1) * cellHeight + 20);
+
+    // 2. Grid lines
+    ctx.strokeStyle = "#78350f";
+    ctx.lineWidth = 1.2;
+
+    // Horizontal Lines (all 10 rows connected)
+    for (let r = 0; r < BOARD_ROWS; r++) {
+      const y = paddingY + r * cellHeight;
+      ctx.beginPath();
+      ctx.moveTo(paddingX, y);
+      ctx.lineTo(paddingX + (BOARD_COLS - 1) * cellWidth, y);
+      ctx.stroke();
+    }
+
+    // Vertical Lines (outer columns 0 & 8 connected through river; middle columns broken at river)
+    for (let c = 0; c < BOARD_COLS; c++) {
+      const x = paddingX + c * cellWidth;
+
+      if (c === 0 || c === BOARD_COLS - 1) {
+        // Outer borders go all the way
+        ctx.beginPath();
+        ctx.moveTo(x, paddingY);
+        ctx.lineTo(x, paddingY + (BOARD_ROWS - 1) * cellHeight);
+        ctx.stroke();
+      } else {
+        // Top half (Black side: row 0 to 4)
+        ctx.beginPath();
+        ctx.moveTo(x, paddingY);
+        ctx.lineTo(x, paddingY + 4 * cellHeight);
+        ctx.stroke();
+
+        // Bottom half (Red side: row 5 to 9)
+        ctx.beginPath();
+        ctx.moveTo(x, paddingY + 5 * cellHeight);
+        ctx.lineTo(x, paddingY + 9 * cellHeight);
+        ctx.stroke();
+      }
+    }
+
+    // 3. Palace Diagonals (九宫格斜线)
+    // Black Palace (top)
+    ctx.beginPath();
+    ctx.moveTo(paddingX + 3 * cellWidth, paddingY + 0 * cellHeight);
+    ctx.lineTo(paddingX + 5 * cellWidth, paddingY + 2 * cellHeight);
+    ctx.moveTo(paddingX + 5 * cellWidth, paddingY + 0 * cellHeight);
+    ctx.lineTo(paddingX + 3 * cellWidth, paddingY + 2 * cellHeight);
+    // Red Palace (bottom)
+    ctx.moveTo(paddingX + 3 * cellWidth, paddingY + 7 * cellHeight);
+    ctx.lineTo(paddingX + 5 * cellWidth, paddingY + 9 * cellHeight);
+    ctx.moveTo(paddingX + 5 * cellWidth, paddingY + 7 * cellHeight);
+    ctx.lineTo(paddingX + 3 * cellWidth, paddingY + 9 * cellHeight);
+    ctx.stroke();
+
+    // 4. River Calligraphy (楚河 漢界)
+    const riverY = paddingY + 4.5 * cellHeight;
+    ctx.font = `bold ${Math.round(cellHeight * 0.42)}px "Kaiti", "STKaiti", "KaiTi_GB2312", "Microsoft YaHei", serif`;
+    ctx.fillStyle = "rgba(120, 53, 15, 0.75)";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    ctx.fillText("楚  河", paddingX + 2 * cellWidth, riverY);
+    ctx.fillText("漢  界", paddingX + 6 * cellWidth, riverY);
+
+    // 5. Star / Cross Markers (兵/炮位十字花)
+    const starMarkers = [
+      // Red cannon & pawns
+      [1, 2], [7, 2], [0, 3], [2, 3], [4, 3], [6, 3], [8, 3],
+      // Black cannon & pawns
+      [1, 7], [7, 7], [0, 6], [2, 6], [4, 6], [6, 6], [8, 6]
+    ];
+    for (const [sx, sy] of starMarkers) {
+      drawCornerMarker(sx, sy);
+    }
+
+    // 6. Last Move Highlights
+    if (lastMove && lastMove.fromX !== undefined && lastMove.toX !== undefined) {
+      const fromPos = getPixelCoord(lastMove.fromX, lastMove.fromY);
+      const toPos = getPixelCoord(lastMove.toX, lastMove.toY);
+      const r = pieceRadius * 1.08;
+
+      ctx.save();
+      ctx.strokeStyle = "rgba(59, 130, 246, 0.85)";
+      ctx.lineWidth = 2.5;
+      ctx.setLineDash([4, 4]);
+      ctx.strokeRect(fromPos.px - r, fromPos.py - r, r * 2, r * 2);
+      ctx.setLineDash([]);
+      ctx.strokeStyle = "rgba(239, 68, 68, 0.9)";
+      ctx.strokeRect(toPos.px - r, toPos.py - r, r * 2, r * 2);
+      ctx.restore();
+    }
+
+    // 7. Render Pieces
+    for (let y = 0; y < BOARD_ROWS; y++) {
+      for (let x = 0; x < BOARD_COLS; x++) {
+        const piece = board[y][x];
+        if (piece !== 0) {
+          const isSelected = selectedCoord && selectedCoord.x === x && selectedCoord.y === y;
+          drawPiece(x, y, piece, isSelected);
+        }
+      }
+    }
+
+    // 8. Render Legal Move Target Indicators
+    if (selectedCoord && legalTargets.length > 0) {
+      for (const target of legalTargets) {
+        const { px, py } = getPixelCoord(target.toX, target.toY);
+        const targetPiece = board[target.toY][target.toX];
+
+        ctx.save();
+        if (targetPiece !== 0) {
+          // Capture Ring
+          ctx.strokeStyle = "rgba(239, 68, 68, 0.85)";
+          ctx.lineWidth = 3;
+          ctx.beginPath();
+          ctx.arc(px, py, pieceRadius * 1.15, 0, Math.PI * 2);
+          ctx.stroke();
+        } else {
+          // Empty Move Dot
+          ctx.fillStyle = "rgba(16, 185, 129, 0.85)";
+          ctx.beginPath();
+          ctx.arc(px, py, pieceRadius * 0.32, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.restore();
+      }
+    }
+  }
+
+  // Client-side quick legal move calculator for instant response
+  function getClientLegalMoves(fromX, fromY) {
+    const piece = board[fromY][fromX];
+    if (piece <= 0) return []; // Red pieces only for player
+    const absPiece = Math.abs(piece);
+    const moves = [];
+
+    const addIfValid = (tx, ty) => {
+      if (tx < 0 || tx >= BOARD_COLS || ty < 0 || ty >= BOARD_ROWS) return;
+      if (board[ty][tx] > 0) return; // Cannot capture own red pieces
+      moves.push({ toX: tx, toY: ty });
+    };
+
+    switch (absPiece) {
+      case 1: { // 帥 King
+        const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+        for (const [dx, dy] of dirs) {
+          const nx = fromX + dx;
+          const ny = fromY + dy;
+          if (nx >= 3 && nx <= 5 && ny >= 0 && ny <= 2) {
+            addIfValid(nx, ny);
+          }
+        }
+        // Flying general
+        let cy = fromY + 1;
+        while (cy < BOARD_ROWS) {
+          const p = board[cy][fromX];
+          if (p !== 0) {
+            if (p === -1) moves.push({ toX: fromX, toY: cy });
+            break;
+          }
+          cy++;
+        }
+        break;
+      }
+      case 2: { // 仕 Advisor
+        const dirs = [[1, 1], [1, -1], [-1, 1], [-1, -1]];
+        for (const [dx, dy] of dirs) {
+          const nx = fromX + dx;
+          const ny = fromY + dy;
+          if (nx >= 3 && nx <= 5 && ny >= 0 && ny <= 2) {
+            addIfValid(nx, ny);
+          }
+        }
+        break;
+      }
+      case 3: { // 相 Bishop
+        const dirs = [[2, 2], [2, -2], [-2, 2], [-2, -2]];
+        for (const [dx, dy] of dirs) {
+          const nx = fromX + dx;
+          const ny = fromY + dy;
+          const ex = fromX + dx / 2;
+          const ey = fromY + dy / 2;
+          if (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny <= 4) {
+            if (board[ey][ex] === 0) addIfValid(nx, ny);
+          }
+        }
+        break;
+      }
+      case 4: { // 傌 Knight
+        const km = [
+          { dx: 1, dy: 2, lx: 0, ly: 1 }, { dx: -1, dy: 2, lx: 0, ly: 1 },
+          { dx: 1, dy: -2, lx: 0, ly: -1 }, { dx: -1, dy: -2, lx: 0, ly: -1 },
+          { dx: 2, dy: 1, lx: 1, ly: 0 }, { dx: 2, dy: -1, lx: 1, ly: 0 },
+          { dx: -2, dy: 1, lx: -1, ly: 0 }, { dx: -2, dy: -1, lx: -1, ly: 0 }
+        ];
+        for (const m of km) {
+          const nx = fromX + m.dx;
+          const ny = fromY + m.dy;
+          if (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny < BOARD_ROWS) {
+            if (board[fromY + m.ly][fromX + m.lx] === 0) addIfValid(nx, ny);
+          }
+        }
+        break;
+      }
+      case 5: { // 俥 Rook
+        const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+        for (const [dx, dy] of dirs) {
+          let nx = fromX + dx, ny = fromY + dy;
+          while (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny < BOARD_ROWS) {
+            const t = board[ny][nx];
+            if (t === 0) {
+              moves.push({ toX: nx, toY: ny });
+            } else {
+              if (t < 0) moves.push({ toX: nx, toY: ny });
+              break;
+            }
+            nx += dx; ny += dy;
+          }
+        }
+        break;
+      }
+      case 6: { // 炮 Cannon
+        const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+        for (const [dx, dy] of dirs) {
+          let nx = fromX + dx, ny = fromY + dy;
+          let jumped = false;
+          while (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny < BOARD_ROWS) {
+            const t = board[ny][nx];
+            if (!jumped) {
+              if (t === 0) moves.push({ toX: nx, toY: ny });
+              else jumped = true;
+            } else {
+              if (t !== 0) {
+                if (t < 0) moves.push({ toX: nx, toY: ny });
+                break;
+              }
+            }
+            nx += dx; ny += dy;
+          }
+        }
+        break;
+      }
+      case 7: { // 兵 Pawn
+        addIfValid(fromX, fromY + 1);
+        if (fromY >= 5) {
+          addIfValid(fromX - 1, fromY);
+          addIfValid(fromX + 1, fromY);
+        }
+        break;
+      }
+    }
+
+    return moves;
+  }
+
+  function handleCanvasClick(e) {
+    if (status !== "playing") {
+      statusText.textContent = "本局已结束，请点击下方【重新开局】。";
+      return;
+    }
+
+    if (turn !== 1) {
+      statusText.textContent = "当前轮到 AI Agent (黑方) 走子，请稍候...";
+      return;
+    }
+
+    const coord = getMouseGridCoord(e);
+    if (!coord) return;
+
+    const { x, y } = coord;
+    const clickedPiece = board[y][x];
+
+    // Case 1: Clicking own Red piece -> Select it
+    if (clickedPiece > 0) {
+      selectedCoord = { x, y };
+      legalTargets = getClientLegalMoves(x, y);
+      statusText.textContent = `已选择【${PIECE_NAMES[clickedPiece]}】，点击绿色标记点移动。`;
+      drawBoard();
+      return;
+    }
+
+    // Case 2: Clicking destination with a piece selected
+    if (selectedCoord) {
+      const isLegal = legalTargets.some((t) => t.toX === x && t.toY === y);
+      if (isLegal) {
+        const fromX = selectedCoord.x;
+        const fromY = selectedCoord.y;
+        const actionId = moveToString(fromX, fromY, x, y);
+        const movingPiece = board[fromY][fromX];
+        const isCapture = board[y][x] < 0;
+
+        // Apply local optimistic update
+        board[y][x] = movingPiece;
+        board[fromY][fromX] = 0;
+        lastMove = { fromX, fromY, toX: x, toY: y, actionId, player: 1 };
+        turn = 2;
+        selectedCoord = null;
+        legalTargets = [];
+
+        playPieceSound(isCapture);
+        updateUI();
+        drawBoard();
+
+        // Notify Host
+        window.parent.postMessage({
+          type: "PLAYER_MOVE",
+          payload: { actionId, fromX, fromY, toX: x, toY: y }
+        }, "*");
+      } else {
+        selectedCoord = null;
+        legalTargets = [];
+        drawBoard();
+      }
+    }
+  }
+
+  function updateUI() {
+    if (status === "player_won") {
+      turnBadge.className = "turn-indicator win";
+      turnBadge.textContent = "🏆 旗开得胜！你赢了";
+      statusText.textContent = "🎉 恭喜你绝杀获胜！棋局已完整保留供复盘截图。";
+      restartBtn.className = "btn primary";
+      restartBtn.textContent = "再来一局";
+      resignBtn.style.display = "none";
+      if (retryAgentBtn) retryAgentBtn.style.display = "none";
+    } else if (status === "agent_won") {
+      turnBadge.className = "turn-indicator lose";
+      turnBadge.textContent = "🤖 Agent 绝杀获胜";
+      statusText.textContent = "本局对战结束，棋局已完整保留供复盘截图。";
+      restartBtn.className = "btn primary";
+      restartBtn.textContent = "再来一局";
+      resignBtn.style.display = "none";
+      if (retryAgentBtn) retryAgentBtn.style.display = "none";
+    } else if (status === "draw") {
+      turnBadge.className = "turn-indicator draw";
+      turnBadge.textContent = "🤝 双方握手言和 (平局)";
+      statusText.textContent = "双方握手言和。点击【再来一局】开启新对决。";
+      restartBtn.className = "btn primary";
+      restartBtn.textContent = "再来一局";
+      resignBtn.style.display = "none";
+      if (retryAgentBtn) retryAgentBtn.style.display = "none";
+    } else {
+      restartBtn.className = "btn";
+      restartBtn.textContent = "重新开局";
+      resignBtn.style.display = "inline-block";
+      if (turn === 1) {
+        turnBadge.className = "turn-indicator active-player";
+        turnBadge.textContent = "轮到你行动 (红方)";
+        statusText.textContent = "点击己方棋子，再点击目标位置移动";
+        if (retryAgentBtn) retryAgentBtn.style.display = "none";
+      } else {
+        turnBadge.className = "turn-indicator active-agent";
+        turnBadge.textContent = "Agent 正在思考中... (黑方)";
+        statusText.textContent = "AI Agent 正在思考走子方案...";
+      }
+    }
+  }
+
+  function syncState(snapshot) {
+    if (!snapshot) return;
+    const prevMove = lastMove;
+    board = snapshot.board || board;
+    turn = snapshot.turn ?? turn;
+    status = snapshot.status || status;
+    lastMove = snapshot.lastMove || null;
+
+    if (snapshot.chatHistory && snapshot.chatHistory.length > 0) {
+      const latestAgentChat = [...snapshot.chatHistory].reverse().find((c) => c.sender === "agent");
+      if (latestAgentChat) {
+        speechText.textContent = latestAgentChat.message;
+      }
+    }
+
+    if (initialized && lastMove && (!prevMove || prevMove.actionId !== lastMove.actionId)) {
+      playPieceSound(Boolean(lastMove.capturedPiece));
+    }
+    initialized = true;
+
+    selectedCoord = null;
+    legalTargets = [];
+    updateUI();
+    drawBoard();
+  }
+
+  // Host Message Listener
+  window.addEventListener("message", (event) => {
+    const data = event.data;
+    if (!data || typeof data !== "object") return;
+
+    if (data.type === "FREEBUDDY_GAME_SYNC" || data.type === "GAME_STATE_UPDATE") {
+      syncState(data.payload);
+    } else if (data.type === "AGENT_CHAT") {
+      speechText.textContent = data.payload?.message || "";
+    } else if (data.type === "AGENT_STALLED") {
+      const isStalled = Boolean(data.payload?.stalled);
+      if (isStalled && turn === 2 && status === "playing") {
+        if (retryAgentBtn) retryAgentBtn.style.display = "inline-block";
+        statusText.textContent = "AI 回复结束但未走子，请点击【重试】";
+      } else {
+        if (retryAgentBtn) retryAgentBtn.style.display = "none";
+      }
+    }
+  });
+
+  // Action Buttons
+  restartBtn.addEventListener("click", () => {
+    window.parent.postMessage({ type: "GAME_RESET" }, "*");
+  });
+
+  resignBtn.addEventListener("click", () => {
+    if (confirm("确定要认输吗？")) {
+      window.parent.postMessage({ type: "GAME_RESIGN" }, "*");
+    }
+  });
+
+  if (retryAgentBtn) {
+    retryAgentBtn.addEventListener("click", () => {
+      window.parent.postMessage({ type: "REMIND_AGENT" }, "*");
+      retryAgentBtn.style.display = "none";
+      statusText.textContent = "已向 AI 重新发送走子请求...";
+    });
+  }
+
+  canvas.addEventListener("click", handleCanvasClick);
+
+  window.addEventListener("resize", resizeCanvas);
+  if (window.ResizeObserver) {
+    const ro = new ResizeObserver(() => {
+      resizeCanvas();
+    });
+    ro.observe(canvas);
+  }
+
+  // Initialize
+  resizeCanvas();
+  updateUI();
+
+  // Notify host that canvas is ready
+  window.parent.postMessage({ type: "GAME_CANVAS_READY" }, "*");
+})();

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -136,11 +136,11 @@
   function updateMuteButtonUI() {
     if (!muteBtn) return;
     if (isMuted) {
-      muteBtn.textContent = "🔇";
+      muteBtn.textContent = "🔇 静音";
       muteBtn.classList.add("muted");
       muteBtn.title = "音效已静音（点击开启）";
     } else {
-      muteBtn.textContent = "🔊";
+      muteBtn.textContent = "🔊 音效";
       muteBtn.classList.remove("muted");
       muteBtn.title = "音效已开启（点击静音）";
     }

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -30,6 +30,37 @@
   const retryAgentBtn = document.getElementById("retry-agent-btn");
   const playerCapturedContainer = document.getElementById("player-captured");
   const agentCapturedContainer = document.getElementById("agent-captured");
+  const agentNameLabel = document.getElementById("agent-name-label");
+  const agentModelBadge = document.getElementById("agent-model-badge");
+  const agentAvatarIcon = document.getElementById("agent-avatar-icon");
+  const speechAvatar = document.getElementById("speech-avatar");
+
+  function updateAgentInfo(info) {
+    if (!info) return;
+    if (info.agentName && agentNameLabel) {
+      agentNameLabel.textContent = info.agentName;
+    }
+    if (agentModelBadge) {
+      if (info.modelName) {
+        agentModelBadge.textContent = info.modelName;
+        agentModelBadge.style.display = "inline-flex";
+        agentModelBadge.title = `运行模型: ${info.modelName}`;
+      } else {
+        agentModelBadge.style.display = "none";
+      }
+    }
+    if (info.avatarUrl) {
+      if (agentAvatarIcon) {
+        agentAvatarIcon.innerHTML = `<img src="${info.avatarUrl}" alt="agent" class="agent-avatar-img" />`;
+      }
+      if (speechAvatar) {
+        speechAvatar.innerHTML = `<img src="${info.avatarUrl}" alt="agent" class="speech-avatar-img" />`;
+      }
+    } else {
+      if (agentAvatarIcon) agentAvatarIcon.textContent = "🤖";
+      if (speechAvatar) speechAvatar.textContent = "🤖";
+    }
+  }
 
   const INITIAL_RED_COUNTS = { 5: 2, 6: 2, 4: 2, 3: 2, 2: 2, 7: 5 };
   const INITIAL_BLACK_COUNTS = { "-5": 2, "-6": 2, "-4": 2, "-3": 2, "-2": 2, "-7": 5 };
@@ -902,6 +933,11 @@
 
     if (data.type === "FREEBUDDY_GAME_SYNC" || data.type === "GAME_STATE_UPDATE") {
       syncState(data.payload);
+      if (data.payload?.agentInfo) {
+        updateAgentInfo(data.payload.agentInfo);
+      }
+    } else if (data.type === "AGENT_INFO_UPDATE") {
+      updateAgentInfo(data.payload);
     } else if (data.type === "AGENT_CHAT") {
       speechText.textContent = data.payload?.message || "";
     } else if (data.type === "AGENT_STALLED") {
@@ -1039,10 +1075,12 @@
     sCtx.fillText(outcomeText, badgeX + 12, badgeY + 20);
 
     // Players Info
-    sCtx.font = "15px -apple-system, sans-serif";
+    const agentName = agentNameLabel?.textContent || "AI Agent";
+    const modelName = agentModelBadge?.style.display !== "none" && agentModelBadge?.textContent ? ` [${agentModelBadge.textContent}]` : "";
+    sCtx.font = "14px -apple-system, sans-serif";
     sCtx.fillStyle = "#e2e8f0";
     sCtx.textAlign = "right";
-    sCtx.fillText("🔴 你 (红先)  VS  ⚫ AI Agent (黑后)", cardWidth - 40, 138);
+    sCtx.fillText(`🔴 玩家 (红)  VS  ⚫ ${agentName}${modelName} (黑)`, cardWidth - 40, 138);
     sCtx.textAlign = "left";
 
     // 4. Draw Chessboard (9:10 ratio)

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -28,6 +28,68 @@
   const restartBtn = document.getElementById("restart-btn");
   const resignBtn = document.getElementById("resign-btn");
   const retryAgentBtn = document.getElementById("retry-agent-btn");
+  const playerCapturedContainer = document.getElementById("player-captured");
+  const agentCapturedContainer = document.getElementById("agent-captured");
+
+  const INITIAL_RED_COUNTS = { 5: 2, 6: 2, 4: 2, 3: 2, 2: 2, 7: 5 };
+  const INITIAL_BLACK_COUNTS = { "-5": 2, "-6": 2, "-4": 2, "-3": 2, "-2": 2, "-7": 5 };
+  const BLACK_ORDER = [-5, -6, -4, -3, -2, -7];
+  const RED_ORDER = [5, 6, 4, 3, 2, 7];
+
+  function updateCapturedTray() {
+    if (!playerCapturedContainer || !agentCapturedContainer) return;
+
+    // Count live pieces on board
+    const liveCounts = {};
+    for (let y = 0; y < BOARD_ROWS; y++) {
+      for (let x = 0; x < BOARD_COLS; x++) {
+        const p = board[y][x];
+        if (p !== 0) {
+          liveCounts[p] = (liveCounts[p] || 0) + 1;
+        }
+      }
+    }
+
+    // Player captured (Missing Black pieces)
+    playerCapturedContainer.innerHTML = "";
+    for (const p of BLACK_ORDER) {
+      const init = INITIAL_BLACK_COUNTS[p] || 0;
+      const live = liveCounts[p] || 0;
+      const capturedCount = init - live;
+      if (capturedCount > 0) {
+        const badge = document.createElement("span");
+        badge.className = "mini-piece-badge black";
+        badge.textContent = PIECE_NAMES[p] || "";
+        if (capturedCount > 1) {
+          const countSpan = document.createElement("span");
+          countSpan.className = "mini-piece-count";
+          countSpan.textContent = `×${capturedCount}`;
+          badge.appendChild(countSpan);
+        }
+        playerCapturedContainer.appendChild(badge);
+      }
+    }
+
+    // Agent captured (Missing Red pieces)
+    agentCapturedContainer.innerHTML = "";
+    for (const p of RED_ORDER) {
+      const init = INITIAL_RED_COUNTS[p] || 0;
+      const live = liveCounts[p] || 0;
+      const capturedCount = init - live;
+      if (capturedCount > 0) {
+        const badge = document.createElement("span");
+        badge.className = "mini-piece-badge red";
+        badge.textContent = PIECE_NAMES[p] || "";
+        if (capturedCount > 1) {
+          const countSpan = document.createElement("span");
+          countSpan.className = "mini-piece-count";
+          countSpan.textContent = `×${capturedCount}`;
+          badge.appendChild(countSpan);
+        }
+        agentCapturedContainer.appendChild(badge);
+      }
+    }
+  }
 
   function createInitialBoard() {
     const b = Array.from({ length: BOARD_ROWS }, () => Array(BOARD_COLS).fill(0));
@@ -813,6 +875,8 @@
         statusText.textContent = "AI Agent 正在思考走子方案...";
       }
     }
+
+    updateCapturedTray();
   }
 
   function syncState(snapshot) {

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -492,30 +492,23 @@
     ctx.fillText("楚  河", paddingX + 2 * cellWidth, riverY);
     ctx.fillText("漢  界", paddingX + 6 * cellWidth, riverY);
 
-    // 4.5 Coordinate Labels (a-i along top/bottom, 0-9 along left/right)
-    ctx.fillStyle = "rgba(120, 53, 15, 0.85)";
-    ctx.font = `600 ${Math.max(10, Math.round(cellWidth * 0.28))}px "Segoe UI", "PingFang SC", -apple-system, sans-serif`;
+    // 4.5 Subtle Coordinate Labels (Only Left & Bottom)
+    ctx.fillStyle = "rgba(120, 53, 15, 0.45)";
+    ctx.font = `500 ${Math.max(9, Math.round(cellWidth * 0.24))}px "Segoe UI", "PingFang SC", -apple-system, sans-serif`;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
 
-    // Column Letters (a - i)
+    // Column Letters (a - i) along bottom only
     for (let c = 0; c < BOARD_COLS; c++) {
       const x = paddingX + c * cellWidth;
-      const colChar = COL_LETTERS[c];
-      // Bottom (below Red baseline)
-      ctx.fillText(colChar, x, height - paddingY * 0.42);
-      // Top (above Black baseline)
-      ctx.fillText(colChar, x, paddingY * 0.42);
+      ctx.fillText(COL_LETTERS[c], x, height - paddingY * 0.42);
     }
 
-    // Row Numbers (0 - 9, UCCI algebraic notation: 0 at Red bottom, 9 at Black top)
+    // Row Numbers (0 - 9) along left only (0 at Red bottom, 9 at Black top)
     for (let r = 0; r < BOARD_ROWS; r++) {
       const y = paddingY + r * cellHeight;
       const rowNum = `${BOARD_ROWS - 1 - r}`;
-      // Left
-      ctx.fillText(rowNum, paddingX * 0.45, y);
-      // Right
-      ctx.fillText(rowNum, width - paddingX * 0.45, y);
+      ctx.fillText(rowNum, paddingX * 0.46, y);
     }
 
     // 5. Star / Cross Markers (兵/炮位十字花)

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -71,26 +71,41 @@
     });
   }
 
-  function getAudioContext() {
-    if (isMuted) return null;
+  function withAudio(callback) {
+    if (isMuted) return;
     try {
       if (!audioCtx) {
         audioCtx = new (window.AudioContext || window.webkitAudioContext)();
       }
       if (audioCtx.state === "suspended") {
+        audioCtx.resume().then(() => {
+          if (audioCtx && audioCtx.state === "running") {
+            callback(audioCtx);
+          }
+        }).catch(() => {});
+      } else if (audioCtx.state === "running") {
+        callback(audioCtx);
+      }
+    } catch {}
+  }
+
+  // Global user interaction unlock
+  const unlockAudio = () => {
+    try {
+      if (!audioCtx) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      if (audioCtx && audioCtx.state === "suspended") {
         audioCtx.resume();
       }
-      return audioCtx;
-    } catch {
-      return null;
-    }
-  }
+    } catch {}
+  };
+  window.addEventListener("pointerdown", unlockAudio, { passive: true });
+  window.addEventListener("keydown", unlockAudio, { passive: true });
 
   // 1. Move Sound: Solid Wood Strike (实木落子)
   function playPieceSound(isCapture = false) {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const now = ctx.currentTime;
       if (isCapture) {
         // Heavy impact capture
@@ -98,79 +113,75 @@
         const gain1 = ctx.createGain();
         osc1.type = "sawtooth";
         osc1.frequency.setValueAtTime(260, now);
-        osc1.frequency.exponentialRampToValueAtTime(45, now + 0.14);
-        gain1.gain.setValueAtTime(0.48, now);
-        gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.14);
+        osc1.frequency.exponentialRampToValueAtTime(45, now + 0.15);
+        gain1.gain.setValueAtTime(0.5, now);
+        gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
         osc1.connect(gain1);
         gain1.connect(ctx.destination);
         osc1.start(now);
-        osc1.stop(now + 0.14);
+        osc1.stop(now + 0.15);
 
         const osc2 = ctx.createOscillator();
         const gain2 = ctx.createGain();
         osc2.type = "triangle";
         osc2.frequency.setValueAtTime(140, now);
-        osc2.frequency.exponentialRampToValueAtTime(30, now + 0.12);
-        gain2.gain.setValueAtTime(0.35, now);
-        gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.12);
+        osc2.frequency.exponentialRampToValueAtTime(30, now + 0.13);
+        gain2.gain.setValueAtTime(0.38, now);
+        gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.13);
         osc2.connect(gain2);
         gain2.connect(ctx.destination);
         osc2.start(now);
-        osc2.stop(now + 0.12);
+        osc2.stop(now + 0.13);
       } else {
         // Solid wood placement
         const osc1 = ctx.createOscillator();
         const gain1 = ctx.createGain();
         osc1.type = "triangle";
         osc1.frequency.setValueAtTime(340, now);
-        osc1.frequency.exponentialRampToValueAtTime(80, now + 0.08);
-        gain1.gain.setValueAtTime(0.38, now);
-        gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+        osc1.frequency.exponentialRampToValueAtTime(80, now + 0.09);
+        gain1.gain.setValueAtTime(0.42, now);
+        gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
         osc1.connect(gain1);
         gain1.connect(ctx.destination);
         osc1.start(now);
-        osc1.stop(now + 0.08);
+        osc1.stop(now + 0.09);
 
         const osc2 = ctx.createOscillator();
         const gain2 = ctx.createGain();
         osc2.type = "sine";
         osc2.frequency.setValueAtTime(120, now);
-        osc2.frequency.exponentialRampToValueAtTime(45, now + 0.09);
-        gain2.gain.setValueAtTime(0.25, now);
-        gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
+        osc2.frequency.exponentialRampToValueAtTime(45, now + 0.1);
+        gain2.gain.setValueAtTime(0.28, now);
+        gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
         osc2.connect(gain2);
         gain2.connect(ctx.destination);
         osc2.start(now);
-        osc2.stop(now + 0.09);
+        osc2.stop(now + 0.1);
       }
-    } catch {}
+    });
   }
 
   // 2. Select Piece Sound: Soft wood tap (选子轻触)
   function playSelectSound() {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const now = ctx.currentTime;
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
       osc.type = "sine";
       osc.frequency.setValueAtTime(560, now);
-      osc.frequency.exponentialRampToValueAtTime(320, now + 0.035);
-      gain.gain.setValueAtTime(0.18, now);
-      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.035);
+      osc.frequency.exponentialRampToValueAtTime(320, now + 0.04);
+      gain.gain.setValueAtTime(0.2, now);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.04);
       osc.connect(gain);
       gain.connect(ctx.destination);
       osc.start(now);
-      osc.stop(now + 0.035);
-    } catch {}
+      osc.stop(now + 0.04);
+    });
   }
 
   // 3. Check Sound: Ancient East Asian Zither / Chime Strike (将军！金石之声)
   function playCheckSound() {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const freqs = [440.0, 554.37, 659.25, 880.0]; // A4, C#5, E5, A5
       const now = ctx.currentTime;
       freqs.forEach((freq, i) => {
@@ -179,21 +190,19 @@
         const gain = ctx.createGain();
         osc.type = "triangle";
         osc.frequency.setValueAtTime(freq, start);
-        gain.gain.setValueAtTime(0.26, start);
+        gain.gain.setValueAtTime(0.28, start);
         gain.gain.exponentialRampToValueAtTime(0.001, start + 0.45);
         osc.connect(gain);
         gain.connect(ctx.destination);
         osc.start(start);
         osc.stop(start + 0.45);
       });
-    } catch {}
+    });
   }
 
   // 4. Victory Sound (旗开得胜)
   function playVictorySound() {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const notes = [523.25, 659.25, 783.99, 1046.5]; // C5, E5, G5, C6
       const now = ctx.currentTime;
       notes.forEach((freq, idx) => {
@@ -202,21 +211,19 @@
         const gain = ctx.createGain();
         osc.type = "triangle";
         osc.frequency.setValueAtTime(freq, start);
-        gain.gain.setValueAtTime(0.28, start);
-        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.35);
+        gain.gain.setValueAtTime(0.3, start);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.38);
         osc.connect(gain);
         gain.connect(ctx.destination);
         osc.start(start);
-        osc.stop(start + 0.35);
+        osc.stop(start + 0.38);
       });
-    } catch {}
+    });
   }
 
   // 5. Defeat Sound (惜败)
   function playDefeatSound() {
-    const ctx = getAudioContext();
-    if (!ctx) return;
-    try {
+    withAudio((ctx) => {
       const notes = [392.0, 349.23, 311.13, 261.63]; // G4, F4, Eb4, C4
       const now = ctx.currentTime;
       notes.forEach((freq, idx) => {
@@ -225,14 +232,14 @@
         const gain = ctx.createGain();
         osc.type = "sine";
         osc.frequency.setValueAtTime(freq, start);
-        gain.gain.setValueAtTime(0.22, start);
-        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.28);
+        gain.gain.setValueAtTime(0.24, start);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.3);
         osc.connect(gain);
         gain.connect(ctx.destination);
         osc.start(start);
-        osc.stop(start + 0.28);
+        osc.stop(start + 0.3);
       });
-    } catch {}
+    });
   }
 
   function coordToString(x, y) {

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -56,16 +56,11 @@
       const init = INITIAL_BLACK_COUNTS[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
-      if (capturedCount > 0) {
+      for (let i = 0; i < capturedCount; i++) {
         const badge = document.createElement("span");
         badge.className = "mini-piece-badge black";
         badge.textContent = PIECE_NAMES[p] || "";
-        if (capturedCount > 1) {
-          const countSpan = document.createElement("span");
-          countSpan.className = "mini-piece-count";
-          countSpan.textContent = `×${capturedCount}`;
-          badge.appendChild(countSpan);
-        }
+        badge.title = PIECE_NAMES[p] || "";
         playerCapturedContainer.appendChild(badge);
       }
     }
@@ -76,16 +71,11 @@
       const init = INITIAL_RED_COUNTS[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
-      if (capturedCount > 0) {
+      for (let i = 0; i < capturedCount; i++) {
         const badge = document.createElement("span");
         badge.className = "mini-piece-badge red";
         badge.textContent = PIECE_NAMES[p] || "";
-        if (capturedCount > 1) {
-          const countSpan = document.createElement("span");
-          countSpan.className = "mini-piece-count";
-          countSpan.textContent = `×${capturedCount}`;
-          badge.appendChild(countSpan);
-        }
+        badge.title = PIECE_NAMES[p] || "";
         agentCapturedContainer.appendChild(badge);
       }
     }

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <title>FreeBuddy Agent Xiangqi</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="game-container">
+    <!-- Header -->
+    <header class="game-header">
+      <div class="player-badge red">
+        <span class="piece-indicator red">帥</span>
+        <span>你 (红方)</span>
+      </div>
+      <div id="turn-badge" class="turn-indicator active-player">
+        轮到你行动 (红方)
+      </div>
+      <div class="player-badge black">
+        <span>AI Agent (黑方)</span>
+        <span class="piece-indicator black">將</span>
+      </div>
+    </header>
+
+    <!-- Agent Dialogue Banner -->
+    <div class="agent-speech-banner">
+      <div class="avatar">🤖</div>
+      <div id="speech-text" class="content">楚河汉界，九宫争雄！请执红先行！</div>
+    </div>
+
+    <!-- Board Area (100% Unobstructed for Screenshot & Analysis) -->
+    <div class="board-wrapper">
+      <canvas id="xiangqi-canvas"></canvas>
+    </div>
+
+    <!-- Footer Controls -->
+    <footer class="game-footer">
+      <div id="status-text" class="status-text">点击己方棋子，再点击目标位置移动</div>
+      <div class="btn-group">
+        <button id="retry-agent-btn" class="btn warning" style="display: none;">⚠️ AI 遗漏走子，点击重试</button>
+        <button id="resign-btn" class="btn danger">认输</button>
+        <button id="restart-btn" class="btn">重新开局</button>
+      </div>
+    </footer>
+  </div>
+
+  <script src="./game.js"></script>
+</body>
+</html>

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -39,10 +39,29 @@
       <div id="status-text" class="status-text">点击己方棋子，再点击目标位置移动</div>
       <div class="btn-group">
         <button id="retry-agent-btn" class="btn warning" style="display: none;">⚠️ AI 遗漏走子，点击重试</button>
+        <button id="share-btn" class="btn" title="生成并分享战报长图">📸 分享</button>
         <button id="resign-btn" class="btn danger">认输</button>
         <button id="restart-btn" class="btn">重新开局</button>
       </div>
     </footer>
+  </div>
+
+  <!-- Share Card Modal -->
+  <div id="share-modal" class="share-modal-backdrop" style="display: none;">
+    <div class="share-modal-card">
+      <div class="share-modal-header">
+        <div class="share-modal-title">📸 象棋对弈战报分享</div>
+        <button id="close-share-btn" class="icon-close-btn" aria-label="关闭">✕</button>
+      </div>
+      <div class="share-preview-wrap">
+        <img id="share-image-preview" class="share-preview-img" alt="战报预览" />
+      </div>
+      <div class="share-modal-actions">
+        <button id="copy-share-btn" class="btn primary">📋 复制图片</button>
+        <button id="download-share-btn" class="btn">💾 保存图片</button>
+      </div>
+      <div id="share-toast" class="share-toast" style="display: none;">已复制到剪贴板！</div>
+    </div>
   </div>
 
   <script src="./game.js"></script>

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -31,7 +31,6 @@
           </div>
           <div id="agent-captured" class="captured-tray right" title="AI 吃掉的红子"></div>
         </div>
-        <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>
     </header>
 
@@ -51,6 +50,7 @@
       <div id="status-text" class="status-text">点击己方棋子，再点击目标位置移动</div>
       <div class="btn-group">
         <button id="retry-agent-btn" class="btn warning" style="display: none;">⚠️ AI 遗漏走子，点击重试</button>
+        <button id="mute-btn" class="btn" title="开启/关闭音效" aria-label="音效开关">🔊 音效</button>
         <button id="share-btn" class="btn" title="生成并分享战报长图">📸 分享</button>
         <button id="resign-btn" class="btn danger">认输</button>
         <button id="restart-btn" class="btn">重新开局</button>

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -25,13 +25,11 @@
           <div class="player-badge black">
             <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
             <span id="agent-name-label">AI Agent</span>
+            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
             <span class="side-tag">(黑方)</span>
             <span class="piece-indicator black">將</span>
           </div>
-          <div class="agent-meta-row">
-            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
-            <div id="agent-captured" class="captured-tray right" title="AI 吃掉的红子"></div>
-          </div>
+          <div id="agent-captured" class="captured-tray right" title="AI 吃掉的红子"></div>
         </div>
         <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -25,7 +25,6 @@
           <div class="player-badge black">
             <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
             <span id="agent-name-label">AI Agent</span>
-            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
             <span class="side-tag">(黑方)</span>
             <span class="piece-indicator black">將</span>
           </div>

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -10,17 +10,23 @@
   <div class="game-container">
     <!-- Header -->
     <header class="game-header">
-      <div class="player-badge red">
-        <span class="piece-indicator red">帥</span>
-        <span>你 (红方)</span>
+      <div class="player-col left">
+        <div class="player-badge red">
+          <span class="piece-indicator red">帥</span>
+          <span>你 (红方)</span>
+        </div>
+        <div id="player-captured" class="captured-tray" title="你吃掉的黑子"></div>
       </div>
       <div id="turn-badge" class="turn-indicator active-player">
         轮到你行动 (红方)
       </div>
       <div class="header-right">
-        <div class="player-badge black">
-          <span>AI Agent (黑方)</span>
-          <span class="piece-indicator black">將</span>
+        <div class="player-col right">
+          <div class="player-badge black">
+            <span>AI Agent (黑方)</span>
+            <span class="piece-indicator black">將</span>
+          </div>
+          <div id="agent-captured" class="captured-tray right" title="AI 吃掉的红子"></div>
         </div>
         <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -23,10 +23,15 @@
       <div class="header-right">
         <div class="player-col right">
           <div class="player-badge black">
-            <span>AI Agent (黑方)</span>
+            <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
+            <span id="agent-name-label">AI Agent</span>
+            <span class="side-tag">(黑方)</span>
             <span class="piece-indicator black">將</span>
           </div>
-          <div id="agent-captured" class="captured-tray right" title="AI 吃掉的红子"></div>
+          <div class="agent-meta-row">
+            <span id="agent-model-badge" class="agent-model-badge" style="display: none;"></span>
+            <div id="agent-captured" class="captured-tray right" title="AI 吃掉的红子"></div>
+          </div>
         </div>
         <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>
@@ -34,7 +39,7 @@
 
     <!-- Agent Dialogue Banner -->
     <div class="agent-speech-banner">
-      <div class="avatar">🤖</div>
+      <div id="speech-avatar" class="avatar">🤖</div>
       <div id="speech-text" class="content">楚河汉界，九宫争雄！请执红先行！</div>
     </div>
 

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -17,9 +17,12 @@
       <div id="turn-badge" class="turn-indicator active-player">
         轮到你行动 (红方)
       </div>
-      <div class="player-badge black">
-        <span>AI Agent (黑方)</span>
-        <span class="piece-indicator black">將</span>
+      <div class="header-right">
+        <div class="player-badge black">
+          <span>AI Agent (黑方)</span>
+          <span class="piece-indicator black">將</span>
+        </div>
+        <button id="mute-btn" class="icon-btn-sound" title="开启/关闭音效" aria-label="音效开关">🔊</button>
       </div>
     </header>
 

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -1,0 +1,250 @@
+:root {
+  --bg-color: #121316;
+  --panel-bg: rgba(26, 29, 36, 0.95);
+  --board-bg: #e6c896;
+  --board-grid: #5c3a21;
+  --text-main: #f0f2f5;
+  --text-muted: #9ba1ad;
+  --accent: #10b981;
+  --accent-glow: rgba(16, 185, 129, 0.35);
+  --red-piece: #dc2626;
+  --black-piece: #1e293b;
+  --danger: #ef4444;
+  --success: #10b981;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  user-select: none;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Segoe UI", Roboto, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.game-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 10px;
+  gap: 10px;
+}
+
+/* Header & Status */
+.game-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--panel-bg);
+  padding: 8px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.player-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.player-badge.red {
+  color: #f87171;
+}
+
+.player-badge.black {
+  color: #94a3b8;
+}
+
+.piece-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: 700;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.piece-indicator.red {
+  background: #fee2e2;
+  color: #b91c1c;
+  border: 1.5px solid #ef4444;
+}
+
+.piece-indicator.black {
+  background: #334155;
+  color: #f8fafc;
+  border: 1.5px solid #64748b;
+}
+
+.turn-indicator {
+  padding: 4px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-muted);
+  transition: all 0.3s ease;
+}
+
+.turn-indicator.active-player {
+  background: rgba(220, 38, 38, 0.2);
+  color: #fca5a5;
+  border: 1px solid #dc2626;
+  box-shadow: 0 0 10px rgba(220, 38, 38, 0.3);
+}
+
+.turn-indicator.active-agent {
+  background: rgba(99, 102, 241, 0.2);
+  color: #c7d2fe;
+  border: 1px solid #6366f1;
+  box-shadow: 0 0 10px rgba(99, 102, 241, 0.3);
+}
+
+/* Agent Dialogue Bubble */
+.agent-speech-banner {
+  position: relative;
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.7), rgba(15, 23, 42, 0.8));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 8px 14px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+}
+
+.agent-speech-banner .avatar {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.agent-speech-banner .content {
+  font-size: 13px;
+  color: #e2e8f0;
+  line-height: 1.4;
+  flex: 1;
+}
+
+/* Board Wrapper */
+.board-wrapper {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 2px;
+}
+
+#xiangqi-canvas {
+  aspect-ratio: 9 / 10;
+  background-color: var(--board-bg);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5), inset 0 0 40px rgba(92, 58, 33, 0.25);
+  cursor: pointer;
+}
+
+/* Footer / Controls */
+.game-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-text {
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.btn-group {
+  display: flex;
+  gap: 8px;
+}
+
+.btn {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-main);
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.btn.primary {
+  background: #10b981;
+  border-color: #10b981;
+}
+
+.btn.primary:hover {
+  background: #059669;
+}
+
+.btn.danger:hover {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: #ef4444;
+}
+
+.btn.warning {
+  background: rgba(245, 158, 11, 0.2);
+  border: 1px solid #f59e0b;
+  color: #fbbf24;
+  animation: pulse-glow 2s infinite ease-in-out;
+}
+
+.btn.warning:hover {
+  background: rgba(245, 158, 11, 0.35);
+}
+
+.turn-indicator.win {
+  background: rgba(16, 185, 129, 0.2);
+  color: #34d399;
+  border: 1px solid #10b981;
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.35);
+}
+
+.turn-indicator.lose {
+  background: rgba(239, 68, 68, 0.2);
+  color: #fca5a5;
+  border: 1px solid #ef4444;
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.35);
+}
+
+.turn-indicator.draw {
+  background: rgba(148, 163, 184, 0.2);
+  color: #cbd5e1;
+  border: 1px solid #94a3b8;
+}
+
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 4px rgba(245, 158, 11, 0.3); }
+  50% { box-shadow: 0 0 12px rgba(245, 158, 11, 0.6); }
+}
+

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -109,12 +109,12 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  position: relative;
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
+  font-family: "Kaiti", "STKaiti", "KaiTi_GB2312", "Microsoft YaHei", sans-serif;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
   animation: popIn 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
@@ -129,20 +129,6 @@ body {
   background: radial-gradient(circle at 35% 35%, #fef3c7, #fde68a 70%, #d97706);
   color: #0f172a;
   border: 1px solid #334155;
-}
-
-.mini-piece-count {
-  position: absolute;
-  top: -4px;
-  right: -5px;
-  background: #3b82f6;
-  color: #fff;
-  font-size: 8px;
-  font-weight: 700;
-  border-radius: 8px;
-  padding: 0 3px;
-  line-height: 11px;
-  border: 1px solid #1e293b;
 }
 
 @keyframes popIn {

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -83,6 +83,79 @@ body {
   filter: grayscale(1);
 }
 
+.player-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.player-col.right {
+  align-items: flex-end;
+}
+
+.captured-tray {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  min-height: 18px;
+  flex-wrap: wrap;
+}
+
+.captured-tray.right {
+  justify-content: flex-end;
+}
+
+.mini-piece-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 700;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  animation: popIn 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.mini-piece-badge.red {
+  background: radial-gradient(circle at 35% 35%, #fef3c7, #fde68a 70%, #d97706);
+  color: #b91c1c;
+  border: 1px solid #b91c1c;
+}
+
+.mini-piece-badge.black {
+  background: radial-gradient(circle at 35% 35%, #fef3c7, #fde68a 70%, #d97706);
+  color: #0f172a;
+  border: 1px solid #334155;
+}
+
+.mini-piece-count {
+  position: absolute;
+  top: -4px;
+  right: -5px;
+  background: #3b82f6;
+  color: #fff;
+  font-size: 8px;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 0 3px;
+  line-height: 11px;
+  border: 1px solid #1e293b;
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .player-badge {
   display: flex;
   align-items: center;

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -248,3 +248,107 @@ body {
   50% { box-shadow: 0 0 12px rgba(245, 158, 11, 0.6); }
 }
 
+/* Share Modal */
+.share-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 16px;
+  animation: fadeIn 0.2s ease;
+}
+
+.share-modal-card {
+  background: #181b22;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  padding: 16px;
+  max-width: 440px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.6);
+  position: relative;
+}
+
+.share-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.share-modal-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.icon-close-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 14px;
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+
+.icon-close-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-main);
+}
+
+.share-preview-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: auto;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 8px;
+}
+
+.share-preview-img {
+  max-width: 100%;
+  max-height: 52vh;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.share-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.share-toast {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(16, 185, 129, 0.95);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -369,6 +369,11 @@ body {
   border-color: rgba(255, 255, 255, 0.25);
 }
 
+.btn.muted {
+  opacity: 0.65;
+  color: var(--text-muted);
+}
+
 .btn.primary {
   background: #10b981;
   border-color: #10b981;

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -96,28 +96,13 @@ body {
 .captured-tray {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   min-height: 18px;
   flex-wrap: wrap;
 }
 
 .captured-tray.right {
   justify-content: flex-end;
-}
-
-.captured-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-}
-
-.captured-count {
-  font-size: 11px;
-  font-weight: 700;
-  color: #cbd5e1;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  margin-right: 3px;
-  line-height: 1;
 }
 
 .mini-piece-badge {
@@ -259,39 +244,27 @@ body {
 }
 
 .turn-indicator {
-  padding: 3px 12px;
-  border-radius: 12px;
-  font-size: 11.5px;
-  font-weight: 500;
-  background: rgba(255, 255, 255, 0.05);
+  padding: 4px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
   color: var(--text-muted);
   transition: all 0.3s ease;
-  border: 1px solid transparent;
-  white-space: nowrap;
 }
 
 .turn-indicator.active-player {
-  background: rgba(239, 68, 68, 0.14);
+  background: rgba(220, 38, 38, 0.2);
   color: #fca5a5;
-  border-color: rgba(239, 68, 68, 0.35);
+  border: 1px solid #dc2626;
+  box-shadow: 0 0 10px rgba(220, 38, 38, 0.3);
 }
 
 .turn-indicator.active-agent {
-  background: rgba(99, 102, 241, 0.14);
+  background: rgba(99, 102, 241, 0.2);
   color: #c7d2fe;
-  border-color: rgba(99, 102, 241, 0.35);
-}
-
-.turn-indicator.win {
-  background: rgba(16, 185, 129, 0.14);
-  color: #6ee7b7;
-  border-color: rgba(16, 185, 129, 0.35);
-}
-
-.turn-indicator.lose {
-  background: rgba(239, 68, 68, 0.14);
-  color: #fca5a5;
-  border-color: rgba(239, 68, 68, 0.35);
+  border: 1px solid #6366f1;
+  box-shadow: 0 0 10px rgba(99, 102, 241, 0.3);
 }
 
 /* Agent Dialogue Bubble */

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -53,6 +53,36 @@ body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.icon-btn-sound {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 3px 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  line-height: 1;
+}
+
+.icon-btn-sound:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.icon-btn-sound.muted {
+  opacity: 0.6;
+  filter: grayscale(1);
+}
+
 .player-badge {
   display: flex;
   align-items: center;

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -164,46 +164,26 @@ body {
   font-weight: normal;
 }
 
-.agent-model-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0 5px;
-  background: rgba(99, 102, 241, 0.16);
-  color: #a5b4fc;
-  border: 1px solid rgba(99, 102, 241, 0.32);
-  border-radius: 4px;
-  font-size: 9.5px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-weight: 500;
-  max-width: 110px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 16px;
-  height: 16px;
-  vertical-align: middle;
-}
-
 .agent-avatar-mini {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  max-width: 20px;
-  max-height: 20px;
+  width: 18px;
+  height: 18px;
+  max-width: 18px;
+  max-height: 18px;
   border-radius: 50%;
   overflow: hidden;
   background: rgba(255, 255, 255, 0.08);
-  font-size: 12px;
+  font-size: 11px;
   flex-shrink: 0;
 }
 
 .agent-avatar-img {
-  width: 20px;
-  height: 20px;
-  max-width: 20px;
-  max-height: 20px;
+  width: 18px;
+  height: 18px;
+  max-width: 18px;
+  max-height: 18px;
   object-fit: cover;
   border-radius: 50%;
   display: block;

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -96,13 +96,28 @@ body {
 .captured-tray {
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 4px;
   min-height: 18px;
   flex-wrap: wrap;
 }
 
 .captured-tray.right {
   justify-content: flex-end;
+}
+
+.captured-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.captured-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: #cbd5e1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  margin-right: 3px;
+  line-height: 1;
 }
 
 .mini-piece-badge {
@@ -244,27 +259,39 @@ body {
 }
 
 .turn-indicator {
-  padding: 4px 14px;
-  border-radius: 20px;
-  font-size: 12px;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.06);
+  padding: 3px 12px;
+  border-radius: 12px;
+  font-size: 11.5px;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.05);
   color: var(--text-muted);
   transition: all 0.3s ease;
+  border: 1px solid transparent;
+  white-space: nowrap;
 }
 
 .turn-indicator.active-player {
-  background: rgba(220, 38, 38, 0.2);
+  background: rgba(239, 68, 68, 0.14);
   color: #fca5a5;
-  border: 1px solid #dc2626;
-  box-shadow: 0 0 10px rgba(220, 38, 38, 0.3);
+  border-color: rgba(239, 68, 68, 0.35);
 }
 
 .turn-indicator.active-agent {
-  background: rgba(99, 102, 241, 0.2);
+  background: rgba(99, 102, 241, 0.14);
   color: #c7d2fe;
-  border: 1px solid #6366f1;
-  box-shadow: 0 0 10px rgba(99, 102, 241, 0.3);
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.turn-indicator.win {
+  background: rgba(16, 185, 129, 0.14);
+  color: #6ee7b7;
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.turn-indicator.lose {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fca5a5;
+  border-color: rgba(239, 68, 68, 0.35);
 }
 
 /* Agent Dialogue Bubble */

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -145,7 +145,7 @@ body {
 .player-badge {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   font-size: 13px;
   font-weight: 600;
 }
@@ -155,7 +155,66 @@ body {
 }
 
 .player-badge.black {
+  color: #e2e8f0;
+}
+
+.side-tag {
   color: #94a3b8;
+  font-size: 12px;
+  font-weight: normal;
+}
+
+.agent-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  margin-top: 2px;
+}
+
+.agent-model-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  background: rgba(99, 102, 241, 0.18);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: 6px;
+  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-weight: 500;
+  max-width: 140px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 14px;
+}
+
+.agent-avatar-mini {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.agent-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.speech-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
 }
 
 .piece-indicator {

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -194,27 +194,35 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
+  max-width: 20px;
+  max-height: 20px;
   border-radius: 50%;
   overflow: hidden;
   background: rgba(255, 255, 255, 0.08);
-  font-size: 13px;
+  font-size: 12px;
   flex-shrink: 0;
 }
 
 .agent-avatar-img {
-  width: 100%;
-  height: 100%;
+  width: 20px;
+  height: 20px;
+  max-width: 20px;
+  max-height: 20px;
   object-fit: cover;
   border-radius: 50%;
+  display: block;
 }
 
 .speech-avatar-img {
-  width: 100%;
-  height: 100%;
+  width: 24px;
+  height: 24px;
+  max-width: 24px;
+  max-height: 24px;
   object-fit: cover;
   border-radius: 50%;
+  display: block;
 }
 
 .piece-indicator {
@@ -279,8 +287,29 @@ body {
 }
 
 .agent-speech-banner .avatar {
-  font-size: 20px;
+  width: 24px;
+  height: 24px;
+  max-width: 24px;
+  max-height: 24px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
   line-height: 1;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.agent-speech-banner .avatar img {
+  width: 24px;
+  height: 24px;
+  max-width: 24px;
+  max-height: 24px;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
 }
 
 .agent-speech-banner .content {

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -164,30 +164,24 @@ body {
   font-weight: normal;
 }
 
-.agent-meta-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  justify-content: flex-end;
-  margin-top: 2px;
-}
-
 .agent-model-badge {
   display: inline-flex;
   align-items: center;
-  padding: 1px 7px;
-  background: rgba(99, 102, 241, 0.18);
+  padding: 0 5px;
+  background: rgba(99, 102, 241, 0.16);
   color: #a5b4fc;
-  border: 1px solid rgba(99, 102, 241, 0.35);
-  border-radius: 6px;
-  font-size: 10px;
+  border: 1px solid rgba(99, 102, 241, 0.32);
+  border-radius: 4px;
+  font-size: 9.5px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-weight: 500;
-  max-width: 140px;
+  max-width: 110px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 14px;
+  line-height: 16px;
+  height: 16px;
+  vertical-align: middle;
 }
 
 .agent-avatar-mini {

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -41,52 +41,23 @@ body {
   gap: 10px;
 }
 
-/* Header & Status */
 .game-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: var(--panel-bg);
-  padding: 8px 16px;
+  padding: 8px 12px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.icon-btn-sound {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 13px;
-  padding: 3px 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-  line-height: 1;
-}
-
-.icon-btn-sound:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.icon-btn-sound.muted {
-  opacity: 0.6;
-  filter: grayscale(1);
+  gap: 8px;
 }
 
 .player-col {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
 }
 
 .player-col.right {

--- a/src/components/Browser/BrowserCanvas.tsx
+++ b/src/components/Browser/BrowserCanvas.tsx
@@ -417,9 +417,15 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
           const suggestedCoord = legalMoves?.[0]?.coord || "H8";
 
           if (sendMessage) {
+            const isXiangqi = moveRes?.gameState?.gameType === "xiangqi";
+            const isWon = moveRes?.gameState?.status === "player_won";
+            const promptText = isWon
+              ? (isXiangqi ? `玩家走子：${actionId}，绝杀获胜！` : `玩家落子：${actionId}，五连珠获胜！`)
+              : (isXiangqi ? `玩家走子：${actionId}` : `玩家落子：${actionId}`);
+
             void sendMessage({
               conversationId: activeId,
-              prompt: `[玩家落子] 坐标：${actionId}。轮到你行动，请直接调用 MCP 工具 game_make_move(actionId, reason) 落子，并调用 game_send_chat(message, mood) 发送台词。`
+              prompt: promptText
             });
           }
         } catch (err) {
@@ -443,7 +449,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
           if (sendMessage) {
             void sendMessage({
               conversationId: activeId,
-              prompt: `【重新开局】我已重置了棋盘。我执黑先行，你执白后手。请调用 game_send_chat 工具向我打个招呼，并准备接招！`
+              prompt: `【重新开局】我已重置了棋盘，准备开始新一局！`
             });
           }
         } catch (err) {
@@ -453,7 +459,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
         if (sendMessage) {
           void sendMessage({
             conversationId: activeId,
-            prompt: `【催促落子】轮到你执白行动，请直接调用 MCP 工具 game_make_move(actionId, reason) 尽快完成落子！`
+            prompt: `轮到你行动，请尽快出招。`
           });
         }
       } else if (data.type === "GAME_RESIGN") {

--- a/src/components/Browser/BrowserCanvas.tsx
+++ b/src/components/Browser/BrowserCanvas.tsx
@@ -17,6 +17,9 @@ import {
   clipFeedTitle,
   isFeedInterpretConversation
 } from "../Feeds/feedInterpretation";
+import { builtinCliMembers } from "@/config/aiMembers";
+import { getAgentIconId } from "@/config/agentIcon";
+import { lobehubAvatarUrl } from "@/utils/lobehubAvatar";
 import { BrowserToolbar, type BrowserViewport } from "./BrowserToolbar";
 import { MarkdownText } from "../CLI/StreamItem";
 
@@ -401,6 +404,41 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
   // Bridge game canvas iframe with FreeBuddy Game Service and Agent session
   const processedMessageIdsRef = useRef<Set<string>>(new Set());
 
+  const activeConversation = useConversationStore((s) =>
+    activeId ? s.conversations.find((c) => c.id === activeId) : undefined
+  );
+
+  const agentInfo = useMemo(() => {
+    if (!activeConversation) return null;
+    const member = builtinCliMembers.find((m) => m.id === activeConversation.agentId);
+    const iconId =
+      activeConversation.agentId === "cli-butlerbuddy"
+        ? "Bilibili"
+        : getAgentIconId(activeConversation.adapter, member?.avatar);
+    const avatarUrl = iconId ? lobehubAvatarUrl(iconId) : undefined;
+    const model =
+      activeConversation.configOptionOverrides?.model ||
+      activeConversation.configOptionOverrides?.model_config ||
+      (activeConversation.metadata as any)?.model ||
+      "";
+
+    return {
+      agentId: activeConversation.agentId,
+      agentName: activeConversation.agentName || member?.name || "AI Agent",
+      avatarUrl: avatarUrl || "",
+      modelName: model ? String(model) : ""
+    };
+  }, [activeConversation]);
+
+  useEffect(() => {
+    if (frameRef.current?.contentWindow && agentInfo) {
+      frameRef.current.contentWindow.postMessage(
+        { type: "AGENT_INFO_UPDATE", payload: agentInfo },
+        "*"
+      );
+    }
+  }, [agentInfo]);
+
   useEffect(() => {
     const handleMessage = async (event: MessageEvent) => {
       const data = event.data;
@@ -436,7 +474,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
           const state = await window.freebuddy?.game?.getState(activeId);
           if (state && frameRef.current?.contentWindow) {
             frameRef.current.contentWindow.postMessage(
-              { type: "FREEBUDDY_GAME_SYNC", payload: state },
+              { type: "FREEBUDDY_GAME_SYNC", payload: { ...state, agentInfo } },
               "*"
             );
           }

--- a/src/components/Browser/BrowserCanvas.tsx
+++ b/src/components/Browser/BrowserCanvas.tsx
@@ -108,6 +108,89 @@ export function isExternalOnlyBrowserTarget(value: string | undefined): boolean 
   }
 }
 
+function extractAssistantText(content: string): string {
+  if (!content) return "";
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((item: any) => {
+          if (typeof item === "string") return item;
+          if (item?.type === "text" || item?.kind === "text") return item.text || item.content || "";
+          if (item?.type === "message" || item?.kind === "message") return item.text || item.content || "";
+          return item?.text || item?.content || "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+  } catch {
+    /* plain text */
+  }
+  return content;
+}
+
+function extractAgentMoveFromText(text: string): {
+  action: string;
+  speech?: string;
+  thought?: string;
+  mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring";
+} | null {
+  if (!text) return null;
+
+  // 1. Try finding json code blocks
+  const jsonBlocks = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/gi);
+  if (jsonBlocks) {
+    for (const block of jsonBlocks) {
+      const clean = block.replace(/```(?:json)?/gi, "").replace(/```/g, "").trim();
+      try {
+        const parsed = JSON.parse(clean);
+        if (parsed && typeof parsed === "object") {
+          const action = parsed.action || parsed.actionId || parsed.move || parsed.position || parsed.coord;
+          if (typeof action === "string" && /^(?:[A-O]\d{1,2}|[a-i]\d[a-i]\d)$/i.test(action.trim())) {
+            return {
+              action: action.trim(),
+              speech: parsed.speech || parsed.chat || parsed.message || parsed.reply,
+              thought: parsed.thought || parsed.reason,
+              mood: parsed.mood
+            };
+          }
+        }
+      } catch {
+        /* try next block */
+      }
+    }
+  }
+
+  // 2. Try parsing raw JSON
+  try {
+    const parsed = JSON.parse(text.trim());
+    if (parsed && typeof parsed === "object") {
+      const action = parsed.action || parsed.actionId || parsed.move || parsed.position || parsed.coord;
+      if (typeof action === "string" && /^(?:[A-O]\d{1,2}|[a-i]\d[a-i]\d)$/i.test(action.trim())) {
+        return {
+          action: action.trim(),
+          speech: parsed.speech || parsed.chat || parsed.message,
+          thought: parsed.thought || parsed.reason,
+          mood: parsed.mood
+        };
+      }
+    }
+  } catch {
+    /* fallback to regex */
+  }
+
+  // 3. Fallback regex for "落子：H8" or "走子: b2e2"
+  const regexMatch = text.match(/(?:落子|走子|走步|action|move|coordinate|坐标|走|下在)[:：\s*#]+([A-O]\d{1,2}|[a-i]\d[a-i]\d)\b/i);
+  if (regexMatch) {
+    return {
+      action: regexMatch[1].trim(),
+      speech: text.replace(/[#*`]/g, "").slice(0, 100).trim()
+    };
+  }
+
+  return null;
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
   return (
@@ -230,6 +313,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
   const members = useConversationStore((s) => s.members);
   const newConversation = useConversationStore((s) => s.newConversation);
   const sendMessage = useConversationStore((s) => s.sendMessage);
+  const isRunning = useConversationStore((s) => (s.activeId ? s.isRunning(s.activeId) : false));
   const feedItems = useFeedStore((s) => s.items);
   const markInterpreted = useFeedStore((s) => s.markInterpreted);
   const entry = useBrowserStore((s) =>
@@ -313,6 +397,150 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
         .setLoadState(activeId, state.isLoading ? "loading" : "ready");
     });
   }, [activeId, isNativeRemote, nativeBrowserAvailable]);
+
+  // Bridge game canvas iframe with FreeBuddy Game Service and Agent session
+  const processedMessageIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const handleMessage = async (event: MessageEvent) => {
+      const data = event.data;
+      if (!data || typeof data !== "object" || !activeId) return;
+
+      if (data.type === "PLAYER_MOVE" && data.payload?.actionId) {
+        const actionId = String(data.payload.actionId);
+        try {
+          const moveRes = await window.freebuddy?.game?.playerMove(activeId, actionId);
+          const legalMoves = moveRes?.gameState?.legalMoves;
+          const candidateList = legalMoves && legalMoves.length > 0
+            ? legalMoves.slice(0, 12).map((m: any) => `${m.coord}(${m.description || ""})`).join(", ")
+            : "H8, G7, I9, H9";
+          const suggestedCoord = legalMoves?.[0]?.coord || "H8";
+
+          if (sendMessage) {
+            void sendMessage({
+              conversationId: activeId,
+              prompt: `[玩家落子] 坐标：${actionId}。轮到你行动，请直接调用 MCP 工具 game_make_move(actionId, reason) 落子，并调用 game_send_chat(message, mood) 发送台词。`
+            });
+          }
+        } catch (err) {
+          console.error("[FreeBuddy] Failed to process player game move:", err);
+        }
+      } else if (data.type === "GAME_CANVAS_READY" || data.type === "REQUEST_SYNC") {
+        try {
+          const state = await window.freebuddy?.game?.getState(activeId);
+          if (state && frameRef.current?.contentWindow) {
+            frameRef.current.contentWindow.postMessage(
+              { type: "FREEBUDDY_GAME_SYNC", payload: state },
+              "*"
+            );
+          }
+        } catch (err) {
+          console.error("[FreeBuddy] Failed to fetch game state:", err);
+        }
+      } else if (data.type === "GAME_RESET") {
+        try {
+          await window.freebuddy?.game?.resetGame(activeId);
+          if (sendMessage) {
+            void sendMessage({
+              conversationId: activeId,
+              prompt: `【重新开局】我已重置了棋盘。我执黑先行，你执白后手。请调用 game_send_chat 工具向我打个招呼，并准备接招！`
+            });
+          }
+        } catch (err) {
+          console.error("[FreeBuddy] Failed to reset game:", err);
+        }
+      } else if (data.type === "REMIND_AGENT") {
+        if (sendMessage) {
+          void sendMessage({
+            conversationId: activeId,
+            prompt: `【催促落子】轮到你执白行动，请直接调用 MCP 工具 game_make_move(actionId, reason) 尽快完成落子！`
+          });
+        }
+      } else if (data.type === "GAME_RESIGN") {
+        if (sendMessage) {
+          void sendMessage({
+            conversationId: activeId,
+            prompt: `我认输了，这一局你下得漂亮！`
+          });
+        }
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    const unbindGameEvent = window.freebuddy?.game?.onGameEvent((event: any) => {
+      if (frameRef.current?.contentWindow && event?.payload) {
+        frameRef.current.contentWindow.postMessage(
+          { type: "FREEBUDDY_GAME_SYNC", payload: event.payload },
+          "*"
+        );
+      }
+    });
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+      unbindGameEvent?.();
+    };
+  }, [activeId, sendMessage]);
+
+  // Observe assistant messages in game conversations to extract moves even without native MCP tool calling
+  useEffect(() => {
+    if (!activeId || !messages.length) return;
+    const lastMsg = messages[messages.length - 1];
+    if (lastMsg && lastMsg.role === "assistant") {
+      const text = extractAssistantText(lastMsg.content);
+      const move = extractAgentMoveFromText(text);
+      if (move) {
+        const moveKey = `${lastMsg.id}:${move.action}`;
+        if (!processedMessageIdsRef.current.has(moveKey)) {
+          processedMessageIdsRef.current.add(moveKey);
+          void window.freebuddy?.game?.agentMove(
+            activeId,
+            move.action,
+            move.thought,
+            move.speech,
+            move.mood
+          );
+        }
+      }
+    }
+  }, [activeId, messages]);
+
+  // Monitor for abnormal stalls (Agent finished generation but turn is still White/2)
+  useEffect(() => {
+    if (!activeId) return;
+    let timer: NodeJS.Timeout | null = null;
+
+    const checkStall = async () => {
+      try {
+        const state = await window.freebuddy?.game?.getState(activeId);
+        if (state && state.status === "playing" && state.turn === 2 && !isRunning) {
+          timer = setTimeout(() => {
+            if (frameRef.current?.contentWindow) {
+              frameRef.current.contentWindow.postMessage(
+                { type: "AGENT_STALLED", payload: { stalled: true } },
+                "*"
+              );
+            }
+          }, 2500);
+        } else {
+          if (frameRef.current?.contentWindow) {
+            frameRef.current.contentWindow.postMessage(
+              { type: "AGENT_STALLED", payload: { stalled: false } },
+              "*"
+            );
+          }
+        }
+      } catch {
+        /* best effort */
+      }
+    };
+
+    void checkStall();
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [activeId, isRunning, messages]);
 
   useEffect(() => {
     if (!nativeBrowserAvailable || !isNativeRemote || !entry?.manualEntry) {

--- a/src/components/CLI/ConversationList.tsx
+++ b/src/components/CLI/ConversationList.tsx
@@ -19,6 +19,7 @@ import {
   ChevronUp,
   Folder,
   FolderOpen,
+  Gamepad2,
   LoaderCircle,
   MessageSquare,
   MoreHorizontal,
@@ -31,6 +32,7 @@ import {
 } from "lucide-react";
 import { AgentAvatar } from "./AgentAvatar";
 import { ProjectFormModal } from "./ProjectFormModal";
+import { useDetailLayoutStore } from "@/store/detailLayoutStore";
 import {
   PROJECT_LIST_LIMIT,
   PROJECT_PREVIEW_LIMIT,
@@ -82,11 +84,21 @@ const ConversationRow = memo(function ConversationRow({
         }
       }}
     >
-      <AgentAvatar
-        adapter={conversation.adapter}
-        className="conv-item-avatar"
-        fallback={<MessageSquare aria-hidden="true" />}
-      />
+      {conversation.kind === "game" ? (
+        <span
+          className="conv-item-avatar flex items-center justify-center text-amber-500 font-bold"
+          title="对局会话"
+          style={{ display: "inline-flex", alignItems: "center", justifyContent: "center" }}
+        >
+          <Gamepad2 size={16} />
+        </span>
+      ) : (
+        <AgentAvatar
+          adapter={conversation.adapter}
+          className="conv-item-avatar"
+          fallback={<MessageSquare aria-hidden="true" />}
+        />
+      )}
       <div className="conv-item-main">
         <div className="conv-item-title-row">
           <strong>{conversation.title}</strong>
@@ -483,8 +495,13 @@ export function ConversationList({
   const handleSelect = useCallback(
     (id: string) => {
       void setActive(id);
+      const conv = conversations.find((c) => c.id === id);
+      if (conv?.kind === "game") {
+        useDetailLayoutStore.getState().setActiveTab("preview");
+        useDetailLayoutStore.getState().setDetailCollapsed(false);
+      }
     },
-    [setActive]
+    [setActive, conversations]
   );
   const handleDelete = useCallback(
     (id: string, title: string) => {

--- a/src/components/Games/GameSetupModal.tsx
+++ b/src/components/Games/GameSetupModal.tsx
@@ -220,24 +220,24 @@ export function GameSetupModal({ open, onClose }: GameSetupModalProps) {
         if (selectedHand === "player_first") {
           void convStore.sendMessage({
             conversationId: conv.id,
-            prompt: `【中国象棋对局开始】我已经进入对战棋盘。我执红先行，你执黑后手。请调用 game_send_chat 工具向我打个招呼，并准备迎战！`
+            prompt: `【中国象棋对局开始】我执红先行，你执黑后手。准备迎战！`
           });
         } else {
           void convStore.sendMessage({
             conversationId: conv.id,
-            prompt: `【中国象棋对局开始】本局你执红先行！请调用 game_make_move(actionId, reason) 走出第一步棋（如中炮 b2e2 / 炮二平五，或起马 h0g2 / 马八进七），并调用 game_send_chat(message, mood) 发送你的开局台词！`
+            prompt: `【中国象棋对局开始】本局你执红先行，请出招！`
           });
         }
       } else {
         if (selectedHand === "player_first") {
           void convStore.sendMessage({
             conversationId: conv.id,
-            prompt: `【五子棋对局开始】我已经进入对战棋盘。我执黑先行，你执白后手。请调用 game_send_chat 工具向我打个招呼，并准备接招！`
+            prompt: `【五子棋对局开始】我执黑先行，你执白后手。准备接招！`
           });
         } else {
           void convStore.sendMessage({
             conversationId: conv.id,
-            prompt: `【五子棋对局开始】本局你执黑先行！请调用 game_make_move(actionId, reason) 落出第一子（如天元 H8），并调用 game_send_chat(message, mood) 发送你的开局台词！`
+            prompt: `【五子棋对局开始】本局你执黑先行，请落子！`
           });
         }
       }

--- a/src/components/Games/GameSetupModal.tsx
+++ b/src/components/Games/GameSetupModal.tsx
@@ -1,0 +1,392 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, X } from "lucide-react";
+
+import type { CLIMember } from "@/config/aiMembers";
+import { builtinCliMembers } from "@/config/aiMembers";
+import { cliClient } from "@/services/cli/client";
+import type {
+  SessionConfigOption,
+  SessionConfigProbeInput
+} from "@/services/cli/types";
+import { useBrowserStore } from "@/store/browserStore";
+import { useCliExecutorStore } from "@/store/cliExecutorStore";
+import { useConversationStore } from "@/store/conversationStore";
+import { useDetailLayoutStore } from "@/store/detailLayoutStore";
+
+export interface GameSetupModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export type SupportedGameType = "gomoku" | "chinese_chess" | "go";
+
+interface GameOptionDef {
+  id: SupportedGameType;
+  title: string;
+  ready: boolean;
+  tag?: string;
+}
+
+const AVAILABLE_GAMES: GameOptionDef[] = [
+  {
+    id: "gomoku",
+    title: "五子棋",
+    ready: true
+  },
+  {
+    id: "chinese_chess",
+    title: "中国象棋",
+    ready: true
+  },
+  {
+    id: "go",
+    title: "围棋",
+    ready: false,
+    tag: "敬请期待"
+  }
+];
+
+export function GameSetupModal({ open, onClose }: GameSetupModalProps) {
+  const { t } = useTranslation();
+  const titleId = useId();
+  const descriptionId = useId();
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const convStore = useConversationStore();
+  const members = useMemo(
+    () => convStore.members.filter((m) => m.enabled !== false),
+    [convStore.members]
+  );
+
+  const [selectedGame, setSelectedGame] = useState<SupportedGameType>("gomoku");
+  const [selectedAgentId, setSelectedAgentId] = useState<string>("");
+  const [selectedModel, setSelectedModel] = useState<string>("");
+  const [selectedHand, setSelectedHand] = useState<"player_first" | "agent_first">("player_first");
+  const [isLaunching, setIsLaunching] = useState(false);
+
+  // Model probing states
+  const [modelOptionsByAgent, setModelOptionsByAgent] = useState<
+    Record<string, SessionConfigOption[]>
+  >({});
+  const [modelLoadingByAgent, setModelLoadingByAgent] = useState<
+    Record<string, boolean>
+  >({});
+
+  // Initialize selected agent
+  useEffect(() => {
+    if (!open) return;
+    if (!selectedAgentId || !members.some((m) => m.id === selectedAgentId)) {
+      const defaultAgent =
+        members.find((m) => m.id === "cli-butlerbuddy") ||
+        members[0] ||
+        builtinCliMembers[0];
+      if (defaultAgent) {
+        setSelectedAgentId(defaultAgent.id);
+      }
+    }
+  }, [open, members, selectedAgentId]);
+
+  const selectedMember: CLIMember | undefined = useMemo(() => {
+    return (
+      members.find((m) => m.id === selectedAgentId) ||
+      builtinCliMembers.find((m) => m.id === selectedAgentId) ||
+      members[0] ||
+      builtinCliMembers[0]
+    );
+  }, [members, selectedAgentId]);
+
+  // Session probe input helper
+  const sessionProbeInputForAgent = useCallback(
+    (agentId: string): SessionConfigProbeInput | undefined => {
+      const member =
+        members.find((entry) => entry.id === agentId) ||
+        builtinCliMembers.find((entry) => entry.id === agentId);
+      if (!member) return undefined;
+      const resolved = useCliExecutorStore
+        .getState()
+        .resolve(member.cli.adapter);
+      return {
+        agentId: member.id,
+        adapter: member.cli.adapter,
+        binary: member.cli.binary || resolved?.binary,
+        extraArgs: [
+          ...(resolved?.extraArgs ?? []),
+          ...(member.cli.extraArgs ?? [])
+        ],
+        env: { ...(resolved?.env ?? {}), ...(member.cli.env ?? {}) }
+      };
+    },
+    [members]
+  );
+
+  // Probe models for selected agent
+  const refreshAgentModels = useCallback(
+    async (agentId: string) => {
+      if (!agentId || !cliClient.isAvailable()) return;
+      const input = sessionProbeInputForAgent(agentId);
+      if (!input) return;
+
+      setModelLoadingByAgent((prev) => ({ ...prev, [agentId]: true }));
+      try {
+        const cached = await cliClient.getCachedSessionConfigOptions(input);
+        if (cached && cached.length > 0) {
+          setModelOptionsByAgent((prev) => ({ ...prev, [agentId]: cached }));
+        }
+        const fresh = await cliClient.inspectSessionConfigOptions(input);
+        if (fresh && fresh.length > 0) {
+          setModelOptionsByAgent((prev) => ({ ...prev, [agentId]: fresh }));
+        }
+      } catch (err) {
+        console.warn("[FreeBuddy] Failed to probe model options for agent:", agentId, err);
+      } finally {
+        setModelLoadingByAgent((prev) => ({ ...prev, [agentId]: false }));
+      }
+    },
+    [sessionProbeInputForAgent]
+  );
+
+  // Load models whenever selected agent changes
+  useEffect(() => {
+    if (!open || !selectedAgentId) return;
+    if (!modelOptionsByAgent[selectedAgentId]) {
+      void refreshAgentModels(selectedAgentId);
+    }
+  }, [open, selectedAgentId, modelOptionsByAgent, refreshAgentModels]);
+
+  // Extract model options for current agent
+  const currentModelOption = useMemo(() => {
+    if (!selectedAgentId) return undefined;
+    const options = modelOptionsByAgent[selectedAgentId] ?? [];
+    return (
+      options.find((entry) => entry.category === "model") ??
+      options.find((entry) => entry.id === "model")
+    );
+  }, [selectedAgentId, modelOptionsByAgent]);
+
+  const availableModels = useMemo(() => {
+    const values = [...(currentModelOption?.values ?? [])];
+    return values;
+  }, [currentModelOption]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleLaunchMatch = async () => {
+    if (!selectedMember || isLaunching) return;
+    setIsLaunching(true);
+    try {
+      const modelName = selectedModel ? ` (${selectedModel})` : "";
+      const gameName = selectedGame === "chinese_chess" ? "中国象棋" : "五子棋";
+      const gamePath = selectedGame === "chinese_chess" ? "xiangqi" : selectedGame;
+      const title = `[${gameName}] vs ${selectedMember.name}${modelName}`;
+
+      const modelOptionId = currentModelOption?.id ?? "model";
+      const configOverrides = selectedModel
+        ? { [modelOptionId]: selectedModel }
+        : undefined;
+
+      const conv = await convStore.newConversation({
+        member: selectedMember,
+        title,
+        kind: "game",
+        metadata: {
+          gameType: gamePath,
+          opponentAgentId: selectedMember.id,
+          opponentModel: selectedModel || undefined,
+          hand: selectedHand
+        },
+        configOptionOverrides: configOverrides,
+        skillIds: ["game-arena"]
+      });
+
+      // Load game URL in built-in browser
+      const gameUrl = new URL(`games/${gamePath}/index.html`, window.location.href).href;
+      useBrowserStore.getState().navigate(conv.id, gameUrl);
+      useDetailLayoutStore.getState().setActiveTab("preview");
+      useDetailLayoutStore.getState().setDetailCollapsed(false);
+
+      // Send opening welcome prompt
+      if (selectedGame === "chinese_chess") {
+        if (selectedHand === "player_first") {
+          void convStore.sendMessage({
+            conversationId: conv.id,
+            prompt: `【中国象棋对局开始】我已经进入对战棋盘。我执红先行，你执黑后手。请调用 game_send_chat 工具向我打个招呼，并准备迎战！`
+          });
+        } else {
+          void convStore.sendMessage({
+            conversationId: conv.id,
+            prompt: `【中国象棋对局开始】本局你执红先行！请调用 game_make_move(actionId, reason) 走出第一步棋（如中炮 b2e2 / 炮二平五，或起马 h0g2 / 马八进七），并调用 game_send_chat(message, mood) 发送你的开局台词！`
+          });
+        }
+      } else {
+        if (selectedHand === "player_first") {
+          void convStore.sendMessage({
+            conversationId: conv.id,
+            prompt: `【五子棋对局开始】我已经进入对战棋盘。我执黑先行，你执白后手。请调用 game_send_chat 工具向我打个招呼，并准备接招！`
+          });
+        } else {
+          void convStore.sendMessage({
+            conversationId: conv.id,
+            prompt: `【五子棋对局开始】本局你执黑先行！请调用 game_make_move(actionId, reason) 落出第一子（如天元 H8），并调用 game_send_chat(message, mood) 发送你的开局台词！`
+          });
+        }
+      }
+
+      onClose();
+    } catch (err) {
+      console.error("[FreeBuddy] Failed to launch game match:", err);
+    } finally {
+      setIsLaunching(false);
+    }
+  };
+
+  return (
+    <div
+      className="modal-backdrop"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="modal game-setup-dialog"
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="game-setup-dialog-header">
+          <div>
+            <h3 id={titleId}>对战大厅</h3>
+            <p id={descriptionId} className="game-setup-dialog-desc">
+              选择对弈项目与 AI 智能体，开启棋牌对决
+            </p>
+          </div>
+          <button
+            type="button"
+            className="icon-btn"
+            onClick={onClose}
+            aria-label={t("common.close")}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="game-setup-dialog-form">
+          {/* Game Selection */}
+          <div className="game-setup-field">
+            <span className="game-setup-field-label">游戏项目</span>
+            <div className="game-setup-choice-group">
+              {AVAILABLE_GAMES.map((game) => (
+                <button
+                  key={game.id}
+                  type="button"
+                  className={selectedGame === game.id ? "active" : ""}
+                  disabled={!game.ready}
+                  onClick={() => game.ready && setSelectedGame(game.id)}
+                >
+                  {game.title}
+                  {game.tag ? ` (${game.tag})` : ""}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* AI Agent Selection */}
+          <div className="game-setup-field">
+            <span className="game-setup-field-label">AI 对手</span>
+            <div className="custom-select-wrapper">
+              <select
+                value={selectedAgentId}
+                onChange={(e) => {
+                  setSelectedAgentId(e.target.value);
+                  setSelectedModel("");
+                }}
+              >
+                {members.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name} ({m.profile === "butler" ? "管家助手" : m.cli.adapter})
+                  </option>
+                ))}
+              </select>
+              <span className="custom-select-arrow">
+                <ChevronDown size={14} />
+              </span>
+            </div>
+          </div>
+
+          {/* Model & Hand in 2 Columns */}
+          <div className="game-setup-grid-row">
+            <div className="game-setup-field">
+              <span className="game-setup-field-label">对弈模型</span>
+              <div className="custom-select-wrapper">
+                <select
+                  value={selectedModel}
+                  onFocus={() => selectedAgentId && void refreshAgentModels(selectedAgentId)}
+                  onChange={(e) => setSelectedModel(e.target.value)}
+                >
+                  <option value="">默认模型 (Default)</option>
+                  {modelLoadingByAgent[selectedAgentId] && availableModels.length === 0 ? (
+                    <option disabled>正在读取模型...</option>
+                  ) : null}
+                  {availableModels.map((val) => (
+                    <option key={val.id} value={val.id}>
+                      {val.name || val.id}
+                    </option>
+                  ))}
+                </select>
+                <span className="custom-select-arrow">
+                  <ChevronDown size={14} />
+                </span>
+              </div>
+            </div>
+
+            <div className="game-setup-field">
+              <span className="game-setup-field-label">先后手</span>
+              <div className="game-setup-choice-group two-cols">
+                <button
+                  type="button"
+                  className={selectedHand === "player_first" ? "active" : ""}
+                  onClick={() => setSelectedHand("player_first")}
+                >
+                  我先手 ({selectedGame === "chinese_chess" ? "红" : "黑"})
+                </button>
+                <button
+                  type="button"
+                  className={selectedHand === "agent_first" ? "active" : ""}
+                  onClick={() => setSelectedHand("agent_first")}
+                >
+                  AI 先手 ({selectedGame === "chinese_chess" ? "红" : "黑"})
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="modal-actions">
+          <button type="button" onClick={onClose} disabled={isLaunching}>
+            {t("common.cancel")}
+          </button>
+          <button
+            type="button"
+            className="primary"
+            disabled={!selectedMember || isLaunching}
+            onClick={() => void handleLaunchMatch()}
+          >
+            {isLaunching ? "正在进入..." : "开始对战"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SidebarUserMenu.tsx
+++ b/src/components/SidebarUserMenu.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Dog, LogOut, Settings } from "lucide-react";
+import { Dog, Gamepad2, LogOut, Settings } from "lucide-react";
 import { useConversationStore } from "@/store/conversationStore";
 import { useSettingsStore } from "@/store/settingsStore";
+import { GameSetupModal } from "@/components/Games/GameSetupModal";
 
 export function SidebarUserMenu({
   onOpenSettings,
@@ -23,6 +24,7 @@ export function SidebarUserMenu({
     me?.username?.trim() ||
     (platform !== "web" ? t("sidebar.hostAccount") : "");
   const [open, setOpen] = useState(false);
+  const [gameModalOpen, setGameModalOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -54,61 +56,80 @@ export function SidebarUserMenu({
   const initial = (username.trim()[0] ?? "?").toUpperCase();
 
   return (
-    <div className="sidebar-user-menu" ref={ref}>
-      <button
-        type="button"
-        className={`footer-action sidebar-user-trigger${open ? " open" : ""}`}
-        onClick={() => setOpen((v) => !v)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title={username}
-      >
-        <span className="sidebar-user-avatar" aria-hidden="true">
-          {initial}
-        </span>
-        <span className="sidebar-user-name">{username}</span>
-      </button>
-      {open && (
-        <div className="sidebar-user-dropdown" role="menu">
-          <button
-            type="button"
-            className="sidebar-user-item"
-            role="menuitem"
-            onClick={() => {
-              setOpen(false);
-              onOpenSettings();
-            }}
-          >
-            <Settings size={15} strokeWidth={1.8} />
-            {t("common.settings")}
-          </button>
-          {canTogglePet && (
+    <>
+      <div className="sidebar-user-menu" ref={ref}>
+        <button
+          type="button"
+          className={`footer-action sidebar-user-trigger${open ? " open" : ""}`}
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          title={username}
+        >
+          <span className="sidebar-user-avatar" aria-hidden="true">
+            {initial}
+          </span>
+          <span className="sidebar-user-name">{username}</span>
+        </button>
+        {open && (
+          <div className="sidebar-user-dropdown" role="menu">
             <button
               type="button"
               className="sidebar-user-item"
               role="menuitem"
               onClick={() => {
                 setOpen(false);
-                void updateButler({ visible: !butlerVisible });
+                onOpenSettings();
               }}
             >
-              <Dog size={15} strokeWidth={1.8} />
-              {butlerVisible ? t("sidebar.hidePet") : t("sidebar.showPet")}
+              <Settings size={15} strokeWidth={1.8} />
+              {t("common.settings")}
             </button>
-          )}
-          {showLogout && (
             <button
               type="button"
-              className="sidebar-user-item danger"
+              className="sidebar-user-item"
               role="menuitem"
-              onClick={handleLogout}
+              onClick={() => {
+                setOpen(false);
+                setGameModalOpen(true);
+              }}
             >
-              <LogOut size={15} strokeWidth={1.8} />
-              {t("sidebar.logout")}
+              <Gamepad2 size={15} strokeWidth={1.8} />
+              对战大厅 (玩一把)
             </button>
-          )}
-        </div>
-      )}
-    </div>
+            {canTogglePet && (
+              <button
+                type="button"
+                className="sidebar-user-item"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  void updateButler({ visible: !butlerVisible });
+                }}
+              >
+                <Dog size={15} strokeWidth={1.8} />
+                {butlerVisible ? t("sidebar.hidePet") : t("sidebar.showPet")}
+              </button>
+            )}
+            {showLogout && (
+              <button
+                type="button"
+                className="sidebar-user-item danger"
+                role="menuitem"
+                onClick={handleLogout}
+              >
+                <LogOut size={15} strokeWidth={1.8} />
+                {t("sidebar.logout")}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <GameSetupModal
+        open={gameModalOpen}
+        onClose={() => setGameModalOpen(false)}
+      />
+    </>
   );
 }

--- a/src/services/cli/types.ts
+++ b/src/services/cli/types.ts
@@ -592,12 +592,16 @@ export interface ProjectInput {
   primaryPath: string;
 }
 
+export type ConversationKind = "default" | "game" | "workflow" | "scheduled" | string;
+
 export interface Conversation {
   id: string;
   title: string;
   agentId: string;
   agentName: string;
   adapter: string;
+  kind?: ConversationKind;
+  metadata?: Record<string, unknown>;
   cwd?: string;
   /** Assigned source path for display; cwd remains the real execution path. */
   sourceCwd?: string;
@@ -654,6 +658,8 @@ export interface CreateConversationInput {
   agentId: string;
   agentName: string;
   adapter: string;
+  kind?: ConversationKind;
+  metadata?: Record<string, unknown>;
   cwd?: string;
   projectId?: string;
   approvalMode?: "auto" | "ask";

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -14,6 +14,7 @@ import type {
   CliRunArgs,
   ChatAttachment,
   Conversation,
+  ConversationKind,
   ConversationMessage
 } from "@/services/cli/types";
 import type {
@@ -117,6 +118,8 @@ export interface ConversationState {
     cwd?: string;
     projectId?: string;
     title?: string;
+    kind?: ConversationKind;
+    metadata?: Record<string, unknown>;
     approvalMode?: "auto" | "ask";
     configOptionOverrides?: Record<string, string>;
     skillIds?: string[];
@@ -843,6 +846,8 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     cwd,
     projectId,
     title,
+    kind,
+    metadata,
     approvalMode,
     configOptionOverrides,
     skillIds
@@ -854,6 +859,8 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       agentId: member.id,
       agentName: member.name,
       adapter: member.cli.adapter,
+      kind: kind ?? "default",
+      metadata,
       cwd,
       projectId,
       approvalMode: approvalMode ?? member.cli.approvalMode,

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -904,6 +904,21 @@ declare global {
     shell: FreebuddyShell;
     remote: FreebuddyRemote;
     butlerBuddy: FreebuddyButlerBuddy;
+    game: FreebuddyGame;
+  }
+
+  interface FreebuddyGame {
+    getState(conversationId: string): Promise<any>;
+    playerMove(conversationId: string, actionId: string): Promise<any>;
+    agentMove(
+      conversationId: string,
+      actionId: string,
+      reason?: string,
+      speech?: string,
+      mood?: string
+    ): Promise<any>;
+    resetGame(conversationId: string): Promise<any>;
+    onGameEvent(cb: (event: any) => void): () => void;
   }
 
   interface Window {

--- a/styles.css
+++ b/styles.css
@@ -4101,23 +4101,60 @@ html[data-surface="butler-screen-ball"] #root {
   to { transform: rotate(360deg); }
 }
 
+.modal-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 8px;
+  border: 1px solid var(--fb-border-strong);
+  background: var(--fb-panel-soft);
+  color: var(--fb-text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.modal-actions button:hover:not(:disabled) {
+  background: var(--fb-hover);
+  color: var(--fb-text-primary);
+  border-color: var(--fb-border-strong);
+}
+
+.modal-actions button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.modal-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.modal-actions button.primary,
 .modal-actions .primary {
   background: var(--fb-brand-gradient);
   color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 8px 16px;
+  border: 1px solid transparent;
+  padding: 7px 18px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 194, 154, 0.2);
-  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.2);
+  transition: all 0.15s ease;
 }
-.modal-actions .primary:hover {
+
+.modal-actions button.primary:hover:not(:disabled),
+.modal-actions .primary:hover:not(:disabled) {
+  opacity: 0.92;
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(0, 194, 154, 0.3);
+  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
 }
-.modal-actions .primary:active {
+
+.modal-actions button.primary:active:not(:disabled),
+.modal-actions .primary:active:not(:disabled) {
   transform: translateY(0);
 }
 
@@ -22130,3 +22167,117 @@ button.ghost:focus-visible,
   justify-content: flex-end;
   gap: 8px;
 }
+
+/* ==========================================================================
+   Game Setup Dialog (Consistent with Settings & Transfer Dialogs)
+   ========================================================================== */
+.modal.game-setup-dialog {
+  width: 460px;
+  max-width: 95vw;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+}
+
+.game-setup-dialog-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.game-setup-dialog-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--fb-text-primary);
+}
+
+.game-setup-dialog-desc {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--fb-text-secondary);
+}
+
+.game-setup-dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.game-setup-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.game-setup-field-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fb-text-secondary);
+}
+
+.game-setup-choice-group {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--fb-border);
+  border-radius: 8px;
+  background: var(--fb-panel-soft);
+}
+
+.game-setup-choice-group.two-cols {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.game-setup-choice-group button {
+  border: 0;
+  background: transparent;
+  color: var(--fb-text-secondary);
+  box-shadow: none;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.game-setup-choice-group button:hover:not(:disabled):not(.active) {
+  color: var(--fb-text-primary);
+}
+
+.game-setup-choice-group button.active {
+  background: var(--fb-panel-bg);
+  color: var(--fb-text-primary);
+  font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="dark"] .game-setup-choice-group button.active {
+  background: var(--fb-panel-bg);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.game-setup-choice-group button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.game-setup-grid-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (max-width: 460px) {
+  .game-setup-grid-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+
+
+

--- a/tests/game-mcp.test.mjs
+++ b/tests/game-mcp.test.mjs
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -84,4 +87,18 @@ test("Game tool service dispatches actions correctly", async () => {
   assert.equal(resignRes.ok, true);
   assert.equal(resignRes.gameState.status, "player_won");
   assert.equal(resignRes.gameState.winner, PLAYER_BLACK);
+});
+
+test("Frontend game scripts (Gomoku & Xiangqi) have valid JS syntax", () => {
+  const gameFiles = [
+    path.resolve(process.cwd(), "public/games/gomoku/game.js"),
+    path.resolve(process.cwd(), "public/games/xiangqi/game.js")
+  ];
+
+  for (const filePath of gameFiles) {
+    const code = fs.readFileSync(filePath, "utf-8");
+    assert.doesNotThrow(() => {
+      new vm.Script(code, { filename: path.basename(filePath) });
+    }, `Syntax error in ${filePath}`);
+  }
 });

--- a/tests/game-mcp.test.mjs
+++ b/tests/game-mcp.test.mjs
@@ -68,7 +68,16 @@ test("Game tool service dispatches actions correctly", async () => {
   assert.equal(chatRes.chat.message, "这一步走得不错，不过我的白子已经盯紧你了！");
   assert.equal(chatRes.chat.mood, "confident");
 
-  // 6. Agent resigns
+  // 6. Test get_history action
+  const historyRes = await dispatchGameAction(binding, "get_history", {});
+  assert.equal(historyRes.ok, true);
+  assert.equal(historyRes.moveHistory.length, 2, "Should have 2 moves in history");
+  assert.equal(historyRes.chatHistory.length, 1, "Should have 1 chat in history");
+
+  // Verify lean snapshot in get_state does not contain full moveHistory
+  assert.equal(stateRes.gameState.moveHistory, undefined, "Lean snapshot should omit moveHistory");
+
+  // 7. Agent resigns
   const resignRes = await dispatchGameAction(binding, "resign", {
     reason: "局势不妙，甘拜下风"
   });

--- a/tests/game-mcp.test.mjs
+++ b/tests/game-mcp.test.mjs
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  GomokuGameInstance,
+  PLAYER_BLACK,
+  PLAYER_WHITE
+} from "../dist-electron/games/gomokuEngine.js";
+import {
+  dispatchGameAction,
+  getOrCreateGame,
+  handlePlayerMove
+} from "../dist-electron/gameToolService.js";
+import { createGameMcpServer } from "../dist-electron/mcp/gameMcpServer.js";
+
+test("Game MCP server creates properly with expected tools", () => {
+  const server = createGameMcpServer();
+  assert.ok(server);
+});
+
+test("Game tool service dispatches actions correctly", async () => {
+  const conversationId = `conv-test-${Date.now()}`;
+  const binding = {
+    token: "test-token",
+    taskSessionId: "session-1",
+    conversationId,
+    gameType: "gomoku"
+  };
+
+  // 1. Get initial state
+  const stateRes = await dispatchGameAction(binding, "get_state", {});
+  assert.equal(stateRes.ok, true);
+  assert.ok(stateRes.gameState);
+  assert.equal(stateRes.gameState.gameType, "gomoku");
+  assert.equal(stateRes.gameState.turn, PLAYER_BLACK);
+  assert.equal(stateRes.gameState.legalMoves.length > 0, true);
+
+  // 2. Player makes a move: H8
+  const playerRes = handlePlayerMove(conversationId, "H8");
+  assert.equal(playerRes.ok, true);
+  assert.equal(playerRes.gameState.turn, PLAYER_WHITE);
+  assert.equal(playerRes.gameState.board[7][7], PLAYER_BLACK);
+
+  // 3. Agent attempts illegal move on occupied H8
+  const illegalRes = await dispatchGameAction(binding, "make_move", {
+    actionId: "H8"
+  });
+  assert.equal(illegalRes.ok, false);
+  assert.match(illegalRes.error, /already occupied/i);
+
+  // 4. Agent makes legal move: H9
+  const legalMoveRes = await dispatchGameAction(binding, "make_move", {
+    actionId: "H9",
+    reason: "抢占中路邻近要点"
+  });
+  assert.equal(legalMoveRes.ok, true);
+  assert.equal(legalMoveRes.actionId, "H9");
+  assert.equal(legalMoveRes.gameState.turn, PLAYER_BLACK);
+  assert.equal(legalMoveRes.gameState.board[6][7], PLAYER_WHITE);
+
+  // 5. Agent sends in-game chat
+  const chatRes = await dispatchGameAction(binding, "send_chat", {
+    message: "这一步走得不错，不过我的白子已经盯紧你了！",
+    mood: "confident"
+  });
+  assert.equal(chatRes.ok, true);
+  assert.equal(chatRes.chat.sender, "agent");
+  assert.equal(chatRes.chat.message, "这一步走得不错，不过我的白子已经盯紧你了！");
+  assert.equal(chatRes.chat.mood, "confident");
+
+  // 6. Agent resigns
+  const resignRes = await dispatchGameAction(binding, "resign", {
+    reason: "局势不妙，甘拜下风"
+  });
+  assert.equal(resignRes.ok, true);
+  assert.equal(resignRes.gameState.status, "player_won");
+  assert.equal(resignRes.gameState.winner, PLAYER_BLACK);
+});

--- a/tests/gomoku-engine.test.mjs
+++ b/tests/gomoku-engine.test.mjs
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  GomokuGameInstance,
+  coordToString,
+  stringToCoord,
+  checkWin,
+  evaluateThreat,
+  getCandidateMoves,
+  PLAYER_BLACK,
+  PLAYER_WHITE
+} from "../dist-electron/games/gomokuEngine.js";
+
+test("Gomoku coordinate conversion", () => {
+  // Center: (7, 7) -> H8
+  assert.equal(coordToString(7, 7), "H8");
+  assert.deepEqual(stringToCoord("H8"), { x: 7, y: 7 });
+
+  // Top-left: (0, 0) -> A15
+  assert.equal(coordToString(0, 0), "A15");
+  assert.deepEqual(stringToCoord("A15"), { x: 0, y: 0 });
+
+  // Bottom-right: (14, 14) -> O1
+  assert.equal(coordToString(14, 14), "O1");
+  assert.deepEqual(stringToCoord("O1"), { x: 14, y: 14 });
+
+  // Case insensitive
+  assert.deepEqual(stringToCoord("h8"), { x: 7, y: 7 });
+  assert.equal(stringToCoord("Z99"), null);
+});
+
+test("Gomoku horizontal win detection", () => {
+  const game = new GomokuGameInstance("test-game-1");
+  assert.equal(game.status, "playing");
+  assert.equal(game.turn, PLAYER_BLACK);
+
+  // Black: H8, White: H9, Black: I8, White: I9, Black: J8, White: J9, Black: K8, White: K9, Black: L8 (Win!)
+  assert.equal(game.applyMove("H8", PLAYER_BLACK).ok, true);
+  assert.equal(game.applyMove("H9", PLAYER_WHITE).ok, true);
+  assert.equal(game.applyMove("I8", PLAYER_BLACK).ok, true);
+  assert.equal(game.applyMove("I9", PLAYER_WHITE).ok, true);
+  assert.equal(game.applyMove("J8", PLAYER_BLACK).ok, true);
+  assert.equal(game.applyMove("J9", PLAYER_WHITE).ok, true);
+  assert.equal(game.applyMove("K8", PLAYER_BLACK).ok, true);
+  assert.equal(game.applyMove("K9", PLAYER_WHITE).ok, true);
+
+  const finalMove = game.applyMove("L8", PLAYER_BLACK);
+  assert.equal(finalMove.ok, true);
+  assert.equal(finalMove.winner, PLAYER_BLACK);
+  assert.equal(game.status, "player_won");
+});
+
+test("Gomoku diagonal win detection", () => {
+  const game = new GomokuGameInstance("test-game-2");
+  // Black: D4, White: A1, Black: E5, White: A2, Black: F6, White: A3, Black: G7, White: A4, Black: H8 (Win!)
+  game.applyMove("D4", PLAYER_BLACK);
+  game.applyMove("A1", PLAYER_WHITE);
+  game.applyMove("E5", PLAYER_BLACK);
+  game.applyMove("A2", PLAYER_WHITE);
+  game.applyMove("F6", PLAYER_BLACK);
+  game.applyMove("A3", PLAYER_WHITE);
+  game.applyMove("G7", PLAYER_BLACK);
+  game.applyMove("A4", PLAYER_WHITE);
+
+  const res = game.applyMove("H8", PLAYER_BLACK);
+  assert.equal(res.ok, true);
+  assert.equal(res.winner, PLAYER_BLACK);
+  assert.equal(game.status, "player_won");
+});
+
+test("Gomoku threat evaluation & candidate moves", () => {
+  const game = new GomokuGameInstance("test-game-3");
+  // First move should suggest center H8
+  const initialMoves = game.getSnapshot().legalMoves;
+  assert.ok(initialMoves.length > 0);
+  assert.equal(initialMoves[0].coord, "H8");
+
+  // Place Black at H8, I8, J8, K8 (4 in a row)
+  game.applyMove("H8", PLAYER_BLACK);
+  game.applyMove("A1", PLAYER_WHITE);
+  game.applyMove("I8", PLAYER_BLACK);
+  game.applyMove("A2", PLAYER_WHITE);
+  game.applyMove("J8", PLAYER_BLACK);
+  game.applyMove("A3", PLAYER_WHITE);
+  game.applyMove("K8", PLAYER_BLACK);
+
+  // Now White's turn. White should see critical block needed at G8 or L8!
+  const whiteCandidates = game.getSnapshot().legalMoves;
+  const critical = whiteCandidates.filter(m => m.threatLevel === "critical_block");
+  assert.ok(critical.length > 0);
+  const coords = critical.map(c => c.coord);
+  assert.ok(coords.includes("G8") || coords.includes("L8"));
+});

--- a/tests/xiangqi-engine.test.mjs
+++ b/tests/xiangqi-engine.test.mjs
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createInitialBoard,
+  coordToString,
+  moveToString,
+  stringToMove,
+  getPseudoLegalMoves,
+  getLegalMoves,
+  isKingInCheck,
+  getCandidateMoves,
+  XiangqiGameInstance,
+  PIECE_KING,
+  PIECE_ADVISOR,
+  PIECE_BISHOP,
+  PIECE_KNIGHT,
+  PIECE_ROOK,
+  PIECE_CANNON,
+  PIECE_PAWN,
+  PLAYER_RED,
+  PLAYER_BLACK
+} from "../dist-electron/games/xiangqiEngine.js";
+
+test("Xiangqi initial board layout and coordinate conversion", () => {
+  const board = createInitialBoard();
+  assert.equal(board.length, 10, "Should have 10 rows");
+  assert.equal(board[0].length, 9, "Should have 9 columns");
+
+  // Red pieces
+  assert.equal(board[0][4], PIECE_KING, "Red King at (4,0)");
+  assert.equal(board[0][0], PIECE_ROOK, "Red left Rook at (0,0)");
+  assert.equal(board[0][8], PIECE_ROOK, "Red right Rook at (8,0)");
+  assert.equal(board[2][1], PIECE_CANNON, "Red left Cannon at (1,2)");
+  assert.equal(board[3][4], PIECE_PAWN, "Red central Pawn at (4,3)");
+
+  // Black pieces
+  assert.equal(board[9][4], -PIECE_KING, "Black King at (4,9)");
+  assert.equal(board[7][1], -PIECE_CANNON, "Black left Cannon at (1,7)");
+  assert.equal(board[6][4], -PIECE_PAWN, "Black central Pawn at (4,6)");
+
+  // Coordinate string conversions
+  assert.equal(coordToString(1, 2), "b2");
+  assert.equal(coordToString(4, 2), "e2");
+  assert.equal(moveToString(1, 2, 4, 2), "b2e2");
+
+  const parsed = stringToMove("b2e2");
+  assert.deepEqual(parsed, { fromX: 1, fromY: 2, toX: 4, toY: 2 });
+});
+
+test("Xiangqi piece rules: Knight leg block and Cannon jump", () => {
+  const board = Array.from({ length: 10 }, () => Array(9).fill(0));
+
+  // 1. Knight at (4, 4)
+  board[4][4] = PIECE_KNIGHT;
+  let knightMoves = getPseudoLegalMoves(board, 4, 4);
+  assert.equal(knightMoves.length, 8, "Free knight in center should have 8 moves");
+
+  // Block top horse leg at (4, 5)
+  board[5][4] = PIECE_PAWN;
+  knightMoves = getPseudoLegalMoves(board, 4, 4);
+  assert.equal(knightMoves.length, 6, "Knight with one leg blocked should have 6 moves");
+
+  // 2. Cannon at (1, 2) with screen at (4, 2) and black target at (7, 2)
+  const cBoard = Array.from({ length: 10 }, () => Array(9).fill(0));
+  cBoard[2][1] = PIECE_CANNON;
+  cBoard[2][4] = PIECE_PAWN; // Screen (炮架)
+  cBoard[2][7] = -PIECE_KNIGHT; // Target
+  const cannonMoves = getPseudoLegalMoves(cBoard, 1, 2);
+
+  // Should contain normal moves up to screen (x=2, 3), and jump capture at (7, 2)
+  const canCapture = cannonMoves.some((m) => m.toX === 7 && m.toY === 2);
+  assert.equal(canCapture, true, "Cannon should jump over 1 screen to capture target");
+});
+
+test("Xiangqi piece rules: Elephant eye block and river limit", () => {
+  const board = Array.from({ length: 10 }, () => Array(9).fill(0));
+
+  // Red Elephant at (2, 0)
+  board[0][2] = PIECE_BISHOP;
+  let moves = getPseudoLegalMoves(board, 2, 0);
+  assert.equal(moves.length, 2, "Opening elephant should have 2 moves ((0,2), (4,2))");
+
+  // Block elephant eye at (1, 1)
+  board[1][1] = PIECE_PAWN;
+  moves = getPseudoLegalMoves(board, 2, 0);
+  assert.equal(moves.length, 1, "Blocked elephant eye removes diagonal move");
+  assert.deepEqual(moves[0], { toX: 4, toY: 2 });
+});
+
+test("Xiangqi piece rules: Pawn river crossing", () => {
+  const board = Array.from({ length: 10 }, () => Array(9).fill(0));
+
+  // Red pawn before river (y=3)
+  board[3][4] = PIECE_PAWN;
+  let moves = getPseudoLegalMoves(board, 4, 3);
+  assert.equal(moves.length, 1, "Pawn before river can only move forward 1 step");
+  assert.deepEqual(moves[0], { toX: 4, toY: 4 });
+
+  // Red pawn after crossing river (y=6)
+  board[6][4] = PIECE_PAWN;
+  moves = getPseudoLegalMoves(board, 4, 6);
+  assert.equal(moves.length, 3, "Pawn after river can move forward and sideways");
+});
+
+test("Xiangqi Flying General check (对将 / 飞将)", () => {
+  const board = Array.from({ length: 10 }, () => Array(9).fill(0));
+  board[0][4] = PIECE_KING;   // Red King
+  board[9][4] = -PIECE_KING;  // Black King (same column, no pieces in between)
+
+  const isChecked = isKingInCheck(board, PLAYER_RED);
+  assert.equal(isChecked, true, "Direct line of sight between Kings should trigger check");
+
+  // Place a piece in between
+  board[4][4] = PIECE_PAWN;
+  const isCheckedAfterBlock = isKingInCheck(board, PLAYER_RED);
+  assert.equal(isCheckedAfterBlock, false, "Piece between Kings blocks Flying General");
+});
+
+test("Xiangqi Game Instance execution and candidate generation", () => {
+  const game = new XiangqiGameInstance("test-game-1");
+  assert.equal(game.status, "playing");
+  assert.equal(game.turn, PLAYER_RED);
+
+  // Legal candidate moves should exist for opening
+  const candidates = getCandidateMoves(game.board, PLAYER_RED);
+  assert.ok(candidates.length > 0, "Should generate candidate legal opening moves");
+
+  // Execute standard opening: Central Cannon (炮二平五 / b2e2)
+  const res = game.applyMove("b2e2", PLAYER_RED, "当头炮架中路控局");
+  assert.equal(res.ok, true, "Move b2e2 should be accepted");
+  assert.equal(game.turn, PLAYER_BLACK, "Turn should switch to Black");
+  assert.equal(game.board[2][4], PIECE_CANNON, "Cannon should now be at (4,2)");
+  assert.equal(game.board[2][1], 0, "Original square (1,2) should now be empty");
+
+  // Snapshot integrity
+  const snapshot = game.getSnapshot();
+  assert.equal(snapshot.gameType, "xiangqi");
+  assert.equal(snapshot.stepCount, 1);
+  assert.equal(snapshot.lastMove?.actionId, "b2e2");
+});


### PR DESCRIPTION
## 概要

在 FreeBuddy 中引入完整的 **对战大厅 (Game Arena)** 体系，支持五子棋 (Gomoku) 与中国象棋 (Xiangqi) 的人机智能博弈。

### 主要更新

1. **核心对弈引擎**
   - **五子棋引擎 (\gomokuEngine.ts\)**：支持 15×15 棋盘连五胜负判定、防守/进攻威胁评估与候选着法推荐。
   - **中国象棋引擎 (\xiangqiEngine.ts\)**：支持 10×9 棋盘全套规则（馬腿/象眼阻挡、炮翻山吃子、过河兵进退横移、九宫格限制与老将对脸飞将等）、将军/绝杀/困毙判定以及中文棋谱转换（如 \炮二平五\）。

2. **后端服务与 MCP 协议集成**
   - 实现 \reebuddy-game\ MCP 服务与通用多游戏实例管理 (\gameToolService.ts\)；
   - 支持对局状态持久化、多窗口状态广播及 Agent 思考中断后的落子重试。

3. **对战大厅与游戏界面 (Canvas 前端)**
   - **启动大厅 (\GameSetupModal.tsx\)**：统一 FreeBuddy 简约设计风格，支持选择游戏项目、AI 对手 Agent、模型以及先后手；
   - **Canvas 交互棋盘**：
     - 五子棋与中国象棋各自具备独立的高清 3D 质感棋子与木质纹理底色；
     - 集成 Web Audio 实时合成沉稳落子与吃子音效；
     - 彻底优化对局结束展示：移除遮挡棋局的暗色弹层，100% 完整清晰保留终局棋盘，便于复盘与截图分析。

4. **自动化测试**
   - 新增全套单元测试覆盖（\gomoku-engine.test.mjs\、\xiangqi-engine.test.mjs\、\game-mcp.test.mjs\），测试用例全部通过。