### PR TITLE
fix(games): 修复安装版与 WebUI 象棋/五子棋无法开局

### DIFF
--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -1260,7 +1260,9 @@ export async function runAcpAgent({
             webContents
           })
         );
-        const conv = args.conversationId ? getConversation(args.conversationId) : undefined;
+      }
+      if (args.conversationId) {
+        const conv = getConversation(args.conversationId);
         const isGameSession =
           conv?.kind === "game" ||
           args.skills?.some((s) => s.id === "game-arena" || s.name === "game-arena");

--- a/electron/gameToolService.ts
+++ b/electron/gameToolService.ts
@@ -101,12 +101,18 @@ export function getOrCreateGame(conversationId: string, gameType: GameType = "go
   return game;
 }
 
-export function broadcastGameUpdate(webContents: WebContents | undefined, snapshot: GameStateSnapshot): void {
+export function broadcastGameUpdate(
+  webContents: WebContents | undefined,
+  snapshot: GameStateSnapshot,
+  conversationId?: string
+): void {
+  const event = {
+    type: "GAME_STATE_UPDATE",
+    conversationId: conversationId || snapshot.gameId,
+    payload: snapshot
+  };
   if (webContents && !webContents.isDestroyed()) {
-    safeSendToWebContents(webContents, "freebuddy://game-event", {
-      type: "GAME_STATE_UPDATE",
-      payload: snapshot
-    });
+    safeSendToWebContents(webContents, "freebuddy://game-event", event);
   }
   try {
     // Dynamic require so tests outside electron don't fail
@@ -115,10 +121,7 @@ export function broadcastGameUpdate(webContents: WebContents | undefined, snapsh
     if (BrowserWindow && typeof BrowserWindow.getAllWindows === "function") {
       for (const win of BrowserWindow.getAllWindows()) {
         if (!win.isDestroyed() && (!webContents || win.webContents !== webContents)) {
-          safeSendToWebContents(win.webContents, "freebuddy://game-event", {
-            type: "GAME_STATE_UPDATE",
-            payload: snapshot
-          });
+          safeSendToWebContents(win.webContents, "freebuddy://game-event", event);
         }
       }
     }
@@ -171,7 +174,7 @@ export async function dispatchGameAction(
 
     persistGameState(binding.conversationId, game);
     const snapshot = game.getSnapshot();
-    broadcastGameUpdate(binding.webContents, snapshot);
+    broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
 
     const moveLabel = res.chineseMove ? `${res.chineseMove} (${actionId})` : actionId;
     return {
@@ -195,7 +198,7 @@ export async function dispatchGameAction(
     const chat = game.addChat("agent", message, mood);
     persistGameState(binding.conversationId, game);
     const snapshot = game.getSnapshot();
-    broadcastGameUpdate(binding.webContents, snapshot);
+    broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
 
     return {
       ok: true,
@@ -209,7 +212,7 @@ export async function dispatchGameAction(
     const res = game.resign(2, reason);
     persistGameState(binding.conversationId, game);
     const snapshot = game.getSnapshot();
-    broadcastGameUpdate(binding.webContents, snapshot);
+    broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
 
     return {
       ok: true,
@@ -226,7 +229,7 @@ export async function dispatchGameAction(
     activeGamesByConversation.set(binding.conversationId, newGame);
     persistGameState(binding.conversationId, newGame);
     const snapshot = newGame.getSnapshot();
-    broadcastGameUpdate(binding.webContents, snapshot);
+    broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
 
     return {
       ok: true,
@@ -253,7 +256,7 @@ export function handlePlayerMove(
   }
   persistGameState(conversationId, game);
   const snapshot = game.getSnapshot();
-  broadcastGameUpdate(webContents, snapshot);
+  broadcastGameUpdate(webContents, snapshot, conversationId);
   return {
     ok: true,
     actionId,
@@ -280,7 +283,7 @@ export function handleAgentMove(
   }
   persistGameState(conversationId, game);
   const snapshot = game.getSnapshot();
-  broadcastGameUpdate(webContents, snapshot);
+  broadcastGameUpdate(webContents, snapshot, conversationId);
   return {
     ok: true,
     actionId,
@@ -301,7 +304,7 @@ export function handleResetGame(
   activeGamesByConversation.set(conversationId, newGame);
   persistGameState(conversationId, newGame);
   const snapshot = newGame.getSnapshot();
-  broadcastGameUpdate(webContents, snapshot);
+  broadcastGameUpdate(webContents, snapshot, conversationId);
   return {
     ok: true,
     gameId: newGame.gameId,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,10 +12,15 @@ import { handleFreebuddyFileRequest } from "./freebuddyFileProtocol.js";
 import { handleBrowserRequest } from "./browserProtocol.js";
 import { startPreviewServer } from "./previewServer.js";
 import { startWebUIServer } from "./webUIServer.js";
-import { setLocalInvokeWindowGetter } from "./invokeRegistry.js";
+import { setLocalInvokeWindowGetter, registerHandler } from "./invokeRegistry.js";
 import { setButlerAppWindowGetter } from "./butlerToolService.js";
 import { ensureOwnerUser, getOwnerUser } from "./cli/users.js";
-import { bindConversationNotifier, getConversation, updateConversationMetadata } from "./cli/conversations.js";
+import {
+  bindConversationNotifier,
+  getConversation,
+  requireOwnedConversation,
+  updateConversationMetadata
+} from "./cli/conversations.js";
 import { bindDelegationRunFinishedNotifier } from "./cli/delegationRuns.js";
 import { applyOwnerBackfill } from "./cli/ownerBackfill.js";
 import { initFileBridge } from "./fileBridge.js";
@@ -1234,16 +1239,20 @@ function registerButlerBuddyWindowIpc() {
     if (!isButlerBuddyTaskResultSender(event.sender)) return;
     butlerBuddyStateCoordinator.reportTaskResult(result);
   });
-  ipcMain.handle("game:getState", (_event, conversationId: string) => {
+  registerHandler("game:getState", (_event, conversationId: string) => {
+    if (!requireOwnedConversation(conversationId)) return undefined;
     return getOrCreateGame(conversationId).getSnapshot();
   });
-  ipcMain.handle(
+  registerHandler(
     "game:playerMove",
     (event, payload: { conversationId: string; actionId: string }) => {
+      if (!requireOwnedConversation(payload.conversationId)) {
+        return { ok: false, error: "conversation_not_found" };
+      }
       return handlePlayerMove(payload.conversationId, payload.actionId, event.sender);
     }
   );
-  ipcMain.handle(
+  registerHandler(
     "game:agentMove",
     (
       event,
@@ -1255,6 +1264,9 @@ function registerButlerBuddyWindowIpc() {
         mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring";
       }
     ) => {
+      if (!requireOwnedConversation(payload.conversationId)) {
+        return { ok: false, error: "conversation_not_found" };
+      }
       return handleAgentMove(
         payload.conversationId,
         payload.actionId,
@@ -1265,7 +1277,10 @@ function registerButlerBuddyWindowIpc() {
       );
     }
   );
-  ipcMain.handle("game:resetGame", (event, conversationId: string) => {
+  registerHandler("game:resetGame", (event, conversationId: string) => {
+    if (!requireOwnedConversation(conversationId)) {
+      return { ok: false, error: "conversation_not_found" };
+    }
     return handleResetGame(conversationId, event.sender);
   });
   ipcMain.handle(

--- a/electron/shared/remoteChannelPolicy.ts
+++ b/electron/shared/remoteChannelPolicy.ts
@@ -168,7 +168,14 @@ const ALLOW = [
   "delegation:listTeams",
   "delegation:stopRun",
   "delegation:hasRunForConversation",
-  "delegation:followUp"
+  "delegation:followUp",
+
+  // Bundled board games (Gomoku / Xiangqi). Ownership is enforced in the
+  // handlers through requireOwnedConversation.
+  "game:getState",
+  "game:playerMove",
+  "game:agentMove",
+  "game:resetGame"
 ] as const;
 
 const ADMIN_ONLY = [

--- a/electron/shared/wsChannelPolicy.ts
+++ b/electron/shared/wsChannelPolicy.ts
@@ -16,7 +16,9 @@ const GLOBAL_CHANNELS = new Set([
 const CONVERSATION_PAYLOAD_CHANNELS = new Set([
   "messages://changed",
   // Browser MCP events include conversationId in the payload.
-  "freebuddy://browser-tool"
+  "freebuddy://browser-tool",
+  // Game board sync events include conversationId in the payload.
+  "freebuddy://game-event"
 ]);
 const OWNER_PAYLOAD_CHANNELS = new Set(["scheduledTasks://changed"]);
 const CLI_SESSION_PREFIX = "cli://";

--- a/electron/webUIServer.ts
+++ b/electron/webUIServer.ts
@@ -178,7 +178,9 @@ function serveStatic(
     if (stat.isDirectory()) {
       const indexPath = path.join(filePath, "index.html");
       if (fs.existsSync(indexPath) && fs.statSync(indexPath).isFile()) {
-        serveSpaIndex(res, distDir);
+        // Serve the directory's own index (e.g. /games/xiangqi/) instead of
+        // the SPA shell, which would hide the bundled board games.
+        serveFile(res, indexPath);
         return true;
       }
     }

--- a/public/web-preload.js
+++ b/public/web-preload.js
@@ -451,6 +451,24 @@
       onPreferencesChanged: function () { return noopUnsub(); }
     },
 
+    game: {
+      getState: function (conversationId) { return invoke("game:getState", conversationId); },
+      playerMove: function (conversationId, actionId) {
+        return invoke("game:playerMove", { conversationId: conversationId, actionId: actionId });
+      },
+      agentMove: function (conversationId, actionId, reason, speech, mood) {
+        return invoke("game:agentMove", {
+          conversationId: conversationId,
+          actionId: actionId,
+          reason: reason,
+          speech: speech,
+          mood: mood
+        });
+      },
+      resetGame: function (conversationId) { return invoke("game:resetGame", conversationId); },
+      onGameEvent: function (cb) { return subscribe("freebuddy://game-event", cb); }
+    },
+
     remote: {
       whoami: function () { return invoke("remote:whoami"); },
       getStatus: function () { return invoke("remote:getStatus"); },

--- a/src/components/Browser/BrowserCanvas.tsx
+++ b/src/components/Browser/BrowserCanvas.tsx
@@ -7,6 +7,8 @@ import type { FeedItem } from "@/services/feed/types";
 import { cliClient } from "@/services/cli/client";
 import { useConversationStore } from "@/store/conversationStore";
 import {
+  bundledGameEntry,
+  isBundledGameType,
   remoteBrowserOrigin,
   splitAbsoluteLocalFile,
   useBrowserStore
@@ -357,6 +359,15 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
     void useBrowserStore.getState().ensureFor(activeId, cwd);
   }, [activeId, cwd]);
 
+  useEffect(() => {
+    if (!activeId || active?.kind !== "game") return;
+    const gameType = active.metadata?.gameType;
+    if (!isBundledGameType(gameType)) return;
+    const current = useBrowserStore.getState().byConv[activeId];
+    if (current?.manualEntry) return;
+    useBrowserStore.getState().navigate(activeId, bundledGameEntry(gameType));
+  }, [activeId, active?.kind, active?.metadata]);
+
   const lastEditPath = useMemo(
     () => extractLastFileEditPath(liveItems, messages),
     [liveItems, messages]
@@ -512,6 +523,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
 
     window.addEventListener("message", handleMessage);
     const unbindGameEvent = window.freebuddy?.game?.onGameEvent((event: any) => {
+      if (event?.conversationId && event.conversationId !== activeId) return;
       if (frameRef.current?.contentWindow && event?.payload) {
         frameRef.current.contentWindow.postMessage(
           { type: "FREEBUDDY_GAME_SYNC", payload: event.payload },

--- a/src/components/CLI/DetailColumn.tsx
+++ b/src/components/CLI/DetailColumn.tsx
@@ -21,10 +21,12 @@ export function DetailColumn({ runningCount }: { runningCount: number }) {
 
   useEffect(() => {
     if (!activeId) return;
-    useDetailLayoutStore.getState().setActiveTab("overview");
     const conv = useConversationStore
       .getState()
       .conversations.find((c) => c.id === activeId);
+    useDetailLayoutStore
+      .getState()
+      .setActiveTab(conv?.kind === "game" ? "preview" : "overview");
     void useBrowserStore.getState().ensureFor(activeId, conv?.cwd);
   }, [activeId]);
 

--- a/src/components/Games/GameSetupModal.tsx
+++ b/src/components/Games/GameSetupModal.tsx
@@ -9,7 +9,7 @@ import type {
   SessionConfigOption,
   SessionConfigProbeInput
 } from "@/services/cli/types";
-import { useBrowserStore } from "@/store/browserStore";
+import { bundledGameEntry, useBrowserStore } from "@/store/browserStore";
 import { useCliExecutorStore } from "@/store/cliExecutorStore";
 import { useConversationStore } from "@/store/conversationStore";
 import { useDetailLayoutStore } from "@/store/detailLayoutStore";
@@ -209,9 +209,10 @@ export function GameSetupModal({ open, onClose }: GameSetupModalProps) {
         skillIds: ["game-arena"]
       });
 
-      // Load game URL in built-in browser
-      const gameUrl = new URL(`games/${gamePath}/index.html`, window.location.href).href;
-      useBrowserStore.getState().navigate(conv.id, gameUrl);
+      // Load game URL in built-in browser. Packaged Electron cannot iframe
+      // file:// assets from app.asar; bundledGameEntry converts them to a
+      // freebuddy-browser path. WebUI uses a same-origin /games/... URL.
+      useBrowserStore.getState().navigate(conv.id, bundledGameEntry(gamePath));
       useDetailLayoutStore.getState().setActiveTab("preview");
       useDetailLayoutStore.getState().setDetailCollapsed(false);
 

--- a/src/store/browserStore.ts
+++ b/src/store/browserStore.ts
@@ -211,6 +211,45 @@ const COMMON_WEB_TLDS = new Set([
   "us", "ca", "au", "in", "eu", "tech", "space", "store", "fun", "club"
 ]);
 
+/** Convert a `file://` URL to a POSIX-ish absolute path the preview stack understands. */
+export function pathFromFileUrl(target: string): string | null {
+  try {
+    const parsed = new URL(target);
+    if (parsed.protocol !== "file:") return null;
+    let pathname = decodeURIComponent(parsed.pathname);
+    // Windows: file:///C:/Users/... → /C:/Users/...
+    if (/^\/[A-Za-z]:/.test(pathname)) pathname = pathname.slice(1);
+    return pathname.replace(/\\/g, "/");
+  } catch {
+    return null;
+  }
+}
+
+export function isBundledGameType(value: unknown): value is "gomoku" | "xiangqi" {
+  return value === "gomoku" || value === "xiangqi";
+}
+
+/**
+ * Preview target for the packaged Gomoku / Xiangqi boards.
+ * Packaged Electron loads `file://.../app.asar/dist/index.html`, which the
+ * built-in browser cannot iframe; convert that to an absolute path so
+ * `composeBrowserUrl` serves it through `freebuddy-browser` without a workspace.
+ * WebUI / Vite keep a same-origin HTTP URL under `/games/`.
+ */
+export function bundledGameEntry(gamePath: string): string {
+  const rel = `games/${gamePath}/index.html`;
+  if (typeof window === "undefined") return `/${rel}`;
+  if (isWebPlatform()) {
+    return new URL(`/${rel}`, `${window.location.origin}/`).href;
+  }
+  try {
+    const href = new URL(rel, window.location.href).href;
+    return pathFromFileUrl(href) || href;
+  } catch {
+    return `/${rel}`;
+  }
+}
+
 export function normalizeBrowserTarget(input: string | null | undefined): string {
   const trimmed = input?.trim() ?? "";
   if (!trimmed) return "";
@@ -272,6 +311,10 @@ export function composeBrowserUrl(
   }
   if (/^freebuddy-(browser|draft):\/\//i.test(normalized)) {
     return normalized;
+  }
+  if (/^file:\/\//i.test(normalized)) {
+    const filePath = pathFromFileUrl(normalized);
+    return filePath ? composeBrowserUrl(cwd, filePath, nonce) : "";
   }
   if (isAbsoluteLocalPath(normalized)) {
     const ext = localFileExtension(normalized);

--- a/tests/browser-file-preview.test.mjs
+++ b/tests/browser-file-preview.test.mjs
@@ -201,6 +201,70 @@ test("Browser preview resolves workspace-relative images to absolute file previe
   }
 });
 
+test("Browser preview converts file:// HTML URLs to render URLs without a workspace", async () => {
+  const { composeBrowserUrl, pathFromFileUrl } = await loadBrowserStoreModule();
+  const source =
+    "file:///Applications/FreeBuddy.app/Contents/Resources/app.asar/dist/games/xiangqi/index.html";
+  const url = composeBrowserUrl("", source, 6);
+  const parsed = new URL(url);
+
+  assert.equal(parsed.hostname, "render");
+  assert.equal(
+    parsed.pathname,
+    "/%2FApplications%2FFreeBuddy.app%2FContents%2FResources%2Fapp.asar%2Fdist%2Fgames%2Fxiangqi/index.html"
+  );
+  assert.equal(parsed.searchParams.get("v"), "6");
+  assert.equal(
+    pathFromFileUrl(source),
+    "/Applications/FreeBuddy.app/Contents/Resources/app.asar/dist/games/xiangqi/index.html"
+  );
+});
+
+test("Browser preview converts Windows file:// HTML URLs without a workspace", async () => {
+  const { composeBrowserUrl, pathFromFileUrl } = await loadBrowserStoreModule();
+  const source = "file:///C:/Users/me/FreeBuddy/dist/games/gomoku/index.html";
+  const url = composeBrowserUrl("", source, 2);
+  const parsed = new URL(url);
+
+  assert.equal(
+    pathFromFileUrl(source),
+    "C:/Users/me/FreeBuddy/dist/games/gomoku/index.html"
+  );
+  assert.equal(parsed.hostname, "render");
+  assert.equal(
+    parsed.pathname,
+    "/C%3A%2FUsers%2Fme%2FFreeBuddy%2Fdist%2Fgames%2Fgomoku/index.html"
+  );
+});
+
+test("bundled game entry uses HTTP on web and an absolute path in packaged Electron", async () => {
+  const { bundledGameEntry } = await loadBrowserStoreModule();
+  const previous = globalThis.window;
+  try {
+    globalThis.window = {
+      freebuddy: { platform: "web" },
+      location: { origin: "http://127.0.0.1:9", href: "http://127.0.0.1:9/" }
+    };
+    assert.equal(
+      bundledGameEntry("xiangqi"),
+      "http://127.0.0.1:9/games/xiangqi/index.html"
+    );
+
+    globalThis.window = {
+      freebuddy: { platform: "darwin" },
+      location: {
+        href: "file:///Applications/FreeBuddy.app/Contents/Resources/app.asar/dist/index.html"
+      }
+    };
+    assert.equal(
+      bundledGameEntry("xiangqi"),
+      "/Applications/FreeBuddy.app/Contents/Resources/app.asar/dist/games/xiangqi/index.html"
+    );
+  } finally {
+    globalThis.window = previous;
+  }
+});
+
 test("Browser preview converts absolute HTML paths to render URLs without a workspace", async () => {
   const { composeBrowserUrl } = await loadBrowserStoreModule();
   const filePath = "/Users/me/docs/v2ex_discussion.html";

--- a/tests/conversation-isolation-wiring.test.mjs
+++ b/tests/conversation-isolation-wiring.test.mjs
@@ -93,6 +93,26 @@ test("conversation mutations and handoff exports enforce ownership", () => {
   }
 });
 
+test("game IPC handlers enforce conversation ownership", () => {
+  const main = read("../electron/main.ts");
+  for (const channel of [
+    "game:getState",
+    "game:playerMove",
+    "game:agentMove",
+    "game:resetGame"
+  ]) {
+    const start = main.indexOf(`"${channel}"`);
+    assert.ok(start > 0, `${channel} is registered`);
+    const next = main.indexOf("registerHandler(", start + 1);
+    const body = next > 0 ? main.slice(start, next) : main.slice(start);
+    assert.match(
+      body,
+      /requireOwnedConversation/,
+      `${channel} checks conversation ownership`
+    );
+  }
+});
+
 test("enabling remote access backfills legacy ownership immediately", () => {
   const remoteControl = read("../electron/cli/remoteControl.ts");
   const main = read("../electron/main.ts");

--- a/tests/game-mcp.test.mjs
+++ b/tests/game-mcp.test.mjs
@@ -102,3 +102,51 @@ test("Frontend game scripts (Gomoku & Xiangqi) have valid JS syntax", () => {
     }, `Syntax error in ${filePath}`);
   }
 });
+
+test("packaged and WebUI game wiring loads the board without a workspace", () => {
+  const gameSetup = fs.readFileSync(
+    new URL("../src/components/Games/GameSetupModal.tsx", import.meta.url),
+    "utf8"
+  );
+  const canvas = fs.readFileSync(
+    new URL("../src/components/Browser/BrowserCanvas.tsx", import.meta.url),
+    "utf8"
+  );
+  const detail = fs.readFileSync(
+    new URL("../src/components/CLI/DetailColumn.tsx", import.meta.url),
+    "utf8"
+  );
+  const preload = fs.readFileSync(
+    new URL("../public/web-preload.js", import.meta.url),
+    "utf8"
+  );
+  const acpRuntime = fs.readFileSync(
+    new URL("../electron/cli/acpRuntime.ts", import.meta.url),
+    "utf8"
+  );
+  const gameService = fs.readFileSync(
+    new URL("../electron/gameToolService.ts", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(gameSetup, /bundledGameEntry\(gamePath\)/);
+  assert.doesNotMatch(gameSetup, /window\.location\.href\)\.href/);
+  assert.match(canvas, /bundledGameEntry\(gameType\)/);
+  assert.match(canvas, /isBundledGameType/);
+  assert.match(detail, /conv\?\.kind === "game" \? "preview" : "overview"/);
+  assert.match(preload, /invoke\("game:getState"/);
+  assert.match(preload, /invoke\("game:playerMove"/);
+  assert.match(preload, /subscribe\("freebuddy:\/\/game-event"/);
+  assert.match(acpRuntime, /registerGameToolSession/);
+  const gameBlock = acpRuntime.slice(
+    acpRuntime.indexOf("const isGameSession"),
+    acpRuntime.indexOf("if (args.skills?.length)")
+  );
+  assert.doesNotMatch(
+    gameBlock,
+    /remoteIsolated/,
+    "WebUI game sessions must still receive the game MCP server"
+  );
+  assert.match(gameService, /conversationId: conversationId \|\| snapshot\.gameId/);
+});
+

--- a/tests/remote-channel-policy.test.mjs
+++ b/tests/remote-channel-policy.test.mjs
@@ -138,7 +138,11 @@ test("the chat surface the web client depends on stays callable", async () => {
     "cli:listProjects",
     "cli:getProject",
     "settings:get",
-    "remote:whoami"
+    "remote:whoami",
+    "game:getState",
+    "game:playerMove",
+    "game:agentMove",
+    "game:resetGame"
   ]) {
     assert.equal(
       isRemoteChannelCallable(channel, false),

--- a/tests/remote-sandbox.test.mjs
+++ b/tests/remote-sandbox.test.mjs
@@ -217,6 +217,11 @@ test("remote runs and ACP terminal commands use the lightweight sandbox", () => 
     /if \(args\.conversationId && !remoteIsolated\)/,
     "remote WebUI sessions must not receive desktop-only Browser MCP servers"
   );
+  assert.match(
+    acpRuntime,
+    /registerGameToolSession/,
+    "game sessions still receive the in-process game MCP server"
+  );
 
   const acpBranch = runtime.slice(
     runtime.indexOf('if (built.protocol === "acp")'),

--- a/tests/workspace-roots.test.mjs
+++ b/tests/workspace-roots.test.mjs
@@ -145,3 +145,20 @@ test("webUIServer serves workspace files via /api/attachment and /api/browser-re
   assert.match(server, /handleBrowserRender/);
   assert.match(server, /handleBrowserRequest/);
 });
+
+test("webUIServer serves bundled game directory indexes instead of the SPA shell", () => {
+  const server = fs.readFileSync(
+    new URL("../electron/webUIServer.ts", import.meta.url),
+    "utf8"
+  );
+  const serveStatic = server.slice(
+    server.indexOf("function serveStatic"),
+    server.indexOf("function isAuthed")
+  );
+  const directoryBranch = serveStatic.slice(
+    serveStatic.indexOf("stat.isDirectory()"),
+    serveStatic.indexOf("} catch")
+  );
+  assert.match(directoryBranch, /serveFile\(res, indexPath\)/);
+  assert.doesNotMatch(directoryBranch, /serveSpaIndex/);
+});

--- a/tests/ws-channel-policy.test.mjs
+++ b/tests/ws-channel-policy.test.mjs
@@ -42,6 +42,9 @@ test("classifyWsChannel routes global, session-scoped, and desktop-only channels
   assert.deepEqual(classifyWsChannel("freebuddy://browser-tool"), {
     kind: "conversationPayload"
   });
+  assert.deepEqual(classifyWsChannel("freebuddy://game-event"), {
+    kind: "conversationPayload"
+  });
 });
 
 test("conversation-scoped channels are classified for per-owner delivery", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

安装版开局后，内置浏览器显示「未选择工作区目录」，棋盘无法加载；WebUI 浏览器同样无法下棋，Agent 也无法通过 MCP 走子。

## 根因

1. **安装版**：`GameSetupModal` 用 `new URL('games/...', window.location.href)` 生成 `file://.../app.asar/dist/games/...` 地址。`composeBrowserUrl` 在无工作区时直接返回空 URL，预览面板空白。
2. **WebUI**：`serveStatic` 访问 `/games/xiangqi/` 时错误回退到 SPA shell，而非游戏 `index.html`；`web-preload.js` 缺少 `game:*` IPC 桥接；远程会话未注册 `freebuddy-game` MCP，Agent 无法调用 `game_make_move`。

## 修复

- 新增 `bundledGameEntry()` / `pathFromFileUrl()`：桌面端转为绝对路径经 `freebuddy-browser` 渲染；WebUI 使用同源 `/games/...` URL。
- `composeBrowserUrl` 支持 `file://` HTML 在无工作区时渲染。
- WebUI 静态服务对目录请求返回目录内 `index.html`。
- `web-preload.js` 暴露 `game.getState/playerMove/agentMove/resetGame/onGameEvent`。
- 远程通道策略放行 `game:*` IPC；游戏 MCP 不再被 `remoteIsolated` 拦截。
- 游戏会话切换时默认打开预览 Tab；旧会话无 manualEntry 时自动补导航。

## 测试

- `tests/browser-file-preview.test.mjs`（file:// 与 bundledGameEntry）
- `tests/game-mcp.test.mjs`（WebUI 接线）
- `tests/conversation-isolation-wiring.test.mjs`（game IPC 归属校验）
- `tests/remote-channel-policy.test.mjs` / `tests/remote-sandbox.test.mjs`
- `tests/workspace-roots.test.mjs` / `tests/ws-channel-policy.test.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc5e837e-1b40-4b61-b3cc-48149a491a57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc5e837e-1b40-4b61-b3cc-48149a491a57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

