### PR TITLE
fix(windows): 优先使用 PowerShell 7，避免中文路径乱码

### DIFF
--- a/electron/cli/sandboxRuntime.ts
+++ b/electron/cli/sandboxRuntime.ts
@@ -19,7 +19,10 @@ import {
 
 import { getCallerUserId, isCallerAdmin } from "./callerContext.js";
 import { getUserById, getUserRoots, listUsers } from "./users.js";
-import { resolveWindowsShellCommand } from "./windowsEnv.js";
+import {
+  resolveWindowsPowerShell,
+  resolveWindowsShellCommand
+} from "./windowsEnv.js";
 import {
   getRemoteWorkspacesRoot,
   getWindowsAgentLinksRoot,
@@ -1002,17 +1005,6 @@ const WINDOWS_NODE_RUNNER = [
 ].join(";");
 
 
-function windowsPowerShell(env: Record<string, string | undefined>): string {
-  const systemRoot = env.SystemRoot || env.SYSTEMROOT || "C:\\Windows";
-  return path.win32.join(
-    systemRoot,
-    "System32",
-    "WindowsPowerShell",
-    "v1.0",
-    "powershell.exe"
-  );
-}
-
 const WINDOWS_SANDBOX_PROXY_ENV = new Set([
   "HTTP_PROXY",
   "HTTPS_PROXY",
@@ -1363,7 +1355,7 @@ export async function prepareSandboxedSpawn(input: {
           "exit $LASTEXITCODE"
         ].join("; ");
         shell = {
-          exe: windowsPowerShell(input.env),
+          exe: resolveWindowsPowerShell(input.env),
           args: [
             "-NoLogo",
             "-NoProfile",

--- a/electron/cli/windowsEnv.ts
+++ b/electron/cli/windowsEnv.ts
@@ -40,25 +40,27 @@ export function resolveWindowsPowerShell(
     "powershell.exe"
   );
 
-  const override = env.FREEBUDDY_PWSH?.trim();
-  if (override && isFile(override)) return override;
+  const override = unwrapWindowsPathEntry(env.FREEBUDDY_PWSH || "");
+  if (override && path.win32.isAbsolute(override) && isFile(override)) {
+    return override;
+  }
 
-  const programFiles =
-    env.ProgramFiles ||
-    env.PROGRAMFILES ||
-    env.ProgramW6432 ||
-    path.win32.join(
-      path.win32.parse(systemRoot).root || "C:\\",
-      "Program Files"
-    );
-  const pwsh7 = path.win32.join(programFiles, "PowerShell", "7", "pwsh.exe");
-  if (isFile(pwsh7)) return pwsh7;
-
-  for (const rawEntry of (env.PATH || env.Path || "").split(";")) {
-    const dir = unwrapWindowsPathEntry(rawEntry);
-    if (!dir) continue;
-    const candidate = path.win32.join(dir, "pwsh.exe");
-    if (isFile(candidate)) return candidate;
+  const driveRoot = path.win32.parse(systemRoot).root || "C:\\";
+  const programFilesRoots = [
+    env.ProgramFiles,
+    env.PROGRAMFILES,
+    env.ProgramW6432,
+    path.win32.join(driveRoot, "Program Files")
+  ];
+  const seenRoots = new Set<string>();
+  for (const root of programFilesRoots) {
+    const programFiles = (root || "").trim();
+    if (!programFiles) continue;
+    const key = programFiles.toLowerCase();
+    if (seenRoots.has(key)) continue;
+    seenRoots.add(key);
+    const pwsh7 = path.win32.join(programFiles, "PowerShell", "7", "pwsh.exe");
+    if (isFile(pwsh7)) return pwsh7;
   }
 
   return powershell51;

--- a/electron/cli/windowsEnv.ts
+++ b/electron/cli/windowsEnv.ts
@@ -12,15 +12,56 @@ const WINDOWS_PATH_QUERY = [
 
 const COMMAND_RESULT_MARKER = "__FREEBUDDY_COMMAND__";
 
-function windowsPowerShell(env: NodeJS.ProcessEnv): string {
+function unwrapWindowsPathEntry(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
+    ? trimmed.slice(1, -1).trim()
+    : trimmed;
+}
+
+function isExistingFile(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveWindowsPowerShell(
+  env: NodeJS.ProcessEnv,
+  isFile: (candidate: string) => boolean = isExistingFile
+): string {
   const systemRoot = env.SystemRoot || env.SYSTEMROOT || "C:\\Windows";
-  return path.win32.join(
+  const powershell51 = path.win32.join(
     systemRoot,
     "System32",
     "WindowsPowerShell",
     "v1.0",
     "powershell.exe"
   );
+
+  const override = env.FREEBUDDY_PWSH?.trim();
+  if (override && isFile(override)) return override;
+
+  const programFiles =
+    env.ProgramFiles ||
+    env.PROGRAMFILES ||
+    env.ProgramW6432 ||
+    path.win32.join(
+      path.win32.parse(systemRoot).root || "C:\\",
+      "Program Files"
+    );
+  const pwsh7 = path.win32.join(programFiles, "PowerShell", "7", "pwsh.exe");
+  if (isFile(pwsh7)) return pwsh7;
+
+  for (const rawEntry of (env.PATH || env.Path || "").split(";")) {
+    const dir = unwrapWindowsPathEntry(rawEntry);
+    if (!dir) continue;
+    const candidate = path.win32.join(dir, "pwsh.exe");
+    if (isFile(candidate)) return candidate;
+  }
+
+  return powershell51;
 }
 
 function runPowerShell(
@@ -38,7 +79,7 @@ function runPowerShell(
       `[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;${script}`
     );
     const child = spawn(
-      windowsPowerShell(env),
+      resolveWindowsPowerShell(env),
       args,
       { env }
     );
@@ -67,11 +108,7 @@ export function mergeWindowsPath(...values: Array<string | undefined>): string {
   const seen = new Set<string>();
   for (const value of values) {
     for (const rawEntry of (value || "").split(";")) {
-      const trimmed = rawEntry.trim();
-      const entry =
-        trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
-          ? trimmed.slice(1, -1).trim()
-          : trimmed;
+      const entry = unwrapWindowsPathEntry(rawEntry);
       if (!entry) continue;
       const key = entry.replace(/[\\/]+$/, "").toLowerCase();
       if (seen.has(key)) continue;
@@ -80,14 +117,6 @@ export function mergeWindowsPath(...values: Array<string | undefined>): string {
     }
   }
   return entries.join(";");
-}
-
-function isExistingFile(candidate: string): boolean {
-  try {
-    return fs.statSync(candidate).isFile();
-  } catch {
-    return false;
-  }
 }
 
 export function parseWindowsWhereOutput(

--- a/tests/windows-env.test.mjs
+++ b/tests/windows-env.test.mjs
@@ -1,12 +1,23 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 
 import {
   mergeWindowsPath,
   parseWindowsShellCommandOutput,
   parseWindowsWhereOutput,
+  resolveWindowsPowerShell,
   windowsInstallInvocation
 } from "../dist-electron/cli/windowsEnv.js";
+
+const POWERSHELL_51 =
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+const PWSH7 = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
+
+function filesExist(...paths) {
+  const existing = new Set(paths.map((value) => value.toLowerCase()));
+  return (candidate) => existing.has(candidate.toLowerCase());
+}
 
 test("mergeWindowsPath prefers fresh entries and removes case-insensitive duplicates", () => {
   assert.equal(
@@ -68,4 +79,96 @@ test("PowerShell command resolution ignores profile output before its marker", (
     "C:\\tools\\npm.cmd"
   );
   assert.equal(parseWindowsShellCommandOutput("profile output only"), undefined);
+});
+
+test("resolveWindowsPowerShell prefers FREEBUDDY_PWSH when that file exists", () => {
+  const override = "D:\\tools\\pwsh.exe";
+  assert.equal(
+    resolveWindowsPowerShell(
+      {
+        SystemRoot: "C:\\Windows",
+        FREEBUDDY_PWSH: override,
+        ProgramFiles: "C:\\Program Files"
+      },
+      filesExist(override, PWSH7, POWERSHELL_51)
+    ),
+    override
+  );
+});
+
+test("resolveWindowsPowerShell ignores a missing FREEBUDDY_PWSH override", () => {
+  assert.equal(
+    resolveWindowsPowerShell(
+      {
+        SystemRoot: "C:\\Windows",
+        FREEBUDDY_PWSH: "D:\\missing\\pwsh.exe",
+        ProgramFiles: "C:\\Program Files"
+      },
+      filesExist(PWSH7, POWERSHELL_51)
+    ),
+    PWSH7
+  );
+});
+
+test("resolveWindowsPowerShell prefers PowerShell 7 over Windows PowerShell 5.1", () => {
+  assert.equal(
+    resolveWindowsPowerShell(
+      {
+        SystemRoot: "C:\\Windows",
+        ProgramFiles: "C:\\Program Files"
+      },
+      filesExist(PWSH7, POWERSHELL_51)
+    ),
+    PWSH7
+  );
+});
+
+test("resolveWindowsPowerShell derives Program Files from SystemRoot when unset", () => {
+  assert.equal(
+    resolveWindowsPowerShell(
+      { SystemRoot: "C:\\Windows" },
+      filesExist(PWSH7, POWERSHELL_51)
+    ),
+    PWSH7
+  );
+});
+
+test("resolveWindowsPowerShell finds pwsh.exe on PATH before falling back to 5.1", () => {
+  const pathPwsh = "D:\\scoop\\shims\\pwsh.exe";
+  assert.equal(
+    resolveWindowsPowerShell(
+      {
+        SystemRoot: "C:\\Windows",
+        ProgramFiles: "C:\\Program Files",
+        PATH: "D:\\scoop\\shims;C:\\Windows\\System32"
+      },
+      filesExist(pathPwsh, POWERSHELL_51)
+    ),
+    pathPwsh
+  );
+});
+
+test("resolveWindowsPowerShell falls back to Windows PowerShell 5.1", () => {
+  assert.equal(
+    resolveWindowsPowerShell(
+      {
+        SystemRoot: "C:\\Windows",
+        ProgramFiles: "C:\\Program Files"
+      },
+      filesExist(POWERSHELL_51)
+    ),
+    POWERSHELL_51
+  );
+});
+
+test("sandbox runtime reuses resolveWindowsPowerShell instead of hardcoding 5.1", () => {
+  const sandboxSource = fs.readFileSync(
+    new URL("../electron/cli/sandboxRuntime.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(sandboxSource, /resolveWindowsPowerShell/);
+  assert.equal(
+    sandboxSource.includes("function windowsPowerShell("),
+    false
+  );
 });

--- a/tests/windows-env.test.mjs
+++ b/tests/windows-env.test.mjs
@@ -87,12 +87,26 @@ test("resolveWindowsPowerShell prefers FREEBUDDY_PWSH when that file exists", ()
     resolveWindowsPowerShell(
       {
         SystemRoot: "C:\\Windows",
-        FREEBUDDY_PWSH: override,
+        FREEBUDDY_PWSH: `"${override}"`,
         ProgramFiles: "C:\\Program Files"
       },
       filesExist(override, PWSH7, POWERSHELL_51)
     ),
     override
+  );
+});
+
+test("resolveWindowsPowerShell ignores a relative FREEBUDDY_PWSH override", () => {
+  assert.equal(
+    resolveWindowsPowerShell(
+      {
+        SystemRoot: "C:\\Windows",
+        FREEBUDDY_PWSH: "pwsh.exe",
+        ProgramFiles: "C:\\Program Files"
+      },
+      filesExist("pwsh.exe", PWSH7, POWERSHELL_51)
+    ),
+    PWSH7
   );
 });
 
@@ -133,7 +147,22 @@ test("resolveWindowsPowerShell derives Program Files from SystemRoot when unset"
   );
 });
 
-test("resolveWindowsPowerShell finds pwsh.exe on PATH before falling back to 5.1", () => {
+test("resolveWindowsPowerShell uses ProgramW6432 when ProgramFiles has no pwsh", () => {
+  const wow64Pwsh = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
+  assert.equal(
+    resolveWindowsPowerShell(
+      {
+        SystemRoot: "C:\\Windows",
+        ProgramFiles: "C:\\Program Files (x86)",
+        ProgramW6432: "C:\\Program Files"
+      },
+      filesExist(wow64Pwsh, POWERSHELL_51)
+    ),
+    wow64Pwsh
+  );
+});
+
+test("resolveWindowsPowerShell does not use PATH-discovered pwsh.exe", () => {
   const pathPwsh = "D:\\scoop\\shims\\pwsh.exe";
   assert.equal(
     resolveWindowsPowerShell(
@@ -144,7 +173,7 @@ test("resolveWindowsPowerShell finds pwsh.exe on PATH before falling back to 5.1
       },
       filesExist(pathPwsh, POWERSHELL_51)
     ),
-    pathPwsh
+    POWERSHELL_51
   );
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/maojindao55/freebuddy/issues/130

## 问题

Windows 上沙箱命令和内部 PowerShell 脚本把 shell 硬编码为 Windows PowerShell 5.1（`System32\WindowsPowerShell\v1.0\powershell.exe`）。PS 5.1 默认控制台编码是 GBK，含中文路径/文件名的命令会乱码失败。即使系统已安装 PowerShell 7（`pwsh`，默认 UTF-8），也不会被用到。

## 修复

抽出 `resolveWindowsPowerShell()`，按下面顺序探测，找不到再回退 5.1：

1. `FREEBUDDY_PWSH` 显式覆盖（必须是存在的绝对路径）
2. `%ProgramFiles%` / `%ProgramW6432%` / 由 `SystemRoot` 推导的 `Program Files\PowerShell\7\pwsh.exe`
3. Windows PowerShell 5.1

不扫描 `PATH`：Scoop / 用户目录下的 `pwsh.exe` 作为 SRT 内部 shell 可能无法被沙箱用户执行。`-Command` / `-ExecutionPolicy Bypass` 参数不变。

沙箱 runtime 与 `windowsEnv` 共用同一套探测。ACP adapter 在能解析到 Node 时仍走 stdin-bridge，不经过 PowerShell；本修复覆盖 `windowsEnv` 的内部脚本，以及走 PowerShell wrap 的非 ACP / Node 不可用路径。

## 测试

`tests/windows-env.test.mjs` 覆盖覆盖项、相对路径忽略、pwsh 7 优先、ProgramW6432、PATH 不参与、5.1 回退，以及 sandbox runtime 必须复用该函数。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66b7315f-748e-46c0-ad4b-ed32e0c20ab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66b7315f-748e-46c0-ad4b-ed32e0c20ab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

