### PR TITLE
feat: improve game AI strength and reliability

### DIFF
--- a/assets/skills/game-arena/SKILL.md
+++ b/assets/skills/game-arena/SKILL.md
@@ -5,20 +5,74 @@ description: Play board and card games (such as Gomoku, Chinese Chess) with the 
 
 # Game Arena
 
-You are playing a turn-based board or card game with the user inside FreeBuddy.
+You are playing a competitive board game against the user inside FreeBuddy.
+
+**Your primary objective is to WIN the game.** Play to win on every single move: capture the opponent's pieces, defend your own, and never give away material for free ("送子" / hanging pieces is the worst mistake you can make). In-game chat and personality are secondary decoration - losing gracefully is still losing.
 
 ## Available Game Tools (MCP)
 
 You have access to the `freebuddy-game` MCP toolset:
-- `game_get_state`: Query current board matrix, active turn, last move, and legal candidate moves (lean token footprint).
+- `game_get_state`: Query current board (ASCII rendering with coordinates), active turn, last move, opponent threat warnings, and legal candidate moves sorted by tactical value.
 - `game_make_move`: Execute a piece placement or card move by providing `actionId` (e.g. `"H8"`, `"b2e2"`).
 - `game_send_chat`: Send in-game psychological chat/dialogue to the player.
 - `game_get_history`: Query historical moves and dialogue records for post-game review or tactical recap (optional).
 - `game_resign`: Resign/surrender if the match is lost.
 
-## Playing Instructions
+## Reading the State Output (computed facts - always trust them)
 
-1. Whenever you are prompted that it is your turn to act:
-   - Call `game_make_move` with the chosen `actionId` (e.g. `actionId: "H8"`).
-   - Call `game_send_chat` to send an in-game personality reaction or dialogue to the opponent.
-2. Do NOT run system terminal commands (PowerShell/Bash) to search for games or processes. All game interactions are handled purely via the MCP tools.
+- `⚠ 对方威胁：你的 f9士 正被 f2俥 盯住（无保护，会被白吃）` — the engine has computed that the opponent can capture this piece. If it says 无保护 (undefended), you WILL lose it unless you act (move it, defend it, or eliminate the attacker).
+- Candidate move tags: `🚨[招致绝杀!]` = playing this lets the opponent deliver mate next move - absolutely forbidden unless it is your only legal move. `⚠[丢X!]` = playing this loses material X for nothing - NEVER play these while safe alternatives exist. `[得子]` = you win material. Untagged = safe.
+- Before grabbing a far pawn or an untagged capture, ask what the moving piece currently GUARDS (a central file, your king's gate). Pieces on defensive duty must not abandon their post for small loot - that is how mates happen.
+- `⚠ 你正被将军` / `[关键封堵]` / `[绝杀胜手]` as before.
+
+## Mandatory Workflow
+
+1. Before EVERY move, call `game_get_state` first. NEVER rely on your memory of earlier positions - always read the fresh board.
+2. Read the ASCII board carefully to understand the position spatially. The legend explains piece symbols and orientation.
+3. Pay attention to the ⚠ threat warning lines: they are computed for you and tell you when you can win immediately or must defend.
+4. Choose your move from the `候选走法` (candidate moves) list - it is pre-sorted by tactical value. Play the highest-priority safe candidate unless you have a concrete reason otherwise.
+5. Call `game_make_move` with that exact `actionId`. If it returns an error, re-read the state and pick a different legal candidate.
+6. The `reason` you pass to `game_make_move` is already shown to the player as your in-game commentary - write only a short tactical intent. Capture/check/checkmate facts are computed by the server, so never invent or repeat them in `reason`.
+7. After `game_make_move` succeeds, end the turn immediately. Do not print the board, repeat the tool result, restate the move, or call `game_send_chat`; the board and factual move banner have already updated for the player.
+
+## Rules Reference (authoritative - trust this over your memory)
+
+The engine enforces standard rules strictly. If a move you expected is illegal, re-read these rules instead of assuming house variants exist.
+
+### Gomoku (15x15, no forbidden moves)
+
+- Players alternate placing one stone per turn on empty intersections. Black moves first. Stones never move or get captured.
+- First side with **five or more** consecutive stones (horizontal / vertical / diagonal) wins. Long rows of 6+ also win.
+- No forbidden-move rule is enforced in this implementation.
+
+### Chinese Chess (coordinates: columns `a`-`i`, rows `0`-`9`; row `0` is Red's back rank, row `9` is Black's)
+
+- **帥/將 K**: one step orthogonal inside the palace (3x3). The two Kings may NEVER face each other on an open file (flying-general rule).
+- **仕/士 A**: one diagonal step inside the palace.
+- **相/象 B**: two-point diagonal ("田"). Blocked if the diagonal midpoint ("象眼") is occupied. May NOT cross the river.
+- **傌/馬 N**: "日" pattern (one orthogonal + one diagonal outward). Blocked if the adjacent orthogonal square ("马腿") is occupied.
+- **俥/車 R**: any distance along an unobstructed rank or file.
+- **炮/砲 C**: moves like Rook; to CAPTURE there must be exactly one piece (screen) between it and the target.
+- **兵/卒 P**: before crossing the river - forward one step only. After crossing - forward OR sideways one step, **never backward**.
+  - A crossed-river pawn capturing SIDEWAYS (e.g. red pawn `g5` takes `h5`) is **standard chess-xiangqi rules**, not a special variant of this app.
+- Capturing = moving onto a square holding an enemy piece (Cannon exception above).
+- You MUST respond to check. Having zero legal moves loses the game (checkmate or stalemate).
+
+## Tactical Checklist (evaluate in this order)
+
+1. **Win now**: if any candidate is tagged `[绝杀胜手]` or the state warns of an immediate winning point, play it immediately.
+2. **Block loss**: if any candidate is tagged `[关键封堵]` or the state warns the opponent can complete five-in-a-row / deliver mate next move, block that point. Skipping this loses the game.
+3. **Save attacked pieces**: if the state lists 对方威胁 warnings, address them first - move the piece away, defend it, or capture the attacker. Never ignore a 无保护 warning.
+4. **Never hang material**: do not choose any candidate tagged `⚠[丢X!]` while safe alternatives exist. Before committing, check your destination square against the threat list.
+5. **Check status**: in Chinese Chess, if the state says 你正被将军, you MUST respond to the check.
+6. **Attack with your big pieces**: being ahead in material means nothing if you never use it. Prefer moves that develop Rooks/Knights toward the attack, create threats, and force the opponent to respond - avoid passive shuffling of pawns/edge tokens while your heavy pieces sit at home.
+7. **Development before raids**: in the opening, a `[兑子]` raid deep into enemy territory (e.g. cannon jumps the board to eat a guarded piece) usually trades your most flexible attacker for a minor piece and gets trapped afterwards. Prefer developing moves that keep your pieces coordinated and safe.
+8. **Stay connected**: never play far away from all existing stones (Gomoku) unless the center is empty.
+
+## Difficulty Note
+
+When session difficulty is set to hard, a local engine may answer moves automatically on your behalf. In that case focus your replies on commentary and chat only, and do not attempt stale moves after the engine has already replied.
+
+## Prohibited Actions
+
+Do NOT run system terminal commands (PowerShell/Bash) to search for games, engines, or processes. All game interactions are handled purely via the MCP tools above.

--- a/assets/skills/game-arena/SKILL.md
+++ b/assets/skills/game-arena/SKILL.md
@@ -71,7 +71,10 @@ The engine enforces standard rules strictly. If a move you expected is illegal, 
 
 ## Difficulty Note
 
-When session difficulty is set to hard, a local engine may answer moves automatically on your behalf. In that case focus your replies on commentary and chat only, and do not attempt stale moves after the engine has already replied.
+When session difficulty is set to hard, a local engine answers moves automatically on your behalf. In that case:
+- Do NOT call `game_make_move` after the engine has already moved.
+- You may analyze the game and thoughts in the conversation chat.
+- When you want to send short in-character commentary or psychological banter (under 30 words) to display in the board dialogue bubble, call the `game_send_chat` tool.
 
 ## Prohibited Actions
 

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -4,7 +4,8 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  realpathSync as fsRealpath
+  realpathSync as fsRealpath,
+  unlinkSync
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -602,8 +603,10 @@ export function extraArgsHaveDshConfig(args: string[]): boolean {
 /** Resolve the `dsh-acp-demo` entry we should spawn with `node`, if any. */
 export function resolveDshAcpDemoBinJs(input: {
   binary?: string;
+  cwd?: string;
   dshAcpRuntimeRoot?: string;
 }): string | undefined {
+  const configPath = resolveDshAcpConfigPath(input.cwd, input.dshAcpRuntimeRoot);
   const standaloneManagedBin = input.dshAcpRuntimeRoot
     ? path.join(
         input.dshAcpRuntimeRoot,
@@ -613,7 +616,11 @@ export function resolveDshAcpDemoBinJs(input: {
         "bin.js"
       )
     : "";
-  if (isDefaultDshAcpBinary(input.binary) && standaloneManagedBin && existsSync(standaloneManagedBin)) {
+  const standaloneReady =
+    Boolean(standaloneManagedBin) &&
+    existsSync(standaloneManagedBin) &&
+    dshAcpCompositionReady(standaloneManagedBin, configPath);
+  if (isDefaultDshAcpBinary(input.binary) && standaloneReady) {
     return standaloneManagedBin;
   }
   const managedBin = input.dshAcpRuntimeRoot
@@ -629,7 +636,7 @@ export function resolveDshAcpDemoBinJs(input: {
   const managedReady =
     Boolean(managedBin) &&
     existsSync(managedBin) &&
-    dshAcpCompositionReady(managedBin);
+    dshAcpCompositionReady(managedBin, configPath);
   if (isDefaultDshAcpBinary(input.binary) && managedReady) return managedBin;
   const fromHint = dshAcpDemoBinJsFromBinaryHint(input.binary);
   if (fromHint) return fromHint;
@@ -985,6 +992,24 @@ export function patchDshAcpRuntimeFromCommand(command: {
   if (entry) patchDshAcpRuntimeFromBin(entry);
 }
 
+/** Clean up legacy package.json and lockfile in the managed runtime if they hold stale granular dependencies. */
+export function cleanupLegacyDshAcpManagedFiles(root: string): void {
+  const pkgJsonPath = path.join(root, "package.json");
+  if (existsSync(pkgJsonPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+      const deps = { ...parsed.dependencies, ...parsed.devDependencies };
+      if (deps["@deepseek-ai/dsh-acp-demo"] || !deps["deepseek-harness-acp"]) {
+        unlinkSync(pkgJsonPath);
+        const lockPath = path.join(root, "package-lock.json");
+        if (existsSync(lockPath)) unlinkSync(lockPath);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
 /** Refresh the managed composition from the bundled default before spawn/install. */
 export function syncDshAcpManagedConfig(dataDir: string): string {
   const root = dshAcpManagedRoot(dataDir);
@@ -994,6 +1019,7 @@ export function syncDshAcpManagedConfig(dataDir: string): string {
   } catch {
     /* ignore permission errors */
   }
+  cleanupLegacyDshAcpManagedFiles(root);
   patchDshAcpManagedRuntime(root);
   return root;
 }
@@ -1088,25 +1114,32 @@ export function isStandaloneDshAcpBinary(binary?: string): boolean {
   return base.startsWith("deepseek-harness-acp") || base.startsWith("dsh-acp");
 }
 
-export function dshAcpCompositionReady(binPath: string): boolean {
+export function dshAcpCompositionReady(
+  binPath: string,
+  configPath?: string
+): boolean {
   const pkgDir = resolveDshAcpDemoDirFromBinary(binPath) ?? path.dirname(binPath);
-  if (
-    pkgDir.endsWith("deepseek-harness-acp") ||
-    isStandaloneDshAcpBinary(binPath)
-  ) {
-    return (
-      existsSync(path.join(pkgDir, "package.json")) ||
-      nodeModulesHasPackage(pkgDir, "deepseek-harness-acp") ||
-      nodeModulesHasPackage(pkgDir, DSH_ACP_PROBE_PACKAGE)
-    );
+  if (!nodeModulesHasPackage(pkgDir, DSH_ACP_PROBE_PACKAGE)) {
+    return false;
   }
-  return nodeModulesHasPackage(pkgDir, DSH_ACP_PROBE_PACKAGE);
+  const cfg = configPath && existsSync(configPath) ? configPath : undefined;
+  if (cfg) {
+    try {
+      const packages = parseDshAcpCompositionPackages(readFileSync(cfg, "utf8"));
+      return packages.every((pkg) => nodeModulesHasPackage(pkgDir, pkg));
+    } catch {
+      /* ignore unreadable config */
+    }
+  }
+  return true;
 }
 
 /** Bare npm package names referenced by the bundled ACP composition. */
 export function parseDshAcpCompositionPackages(yamlText: string): string[] {
-  const names = new Set<string>(["@deepseek-ai/dsh-acp-demo"]);
-  for (const match of yamlText.matchAll(/^\s*name:\s*'(@deepseek-ai\/[^']+)'/gm)) {
+  const names = new Set<string>();
+  for (const match of yamlText.matchAll(
+    /^\s*(?:-\s+)?name:\s*['"]?(@deepseek-ai\/[^'"\s]+)['"]?/gm
+  )) {
     names.add(match[1].split("/").slice(0, 2).join("/"));
   }
   return [...names];
@@ -1445,6 +1478,7 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
     case "dsh-acp": {
       const nodeEntry = resolveDshAcpDemoBinJs({
         binary: input.binary,
+        cwd: input.cwd,
         dshAcpRuntimeRoot: input.dshAcpRuntimeRoot
       });
       const args = extraArgsHaveDshConfig(extra)

--- a/electron/cli/check.ts
+++ b/electron/cli/check.ts
@@ -5,6 +5,8 @@ import { BrowserWindow } from "electron";
 import {
   adapterBinary,
   applyDshAcpNpmInstallEnv,
+  bundledDshAcpConfigPath,
+  cleanupLegacyDshAcpManagedFiles,
   dshAcpCompositionReady,
   dshAcpInstallCommand,
   dshAcpManagedDemoBin,
@@ -384,8 +386,9 @@ export async function cliCheck(
     }
   }
   if (adapter === "dsh-acp") {
+    const cfgPath = bundledDshAcpConfigPath();
     const managedBin = dshAcpManagedDemoBin(getDataDir());
-    if (fs.existsSync(managedBin) && dshAcpCompositionReady(managedBin)) {
+    if (fs.existsSync(managedBin) && dshAcpCompositionReady(managedBin, cfgPath)) {
       const result: CliCheckResult = { installed: true, path: managedBin };
       upsertRuntime(runtimeKey, true, managedBin);
       trackAgentSetup(adapter, "check", "detected");
@@ -396,7 +399,7 @@ export async function cliCheck(
       trackAgentSetup(adapter, "check", "missing", "binary not found");
       return { installed: false };
     }
-    if (!dshAcpCompositionReady(resolved)) {
+    if (!dshAcpCompositionReady(resolved, cfgPath)) {
       upsertRuntime(
         runtimeKey,
         false,
@@ -913,6 +916,7 @@ async function removeDshAcpWindowsResidue(
 
 function prepareDshAcpManagedInstall(): string {
   const root = syncDshAcpManagedConfig(getDataDir());
+  cleanupLegacyDshAcpManagedFiles(root);
   return dshAcpInstallCommand({ prefix: root });
 }
 

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -234,13 +234,14 @@ export async function cliRun(
   await waitForCodexToolchainAutoUpdate(args.adapter);
 
   const skillSupport = definition?.capabilities.skills;
+  let nativeSkillsMounted = false;
   if (
     !readOnlyWorkspace &&
     args.cwd &&
     args.skills &&
     skillSupport?.nativeDirs?.length
   ) {
-    reconcileNativeSkillLinks(
+    nativeSkillsMounted = reconcileNativeSkillLinks(
       args.cwd,
       skillSupport.nativeDirs,
       args.skills,
@@ -249,7 +250,12 @@ export async function cliRun(
   }
   const effectiveArgs: CliRunArgs =
     args.announceSkills && args.skills?.length
-      ? { ...args, prompt: buildSkillAnnouncement(args.prompt, args.skills) }
+      ? {
+          ...args,
+          prompt: buildSkillAnnouncement(args.prompt, args.skills, {
+            nativeSkillsMounted
+          })
+        }
       : args;
   const withWorkspace: CliRunArgs =
     effectiveArgs.adapter === "dsh-acp"

--- a/electron/cli/skillRuntime.ts
+++ b/electron/cli/skillRuntime.ts
@@ -5,13 +5,17 @@ import type { SkillSnapshot } from "./skillTypes.js";
 
 export function buildSkillAnnouncement(
   prompt: string,
-  skills: readonly SkillSnapshot[]
+  skills: readonly SkillSnapshot[],
+  options: { nativeSkillsMounted?: boolean } = {}
 ): string {
   if (skills.length === 0) return prompt;
   const catalog = skills
     .map((skill) => `- ${skill.name} (${skill.version}): ${skill.description}`)
     .join("\n");
-  return `[FreeBuddy active skills]\n${catalog}\n\nUse the skill_list and skill_load tools to read the selected skill instructions before applying them. Use skill_read_resource for files referenced by SKILL.md. Native skill discovery may also expose the same skills.\n\n${prompt}`;
+  const accessGuidance = options.nativeSkillsMounted
+    ? "Use the freebuddy-skills MCP tools skill_list and skill_load to read the selected skill instructions before applying them. Use skill_read_resource for files referenced by SKILL.md. Adapter-native skill discovery may also expose the mounted copies."
+    : "These selected skills are available through the freebuddy-skills MCP server. Use skill_list and skill_load to read their instructions before applying them, and use skill_read_resource for files referenced by SKILL.md. Do not call adapter-native skill commands or search the filesystem with terminal tools to locate these skills.";
+  return `[FreeBuddy active skills]\n${catalog}\n\n${accessGuidance}\n\n${prompt}`;
 }
 
 function isInside(parent: string, child: string): boolean {
@@ -32,7 +36,8 @@ export function reconcileNativeSkillLinks(
   nativeDirs: readonly string[],
   selected: readonly SkillSnapshot[],
   registeredRoots: readonly string[]
-): void {
+): boolean {
+  let mountedAny = false;
   for (const relativeDir of nativeDirs) {
     const directory = path.resolve(cwd, relativeDir);
     if (!isInside(cwd, directory)) continue;
@@ -56,16 +61,25 @@ export function reconcileNativeSkillLinks(
     }
     for (const skill of selected) {
       const target = path.join(directory, skill.name);
-      if (fs.existsSync(target)) continue;
+      if (fs.existsSync(target)) {
+        try {
+          if (canonicalPath(target) === canonicalPath(skill.rootPath)) mountedAny = true;
+        } catch {
+          /* leave an existing path that FreeBuddy does not own */
+        }
+        continue;
+      }
       try {
         fs.symlinkSync(
           skill.rootPath,
           target,
           process.platform === "win32" ? "junction" : "dir"
         );
+        mountedAny = true;
       } catch (error) {
         console.warn(`[skills] could not mount ${skill.name} in ${relativeDir}:`, error);
       }
     }
   }
+  return mountedAny;
 }

--- a/electron/debugLogExport.ts
+++ b/electron/debugLogExport.ts
@@ -26,7 +26,9 @@ import {
   type PathMask
 } from "./shared/logSanitize.js";
 import {
+  collapseAcpHistoryReplayLines,
   filterJsonlLinesByTimestamp,
+  groupSessionLogEntries,
   localDayRange,
   type TimestampRange
 } from "./shared/debugLogExportCore.js";
@@ -169,23 +171,42 @@ function readAppLogFiles(
   return out;
 }
 
-// On failure returns an empty set so a broken scope filter can never leak
-// other conversations' sessions into a conversation-scoped export.
-function sessionIdsForConversation(conversationId: string): Set<string> {
-  const ids = new Set<string>();
+interface ConversationSessionSelection {
+  taskIds: Set<string>;
+  toolSessionIdByTask: Map<string, string>;
+}
+
+// On failure returns an empty selection so a broken scope filter can never
+// leak other conversations' sessions into a conversation-scoped export.
+function sessionsForConversation(conversationId: string): ConversationSessionSelection {
+  const selection: ConversationSessionSelection = {
+    taskIds: new Set<string>(),
+    toolSessionIdByTask: new Map<string, string>()
+  };
   try {
     const rows = getDb()
       .prepare(
-        "SELECT DISTINCT task_id FROM conversation_messages WHERE conversation_id = ? AND task_id IS NOT NULL"
+        `SELECT DISTINCT m.task_id, t.tool_session_id
+         FROM conversation_messages m
+         LEFT JOIN cli_tasks t ON t.id = m.task_id
+         WHERE m.conversation_id = ? AND m.task_id IS NOT NULL`
       )
-      .all(conversationId) as Array<{ task_id: string }>;
+      .all(conversationId) as Array<{ task_id: string; tool_session_id: string | null }>;
     for (const row of rows) {
-      if (row.task_id) ids.add(row.task_id);
+      if (!row.task_id) continue;
+      selection.taskIds.add(row.task_id);
+      const toolSessionId = row.tool_session_id?.trim();
+      if (toolSessionId) selection.toolSessionIdByTask.set(row.task_id, toolSessionId);
     }
   } catch {
     /* keep empty */
   }
-  return ids;
+  return selection;
+}
+
+function safeSessionLogName(logicalSessionId: string): string {
+  const safe = logicalSessionId.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 160);
+  return `${safe || "session"}.jsonl`;
 }
 
 function readSessionLogFiles(
@@ -200,52 +221,68 @@ function readSessionLogFiles(
   } catch {
     return out;
   }
+  let toolSessionIdByTask = new Map<string, string>();
   if (conversationId) {
-    const allowed = sessionIdsForConversation(conversationId);
-    names = names.filter((n) => allowed.has(n.replace(/\.jsonl$/, "")));
+    const selection = sessionsForConversation(conversationId);
+    toolSessionIdByTask = selection.toolSessionIdByTask;
+    names = names.filter((n) => selection.taskIds.has(n.replace(/\.jsonl$/, "")));
   }
-  const stat: Array<{ name: string; mtimeMs: number }> = [];
+  const stat: Array<{ taskId: string; name: string; mtimeMs: number }> = [];
   const recencyCutoff = Date.now() - LOG_RETENTION_DAYS * 86_400_000; // sessions are "近 7 天"
   for (const name of names) {
     try {
       const mtimeMs = fs.statSync(path.join(getLogDir(), name)).mtimeMs;
       if (mtimeMs < recencyCutoff) continue;
-      stat.push({ name, mtimeMs });
+      stat.push({ taskId: name.replace(/\.jsonl$/, ""), name, mtimeMs });
     } catch {
       /* file deleted or unreadable mid-scan — skip it, keep the rest */
     }
   }
-  stat.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  for (const { name } of stat.slice(0, MAX_SESSION_FILES)) {
-    const file = path.join(getLogDir(), name);
-    try {
-      const size = fs.statSync(file).size;
-      let text: string;
-      let truncated = false;
-      if (size > SESSION_TAIL_BYTES) {
-        const fd = fs.openSync(file, "r");
-        try {
-          const buf = Buffer.alloc(SESSION_TAIL_BYTES);
-          const bytesRead = fs.readSync(fd, buf, 0, SESSION_TAIL_BYTES, size - SESSION_TAIL_BYTES);
-          text = buf.subarray(0, bytesRead).toString("utf8");
-        } finally {
-          fs.closeSync(fd);
+  const groups = groupSessionLogEntries(
+    stat,
+    toolSessionIdByTask,
+    MAX_SESSION_FILES
+  );
+  for (const group of groups) {
+    const mergedLines: string[] = [];
+    for (const { name } of group.entries) {
+      const file = path.join(getLogDir(), name);
+      try {
+        const size = fs.statSync(file).size;
+        let text: string;
+        let truncated = false;
+        if (size > SESSION_TAIL_BYTES) {
+          const fd = fs.openSync(file, "r");
+          try {
+            const buf = Buffer.alloc(SESSION_TAIL_BYTES);
+            const bytesRead = fs.readSync(fd, buf, 0, SESSION_TAIL_BYTES, size - SESSION_TAIL_BYTES);
+            text = buf.subarray(0, bytesRead).toString("utf8");
+          } finally {
+            fs.closeSync(fd);
+          }
+          const idx = text.indexOf("\n");
+          if (idx >= 0) text = text.slice(idx + 1); // drop partial first line
+          truncated = true;
+        } else {
+          text = fs.readFileSync(file, "utf8");
         }
-        const idx = text.indexOf("\n");
-        if (idx >= 0) text = text.slice(idx + 1); // drop partial first line
-        truncated = true;
-      } else {
-        text = fs.readFileSync(file, "utf8");
+        const compacted = collapseAcpHistoryReplayLines(text.split("\n"));
+        const lines = filterLines(compacted, "session", mode, masks);
+        if (truncated) {
+          lines.unshift(
+            JSON.stringify({
+              type: "system",
+              content: `[export] ${name} truncated to last 2MB`
+            })
+          );
+        }
+        mergedLines.push(...lines);
+      } catch {
+        /* skip unreadable file */
       }
-      const lines = filterLines(text.split("\n"), "session", mode, masks);
-      if (truncated) {
-        lines.unshift(
-          JSON.stringify({ type: "system", content: "[export] truncated to last 2MB" })
-        );
-      }
-      out.push({ name, lines });
-    } catch {
-      /* skip unreadable file */
+    }
+    if (mergedLines.length > 0) {
+      out.push({ name: safeSessionLogName(group.logicalSessionId), lines: mergedLines });
     }
   }
   return out;

--- a/electron/gameToolService.ts
+++ b/electron/gameToolService.ts
@@ -1,12 +1,14 @@
 import { randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
 import type { WebContents } from "electron";
 
 import { waitForActiveBridgePort } from "./agentBridge.js";
 import { safeSendToWebContents } from "./cli/ipcSend.js";
-import { GomokuGameInstance, PLAYER_BLACK as GOMOKU_BLACK, PLAYER_WHITE as GOMOKU_WHITE } from "./games/gomokuEngine.js";
-import { XiangqiGameInstance, PLAYER_RED as XIANGQI_RED, PLAYER_BLACK as XIANGQI_BLACK } from "./games/xiangqiEngine.js";
+import { GomokuGameInstance } from "./games/gomokuEngine.js";
+import { renderGomokuBoardAscii, renderXiangqiBoardAscii } from "./games/boardDisplay.js";
+import { XiangqiGameInstance } from "./games/xiangqiEngine.js";
 import type {
   GameAction,
   GameChatMessage,
@@ -26,11 +28,29 @@ export interface GameInstance {
   gameId: string;
   status: GameStatus;
   turn: number;
+  playerSide: number;
+  agentSide: number;
   winner: number | null;
   moveHistory: GameMoveRecord[];
   chatHistory: GameChatMessage[];
   getSnapshot(options?: { includeHistory?: boolean }): GameStateSnapshot;
-  applyMove(actionId: string, player: number, reason?: string): { ok: boolean; error?: string; winner?: number | null; chineseMove?: string };
+  applyMove(
+    actionId: string,
+    player: number,
+    reason?: string,
+    options?: { rejectAvoidableMate?: boolean }
+  ): {
+    ok: boolean;
+    error?: string;
+    winner?: number | null;
+    draw?: boolean;
+    chineseMove?: string;
+    capturedPiece?: number;
+    capturedPieceName?: string;
+    isCheck?: boolean;
+    isCheckmate?: boolean;
+    isStalemate?: boolean;
+  };
   addChat(sender: "player" | "agent" | "system", message: string, mood?: any): GameChatMessage;
   resign(player: number, reason?: string): { ok: boolean; winner: number };
 }
@@ -57,6 +77,29 @@ const bindingsByToken = new Map<string, GameSessionBinding>();
 const tokensByTaskSession = new Map<string, string>();
 const activeGamesByConversation = new Map<string, GameInstance>();
 
+interface PendingAutoMove {
+  timer: NodeJS.Timeout;
+  worker?: Worker;
+}
+
+interface EngineSuggestion {
+  actionId: string;
+  reason?: string;
+}
+
+const pendingAutoMoves = new Map<string, PendingAutoMove>();
+
+export const ENGINE_AUTO_MOVE_DELAY_MS = 550;
+
+function withAsciiBoard(game: GameInstance): GameStateSnapshot {
+  const snapshot = game.getSnapshot();
+  snapshot.asciiBoard =
+    snapshot.gameType === "xiangqi"
+      ? renderXiangqiBoardAscii(snapshot.board)
+      : renderGomokuBoardAscii(snapshot.board);
+  return snapshot;
+}
+
 function gameMcpServerPath(): string {
   return fileURLToPath(new URL("./mcp/gameMcpServer.js", import.meta.url));
 }
@@ -82,18 +125,24 @@ export function getOrCreateGame(conversationId: string, gameType: GameType = "go
     const conv = getConversationFn ? getConversationFn(conversationId) : undefined;
     const saved = conv?.metadata?.gameState as GameStateSnapshot | undefined;
     const effectiveType = (saved?.gameType || conv?.metadata?.gameType || gameType) as GameType;
+    const configuredPlayerSide =
+      saved?.playerSide === 1 || saved?.playerSide === 2
+        ? saved.playerSide
+        : conv?.metadata?.hand === "agent_first"
+          ? 2
+          : 1;
 
     if (effectiveType === "xiangqi") {
       if (saved && saved.board && Array.isArray(saved.board) && saved.board.length === 10) {
-        game = XiangqiGameInstance.fromSnapshot(saved);
+        game = XiangqiGameInstance.fromSnapshot(saved, configuredPlayerSide);
       } else {
-        game = new XiangqiGameInstance(conversationId);
+        game = new XiangqiGameInstance(conversationId, configuredPlayerSide);
       }
     } else {
       if (saved && saved.board && Array.isArray(saved.board) && saved.board.length === 15) {
-        game = GomokuGameInstance.fromSnapshot(saved);
+        game = GomokuGameInstance.fromSnapshot(saved, configuredPlayerSide);
       } else {
-        game = new GomokuGameInstance(conversationId);
+        game = new GomokuGameInstance(conversationId, configuredPlayerSide);
       }
     }
     activeGamesByConversation.set(conversationId, game);
@@ -141,7 +190,7 @@ export async function dispatchGameAction(
     return {
       ok: true,
       gameId: game.gameId,
-      gameState: game.getSnapshot()
+      gameState: withAsciiBoard(game)
     };
   }
 
@@ -166,25 +215,54 @@ export async function dispatchGameAction(
       return { ok: false, error: "Missing required 'actionId'." };
     }
 
-    // Agent is player 2
-    const res = game.applyMove(actionId, 2, reason);
+    const res = game.applyMove(actionId, game.agentSide, reason, {
+      rejectAvoidableMate: true
+    });
     if (!res.ok) {
       return { ok: false, error: res.error };
     }
+    cancelAgentAutoMove(binding.conversationId);
+
+    const trimmedReason = reason?.trim();
+    const chat =
+      trimmedReason && trimmedReason.length > 0
+        ? game.addChat("agent", trimmedReason)
+        : undefined;
 
     persistGameState(binding.conversationId, game);
-    const snapshot = game.getSnapshot();
+    const snapshot = withAsciiBoard(game);
     broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
 
     const moveLabel = res.chineseMove ? `${res.chineseMove} (${actionId})` : actionId;
+    const factParts: string[] = [];
+    if (res.capturedPieceName) factParts.push(`吃${res.capturedPieceName}`);
+    if (res.isCheckmate) factParts.push("绝杀");
+    else if (res.isCheck) factParts.push("将军");
+    if (res.draw) factParts.push("三次重复，和棋");
+    const factSuffix = factParts.length > 0 ? `；${factParts.join("，")}` : "";
     return {
       ok: true,
       actionId,
       gameId: game.gameId,
-      gameState: snapshot,
+      gameType: snapshot.gameType,
+      status: snapshot.status,
+      winner: snapshot.winner,
+      stepCount: snapshot.stepCount,
+      chat,
+      moveFacts: {
+        chineseMove: res.chineseMove,
+        capturedPiece: res.capturedPiece,
+        capturedPieceName: res.capturedPieceName,
+        isCheck: res.isCheck ?? false,
+        isCheckmate: res.isCheckmate ?? false,
+        isStalemate: res.isStalemate ?? false,
+        draw: res.draw ?? false
+      },
       message: res.winner
-        ? `落子 ${moveLabel} 成功，并获得胜利！`
-        : `落子 ${moveLabel} 成功，轮到玩家行动。`
+        ? `落子 ${moveLabel} 成功${factSuffix}，本局获胜。`
+        : res.draw
+          ? `落子 ${moveLabel} 成功${factSuffix}。`
+          : `落子 ${moveLabel} 成功${factSuffix}，轮到玩家行动。`
     };
   }
 
@@ -197,21 +275,27 @@ export async function dispatchGameAction(
 
     const chat = game.addChat("agent", message, mood);
     persistGameState(binding.conversationId, game);
-    const snapshot = game.getSnapshot();
+    const snapshot = withAsciiBoard(game);
     broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
 
     return {
       ok: true,
       chat,
-      gameState: snapshot
+      gameId: game.gameId,
+      gameType: snapshot.gameType,
+      status: snapshot.status,
+      stepCount: snapshot.stepCount
     };
   }
 
   if (action === "resign") {
     const reason = typeof params.reason === "string" ? params.reason : undefined;
-    const res = game.resign(2, reason);
+    const res = game.resign(game.agentSide, reason);
+    if (!res.ok) {
+      return { ok: false, error: "Game is already over." };
+    }
     persistGameState(binding.conversationId, game);
-    const snapshot = game.getSnapshot();
+    const snapshot = withAsciiBoard(game);
     broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
 
     return {
@@ -224,21 +308,185 @@ export async function dispatchGameAction(
   if (action === "reset") {
     const newGame =
       binding.gameType === "xiangqi"
-        ? new XiangqiGameInstance(binding.conversationId)
-        : new GomokuGameInstance(binding.conversationId);
+        ? new XiangqiGameInstance(binding.conversationId, game.playerSide)
+        : new GomokuGameInstance(binding.conversationId, game.playerSide);
     activeGamesByConversation.set(binding.conversationId, newGame);
     persistGameState(binding.conversationId, newGame);
-    const snapshot = newGame.getSnapshot();
+    const snapshot = withAsciiBoard(newGame);
     broadcastGameUpdate(binding.webContents, snapshot, binding.conversationId);
+    const autoPlayScheduled = scheduleAgentAutoMove(
+      binding.conversationId,
+      binding.webContents
+    );
 
     return {
       ok: true,
       gameState: snapshot,
+      agentAutoPlayScheduled: autoPlayScheduled,
       message: "对局已重置。"
     };
   }
 
   return { ok: false, error: `Unknown game action '${action}'.` };
+}
+
+function conversationDifficulty(conversationId: string): string | undefined {
+  const conv = getConversationFn ? getConversationFn(conversationId) : undefined;
+  return conv?.metadata?.gameDifficulty;
+}
+
+export function cancelAgentAutoMove(conversationId: string): void {
+  const pending = pendingAutoMoves.get(conversationId);
+  if (pending) {
+    clearTimeout(pending.timer);
+    if (pending.worker) void pending.worker.terminate();
+    pendingAutoMoves.delete(conversationId);
+  }
+}
+
+function searchInWorker(
+  conversationId: string,
+  pending: PendingAutoMove,
+  snapshot: GameStateSnapshot,
+  positionHistory?: string[],
+  recentMoves?: GameMoveRecord[]
+): Promise<EngineSuggestion | null> {
+  return new Promise((resolve) => {
+    let worker: Worker;
+    try {
+      worker = new Worker(new URL("./games/gameSearchWorker.js", import.meta.url));
+    } catch (err) {
+      console.warn(`[FreeBuddy] Failed to start engine worker for ${conversationId}:`, err);
+      resolve(null);
+      return;
+    }
+    pending.worker = worker;
+    let settled = false;
+    const finish = (suggestion: EngineSuggestion | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(safetyTimer);
+      void worker.terminate();
+      resolve(suggestion);
+    };
+    const safetyTimer = setTimeout(() => finish(null), 1_500);
+    worker.once("message", (message: { ok?: boolean; suggestion?: EngineSuggestion }) => {
+      finish(message?.ok ? message.suggestion ?? null : null);
+    });
+    worker.once("error", (err) => {
+      console.warn(`[FreeBuddy] Engine worker failed for ${conversationId}:`, err);
+      finish(null);
+    });
+    try {
+      worker.postMessage({
+        gameType: snapshot.gameType,
+        board: snapshot.board,
+        player: snapshot.agentSide,
+        maxDepth: snapshot.gameType === "xiangqi" ? 3 : 6,
+        timeBudgetMs: 700,
+        positionHistory,
+        recentMoves
+      });
+    } catch (err) {
+      console.warn(`[FreeBuddy] Failed to dispatch engine search for ${conversationId}:`, err);
+      finish(null);
+    }
+  });
+}
+
+function applyEngineSuggestion(
+  conversationId: string,
+  game: GameInstance,
+  suggestion: EngineSuggestion | null,
+  webContents?: WebContents
+): boolean {
+  const snapshot = game.getSnapshot();
+  const safeFallbackIds = snapshot.legalMoves
+    .filter((move) => move.allowsMate !== true)
+    .map((move) => move.actionId);
+  const allFallbackIds = snapshot.legalMoves.map((move) => move.actionId);
+  const actionIds = [suggestion?.actionId, ...safeFallbackIds, ...allFallbackIds].filter(
+    (actionId, index, all): actionId is string =>
+      Boolean(actionId) && all.indexOf(actionId) === index
+  );
+
+  for (const actionId of actionIds) {
+    const reason = actionId === suggestion?.actionId ? suggestion.reason : "选择安全合法着法";
+    const result = game.applyMove(actionId, game.agentSide, reason, {
+      rejectAvoidableMate: true
+    });
+    if (!result.ok) continue;
+    persistGameState(conversationId, game);
+    broadcastGameUpdate(webContents, withAsciiBoard(game), conversationId);
+    return true;
+  }
+  return false;
+}
+
+function scheduleAgentAutoMove(
+  conversationId: string,
+  webContents?: WebContents
+): boolean {
+  if (conversationDifficulty(conversationId) !== "hard") return false;
+  const game = activeGamesByConversation.get(conversationId);
+  if (!game || game.status !== "playing" || game.turn !== game.agentSide) {
+    return false;
+  }
+
+  if (pendingAutoMoves.has(conversationId)) return true;
+  let pending: PendingAutoMove;
+  const expectedGameId = game.gameId;
+  const expectedStepCount = game.moveHistory.length;
+  const timer = setTimeout(() => {
+    void (async () => {
+      try {
+        const inst = getOrCreateGame(conversationId);
+        if (
+          inst.gameId !== expectedGameId ||
+          inst.status !== "playing" ||
+          inst.turn !== inst.agentSide ||
+          inst.moveHistory.length !== expectedStepCount
+        ) return;
+
+        const boardSnapshot = inst.getSnapshot();
+        const suggestion = await searchInWorker(
+          conversationId,
+          pending,
+          boardSnapshot,
+          inst instanceof XiangqiGameInstance ? inst.positionHistory : undefined,
+          inst.moveHistory
+        );
+        const current = getOrCreateGame(conversationId);
+        if (
+          current.gameId !== expectedGameId ||
+          current.status !== "playing" ||
+          current.turn !== current.agentSide ||
+          current.moveHistory.length !== expectedStepCount
+        ) return;
+        if (!applyEngineSuggestion(conversationId, current, suggestion, webContents)) {
+          console.warn(`[FreeBuddy] Engine found no acceptable move for ${conversationId}.`);
+        }
+      } catch (err) {
+        console.warn(`[FreeBuddy] Engine auto move failed for ${conversationId}:`, err);
+      } finally {
+        if (pendingAutoMoves.get(conversationId) === pending) {
+          pendingAutoMoves.delete(conversationId);
+        }
+      }
+    })();
+  }, ENGINE_AUTO_MOVE_DELAY_MS);
+  pending = { timer };
+  pendingAutoMoves.set(conversationId, pending);
+  return true;
+}
+
+export function handleGetGameState(
+  conversationId: string,
+  webContents?: WebContents
+): GameStateSnapshot {
+  const game = getOrCreateGame(conversationId);
+  scheduleAgentAutoMove(conversationId, webContents);
+  return game.getSnapshot();
 }
 
 export function handlePlayerMove(
@@ -247,21 +495,20 @@ export function handlePlayerMove(
   webContents?: WebContents
 ): GameToolResult {
   const game = getOrCreateGame(conversationId);
-  if (game.turn === 2 && game.status === "playing") {
-    game.turn = 1;
-  }
-  const res = game.applyMove(actionId, 1);
+  const res = game.applyMove(actionId, game.playerSide);
   if (!res.ok) {
     return { ok: false, error: res.error };
   }
   persistGameState(conversationId, game);
-  const snapshot = game.getSnapshot();
+  const snapshot = withAsciiBoard(game);
   broadcastGameUpdate(webContents, snapshot, conversationId);
+  const autoPlayScheduled = scheduleAgentAutoMove(conversationId, webContents);
   return {
     ok: true,
     actionId,
     gameId: game.gameId,
-    gameState: snapshot
+    gameState: snapshot,
+    agentAutoPlayScheduled: autoPlayScheduled
   };
 }
 
@@ -274,15 +521,18 @@ export function handleAgentMove(
   webContents?: WebContents
 ): GameToolResult {
   const game = getOrCreateGame(conversationId);
-  const res = game.applyMove(actionId, 2, reason);
+  const res = game.applyMove(actionId, game.agentSide, reason, {
+    rejectAvoidableMate: true
+  });
   if (!res.ok) {
     return { ok: false, error: res.error };
   }
+  cancelAgentAutoMove(conversationId);
   if (speech) {
     game.addChat("agent", speech, mood);
   }
   persistGameState(conversationId, game);
-  const snapshot = game.getSnapshot();
+  const snapshot = withAsciiBoard(game);
   broadcastGameUpdate(webContents, snapshot, conversationId);
   return {
     ok: true,
@@ -296,18 +546,41 @@ export function handleResetGame(
   conversationId: string,
   webContents?: WebContents
 ): GameToolResult {
-  const existing = activeGamesByConversation.get(conversationId);
-  const isXiangqi = existing?.getSnapshot().gameType === "xiangqi";
+  cancelAgentAutoMove(conversationId);
+  const existing = getOrCreateGame(conversationId);
+  const isXiangqi = existing.getSnapshot().gameType === "xiangqi";
   const newGame = isXiangqi
-    ? new XiangqiGameInstance(conversationId)
-    : new GomokuGameInstance(conversationId);
+    ? new XiangqiGameInstance(conversationId, existing.playerSide)
+    : new GomokuGameInstance(conversationId, existing.playerSide);
   activeGamesByConversation.set(conversationId, newGame);
   persistGameState(conversationId, newGame);
-  const snapshot = newGame.getSnapshot();
+  const snapshot = withAsciiBoard(newGame);
   broadcastGameUpdate(webContents, snapshot, conversationId);
+  const autoPlayScheduled = scheduleAgentAutoMove(conversationId, webContents);
   return {
     ok: true,
     gameId: newGame.gameId,
+    gameState: snapshot,
+    agentAutoPlayScheduled: autoPlayScheduled
+  };
+}
+
+export function handlePlayerResign(
+  conversationId: string,
+  webContents?: WebContents
+): GameToolResult {
+  cancelAgentAutoMove(conversationId);
+  const game = getOrCreateGame(conversationId);
+  const result = game.resign(game.playerSide);
+  if (!result.ok) {
+    return { ok: false, error: "Game is already over." };
+  }
+  persistGameState(conversationId, game);
+  const snapshot = withAsciiBoard(game);
+  broadcastGameUpdate(webContents, snapshot, conversationId);
+  return {
+    ok: true,
+    gameId: game.gameId,
     gameState: snapshot
   };
 }

--- a/electron/gameToolService.ts
+++ b/electron/gameToolService.ts
@@ -382,7 +382,7 @@ function searchInWorker(
         gameType: snapshot.gameType,
         board: snapshot.board,
         player: snapshot.agentSide,
-        maxDepth: snapshot.gameType === "xiangqi" ? 3 : 6,
+        maxDepth: 6,
         timeBudgetMs: 700,
         positionHistory,
         recentMoves
@@ -416,6 +416,9 @@ function applyEngineSuggestion(
       rejectAvoidableMate: true
     });
     if (!result.ok) continue;
+    if (reason && reason.trim()) {
+      game.addChat("agent", reason.trim());
+    }
     persistGameState(conversationId, game);
     broadcastGameUpdate(webContents, withAsciiBoard(game), conversationId);
     return true;
@@ -538,6 +541,28 @@ export function handleAgentMove(
     ok: true,
     actionId,
     gameId: game.gameId,
+    gameState: snapshot
+  };
+}
+
+export function handleSendChat(
+  conversationId: string,
+  message: string,
+  mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring",
+  webContents?: WebContents
+): GameToolResult {
+  const game = getOrCreateGame(conversationId);
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Missing required 'message'." };
+  }
+  const chat = game.addChat("agent", trimmed, mood);
+  persistGameState(conversationId, game);
+  const snapshot = withAsciiBoard(game);
+  broadcastGameUpdate(webContents, snapshot, conversationId);
+  return {
+    ok: true,
+    chat,
     gameState: snapshot
   };
 }

--- a/electron/games/boardDisplay.ts
+++ b/electron/games/boardDisplay.ts
@@ -1,0 +1,165 @@
+import { BOARD_SIZE } from "./gomokuEngine.js";
+import {
+  getOpponentCaptureThreats,
+  getPieceName,
+  isKingInCheck
+} from "./xiangqiEngine.js";
+import type { GameStateSnapshot, LegalGameMove } from "../shared/gameToolProtocol.js";
+
+const GOMOKU_COL_LETTERS = "ABCDEFGHIJKLMNO";
+
+const XIANGQI_LETTERS: Record<number, string> = {
+  1: "K",
+  2: "A",
+  3: "B",
+  4: "N",
+  5: "R",
+  6: "C",
+  7: "P"
+};
+
+export function renderGomokuBoardAscii(board: number[][]): string {
+  const header = `   ${GOMOKU_COL_LETTERS.split("").join(" ")}`;
+  const rows: string[] = [header];
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    const label = String(BOARD_SIZE - y).padStart(2, " ");
+    const cells = board[y]
+      .map((v) => (v === 1 ? "X" : v === 2 ? "O" : "."))
+      .join(" ");
+    rows.push(`${label} ${cells}`);
+  }
+  return rows.join("\n");
+}
+
+export function renderXiangqiBoardAscii(board: number[][]): string {
+  const header = "   a b c d e f g h i";
+  const rows: string[] = [header];
+  for (let y = 9; y >= 0; y--) {
+    const label = String(y).padStart(2, " ");
+    const cells = board[y]
+      .map((piece) => {
+        if (piece === 0) return ".";
+        const letter = XIANGQI_LETTERS[Math.abs(piece)] ?? "?";
+        return piece > 0 ? letter : letter.toLowerCase();
+      })
+      .join(" ");
+    rows.push(`${label} ${cells}`);
+  }
+  return rows.join("\n");
+}
+
+function senderLabel(snapshot: GameStateSnapshot, side: number): string {
+  return side === snapshot.playerSide ? "玩家" : "AI";
+}
+
+export function formatGameStateText(snapshot: GameStateSnapshot): string {
+  const isXiangqi = snapshot.gameType === "xiangqi";
+  const lines: string[] = [];
+
+  lines.push(isXiangqi ? "【中国象棋】" : "【五子棋】");
+
+  const turnPiece = isXiangqi
+    ? snapshot.turn === 1
+      ? "红"
+      : "黑"
+    : snapshot.turn === 1
+      ? "黑"
+      : "白";
+  const statusText: Record<string, string> = {
+    waiting: "等待开始",
+    playing: "进行中",
+    player_won: "玩家获胜",
+    agent_won: "AI 获胜",
+    draw: "平局",
+    resigned: "已认输"
+  };
+  const status = statusText[snapshot.status] ?? snapshot.status;
+  lines.push(
+    snapshot.status === "playing"
+      ? `第 ${snapshot.stepCount} 手 | 轮到 ${senderLabel(snapshot, snapshot.turn)} 执${turnPiece} | 状态：${status}`
+      : `第 ${snapshot.stepCount} 手 | 状态：${status}`
+  );
+
+  if (isXiangqi) {
+    lines.push(
+      `图例：大写=红方(${snapshot.playerSide === 1 ? "玩家" : "AI"})，小写=黑方(${snapshot.playerSide === 2 ? "玩家" : "AI"})；K帅/将 A仕/士 B相/象 N马 R俥/车 C炮 P兵/卒 .=空位；行号9在上(黑方底线) 0在下(红方底线)`
+    );
+    lines.push(renderXiangqiBoardAscii(snapshot.board));
+  } else {
+    lines.push(
+      `图例：X=黑棋(${snapshot.playerSide === 1 ? "玩家" : "AI"}) O=白棋(${snapshot.playerSide === 2 ? "玩家" : "AI"}) .=空位；行号15在上，列A在左`
+    );
+    lines.push(renderGomokuBoardAscii(snapshot.board));
+  }
+
+  const lastMove = snapshot.lastMove;
+  if (lastMove) {
+    let desc = `${senderLabel(snapshot, lastMove.player)} 落子 ${
+      lastMove.chineseMove
+        ? `${lastMove.chineseMove}（${lastMove.actionId}）`
+        : lastMove.actionId
+    }`;
+    if (typeof lastMove.piece === "number" && lastMove.piece !== 0) {
+      desc += `（${getPieceName(lastMove.piece)}）`;
+    }
+    if (lastMove.capturedPieceName) desc += `，吃${lastMove.capturedPieceName}`;
+    if (lastMove.checkmate) desc += "，绝杀";
+    else if (lastMove.givesCheck) desc += "，将军";
+    lines.push(`上一步：${desc}`);
+  }
+
+  if (snapshot.status === "playing") {
+    const winning = snapshot.legalMoves.filter((m) => m.threatLevel === "winning");
+    const blocking = snapshot.legalMoves.filter((m) => m.threatLevel === "critical_block");
+    if (winning.length > 0) {
+      lines.push(
+        `⚠ 存在直接取胜点：${winning.map((m) => m.actionId).join("、")} —— 强烈建议立即执行！`
+      );
+    } else if (blocking.length > 0) {
+      lines.push(
+        `⚠ 对方下一手即可连五取胜，必须封堵威胁点：${blocking.map((m) => m.actionId).join("、")}`
+      );
+    }
+    if (isXiangqi && isKingInCheck(snapshot.board, snapshot.turn)) {
+      lines.push("⚠ 你正被将军，必须应将！");
+    }
+
+    if (isXiangqi) {
+      const threats = getOpponentCaptureThreats(snapshot.board, snapshot.turn)
+        .filter((t) => t.value >= 200 || !t.defended)
+        .slice(0, 4);
+      for (const t of threats) {
+        lines.push(
+          `⚠ 对方威胁：你的 ${t.targetCoord}${t.targetName} 正被 ${t.attackerCoord}${t.attackerName} 盯住（${
+            t.defended ? "有保护，兑子需算清" : "无保护，会被白吃"
+          }）`
+        );
+      }
+    }
+
+    if (snapshot.legalMoves.length > 0) {
+      lines.push(
+        "候选走法（按战术价值排序；[丢X]=白丢该子；[招致绝杀!]=走完对方一步杀，绝不可选）："
+      );
+      const top = snapshot.legalMoves.slice(0, 8);
+      top.forEach((move, index) => {
+        const parts: string[] = [];
+        if (move.allowsMate) parts.push("🚨[招致绝杀!]");
+        else if (move.safety === "lose" && move.lossPiece) parts.push(`⚠[丢${move.lossPiece}!]`);
+        else if (move.threatLevel === "winning") parts.push("[绝杀胜手]");
+        else if (move.threatLevel === "critical_block") parts.push("[关键封堵]");
+        else if (move.safety === "gain") parts.push("[得子]");
+        else if (move.threatLevel === "attack") parts.push("[进攻]");
+        const tag = isXiangqi ? "" : parts.join("");
+        lines.push(
+          ` ${index + 1}. ${tag ? `${tag} ` : ""}${move.actionId}${
+            move.description ? ` ${move.description}` : ""
+          }`
+        );
+      });
+      lines.push("请从候选走法中选择 actionId 调用 game_make_move。优先选择无 [丢X] 标记的着法。");
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/electron/games/gameSearchWorker.ts
+++ b/electron/games/gameSearchWorker.ts
@@ -1,0 +1,38 @@
+import { parentPort } from "node:worker_threads";
+
+import type { GameMoveRecord, GameType } from "../shared/gameToolProtocol.js";
+import { findBestMove } from "./gomokuSearch.js";
+import { findBestXiangqiMove } from "./xiangqiSearch.js";
+
+interface SearchRequest {
+  gameType: GameType;
+  board: number[][];
+  player: number;
+  maxDepth: number;
+  timeBudgetMs: number;
+  positionHistory?: string[];
+  recentMoves?: GameMoveRecord[];
+}
+
+parentPort?.on("message", (request: SearchRequest) => {
+  try {
+    const suggestion =
+      request.gameType === "xiangqi"
+        ? findBestXiangqiMove(request.board, request.player, {
+            maxDepth: request.maxDepth,
+            timeBudgetMs: request.timeBudgetMs,
+            positionHistory: request.positionHistory,
+            recentMoves: request.recentMoves
+          })
+        : findBestMove(request.board, request.player, {
+            maxDepth: request.maxDepth,
+            timeBudgetMs: request.timeBudgetMs
+          });
+    parentPort?.postMessage({ ok: true, suggestion });
+  } catch (error) {
+    parentPort?.postMessage({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+});

--- a/electron/games/gomokuEngine.ts
+++ b/electron/games/gomokuEngine.ts
@@ -7,8 +7,8 @@ import type {
 } from "../shared/gameToolProtocol.js";
 
 export const BOARD_SIZE = 15;
-export const PLAYER_BLACK = 1; // Human / Player
-export const PLAYER_WHITE = 2; // AI / Agent
+export const PLAYER_BLACK = 1;
+export const PLAYER_WHITE = 2;
 
 const COLS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"];
 
@@ -210,19 +210,26 @@ export class GomokuGameInstance {
   public gameId: string;
   public status: GameStatus = "playing";
   public turn: number = PLAYER_BLACK; // Black moves first
+  public playerSide: number;
+  public agentSide: number;
   public board: number[][];
   public moveHistory: GameMoveRecord[] = [];
   public chatHistory: GameChatMessage[] = [];
   public winner: number | null = null;
   public updatedAt: number = Date.now();
 
-  constructor(gameId: string) {
+  constructor(gameId: string, playerSide: number = PLAYER_BLACK) {
     this.gameId = gameId;
+    this.playerSide = playerSide === PLAYER_WHITE ? PLAYER_WHITE : PLAYER_BLACK;
+    this.agentSide = this.playerSide === PLAYER_BLACK ? PLAYER_WHITE : PLAYER_BLACK;
     this.board = createEmptyBoard();
   }
 
-  public static fromSnapshot(snapshot: GameStateSnapshot): GomokuGameInstance {
-    const inst = new GomokuGameInstance(snapshot.gameId);
+  public static fromSnapshot(
+    snapshot: GameStateSnapshot,
+    playerSide: number = snapshot.playerSide ?? PLAYER_BLACK
+  ): GomokuGameInstance {
+    const inst = new GomokuGameInstance(snapshot.gameId, playerSide);
     inst.status = snapshot.status;
     inst.turn = snapshot.turn;
     inst.winner = snapshot.winner ?? null;
@@ -240,6 +247,8 @@ export class GomokuGameInstance {
       gameId: this.gameId,
       status: this.status,
       turn: this.turn,
+      playerSide: this.playerSide,
+      agentSide: this.agentSide,
       stepCount: this.moveHistory.length,
       winner: this.winner,
       board: this.board.map((row) => [...row]),
@@ -291,7 +300,7 @@ export class GomokuGameInstance {
 
     // Check win
     if (checkWin(this.board, x, y, player)) {
-      this.status = player === PLAYER_BLACK ? "player_won" : "agent_won";
+      this.status = player === this.playerSide ? "player_won" : "agent_won";
       this.winner = player;
       return { ok: true, winner: player };
     }
@@ -325,11 +334,11 @@ export class GomokuGameInstance {
       return { ok: false, winner: this.winner || 0 };
     }
     const winningPlayer = player === PLAYER_BLACK ? PLAYER_WHITE : PLAYER_BLACK;
-    this.status = winningPlayer === PLAYER_BLACK ? "player_won" : "agent_won";
+    this.status = winningPlayer === this.playerSide ? "player_won" : "agent_won";
     this.winner = winningPlayer;
     this.updatedAt = Date.now();
     this.addChat(
-      player === PLAYER_BLACK ? "player" : "agent",
+      player === this.playerSide ? "player" : "agent",
       reason ? `认输: ${reason}` : "我认输了，这一局你下得漂亮！",
       "calm"
     );

--- a/electron/games/gomokuSearch.ts
+++ b/electron/games/gomokuSearch.ts
@@ -1,0 +1,465 @@
+import { BOARD_SIZE, checkWin, coordToString } from "./gomokuEngine.js";
+
+export interface GomokuSearchOptions {
+  maxDepth?: number;
+  timeBudgetMs?: number;
+}
+
+export interface GomokuEngineSuggestion {
+  actionId: string;
+  x: number;
+  y: number;
+  score: number;
+  reason: string;
+  depthReached: number;
+}
+
+const SCORE_FIVE = 10_000_000;
+const SCORE_LIVE_FOUR = 800_000;
+const SCORE_RUSH_FOUR = 120_000;
+const SCORE_LIVE_THREE = 90_000;
+const SCORE_SLEEP_THREE = 12_000;
+const SCORE_LIVE_TWO = 3_000;
+const SCORE_SLEEP_TWO = 400;
+const SCORE_ONE = 60;
+
+const DIRECTIONS = [
+  [1, 0],
+  [0, 1],
+  [1, 1],
+  [1, -1]
+];
+
+function opponentOf(player: number): number {
+  return player === 1 ? 2 : 1;
+}
+
+function inBoard(x: number, y: number): boolean {
+  return x >= 0 && x < BOARD_SIZE && y >= 0 && y < BOARD_SIZE;
+}
+
+export function patternScore(count: number, openEnds: number): number {
+  if (count >= 5) return SCORE_FIVE;
+  switch (count) {
+    case 4:
+      if (openEnds >= 2) return SCORE_LIVE_FOUR;
+      if (openEnds === 1) return SCORE_RUSH_FOUR;
+      return 0;
+    case 3:
+      if (openEnds >= 2) return SCORE_LIVE_THREE;
+      if (openEnds === 1) return SCORE_SLEEP_THREE;
+      return 0;
+    case 2:
+      if (openEnds >= 2) return SCORE_LIVE_TWO;
+      if (openEnds === 1) return SCORE_SLEEP_TWO;
+      return 0;
+    default:
+      return openEnds > 0 ? SCORE_ONE : 0;
+  }
+}
+
+interface SideScan {
+  stones: number;
+  openEnd: boolean;
+}
+
+function scanSide(
+  board: number[][],
+  x: number,
+  y: number,
+  dx: number,
+  dy: number,
+  player: number
+): SideScan {
+  let stones = 0;
+  let cx = x + dx;
+  let cy = y + dy;
+  while (inBoard(cx, cy) && board[cy][cx] === player) {
+    stones++;
+    cx += dx;
+    cy += dy;
+  }
+  const openEnd = inBoard(cx, cy) && board[cy][cx] === 0;
+  return { stones, openEnd };
+}
+
+function directionScore(
+  board: number[][],
+  x: number,
+  y: number,
+  dx: number,
+  dy: number,
+  player: number
+): number {
+  const fwd = scanSide(board, x, y, dx, dy, player);
+  const bwd = scanSide(board, x, y, -dx, -dy, player);
+  const count = 1 + fwd.stones + bwd.stones;
+  const openEnds = (fwd.openEnd ? 1 : 0) + (bwd.openEnd ? 1 : 0);
+  let best = patternScore(count, openEnds);
+
+  if (fwd.openEnd) {
+    const gapX = x + dx * (fwd.stones + 1);
+    const gapY = y + dy * (fwd.stones + 1);
+    const beyondX = gapX + dx;
+    const beyondY = gapY + dy;
+    if (inBoard(beyondX, beyondY) && board[beyondY][beyondX] === player) {
+      const chain = scanSide(board, gapX, gapY, dx, dy, player);
+      const merged = count + 1 + chain.stones;
+      best = Math.max(
+        best,
+        patternScore(merged, (bwd.openEnd ? 1 : 0) + (chain.openEnd ? 1 : 0)) *
+          0.85
+      );
+    }
+  }
+
+  if (bwd.openEnd) {
+    const gapX = x - dx * (bwd.stones + 1);
+    const gapY = y - dy * (bwd.stones + 1);
+    const beyondX = gapX - dx;
+    const beyondY = gapY - dy;
+    if (inBoard(beyondX, beyondY) && board[beyondY][beyondX] === player) {
+      const chain = scanSide(board, gapX, gapY, -dx, -dy, player);
+      const merged = count + 1 + chain.stones;
+      best = Math.max(
+        best,
+        patternScore(merged, (fwd.openEnd ? 1 : 0) + (chain.openEnd ? 1 : 0)) *
+          0.85
+      );
+    }
+  }
+
+  return best;
+}
+
+export function pointScore(
+  board: number[][],
+  x: number,
+  y: number,
+  player: number
+): number {
+  let total = 0;
+  for (const [dx, dy] of DIRECTIONS) {
+    const s = directionScore(board, x, y, dx, dy, player);
+    if (s >= SCORE_FIVE) return SCORE_FIVE;
+    total += s;
+  }
+  return total;
+}
+
+function quickMoveScore(
+  board: number[][],
+  x: number,
+  y: number,
+  player: number
+): number {
+  const self = pointScore(board, x, y, player);
+  const opp = pointScore(board, x, y, opponentOf(player));
+  return self + Math.floor(opp * 1.05);
+}
+
+function candidateCells(board: number[][]): { x: number; y: number }[] {
+  let hasStone = false;
+  const cells = new Map<string, { x: number; y: number }>();
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    for (let x = 0; x < BOARD_SIZE; x++) {
+      if (board[y][x] === 0) continue;
+      hasStone = true;
+      for (let dy = -2; dy <= 2; dy++) {
+        for (let dx = -2; dx <= 2; dx++) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (inBoard(nx, ny) && board[ny][nx] === 0) {
+            cells.set(`${nx},${ny}`, { x: nx, y: ny });
+          }
+        }
+      }
+    }
+  }
+  if (!hasStone) {
+    const center = Math.floor(BOARD_SIZE / 2);
+    return [{ x: center, y: center }];
+  }
+  return [...cells.values()];
+}
+
+interface LineCoord {
+  x: number;
+  y: number;
+}
+
+let cachedLines: LineCoord[][] | null = null;
+
+function allLines(): LineCoord[][] {
+  if (cachedLines) return cachedLines;
+  const lines: LineCoord[][] = [];
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    const line: LineCoord[] = [];
+    for (let x = 0; x < BOARD_SIZE; x++) line.push({ x, y });
+    lines.push(line);
+  }
+  for (let x = 0; x < BOARD_SIZE; x++) {
+    const line: LineCoord[] = [];
+    for (let y = 0; y < BOARD_SIZE; y++) line.push({ x, y });
+    lines.push(line);
+  }
+  for (let start = -(BOARD_SIZE - 5); start <= BOARD_SIZE - 5; start++) {
+    const line: LineCoord[] = [];
+    for (let i = 0; i < BOARD_SIZE; i++) {
+      const x = start + i;
+      const y = i;
+      if (inBoard(x, y)) line.push({ x, y });
+    }
+    if (line.length >= 5) lines.push(line);
+  }
+  for (let start = 4; start <= 2 * (BOARD_SIZE - 5) + 4; start++) {
+    const line: LineCoord[] = [];
+    for (let i = 0; i < BOARD_SIZE; i++) {
+      const x = start - i;
+      const y = i;
+      if (inBoard(x, y)) line.push({ x, y });
+    }
+    if (line.length >= 5) lines.push(line);
+  }
+  cachedLines = lines;
+  return lines;
+}
+
+export function evaluateBoard(board: number[][], mover: number): number {
+  let total = 0;
+  for (const line of allLines()) {
+    let i = 0;
+    while (i < line.length) {
+      const startCoord = line[i];
+      const player = board[startCoord.y][startCoord.x];
+      if (player === 0) {
+        i++;
+        continue;
+      }
+
+      const start = i;
+      while (i < line.length) {
+        const coord = line[i];
+        if (board[coord.y][coord.x] !== player) break;
+        i++;
+      }
+      const runLen = i - start;
+      const before = start > 0 ? line[start - 1] : undefined;
+      const after = i < line.length ? line[i] : undefined;
+      const openEnds =
+        (before && board[before.y][before.x] === 0 ? 1 : 0) +
+        (after && board[after.y][after.x] === 0 ? 1 : 0);
+      const score = patternScore(runLen, openEnds);
+      total += player === mover ? score : -Math.round(score * 1.1);
+    }
+  }
+  return total;
+}
+
+interface AbortFlag {
+  aborted: boolean;
+}
+
+function negamax(
+  board: number[][],
+  depth: number,
+  alpha: number,
+  beta: number,
+  player: number,
+  deadline: number,
+  ply: number,
+  abort: AbortFlag
+): number {
+  if (abort.aborted) return 0;
+  if (Date.now() > deadline) {
+    abort.aborted = true;
+    return 0;
+  }
+  if (depth <= 0) return evaluateBoard(board, player);
+
+  const moves = candidateCells(board)
+    .map((c) => ({ c, s: quickMoveScore(board, c.x, c.y, player) }))
+    .sort((a, b) => b.s - a.s)
+    .slice(0, depth >= 3 ? 10 : 14);
+
+  let best = -Infinity;
+  let a = alpha;
+  for (const { c } of moves) {
+    board[c.y][c.x] = player;
+    let val: number;
+    if (checkWin(board, c.x, c.y, player)) {
+      val = SCORE_FIVE - ply * 100;
+    } else {
+      val = -negamax(
+        board,
+        depth - 1,
+        -beta,
+        -a,
+        opponentOf(player),
+        deadline,
+        ply + 1,
+        abort
+      );
+    }
+    board[c.y][c.x] = 0;
+    if (val > best) best = val;
+    if (best > a) a = best;
+    if (a >= beta || abort.aborted) break;
+  }
+  return best;
+}
+
+function describeMove(
+  board: number[][],
+  x: number,
+  y: number,
+  player: number,
+  forcedBlock: boolean,
+  score: number,
+  depth: number
+): string {
+  if (score >= SCORE_FIVE - 1000) return "连五制胜";
+  if (forcedBlock) return "封堵对方连五威胁";
+  const ownBest = Math.max(
+    ...DIRECTIONS.map(([dx, dy]) => directionScore(board, x, y, dx, dy, player))
+  );
+  const oppBest = Math.max(
+    ...DIRECTIONS.map(([dx, dy]) =>
+      directionScore(board, x, y, dx, dy, opponentOf(player))
+    )
+  );
+  if (ownBest >= SCORE_LIVE_FOUR) return "形成活四";
+  if (ownBest >= SCORE_RUSH_FOUR) return "冲四施压";
+  if (ownBest >= SCORE_LIVE_THREE) return "构建活三攻势";
+  if (oppBest >= SCORE_LIVE_THREE) return "压制对方主要连线";
+  return `局部搜索最优着法(深度${depth})`;
+}
+
+export function findBestMove(
+  board: number[][],
+  player: number,
+  options?: GomokuSearchOptions
+): GomokuEngineSuggestion | null {
+  const maxDepth = Math.min(Math.max(options?.maxDepth ?? 6, 2), 8);
+  const timeBudgetMs = options?.timeBudgetMs ?? 750;
+  const deadline = Date.now() + timeBudgetMs;
+  const opponent = opponentOf(player);
+
+  const candidates = candidateCells(board);
+  if (candidates.length === 0) return null;
+
+  const winningCell = candidates.find((c) => {
+    board[c.y][c.x] = player;
+    const won = checkWin(board, c.x, c.y, player);
+    board[c.y][c.x] = 0;
+    return won;
+  });
+  if (winningCell) {
+    return {
+      actionId: coordToString(winningCell.x, winningCell.y),
+      x: winningCell.x,
+      y: winningCell.y,
+      score: SCORE_FIVE,
+      reason: "连五制胜",
+      depthReached: 0
+    };
+  }
+
+  const blockCandidates = candidates.filter((c) => {
+    board[c.y][c.x] = opponent;
+    const won = checkWin(board, c.x, c.y, opponent);
+    board[c.y][c.x] = 0;
+    return won;
+  });
+  if (blockCandidates.length > 0) {
+    let bestBlock = blockCandidates[0];
+    let bestScore = -Infinity;
+    for (const c of blockCandidates) {
+      const s = quickMoveScore(board, c.x, c.y, player);
+      if (s > bestScore) {
+        bestScore = s;
+        bestBlock = c;
+      }
+    }
+    return {
+      actionId: coordToString(bestBlock.x, bestBlock.y),
+      x: bestBlock.x,
+      y: bestBlock.y,
+      score: bestScore,
+      reason: "封堵对方连五威胁",
+      depthReached: 0
+    };
+  }
+
+  const scoredRoot = candidates
+    .map((c) => ({ c, s: quickMoveScore(board, c.x, c.y, player) }))
+    .sort((a, b) => b.s - a.s);
+
+  let bestCell = scoredRoot[0]?.c;
+  let bestScore = scoredRoot[0]?.s ?? 0;
+  let completedDepth = 0;
+
+  for (let depth = 2; depth <= maxDepth; depth += 2) {
+    const abort: AbortFlag = { aborted: false };
+    const width = depth <= 2 ? 16 : depth <= 4 ? 12 : 10;
+    let iterBest: { x: number; y: number } | null = null;
+    let iterScore = -Infinity;
+    let alpha = -Infinity;
+
+    for (const { c } of scoredRoot.slice(0, width)) {
+      if (Date.now() > deadline) {
+        abort.aborted = true;
+        break;
+      }
+      board[c.y][c.x] = player;
+      let val: number;
+      if (checkWin(board, c.x, c.y, player)) {
+        val = SCORE_FIVE - 1;
+      } else {
+        val = -negamax(
+          board,
+          depth - 1,
+          -Infinity,
+          -alpha,
+          opponent,
+          deadline,
+          1,
+          abort
+        );
+      }
+      board[c.y][c.x] = 0;
+      if (val > iterScore) {
+        iterScore = val;
+        iterBest = c;
+        alpha = val;
+      }
+      if (abort.aborted) break;
+    }
+
+    if (iterBest && !abort.aborted) {
+      bestCell = iterBest;
+      bestScore = iterScore;
+      completedDepth = depth;
+    }
+    if (abort.aborted) break;
+  }
+
+  if (!bestCell) return null;
+
+  return {
+    actionId: coordToString(bestCell.x, bestCell.y),
+    x: bestCell.x,
+    y: bestCell.y,
+    score: bestScore,
+    reason: describeMove(
+      board,
+      bestCell.x,
+      bestCell.y,
+      player,
+      false,
+      bestScore,
+      Math.max(completedDepth, 2)
+    ),
+    depthReached: completedDepth
+  };
+}

--- a/electron/games/xiangqiEngine.ts
+++ b/electron/games/xiangqiEngine.ts
@@ -35,6 +35,24 @@ export interface RawXiangqiMove {
   captured?: number;
 }
 
+export interface XiangqiMoveOptions {
+  /** Reject an avoidable move that gives the opponent mate in one. */
+  rejectAvoidableMate?: boolean;
+}
+
+export interface XiangqiMoveResult {
+  ok: boolean;
+  error?: string;
+  winner?: number | null;
+  draw?: boolean;
+  chineseMove?: string;
+  capturedPiece?: number;
+  capturedPieceName?: string;
+  isCheck?: boolean;
+  isCheckmate?: boolean;
+  isStalemate?: boolean;
+}
+
 export function coordToString(x: number, y: number): string {
   const col = COL_LETTERS[x] || `${x}`;
   return `${col}${y}`;
@@ -42,6 +60,10 @@ export function coordToString(x: number, y: number): string {
 
 export function moveToString(fromX: number, fromY: number, toX: number, toY: number): string {
   return `${coordToString(fromX, fromY)}${coordToString(toX, toY)}`;
+}
+
+export function xiangqiPositionKey(board: number[][], turn: number): string {
+  return `${turn}|${board.map((row) => row.join(",")).join("/")}`;
 }
 
 export function stringToMove(moveStr: string): { fromX: number; fromY: number; toX: number; toY: number } | null {
@@ -457,23 +479,207 @@ const PIECE_VALUES: Record<number, number> = {
   [PIECE_PAWN]: 100
 };
 
-export function getCandidateMoves(board: number[][], player: number): LegalGameMove[] {
+export function pieceValue(piece: number): number {
+  return PIECE_VALUES[Math.abs(piece)] || 100;
+}
+
+export interface OpponentCaptureThreat {
+  targetCoord: string;
+  targetName: string;
+  attackerCoord: string;
+  attackerName: string;
+  defended: boolean;
+  value: number;
+}
+
+/**
+ * Static 2-ply threat scan: which of `mover`'s pieces can the opponent
+ * capture right now, and can `mover` recapture afterwards (defended)?
+ */
+export function getOpponentCaptureThreats(
+  board: number[][],
+  mover: number
+): OpponentCaptureThreat[] {
+  const opponent = mover === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+  const seen = new Map<string, OpponentCaptureThreat>();
+
+  for (const m of getLegalMoves(board, opponent)) {
+    if (m.captured === undefined) continue;
+
+    const key = `${m.toX},${m.toY}`;
+    const value = pieceValue(m.captured);
+    const existing = seen.get(key);
+    if (existing && existing.value >= value) continue;
+
+    const nextBoard = board.map((row) => [...row]);
+    nextBoard[m.toY][m.toX] = m.piece;
+    nextBoard[m.fromY][m.fromX] = 0;
+
+    let defended = false;
+    for (const reply of getLegalMoves(nextBoard, mover)) {
+      if (
+        reply.captured !== undefined &&
+        reply.toX === m.toX &&
+        reply.toY === m.toY
+      ) {
+        defended = true;
+        break;
+      }
+    }
+
+    seen.set(key, {
+      targetCoord: coordToString(m.toX, m.toY),
+      targetName: getPieceName(m.captured),
+      attackerCoord: coordToString(m.fromX, m.fromY),
+      attackerName: getPieceName(m.piece),
+      defended,
+      value
+    });
+  }
+
+  return [...seen.values()].sort(
+    (a, b) => (a.defended ? 1 : 0) - (b.defended ? 1 : 0) || b.value - a.value
+  );
+}
+
+function boardAfterMove(board: number[][], move: RawXiangqiMove): number[][] {
+  const nextBoard = board.map((row) => [...row]);
+  nextBoard[move.toY][move.toX] = move.piece;
+  nextBoard[move.fromY][move.fromX] = 0;
+  return nextBoard;
+}
+
+interface CaptureExchangeLoss {
+  targetCoord: string;
+  targetPiece: number;
+  /** Material lost after the best immediate legal recapture. */
+  netLoss: number;
+}
+
+/**
+ * Score every immediate capture separately. This intentionally excludes King
+ * captures: when the side to move is already in check, treating the King as a
+ * 10000-point baseline masks newly hung Rooks/Cannons.
+ */
+function captureExchangeLosses(
+  board: number[][],
+  attacker: number,
+  defender: number
+): Map<string, CaptureExchangeLoss> {
+  const losses = new Map<string, CaptureExchangeLoss>();
+  for (const capture of getLegalMoves(board, attacker)) {
+    if (
+      capture.captured === undefined ||
+      Math.abs(capture.captured) === PIECE_KING
+    ) {
+      continue;
+    }
+
+    const afterCapture = boardAfterMove(board, capture);
+    let recaptureValue = 0;
+    for (const reply of getLegalMoves(afterCapture, defender)) {
+      if (
+        reply.captured !== undefined &&
+        reply.toX === capture.toX &&
+        reply.toY === capture.toY
+      ) {
+        recaptureValue = Math.max(recaptureValue, pieceValue(reply.captured));
+      }
+    }
+
+    const targetCoord = coordToString(capture.toX, capture.toY);
+    const netLoss = Math.max(0, pieceValue(capture.captured) - recaptureValue);
+    const existing = losses.get(targetCoord);
+    if (!existing || netLoss > existing.netLoss) {
+      losses.set(targetCoord, {
+        targetCoord,
+        targetPiece: capture.captured,
+        netLoss
+      });
+    }
+  }
+  return losses;
+}
+
+/** True if `attacker` has a move after which `defender` has zero legal replies. */
+export function canDeliverMateInOne(board: number[][], attacker: number, defender: number): boolean {
+  for (const m of getLegalMoves(board, attacker)) {
+    const nextBoard = board.map((row) => [...row]);
+    nextBoard[m.toY][m.toX] = m.piece;
+    nextBoard[m.fromY][m.fromX] = 0;
+    if (!isKingInCheck(nextBoard, defender)) continue;
+    if (getLegalMoves(nextBoard, defender).length === 0) return true;
+  }
+  return false;
+}
+
+export function moveAllowsMateInOne(
+  board: number[][],
+  move: RawXiangqiMove,
+  player: number
+): boolean {
+  const opponent = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+  return canDeliverMateInOne(boardAfterMove(board, move), opponent, player);
+}
+
+export function getCandidateMoves(
+  board: number[][],
+  player: number,
+  recentMoves: GameMoveRecord[] = [],
+  limit = 30
+): LegalGameMove[] {
   const legal = getLegalMoves(board, player);
   if (legal.length === 0) return [];
 
   const opponent = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+  const baselineLosses = captureExchangeLosses(board, opponent, player);
+  const previousOwnMove = [...recentMoves].reverse().find((move) => move.player === player);
 
   const scored = legal.map((move) => {
     const actionId = moveToString(move.fromX, move.fromY, move.toX, move.toY);
     const chineseDesc = toChineseNotation(board, move, player);
 
     // Simulate move
-    const nextBoard = board.map((row) => [...row]);
-    nextBoard[move.toY][move.toX] = move.piece;
-    nextBoard[move.fromY][move.fromX] = 0;
+    const nextBoard = boardAfterMove(board, move);
 
     const oppInCheck = isKingInCheck(nextBoard, opponent);
-    const oppLegalCount = oppInCheck ? getLegalMoves(nextBoard, opponent).length : 10;
+    const oppMovesAfter = getLegalMoves(nextBoard, opponent);
+    const oppLegalCount = oppInCheck ? oppMovesAfter.length : 10;
+
+    // Compare threats per target instead of using one global maximum. The
+    // moved piece is always a new target at its destination; other pieces only
+    // count when this move newly exposes or worsens their exchange loss.
+    const replyLosses = captureExchangeLosses(nextBoard, opponent, player);
+    let createdLoss = 0;
+    let lossPiece: number | undefined;
+    const destination = coordToString(move.toX, move.toY);
+    for (const loss of replyLosses.values()) {
+      const baseline =
+        loss.targetCoord === destination
+          ? 0
+          : baselineLosses.get(loss.targetCoord)?.netLoss ?? 0;
+      const delta = Math.max(0, loss.netLoss - baseline);
+      if (delta > createdLoss) {
+        createdLoss = delta;
+        lossPiece = loss.targetPiece;
+      }
+    }
+    const ourGain = move.captured ? pieceValue(move.captured) : 0;
+    const materialDelta = ourGain - createdLoss;
+
+    // Does this move hand the opponent a one-move mate?
+    const allowsMate = moveAllowsMateInOne(board, move, player);
+
+    let safety: "lose" | "trade" | "gain" | undefined;
+    if (createdLoss > 0 && materialDelta < 0 && Math.abs(move.piece) !== PIECE_KING) {
+      safety = "lose";
+    } else if (createdLoss > 0 && ourGain > 0 && materialDelta === 0) {
+      safety = "trade";
+    } else if (ourGain > createdLoss) {
+      safety = "gain";
+    }
+
+    if (allowsMate) safety = "lose";
 
     let priority = 10;
     let threatLevel: "winning" | "critical_block" | "attack" | "normal" = "normal";
@@ -482,7 +688,7 @@ export function getCandidateMoves(board: number[][], player: number): LegalGameM
       threatLevel = "winning";
       priority = 10000;
     } else if (move.captured) {
-      const capVal = PIECE_VALUES[Math.abs(move.captured)] || 100;
+      const capVal = ourGain;
       priority = 200 + capVal;
       threatLevel = capVal >= 400 ? "attack" : "normal";
     } else if (oppInCheck) {
@@ -496,10 +702,22 @@ export function getCandidateMoves(board: number[][], player: number): LegalGameM
       if (absPiece === PIECE_ROOK && (move.toY === 0 || move.toY === 9 || move.toX === 1 || move.toX === 7)) priority += 60;
     }
 
+    if (allowsMate) {
+      priority -= 100000;
+    } else if (safety === "lose") {
+      priority -= Math.max(100, -materialDelta) * 2;
+    } else if (safety === "gain") {
+      priority += ourGain / 2;
+    }
+
     let fullDesc = `${chineseDesc} (${coordToString(move.fromX, move.fromY)}->${coordToString(move.toX, move.toY)})`;
     if (threatLevel === "winning") fullDesc += " [绝杀将军]";
     else if (move.captured) fullDesc += ` [吃${getPieceName(move.captured)}]`;
     else if (oppInCheck) fullDesc += " [将军]";
+    if (allowsMate) fullDesc += " [招致绝杀!]";
+    else if (safety === "lose") fullDesc += ` [丢${getPieceName(lossPiece ?? move.piece)}!]`;
+    else if (safety === "trade") fullDesc += " [兑子]";
+    else if (safety === "gain" && move.captured) fullDesc += " [得子]";
 
     return {
       actionId,
@@ -512,13 +730,36 @@ export function getCandidateMoves(board: number[][], player: number): LegalGameM
       coord: actionId,
       description: fullDesc,
       threatLevel,
+      safety,
+      allowsMate,
+      lossPiece:
+        safety === "lose" && !allowsMate
+          ? getPieceName(lossPiece ?? move.piece)
+          : undefined,
       priority
     };
   });
 
+  // Discourage immediate backtracking/oscillation while keeping the move
+  // legal and available when tactics require it.
+  for (const candidate of scored) {
+    if (
+      previousOwnMove?.fromX === candidate.toX &&
+      previousOwnMove?.fromY === candidate.toY &&
+      previousOwnMove?.toX === candidate.fromX &&
+      previousOwnMove?.toY === candidate.fromY
+    ) {
+      candidate.priority -= 250;
+    }
+    const repeats = recentMoves.filter(
+      (move) => move.player === player && move.actionId === candidate.actionId
+    ).length;
+    candidate.priority -= repeats * 120;
+  }
+
   scored.sort((a, b) => b.priority - a.priority);
 
-  return scored.slice(0, 30).map((s) => ({
+  return scored.slice(0, limit).map((s) => ({
     actionId: s.actionId,
     x: s.x,
     y: s.y,
@@ -528,7 +769,10 @@ export function getCandidateMoves(board: number[][], player: number): LegalGameM
     toY: s.toY,
     coord: s.coord,
     description: s.description,
-    threatLevel: s.threatLevel
+    threatLevel: s.threatLevel,
+    safety: s.safety,
+    allowsMate: s.allowsMate,
+    lossPiece: s.lossPiece
   }));
 }
 
@@ -536,24 +780,36 @@ export class XiangqiGameInstance {
   public gameId: string;
   public status: GameStatus = "playing";
   public turn: number = PLAYER_RED; // Red moves first
+  public playerSide: number;
+  public agentSide: number;
   public board: number[][];
   public moveHistory: GameMoveRecord[] = [];
+  public positionHistory: string[];
   public chatHistory: GameChatMessage[] = [];
   public winner: number | null = null;
   public updatedAt: number = Date.now();
 
-  constructor(gameId: string) {
+  constructor(gameId: string, playerSide: number = PLAYER_RED) {
     this.gameId = gameId;
+    this.playerSide = playerSide === PLAYER_BLACK ? PLAYER_BLACK : PLAYER_RED;
+    this.agentSide = this.playerSide === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
     this.board = createInitialBoard();
+    this.positionHistory = [xiangqiPositionKey(this.board, this.turn)];
   }
 
-  public static fromSnapshot(snapshot: GameStateSnapshot): XiangqiGameInstance {
-    const inst = new XiangqiGameInstance(snapshot.gameId);
+  public static fromSnapshot(
+    snapshot: GameStateSnapshot,
+    playerSide: number = snapshot.playerSide ?? PLAYER_RED
+  ): XiangqiGameInstance {
+    const inst = new XiangqiGameInstance(snapshot.gameId, playerSide);
     inst.status = snapshot.status;
     inst.turn = snapshot.turn;
     inst.winner = snapshot.winner ?? null;
     inst.board = snapshot.board ? snapshot.board.map((row) => [...row]) : createInitialBoard();
     inst.moveHistory = [...(snapshot.moveHistory || [])];
+    inst.positionHistory = snapshot.positionHistory?.length
+      ? [...snapshot.positionHistory]
+      : [xiangqiPositionKey(inst.board, inst.turn)];
     inst.chatHistory = [...(snapshot.chatHistory || [])];
     inst.updatedAt = snapshot.updatedAt || Date.now();
     return inst;
@@ -566,13 +822,19 @@ export class XiangqiGameInstance {
       gameId: this.gameId,
       status: this.status,
       turn: this.turn,
+      playerSide: this.playerSide,
+      agentSide: this.agentSide,
       stepCount: this.moveHistory.length,
       winner: this.winner,
       board: this.board.map((row) => [...row]),
       lastMove: this.moveHistory.length > 0 ? this.moveHistory[this.moveHistory.length - 1] : null,
       moveHistory: includeHistory ? [...this.moveHistory] : undefined,
+      positionHistory: includeHistory ? [...this.positionHistory] : undefined,
       recentMoves: this.moveHistory.slice(-3),
-      legalMoves: this.status === "playing" ? getCandidateMoves(this.board, this.turn) : [],
+      legalMoves:
+        this.status === "playing"
+          ? getCandidateMoves(this.board, this.turn, this.moveHistory)
+          : [],
       chatHistory: includeHistory ? [...this.chatHistory] : this.chatHistory.slice(-3),
       updatedAt: this.updatedAt
     };
@@ -581,8 +843,9 @@ export class XiangqiGameInstance {
   public applyMove(
     actionId: string,
     player: number,
-    reason?: string
-  ): { ok: boolean; error?: string; winner?: number | null; chineseMove?: string } {
+    reason?: string,
+    options: XiangqiMoveOptions = {}
+  ): XiangqiMoveResult {
     if (this.status !== "playing") {
       return { ok: false, error: `Game is already over with status '${this.status}'.` };
     }
@@ -613,12 +876,33 @@ export class XiangqiGameInstance {
       return { ok: false, error: `Move '${actionId}' (${getPieceName(piece)}) is illegal according to Xiangqi rules or leaves King in check.` };
     }
 
+    if (options.rejectAvoidableMate && moveAllowsMateInOne(this.board, match, player)) {
+      const hasSafeAlternative = legalMoves.some(
+        (move) =>
+          move !== match &&
+          !moveAllowsMateInOne(this.board, move, player)
+      );
+      if (hasSafeAlternative) {
+        return {
+          ok: false,
+          error: `Move '${actionId}' rejected: it allows mate in one while a safe legal alternative exists.`
+        };
+      }
+    }
+
     const chineseMove = toChineseNotation(this.board, match, player);
     const capturedPiece = this.board[toY][toX] !== 0 ? this.board[toY][toX] : undefined;
 
     // Apply move
     this.board[toY][toX] = piece;
     this.board[fromY][fromX] = 0;
+
+    const opponent = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+    const isCheck = isKingInCheck(this.board, opponent);
+    const opponentLegalMoves = getLegalMoves(this.board, opponent);
+    const isCheckmate = isCheck && opponentLegalMoves.length === 0;
+    const isStalemate = !isCheck && opponentLegalMoves.length === 0;
+    const positionKey = xiangqiPositionKey(this.board, opponent);
 
     const moveRecord: GameMoveRecord = {
       actionId,
@@ -630,28 +914,47 @@ export class XiangqiGameInstance {
       toY,
       piece,
       capturedPiece,
+      chineseMove,
+      capturedPieceName:
+        capturedPiece !== undefined ? getPieceName(capturedPiece) : undefined,
+      givesCheck: isCheck,
+      checkmate: isCheckmate,
+      positionKey,
       player,
       stepIndex: this.moveHistory.length + 1,
       timestamp: Date.now(),
       reason
     };
     this.moveHistory.push(moveRecord);
+    this.positionHistory.push(positionKey);
     this.updatedAt = Date.now();
 
-    // Check opponent status
-    const opponent = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
-    const opponentLegalMoves = getLegalMoves(this.board, opponent);
+    const facts = {
+      chineseMove,
+      capturedPiece,
+      capturedPieceName:
+        capturedPiece !== undefined ? getPieceName(capturedPiece) : undefined,
+      isCheck,
+      isCheckmate,
+      isStalemate
+    };
 
     if (opponentLegalMoves.length === 0) {
       // Opponent is checkmated or stalemated
-      this.status = player === PLAYER_RED ? "player_won" : "agent_won";
+      this.status = player === this.playerSide ? "player_won" : "agent_won";
       this.winner = player;
-      return { ok: true, winner: player, chineseMove };
+      return { ok: true, winner: player, ...facts };
     }
 
     // Switch turn
     this.turn = opponent;
-    return { ok: true, chineseMove };
+    const repetitions = this.positionHistory.filter((key) => key === positionKey).length;
+    if (repetitions >= 3) {
+      this.status = "draw";
+      this.winner = null;
+      return { ok: true, winner: null, draw: true, ...facts };
+    }
+    return { ok: true, ...facts };
   }
 
   public addChat(
@@ -675,11 +978,11 @@ export class XiangqiGameInstance {
       return { ok: false, winner: this.winner || 0 };
     }
     const winningPlayer = player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
-    this.status = winningPlayer === PLAYER_RED ? "player_won" : "agent_won";
+    this.status = winningPlayer === this.playerSide ? "player_won" : "agent_won";
     this.winner = winningPlayer;
     this.updatedAt = Date.now();
     this.addChat(
-      player === PLAYER_RED ? "player" : "agent",
+      player === this.playerSide ? "player" : "agent",
       reason ? `认输: ${reason}` : "我认输了，这一局你下得漂亮！",
       "calm"
     );

--- a/electron/games/xiangqiSearch.ts
+++ b/electron/games/xiangqiSearch.ts
@@ -1,6 +1,9 @@
 import type { GameMoveRecord } from "../shared/gameToolProtocol.js";
 import {
+  PIECE_ADVISOR,
+  PIECE_BISHOP,
   PIECE_CANNON,
+  PIECE_KING,
   PIECE_KNIGHT,
   PIECE_PAWN,
   PIECE_ROOK,
@@ -48,22 +51,138 @@ function undoMove(board: number[][], move: RawXiangqiMove, captured: number): vo
   board[move.toY][move.toX] = captured;
 }
 
+function movesEqual(a: RawXiangqiMove | null | undefined, b: RawXiangqiMove | null | undefined): boolean {
+  if (!a || !b) return false;
+  return a.fromX === b.fromX && a.fromY === b.fromY && a.toX === b.toX && a.toY === b.toY;
+}
+
+// ---------------------------------------------------------------------------
+// Piece-Square Tables (PST) for Red (y=0..9, x=0..8).
+// For Black pieces, coordinates are vertically mirrored: y' = 9 - y.
+// ---------------------------------------------------------------------------
+const PAWN_PST = [
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0], // y = 0
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0], // y = 1
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0], // y = 2
+  [  0,   0,   5,   0,  12,   0,   5,   0,   0], // y = 3 (initial rank)
+  [ 10,  15,  25,  35,  40,  35,  25,  15,  10], // y = 4 (river bank)
+  [ 55,  70,  90, 110, 120, 110,  90,  70,  55], // y = 5 (crossed river)
+  [ 70,  90, 115, 135, 145, 135, 115,  90,  70], // y = 6
+  [ 80, 105, 130, 150, 160, 150, 130, 105,  80], // y = 7 (approaching palace)
+  [ 80, 105, 130, 150, 160, 150, 130, 105,  80], // y = 8
+  [ 40,  50,  60,  70,  70,  70,  60,  50,  40]  // y = 9 (bottom rank)
+];
+
+const KNIGHT_PST = [
+  [  0, -10,   0,   0,   0,   0,   0, -10,   0], // y = 0
+  [  0,   5,  10,  15,  10,  15,  10,   5,   0], // y = 1
+  [  5,  15,  25,  30,  20,  30,  25,  15,   5], // y = 2
+  [ 10,  25,  35,  45,  35,  45,  35,  25,  10], // y = 3
+  [ 15,  30,  40,  50,  40,  50,  40,  30,  15], // y = 4
+  [ 20,  35,  50,  60,  45,  60,  50,  35,  20], // y = 5
+  [ 20,  40,  55,  65,  50,  65,  55,  40,  20], // y = 6 (cross-river threats)
+  [ 15,  35,  50,  60,  40,  60,  50,  35,  15], // y = 7
+  [ 10,  20,  35,  45,  30,  45,  35,  20,  10], // y = 8
+  [  0,   5,  15,  20,  15,  20,  15,   5,   0]  // y = 9
+];
+
+const CANNON_PST = [
+  [  0,   0,   5,   0,  15,   0,   5,   0,   0], // y = 0
+  [  0,   5,  10,  10,  15,  10,  10,   5,   0], // y = 1
+  [  5,  15,  15,  20,  35,  20,  15,  15,   5], // y = 2 (central cannon bonus)
+  [  5,  10,  15,  25,  30,  25,  15,  10,   5], // y = 3
+  [  5,  15,  20,  30,  35,  30,  20,  15,   5], // y = 4
+  [  5,  15,  25,  30,  30,  30,  25,  15,   5], // y = 5
+  [  5,  15,  20,  25,  25,  25,  20,  15,   5], // y = 6
+  [ 10,  15,  20,  20,  20,  20,  20,  15,  10], // y = 7
+  [ 10,  15,  20,  20,  20,  20,  20,  15,  10], // y = 8
+  [ 15,  20,  25,  30,  30,  30,  25,  20,  15]  // y = 9 (bottom rank cannon)
+];
+
+const ROOK_PST = [
+  [  0,  10,   5,  15,  10,  15,   5,  10,   0], // y = 0
+  [ 10,  20,  15,  25,  20,  25,  15,  20,  10], // y = 1
+  [ 15,  25,  25,  30,  30,  30,  25,  25,  15], // y = 2
+  [ 20,  30,  30,  35,  35,  35,  30,  30,  20], // y = 3
+  [ 25,  35,  35,  40,  40,  40,  35,  35,  25], // y = 4
+  [ 30,  40,  40,  45,  45,  45,  40,  40,  30], // y = 5
+  [ 35,  45,  45,  50,  50,  50,  45,  45,  35], // y = 6
+  [ 40,  55,  55,  60,  60,  60,  55,  55,  40], // y = 7 (throat/pressure line)
+  [ 40,  50,  50,  55,  55,  55,  50,  50,  40], // y = 8
+  [ 35,  45,  45,  50,  50,  50,  45,  45,  35]  // y = 9
+];
+
+const ADVISOR_PST = [
+  [  0,   0,   0,  10,   0,  10,   0,   0,   0], // y = 0
+  [  0,   0,   0,   0,  20,   0,   0,   0,   0], // y = 1
+  [  0,   0,   0,  10,   0,  10,   0,   0,   0], // y = 2
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0]
+];
+
+const BISHOP_PST = [
+  [  0,   0,  10,   0,   0,   0,  10,   0,   0], // y = 0
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0], // y = 1
+  [  5,   0,   0,   0,  20,   0,   0,   0,   5], // y = 2
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0], // y = 3
+  [  0,   0,  10,   0,   0,   0,  10,   0,   0], // y = 4
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0]
+];
+
+const KING_PST = [
+  [  0,   0,   0,   5,  10,   5,   0,   0,   0], // y = 0
+  [  0,   0,   0,   0,   5,   0,   0,   0,   0], // y = 1
+  [  0,   0,   0,  -5,  -5,  -5,   0,   0,   0], // y = 2
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0],
+  [  0,   0,   0,   0,   0,   0,   0,   0,   0]
+];
+
 function positionalValue(piece: number, x: number, y: number): number {
   const abs = Math.abs(piece);
   const isRed = piece > 0;
-  const advance = isRed ? y : 9 - y;
-  const center = 4 - Math.abs(4 - x);
-  if (abs === PIECE_PAWN) return advance * 12 + center * 3;
-  if (abs === PIECE_KNIGHT) return center * 9 + (y >= 2 && y <= 7 ? 18 : 0);
-  if (abs === PIECE_CANNON) return center * 6;
-  if (abs === PIECE_ROOK) return center * 3;
-  return 0;
+  const rank = isRed ? y : 9 - y;
+  const file = x;
+
+  if (rank < 0 || rank >= 10 || file < 0 || file >= 9) return 0;
+
+  switch (abs) {
+    case PIECE_PAWN:
+      return PAWN_PST[rank][file];
+    case PIECE_KNIGHT:
+      return KNIGHT_PST[rank][file];
+    case PIECE_CANNON:
+      return CANNON_PST[rank][file];
+    case PIECE_ROOK:
+      return ROOK_PST[rank][file];
+    case PIECE_ADVISOR:
+      return ADVISOR_PST[rank][file];
+    case PIECE_BISHOP:
+      return BISHOP_PST[rank][file];
+    case PIECE_KING:
+      return KING_PST[rank][file];
+    default:
+      return 0;
+  }
 }
 
 export function evaluateXiangqiBoard(board: number[][], player: number): number {
   let score = 0;
-  for (let y = 0; y < board.length; y++) {
-    for (let x = 0; x < board[y].length; x++) {
+  for (let y = 0; y < 10; y++) {
+    for (let x = 0; x < 9; x++) {
       const piece = board[y][x];
       if (piece === 0) continue;
       const value = pieceValue(piece) + positionalValue(piece, x, y);
@@ -76,6 +195,70 @@ export function evaluateXiangqiBoard(board: number[][], player: number): number 
   return score;
 }
 
+// ---------------------------------------------------------------------------
+// Zobrist Hashing for O(1) Transposition Table Keys
+// ---------------------------------------------------------------------------
+class DeterministicPRNG {
+  private s: bigint;
+  constructor(seed = 1070372n) {
+    this.s = seed;
+  }
+  next(): bigint {
+    this.s = (this.s + 0x9e3779b97f4a7c15n) & 0xffffffffffffffffn;
+    let z = this.s;
+    z = ((z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n) & 0xffffffffffffffffn;
+    z = ((z ^ (z >> 27n)) * 0x94d049bb133111ebn) & 0xffffffffffffffffn;
+    return (z ^ (z >> 31n)) & 0xffffffffffffffffn;
+  }
+}
+
+const prng = new DeterministicPRNG();
+const ZOBRIST_PIECES: bigint[][] = Array.from({ length: 15 }, () =>
+  Array.from({ length: 90 }, () => prng.next())
+);
+const ZOBRIST_TURN = prng.next();
+
+function pieceToIndex(piece: number): number {
+  if (piece === 0) return 0;
+  return piece > 0 ? piece : Math.abs(piece) + 7;
+}
+
+function computeZobristHash(board: number[][], turn: number): bigint {
+  let hash = turn === PLAYER_RED ? 0n : ZOBRIST_TURN;
+  for (let y = 0; y < 10; y++) {
+    for (let x = 0; x < 9; x++) {
+      const piece = board[y][x];
+      if (piece !== 0) {
+        hash ^= ZOBRIST_PIECES[pieceToIndex(piece)][y * 9 + x];
+      }
+    }
+  }
+  return hash;
+}
+
+// ---------------------------------------------------------------------------
+// Transposition Table
+// ---------------------------------------------------------------------------
+const TT_SIZE = 1 << 18; // 262,144 entries
+const TT_MASK = BigInt(TT_SIZE - 1);
+
+export const FLAG_EXACT = 0;
+export const FLAG_LOWERBOUND = 1;
+export const FLAG_UPPERBOUND = 2;
+
+export interface TTEntry {
+  hashKey: bigint;
+  depth: number;
+  score: number;
+  flag: number;
+  bestMove?: RawXiangqiMove;
+}
+
+const transpositionTable: (TTEntry | null)[] = new Array(TT_SIZE).fill(null);
+
+// ---------------------------------------------------------------------------
+// Move Ordering and Scoring
+// ---------------------------------------------------------------------------
 function moveOrderScore(board: number[][], move: RawXiangqiMove, player: number): number {
   const captured = move.captured === undefined ? 0 : pieceValue(move.captured);
   const mover = pieceValue(move.piece);
@@ -83,13 +266,11 @@ function moveOrderScore(board: number[][], move: RawXiangqiMove, player: number)
   const taken = applyMove(board, move);
   const givesCheck = isKingInCheck(board, opponentOf(player));
   undoMove(board, move, taken);
-  // MVV-LVA for captures, then checks and central development. Quiet moves by
-  // Kings/Rooks must not be buried merely because the moving piece is valuable.
   return captured * 20 - (captured > 0 ? Math.floor(mover / 20) : 0) +
     (givesCheck ? 20_000 : 0) + center * 8;
 }
 
-function orderedMoves(board: number[][], player: number, depth: number): RawXiangqiMove[] {
+export function orderedMoves(board: number[][], player: number, depth: number): RawXiangqiMove[] {
   void depth;
   return getLegalMoves(board, player).sort(
     (a, b) => moveOrderScore(board, b, player) - moveOrderScore(board, a, player)
@@ -99,15 +280,81 @@ function orderedMoves(board: number[][], player: number, depth: number): RawXian
 interface SearchState {
   deadline: number;
   aborted: boolean;
+  killerMoves: [RawXiangqiMove | null, RawXiangqiMove | null][];
+  historyTable: number[][][];
+  history: bigint[];
 }
 
-function negamax(
+function scoreMoveForOrdering(
+  board: number[][],
+  move: RawXiangqiMove,
+  player: number,
+  ply: number,
+  ttMove: RawXiangqiMove | undefined,
+  state: SearchState
+): number {
+  if (movesEqual(move, ttMove)) {
+    return 500_000;
+  }
+
+  const captured = move.captured !== undefined && move.captured !== 0 ? pieceValue(move.captured) : 0;
+  const moverVal = pieceValue(move.piece);
+
+  if (captured > 0) {
+    // MVV-LVA for captures
+    return 100_000 + captured * 20 - Math.floor(moverVal / 20);
+  }
+
+  // Killer move heuristics
+  if (ply < state.killerMoves.length) {
+    if (movesEqual(state.killerMoves[ply][0], move)) return 80_000;
+    if (movesEqual(state.killerMoves[ply][1], move)) return 70_000;
+  }
+
+  // Check giving bonus
+  const taken = applyMove(board, move);
+  const givesCheck = isKingInCheck(board, opponentOf(player));
+  undoMove(board, move, taken);
+  if (givesCheck) return 50_000;
+
+  // History heuristic
+  const pIdx = pieceToIndex(move.piece);
+  const fromIdx = move.fromY * 9 + move.fromX;
+  const toIdx = move.toY * 9 + move.toX;
+  const historyScore = state.historyTable[pIdx]?.[fromIdx]?.[toIdx] ?? 0;
+
+  // Positional delta
+  const posDelta = positionalValue(move.piece, move.toX, move.toY) -
+                   positionalValue(move.piece, move.fromX, move.fromY);
+
+  return historyScore + posDelta;
+}
+
+function advancedOrderedMoves(
+  board: number[][],
+  moves: RawXiangqiMove[],
+  player: number,
+  ply: number,
+  ttMove: RawXiangqiMove | undefined,
+  state: SearchState
+): RawXiangqiMove[] {
+  return moves.sort(
+    (a, b) =>
+      scoreMoveForOrdering(board, b, player, ply, ttMove, state) -
+      scoreMoveForOrdering(board, a, player, ply, ttMove, state)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Quiescence Search (Q-Search to eliminate Horizon Effect)
+// ---------------------------------------------------------------------------
+function quiescenceSearch(
   board: number[][],
   player: number,
-  depth: number,
   alpha: number,
   beta: number,
   ply: number,
+  qdepth: number,
   state: SearchState
 ): number {
   if (Date.now() >= state.deadline) {
@@ -115,14 +362,131 @@ function negamax(
     return 0;
   }
 
-  const moves = orderedMoves(board, player, depth);
-  if (moves.length === 0) return -MATE_SCORE + ply * 100;
-  if (depth <= 0) return evaluateXiangqiBoard(board, player);
+  const inCheck = isKingInCheck(board, player);
+  const standPat = evaluateXiangqiBoard(board, player);
 
-  let best = -Infinity;
+  if (!inCheck) {
+    if (standPat >= beta) return beta;
+    if (standPat > alpha) alpha = standPat;
+  }
+
+  if (qdepth <= 0) return standPat;
+
+  const opponent = opponentOf(player);
+  const allMoves = getLegalMoves(board, player);
+  if (allMoves.length === 0) {
+    return inCheck ? -MATE_SCORE + ply * 100 : 0;
+  }
+
+  // In check: must search evasions; Not in check: search captures only
+  const candidateMoves = inCheck
+    ? allMoves
+    : allMoves.filter((m) => m.captured !== undefined && m.captured !== 0);
+
+  if (candidateMoves.length === 0) {
+    return standPat;
+  }
+
+  // MVV-LVA sort for Q-Search
+  candidateMoves.sort((a, b) => {
+    const capA = a.captured ? pieceValue(a.captured) : 0;
+    const capB = b.captured ? pieceValue(b.captured) : 0;
+    const movA = pieceValue(a.piece);
+    const movB = pieceValue(b.piece);
+    return capB * 20 - Math.floor(movB / 20) - (capA * 20 - Math.floor(movA / 20));
+  });
+
+  for (const move of candidateMoves) {
+    if (!inCheck && move.captured !== undefined && move.captured !== 0) {
+      const capVal = pieceValue(move.captured);
+      if (standPat + capVal + 150 < alpha) {
+        continue; // Delta pruning
+      }
+    }
+
+    const captured = applyMove(board, move);
+    const score = -quiescenceSearch(
+      board,
+      opponent,
+      -beta,
+      -alpha,
+      ply + 1,
+      qdepth - 1,
+      state
+    );
+    undoMove(board, move, captured);
+
+    if (state.aborted) return 0;
+    if (score >= beta) return beta;
+    if (score > alpha) alpha = score;
+  }
+
+  return alpha;
+}
+
+// ---------------------------------------------------------------------------
+// Negamax Search with Alpha-Beta, TT, and Q-Search
+// ---------------------------------------------------------------------------
+function negamax(
+  board: number[][],
+  player: number,
+  depth: number,
+  alpha: number,
+  beta: number,
+  ply: number,
+  hashKey: bigint,
+  state: SearchState
+): number {
+  if (Date.now() >= state.deadline) {
+    state.aborted = true;
+    return 0;
+  }
+
+  const ttIndex = Number(hashKey & TT_MASK);
+  const ttEntry = transpositionTable[ttIndex];
+  let ttMove: RawXiangqiMove | undefined;
+
+  if (ttEntry && ttEntry.hashKey === hashKey) {
+    ttMove = ttEntry.bestMove;
+    if (ttEntry.depth >= depth && ply > 0) {
+      const score = ttEntry.score;
+      if (ttEntry.flag === FLAG_EXACT) return score;
+      if (ttEntry.flag === FLAG_LOWERBOUND && score >= beta) return score;
+      if (ttEntry.flag === FLAG_UPPERBOUND && score <= alpha) return score;
+    }
+  }
+
+  if (depth <= 0) {
+    return quiescenceSearch(board, player, alpha, beta, ply, 6, state);
+  }
+
+  const moves = getLegalMoves(board, player);
+  if (moves.length === 0) {
+    const inCheck = isKingInCheck(board, player);
+    return inCheck ? -MATE_SCORE + ply * 100 : 0;
+  }
+
+  const sortedMoves = advancedOrderedMoves(board, moves, player, ply, ttMove, state);
+  let bestScore = -Infinity;
+  let bestMove: RawXiangqiMove | undefined = sortedMoves[0];
+  const initialAlpha = alpha;
   let localAlpha = alpha;
   const opponent = opponentOf(player);
-  for (const move of moves) {
+
+  state.history.push(hashKey);
+
+  for (const move of sortedMoves) {
+    const fromIdx = move.fromY * 9 + move.fromX;
+    const toIdx = move.toY * 9 + move.toX;
+    const pIdx = pieceToIndex(move.piece);
+    const cap = move.captured !== undefined && move.captured !== 0 ? move.captured : 0;
+    const capIdx = cap !== 0 ? pieceToIndex(cap) : 0;
+
+    let nextHash = hashKey ^ ZOBRIST_PIECES[pIdx][fromIdx] ^ ZOBRIST_PIECES[pIdx][toIdx] ^ ZOBRIST_TURN;
+    if (capIdx !== 0) {
+      nextHash ^= ZOBRIST_PIECES[capIdx][toIdx];
+    }
+
     const captured = applyMove(board, move);
     const score = -negamax(
       board,
@@ -131,15 +495,57 @@ function negamax(
       -beta,
       -localAlpha,
       ply + 1,
+      nextHash,
       state
     );
     undoMove(board, move, captured);
-    if (state.aborted) return 0;
-    best = Math.max(best, score);
+
+    if (state.aborted) {
+      state.history.pop();
+      return 0;
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMove = move;
+    }
+
     localAlpha = Math.max(localAlpha, score);
-    if (localAlpha >= beta) break;
+
+    if (localAlpha >= beta) {
+      // Beta Cutoff
+      if (cap === 0 && ply < state.killerMoves.length) {
+        if (!movesEqual(state.killerMoves[ply][0], move)) {
+          state.killerMoves[ply][1] = state.killerMoves[ply][0];
+          state.killerMoves[ply][0] = move;
+        }
+        const histVal = (state.historyTable[pIdx]?.[fromIdx]?.[toIdx] || 0) + depth * depth;
+        if (!state.historyTable[pIdx]) state.historyTable[pIdx] = Array.from({ length: 90 }, () => Array(90).fill(0));
+        state.historyTable[pIdx][fromIdx][toIdx] = Math.min(histVal, 40_000);
+      }
+      break;
+    }
   }
-  return best;
+
+  state.history.pop();
+
+  // Store in Transposition Table
+  let flag = FLAG_EXACT;
+  if (bestScore <= initialAlpha) {
+    flag = FLAG_UPPERBOUND;
+  } else if (bestScore >= beta) {
+    flag = FLAG_LOWERBOUND;
+  }
+
+  transpositionTable[ttIndex] = {
+    hashKey,
+    depth,
+    score: bestScore,
+    flag,
+    bestMove
+  };
+
+  return bestScore;
 }
 
 function repetitionPenalty(
@@ -170,7 +576,7 @@ function repetitionPenalty(
 
 function factualReason(board: number[][], move: RawXiangqiMove, player: number): string {
   const notation = toChineseNotation(board, move, player);
-  const capturedName = move.captured === undefined ? "" : getPieceName(move.captured);
+  const capturedName = move.captured === undefined || move.captured === 0 ? "" : getPieceName(move.captured);
   const captured = applyMove(board, move);
   const opponent = opponentOf(player);
   const check = isKingInCheck(board, opponent);
@@ -190,26 +596,57 @@ export function findBestXiangqiMove(
   options: XiangqiSearchOptions = {}
 ): XiangqiEngineSuggestion | null {
   const board = sourceBoard.map((row) => [...row]);
-  const legal = getLegalMoves(board, player).sort(
-    (a, b) => moveOrderScore(board, b, player) - moveOrderScore(board, a, player)
-  );
+  const legal = getLegalMoves(board, player);
   if (legal.length === 0) return null;
 
   const deadline = Date.now() + Math.max(50, options.timeBudgetMs ?? 700);
-  const maxDepth = Math.max(1, options.maxDepth ?? 3);
-  let bestMove = legal[0];
+  const maxDepth = Math.max(1, options.maxDepth ?? 5);
+
+  const state: SearchState = {
+    deadline,
+    aborted: false,
+    killerMoves: Array.from({ length: 64 }, () => [null, null]),
+    historyTable: Array.from({ length: 15 }, () =>
+      Array.from({ length: 90 }, () => Array(90).fill(0))
+    ),
+    history: []
+  };
+
+  const initialHash = computeZobristHash(board, player);
+  const ordered = orderedMoves(board, player, 1);
+  let bestMove = ordered[0];
   let bestScore = -Infinity;
   let depthReached = 0;
 
   for (let depth = 1; depth <= maxDepth; depth++) {
-    const state: SearchState = { deadline, aborted: false };
+    state.aborted = false;
     let iterationMove = bestMove;
     let iterationScore = -Infinity;
     let alpha = -Infinity;
     const opponent = opponentOf(player);
 
-    for (const move of legal) {
+    const movesToSearch = advancedOrderedMoves(
+      board,
+      legal,
+      player,
+      0,
+      bestMove,
+      state
+    );
+
+    for (const move of movesToSearch) {
       const rootPenalty = repetitionPenalty(board, move, player, options);
+      const fromIdx = move.fromY * 9 + move.fromX;
+      const toIdx = move.toY * 9 + move.toX;
+      const pIdx = pieceToIndex(move.piece);
+      const cap = move.captured !== undefined && move.captured !== 0 ? move.captured : 0;
+      const capIdx = cap !== 0 ? pieceToIndex(cap) : 0;
+
+      let nextHash = initialHash ^ ZOBRIST_PIECES[pIdx][fromIdx] ^ ZOBRIST_PIECES[pIdx][toIdx] ^ ZOBRIST_TURN;
+      if (capIdx !== 0) {
+        nextHash ^= ZOBRIST_PIECES[capIdx][toIdx];
+      }
+
       const captured = applyMove(board, move);
       const score =
         -negamax(
@@ -219,10 +656,11 @@ export function findBestXiangqiMove(
           -Infinity,
           -(alpha + rootPenalty),
           1,
+          nextHash,
           state
-        ) -
-        rootPenalty;
+        ) - rootPenalty;
       undoMove(board, move, captured);
+
       if (state.aborted) break;
       if (score > iterationScore) {
         iterationScore = score;
@@ -237,8 +675,7 @@ export function findBestXiangqiMove(
     depthReached = depth;
   }
 
-  // Very small budgets may expire before depth 1 completes. Keep a legal,
-  // ordered fallback and still apply the root repetition preference.
+  // Fallback for very small budgets
   if (depthReached === 0) {
     bestMove = [...legal].sort(
       (a, b) =>
@@ -257,3 +694,4 @@ export function findBestXiangqiMove(
     depthReached
   };
 }
+

--- a/electron/games/xiangqiSearch.ts
+++ b/electron/games/xiangqiSearch.ts
@@ -1,0 +1,259 @@
+import type { GameMoveRecord } from "../shared/gameToolProtocol.js";
+import {
+  PIECE_CANNON,
+  PIECE_KNIGHT,
+  PIECE_PAWN,
+  PIECE_ROOK,
+  PLAYER_BLACK,
+  PLAYER_RED,
+  getLegalMoves,
+  getPieceName,
+  isKingInCheck,
+  moveToString,
+  pieceValue,
+  toChineseNotation,
+  xiangqiPositionKey,
+  type RawXiangqiMove
+} from "./xiangqiEngine.js";
+
+export interface XiangqiSearchOptions {
+  maxDepth?: number;
+  timeBudgetMs?: number;
+  positionHistory?: string[];
+  recentMoves?: GameMoveRecord[];
+}
+
+export interface XiangqiEngineSuggestion {
+  actionId: string;
+  score: number;
+  reason: string;
+  depthReached: number;
+}
+
+const MATE_SCORE = 10_000_000;
+
+function opponentOf(player: number): number {
+  return player === PLAYER_RED ? PLAYER_BLACK : PLAYER_RED;
+}
+
+function applyMove(board: number[][], move: RawXiangqiMove): number {
+  const captured = board[move.toY][move.toX];
+  board[move.toY][move.toX] = move.piece;
+  board[move.fromY][move.fromX] = 0;
+  return captured;
+}
+
+function undoMove(board: number[][], move: RawXiangqiMove, captured: number): void {
+  board[move.fromY][move.fromX] = move.piece;
+  board[move.toY][move.toX] = captured;
+}
+
+function positionalValue(piece: number, x: number, y: number): number {
+  const abs = Math.abs(piece);
+  const isRed = piece > 0;
+  const advance = isRed ? y : 9 - y;
+  const center = 4 - Math.abs(4 - x);
+  if (abs === PIECE_PAWN) return advance * 12 + center * 3;
+  if (abs === PIECE_KNIGHT) return center * 9 + (y >= 2 && y <= 7 ? 18 : 0);
+  if (abs === PIECE_CANNON) return center * 6;
+  if (abs === PIECE_ROOK) return center * 3;
+  return 0;
+}
+
+export function evaluateXiangqiBoard(board: number[][], player: number): number {
+  let score = 0;
+  for (let y = 0; y < board.length; y++) {
+    for (let x = 0; x < board[y].length; x++) {
+      const piece = board[y][x];
+      if (piece === 0) continue;
+      const value = pieceValue(piece) + positionalValue(piece, x, y);
+      const own = player === PLAYER_RED ? piece > 0 : piece < 0;
+      score += own ? value : -value;
+    }
+  }
+  if (isKingInCheck(board, player)) score -= 180;
+  if (isKingInCheck(board, opponentOf(player))) score += 180;
+  return score;
+}
+
+function moveOrderScore(board: number[][], move: RawXiangqiMove, player: number): number {
+  const captured = move.captured === undefined ? 0 : pieceValue(move.captured);
+  const mover = pieceValue(move.piece);
+  const center = 4 - Math.abs(4 - move.toX);
+  const taken = applyMove(board, move);
+  const givesCheck = isKingInCheck(board, opponentOf(player));
+  undoMove(board, move, taken);
+  // MVV-LVA for captures, then checks and central development. Quiet moves by
+  // Kings/Rooks must not be buried merely because the moving piece is valuable.
+  return captured * 20 - (captured > 0 ? Math.floor(mover / 20) : 0) +
+    (givesCheck ? 20_000 : 0) + center * 8;
+}
+
+function orderedMoves(board: number[][], player: number, depth: number): RawXiangqiMove[] {
+  void depth;
+  return getLegalMoves(board, player).sort(
+    (a, b) => moveOrderScore(board, b, player) - moveOrderScore(board, a, player)
+  );
+}
+
+interface SearchState {
+  deadline: number;
+  aborted: boolean;
+}
+
+function negamax(
+  board: number[][],
+  player: number,
+  depth: number,
+  alpha: number,
+  beta: number,
+  ply: number,
+  state: SearchState
+): number {
+  if (Date.now() >= state.deadline) {
+    state.aborted = true;
+    return 0;
+  }
+
+  const moves = orderedMoves(board, player, depth);
+  if (moves.length === 0) return -MATE_SCORE + ply * 100;
+  if (depth <= 0) return evaluateXiangqiBoard(board, player);
+
+  let best = -Infinity;
+  let localAlpha = alpha;
+  const opponent = opponentOf(player);
+  for (const move of moves) {
+    const captured = applyMove(board, move);
+    const score = -negamax(
+      board,
+      opponent,
+      depth - 1,
+      -beta,
+      -localAlpha,
+      ply + 1,
+      state
+    );
+    undoMove(board, move, captured);
+    if (state.aborted) return 0;
+    best = Math.max(best, score);
+    localAlpha = Math.max(localAlpha, score);
+    if (localAlpha >= beta) break;
+  }
+  return best;
+}
+
+function repetitionPenalty(
+  board: number[][],
+  move: RawXiangqiMove,
+  player: number,
+  options: XiangqiSearchOptions
+): number {
+  const captured = applyMove(board, move);
+  const key = xiangqiPositionKey(board, opponentOf(player));
+  undoMove(board, move, captured);
+  const priorOccurrences = (options.positionHistory ?? []).filter((item) => item === key).length;
+
+  let penalty = priorOccurrences * 12_000;
+  const previousOwnMove = [...(options.recentMoves ?? [])]
+    .reverse()
+    .find((item) => item.player === player);
+  if (
+    previousOwnMove?.fromX === move.toX &&
+    previousOwnMove?.fromY === move.toY &&
+    previousOwnMove?.toX === move.fromX &&
+    previousOwnMove?.toY === move.fromY
+  ) {
+    penalty += 800;
+  }
+  return penalty;
+}
+
+function factualReason(board: number[][], move: RawXiangqiMove, player: number): string {
+  const notation = toChineseNotation(board, move, player);
+  const capturedName = move.captured === undefined ? "" : getPieceName(move.captured);
+  const captured = applyMove(board, move);
+  const opponent = opponentOf(player);
+  const check = isKingInCheck(board, opponent);
+  const mate = check && getLegalMoves(board, opponent).length === 0;
+  undoMove(board, move, captured);
+
+  if (mate) return `${notation}，绝杀`;
+  if (capturedName && check) return `${notation}，吃${capturedName}并将军`;
+  if (capturedName) return `${notation}，吃${capturedName}`;
+  if (check) return `${notation}，将军`;
+  return `${notation}，改善子力位置`;
+}
+
+export function findBestXiangqiMove(
+  sourceBoard: number[][],
+  player: number,
+  options: XiangqiSearchOptions = {}
+): XiangqiEngineSuggestion | null {
+  const board = sourceBoard.map((row) => [...row]);
+  const legal = getLegalMoves(board, player).sort(
+    (a, b) => moveOrderScore(board, b, player) - moveOrderScore(board, a, player)
+  );
+  if (legal.length === 0) return null;
+
+  const deadline = Date.now() + Math.max(50, options.timeBudgetMs ?? 700);
+  const maxDepth = Math.max(1, options.maxDepth ?? 3);
+  let bestMove = legal[0];
+  let bestScore = -Infinity;
+  let depthReached = 0;
+
+  for (let depth = 1; depth <= maxDepth; depth++) {
+    const state: SearchState = { deadline, aborted: false };
+    let iterationMove = bestMove;
+    let iterationScore = -Infinity;
+    let alpha = -Infinity;
+    const opponent = opponentOf(player);
+
+    for (const move of legal) {
+      const rootPenalty = repetitionPenalty(board, move, player, options);
+      const captured = applyMove(board, move);
+      const score =
+        -negamax(
+          board,
+          opponent,
+          depth - 1,
+          -Infinity,
+          -(alpha + rootPenalty),
+          1,
+          state
+        ) -
+        rootPenalty;
+      undoMove(board, move, captured);
+      if (state.aborted) break;
+      if (score > iterationScore) {
+        iterationScore = score;
+        iterationMove = move;
+      }
+      alpha = Math.max(alpha, score);
+    }
+
+    if (state.aborted) break;
+    bestMove = iterationMove;
+    bestScore = iterationScore;
+    depthReached = depth;
+  }
+
+  // Very small budgets may expire before depth 1 completes. Keep a legal,
+  // ordered fallback and still apply the root repetition preference.
+  if (depthReached === 0) {
+    bestMove = [...legal].sort(
+      (a, b) =>
+        moveOrderScore(board, b, player) - repetitionPenalty(board, b, player, options) -
+        (moveOrderScore(board, a, player) - repetitionPenalty(board, a, player, options))
+    )[0];
+    bestScore =
+      moveOrderScore(board, bestMove, player) -
+      repetitionPenalty(board, bestMove, player, options);
+  }
+
+  return {
+    actionId: moveToString(bestMove.fromX, bestMove.fromY, bestMove.toX, bestMove.toY),
+    score: bestScore,
+    reason: factualReason(board, bestMove, player),
+    depthReached
+  };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -27,8 +27,9 @@ import { initFileBridge } from "./fileBridge.js";
 import { getDb } from "./cli/db.js";
 import { getSetting, setSetting } from "./cli/settings.js";
 import {
-  getOrCreateGame,
+  handleGetGameState,
   handlePlayerMove,
+  handlePlayerResign,
   handleAgentMove,
   handleResetGame,
   initGamePersistence
@@ -1241,7 +1242,7 @@ function registerButlerBuddyWindowIpc() {
   });
   registerHandler("game:getState", (_event, conversationId: string) => {
     if (!requireOwnedConversation(conversationId)) return undefined;
-    return getOrCreateGame(conversationId).getSnapshot();
+    return handleGetGameState(conversationId, _event.sender);
   });
   registerHandler(
     "game:playerMove",
@@ -1282,6 +1283,12 @@ function registerButlerBuddyWindowIpc() {
       return { ok: false, error: "conversation_not_found" };
     }
     return handleResetGame(conversationId, event.sender);
+  });
+  registerHandler("game:playerResign", (event, conversationId: string) => {
+    if (!requireOwnedConversation(conversationId)) {
+      return { ok: false, error: "conversation_not_found" };
+    }
+    return handlePlayerResign(conversationId, event.sender);
   });
   ipcMain.handle(
     "butlerBuddy:updatePreferences",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -31,6 +31,7 @@ import {
   handlePlayerMove,
   handlePlayerResign,
   handleAgentMove,
+  handleSendChat,
   handleResetGame,
   initGamePersistence
 } from "./gameToolService.js";
@@ -1273,6 +1274,27 @@ function registerButlerBuddyWindowIpc() {
         payload.actionId,
         payload.reason,
         payload.speech,
+        payload.mood,
+        event.sender
+      );
+    }
+  );
+  registerHandler(
+    "game:sendChat",
+    (
+      event,
+      payload: {
+        conversationId: string;
+        message: string;
+        mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring";
+      }
+    ) => {
+      if (!requireOwnedConversation(payload.conversationId)) {
+        return { ok: false, error: "conversation_not_found" };
+      }
+      return handleSendChat(
+        payload.conversationId,
+        payload.message,
         payload.mood,
         event.sender
       );

--- a/electron/mcp/gameMcpServer.ts
+++ b/electron/mcp/gameMcpServer.ts
@@ -6,6 +6,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 import type { GameAction, GameToolResult } from "../shared/gameToolProtocol.js";
+import { formatGameStateText } from "../games/boardDisplay.js";
 
 function bridgeEnvironment(): { endpoint: string; token: string } {
   const endpoint = process.env.FREEBUDDY_GAME_ENDPOINT?.trim();
@@ -43,15 +44,37 @@ export async function invokeGameBridge(
 }
 
 function toolResult(result: GameToolResult) {
+  const text =
+    result.ok && typeof result.message === "string"
+      ? result.message
+      : JSON.stringify(result, null, 2);
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify(result, null, 2)
+        text
       }
     ],
     structuredContent: result,
     ...(result.ok === false ? { isError: true } : {})
+  };
+}
+
+function compactStateResult(result: GameToolResult): GameToolResult {
+  const state = result.gameState;
+  if (!state) return result;
+  return {
+    ok: result.ok,
+    gameId: result.gameId,
+    gameType: state.gameType,
+    status: state.status,
+    turn: state.turn,
+    playerSide: state.playerSide,
+    agentSide: state.agentSide,
+    stepCount: state.stepCount,
+    winner: state.winner,
+    lastMove: state.lastMove,
+    candidateMoveCount: state.legalMoves.length
   };
 }
 
@@ -74,7 +97,7 @@ export function createGameMcpServer(): McpServer {
     {
       title: "Get Board State",
       description:
-        "获取当前棋盘/牌局最新局势。返回当前执子方、手牌/棋盘矩阵、上一步着法，以及按战术威胁排序的合法候选走法列表 (legalMoves)。",
+        "获取当前棋盘/牌局最新局势。返回带坐标的 ASCII 棋盘、双方威胁警告（含对方吃子威胁）、以及按战术价值排序并标注安全性（[丢X]/[兑子]/[得子]）的合法候选走法列表。",
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -84,7 +107,18 @@ export function createGameMcpServer(): McpServer {
     },
     async () => {
       try {
-        return toolResult(await invokeGameBridge("get_state", {}));
+        const result = await invokeGameBridge("get_state", {});
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: result.gameState
+                ? formatGameStateText(result.gameState)
+                : JSON.stringify(result, null, 2)
+            }
+          ],
+          structuredContent: compactStateResult(result)
+        };
       } catch (error) {
         return toolError(error);
       }
@@ -97,7 +131,7 @@ export function createGameMcpServer(): McpServer {
     {
       title: "Make Game Move",
       description:
-        "在当前对局中执行落子或出牌。必须传入合法的 actionId (如 'H8'、'E5' 等)。若落子非法将返回错误信息供你调整。",
+        "在当前对局中执行落子或出牌。必须传入合法的 actionId。成功后只返回精简确认；吃子、将军与绝杀由服务端给出准确事实，请勿自行臆测。",
       inputSchema: {
         actionId: z
           .string()
@@ -108,7 +142,7 @@ export function createGameMcpServer(): McpServer {
           .string()
           .trim()
           .optional()
-          .describe("简要阐明本步落子的战术意图（进攻/防守/封堵）")
+          .describe("只写简短战术意图；不要自行声称吃子、将军或绝杀")
       },
       annotations: {
         readOnlyHint: false,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -852,6 +852,8 @@ const game = {
       mood
     }),
   resetGame: (conversationId: string) => ipcRenderer.invoke("game:resetGame", conversationId),
+  playerResign: (conversationId: string) =>
+    ipcRenderer.invoke("game:playerResign", conversationId),
   onGameEvent: (cb: (event: unknown) => void): (() => void) => {
     const channel = "freebuddy://game-event";
     const handler = (_e: IpcRendererEvent, payload: unknown) => cb(payload);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -851,6 +851,16 @@ const game = {
       speech,
       mood
     }),
+  sendChat: (
+    conversationId: string,
+    message: string,
+    mood?: "confident" | "mocking" | "nervous" | "calm" | "admiring"
+  ) =>
+    ipcRenderer.invoke("game:sendChat", {
+      conversationId,
+      message,
+      mood
+    }),
   resetGame: (conversationId: string) => ipcRenderer.invoke("game:resetGame", conversationId),
   playerResign: (conversationId: string) =>
     ipcRenderer.invoke("game:playerResign", conversationId),

--- a/electron/shared/debugLogExportCore.ts
+++ b/electron/shared/debugLogExportCore.ts
@@ -3,6 +3,17 @@ export interface TimestampRange {
   endMs: number;
 }
 
+export interface SessionLogEntry {
+  taskId: string;
+  name: string;
+  mtimeMs: number;
+}
+
+export interface SessionLogGroup<T extends SessionLogEntry = SessionLogEntry> {
+  logicalSessionId: string;
+  entries: T[];
+}
+
 /** Local calendar-day range. Constructing the next midnight also handles DST days. */
 export function localDayRange(date: Date): TimestampRange {
   return {
@@ -35,4 +46,118 @@ export function filterJsonlLinesByTimestamp(
       return false;
     }
   });
+}
+
+/**
+ * Group per-turn task logs by the underlying resumable ACP session. Entries
+ * inside a logical session are returned oldest-first so they can be merged
+ * into one chronological transcript. The group limit preserves the exporter's
+ * existing cap while no longer counting every turn as a separate session.
+ */
+export function groupSessionLogEntries<T extends SessionLogEntry>(
+  entries: readonly T[],
+  toolSessionIdByTask: ReadonlyMap<string, string>,
+  maxGroups: number
+): SessionLogGroup<T>[] {
+  const groups = new Map<string, T[]>();
+  const newestFirst = [...entries].sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const entry of newestFirst) {
+    const logicalSessionId = toolSessionIdByTask.get(entry.taskId) || entry.taskId;
+    const existing = groups.get(logicalSessionId);
+    if (existing) {
+      existing.push(entry);
+      continue;
+    }
+    if (groups.size >= maxGroups) continue;
+    groups.set(logicalSessionId, [entry]);
+  }
+
+  return [...groups.entries()].map(([logicalSessionId, groupedEntries]) => ({
+    logicalSessionId,
+    entries: groupedEntries.sort((a, b) => a.mtimeMs - b.mtimeMs)
+  }));
+}
+
+interface HistoryReplayLine {
+  replay: boolean;
+  timestamp?: string;
+  reportedItems?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function historyReplayLine(line: string): HistoryReplayLine {
+  try {
+    const outer = JSON.parse(line) as { ts?: unknown; type?: unknown; content?: unknown };
+    if (outer.type !== "stdout" || typeof outer.content !== "string") {
+      return { replay: false };
+    }
+    const payload = JSON.parse(outer.content) as unknown;
+    if (!isRecord(payload)) return { replay: false };
+    const params = isRecord(payload.params) ? payload.params : undefined;
+    const update = isRecord(params?.update) ? params.update : undefined;
+    const metas = [update?._meta, params?._meta, payload._meta].filter(isRecord);
+    const replayMarker = metas
+      .map((meta) => meta["codebuddy.ai/historyReplay"])
+      .find((value) => value === "start" || value === "end");
+    const historyMode = metas.some((meta) => {
+      const codebuddyMeta = meta["codebuddy.ai"];
+      return isRecord(codebuddyMeta) && codebuddyMeta.mode === "history";
+    });
+    const reportedItems = metas
+      .map((meta) => meta["codebuddy.ai/historyReplayTotalItems"])
+      .find((value) => typeof value === "number");
+    return {
+      replay: Boolean(replayMarker || historyMode),
+      timestamp: typeof outer.ts === "string" ? outer.ts : undefined,
+      reportedItems
+    };
+  } catch {
+    return { replay: false };
+  }
+}
+
+/**
+ * ACP adapters may replay the complete prior transcript after every
+ * session/load. Those events are useful to the live renderer but make an
+ * exported conversation contain the same history once per turn. Collapse the
+ * explicitly tagged replay protocol lines into one diagnostic marker while
+ * preserving all live events and malformed/unrecognised lines verbatim.
+ */
+export function collapseAcpHistoryReplayLines(lines: readonly string[]): string[] {
+  const out: string[] = [];
+  let markerIndex = -1;
+  let firstTimestamp: string | undefined;
+  let reportedItems: number | undefined;
+  let omitted = 0;
+
+  for (const line of lines) {
+    const info = historyReplayLine(line);
+    if (!info.replay) {
+      out.push(line);
+      continue;
+    }
+    if (markerIndex < 0) markerIndex = out.length;
+    firstTimestamp ??= info.timestamp;
+    reportedItems ??= info.reportedItems;
+    omitted += 1;
+  }
+
+  if (omitted === 0) return out;
+  const reported = reportedItems === undefined
+    ? ""
+    : `; adapter reported ${reportedItems} replay items`;
+  out.splice(
+    markerIndex,
+    0,
+    JSON.stringify({
+      ts: firstTimestamp ?? null,
+      type: "system",
+      content: `[export] omitted ${omitted} ACP history replay log lines${reported}`
+    })
+  );
+  return out;
 }

--- a/electron/shared/gameToolProtocol.ts
+++ b/electron/shared/gameToolProtocol.ts
@@ -26,7 +26,15 @@ export interface GameMoveRecord {
   toY?: number;
   piece?: number;
   capturedPiece?: number;
-  player: number; // 1: Player, 2: Agent
+  /** Engine-derived Xiangqi notation and tactical facts. */
+  chineseMove?: string;
+  capturedPieceName?: string;
+  givesCheck?: boolean;
+  checkmate?: boolean;
+  /** Position after this move, including the side to move. */
+  positionKey?: string;
+  /** Board side that moved: Gomoku 1=Black/2=White, Xiangqi 1=Red/2=Black. */
+  player: number;
   stepIndex: number;
   timestamp: number;
   reason?: string;
@@ -43,6 +51,12 @@ export interface LegalGameMove {
   coord: string; // e.g. "H8" or "b2e2"
   description?: string;
   threatLevel?: "winning" | "critical_block" | "attack" | "normal";
+  /** Static-exchange result of playing this move (xiangqi). */
+  safety?: "lose" | "trade" | "gain";
+  /** Playing this move lets the opponent deliver mate in one. */
+  allowsMate?: boolean;
+  /** Piece we would hang when safety === "lose". */
+  lossPiece?: string;
 }
 
 export interface GameChatMessage {
@@ -56,12 +70,20 @@ export interface GameStateSnapshot {
   gameType: GameType;
   gameId: string;
   status: GameStatus;
-  turn: number; // 1: Player, 2: Agent
+  /** Board side to move: Gomoku 1=Black/2=White, Xiangqi 1=Red/2=Black. */
+  turn: number;
+  /** Board side controlled by the human player. */
+  playerSide: number;
+  /** Board side controlled by the Agent. */
+  agentSide: number;
   stepCount: number;
   winner?: number | null;
   board: number[][]; // 15x15 for Gomoku, 10x9 for Xiangqi
+  asciiBoard?: string;
   lastMove?: GameMoveRecord | null;
   moveHistory?: GameMoveRecord[];
+  /** Persisted only with full history; used for repetition detection/search. */
+  positionHistory?: string[];
   recentMoves?: GameMoveRecord[];
   legalMoves: LegalGameMove[];
   chatHistory: GameChatMessage[];
@@ -79,6 +101,9 @@ export interface GameToolResult {
   ok: boolean;
   gameId?: string;
   gameType?: GameType;
+  status?: GameStatus;
+  turn?: number;
+  winner?: number | null;
   gameState?: GameStateSnapshot;
   message?: string;
   error?: string;
@@ -87,6 +112,17 @@ export interface GameToolResult {
   moveHistory?: GameMoveRecord[];
   chatHistory?: GameChatMessage[];
   stepCount?: number;
+  lastMove?: GameMoveRecord | null;
+  candidateMoveCount?: number;
+  moveFacts?: {
+    chineseMove?: string;
+    capturedPiece?: number;
+    capturedPieceName?: string;
+    isCheck: boolean;
+    isCheckmate: boolean;
+    isStalemate: boolean;
+    draw: boolean;
+  };
   [key: string]: unknown;
 }
 

--- a/electron/shared/remoteChannelPolicy.ts
+++ b/electron/shared/remoteChannelPolicy.ts
@@ -175,7 +175,8 @@ const ALLOW = [
   "game:getState",
   "game:playerMove",
   "game:agentMove",
-  "game:resetGame"
+  "game:resetGame",
+  "game:playerResign"
 ] as const;
 
 const ADMIN_ONLY = [

--- a/electron/shared/remoteChannelPolicy.ts
+++ b/electron/shared/remoteChannelPolicy.ts
@@ -175,6 +175,7 @@ const ALLOW = [
   "game:getState",
   "game:playerMove",
   "game:agentMove",
+  "game:sendChat",
   "game:resetGame",
   "game:playerResign"
 ] as const;

--- a/public/games/gomoku/game.js
+++ b/public/games/gomoku/game.js
@@ -7,7 +7,9 @@
 
   // State
   let board = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(0));
-  let turn = 1; // 1: Player (Black), 2: Agent (White)
+  let turn = 1; // 1: Black, 2: White
+  let playerSide = 1;
+  let agentSide = 2;
   let status = "playing";
   let lastMove = null;
   let hoverCoord = null;
@@ -24,6 +26,21 @@
   const agentNameLabel = document.getElementById("agent-name-label");
   const agentAvatarIcon = document.getElementById("agent-avatar-icon");
   const speechAvatar = document.getElementById("speech-avatar");
+  const playerSideDot = document.getElementById("player-side-dot");
+  const playerSideLabel = document.getElementById("player-side-label");
+  const agentSideLabel = document.getElementById("agent-side-label");
+  const agentSideDot = document.getElementById("agent-side-dot");
+
+  function sideName(side) {
+    return side === 1 ? "黑子" : "白子";
+  }
+
+  function updateSideLabels() {
+    if (playerSideLabel) playerSideLabel.textContent = `你 (${playerSide === 1 ? "黑棋" : "白棋"})`;
+    if (agentSideLabel) agentSideLabel.textContent = `(${agentSide === 1 ? "黑棋" : "白棋"})`;
+    if (playerSideDot) playerSideDot.className = `stone-dot ${playerSide === 1 ? "black" : "white"}`;
+    if (agentSideDot) agentSideDot.className = `stone-dot ${agentSide === 1 ? "black" : "white"}`;
+  }
 
   function updateAgentInfo(info) {
     if (!info) return;
@@ -335,13 +352,13 @@
     if (lastMove) {
       const lx = padding + lastMove.x * cellSize;
       const ly = padding + lastMove.y * cellSize;
-      ctx.strokeStyle = lastMove.player === 1 ? "#ef4444" : "#3b82f6";
+      ctx.strokeStyle = lastMove.player === playerSide ? "#ef4444" : "#3b82f6";
       ctx.lineWidth = 2.5;
       ctx.strokeRect(lx - stoneRadius * 0.4, ly - stoneRadius * 0.4, stoneRadius * 0.8, stoneRadius * 0.8);
     }
 
     // Hover stone preview & crosshair snap circle
-    if (hoverCoord && status === "playing" && turn === 1 && board[hoverCoord.y][hoverCoord.x] === 0) {
+    if (hoverCoord && status === "playing" && turn === playerSide && board[hoverCoord.y][hoverCoord.x] === 0) {
       const hx = padding + hoverCoord.x * cellSize;
       const hy = padding + hoverCoord.y * cellSize;
 
@@ -354,19 +371,24 @@
 
       ctx.save();
       ctx.globalAlpha = 0.55;
-      drawStone(hx, hy, stoneRadius, 1);
+      drawStone(hx, hy, stoneRadius, playerSide);
       ctx.restore();
     }
   }
 
   function handleCanvasClick(e) {
+    if (!initialized) {
+      statusText.textContent = "正在同步服务器棋面，请稍候...";
+      window.parent.postMessage({ type: "REQUEST_SYNC" }, "*");
+      return;
+    }
     if (status !== "playing") {
       statusText.textContent = "本局已结束，请点击下方【重新开局】发起新一轮对战。";
       return;
     }
 
-    if (turn !== 1) {
-      statusText.textContent = "当前轮到 AI Agent (白子) 行动，请稍候或点击下方【催促 Agent】。";
+    if (turn !== playerSide) {
+      statusText.textContent = `当前轮到 AI Agent (${sideName(agentSide)}) 行动，请稍候或点击下方【催促 Agent】。`;
       return;
     }
 
@@ -382,9 +404,9 @@
     const actionId = coordToString(x, y);
 
     // Local optimistic update
-    board[y][x] = 1;
-    lastMove = { x, y, player: 1, actionId };
-    turn = 2;
+    board[y][x] = playerSide;
+    lastMove = { x, y, player: playerSide, actionId };
+    turn = agentSide;
     hoverCoord = null;
     playStoneSound();
     updateUI();
@@ -456,14 +478,14 @@
       restartBtn.className = "btn";
       restartBtn.textContent = "重新开局";
       resignBtn.style.display = "inline-block";
-      if (turn === 1) {
+      if (turn === playerSide) {
         turnBadge.className = "turn-indicator active-player";
-        turnBadge.textContent = "轮到你行动 (黑子)";
+        turnBadge.textContent = `轮到你行动 (${sideName(playerSide)})`;
         statusText.textContent = "请在棋盘上点击落子";
         if (retryAgentBtn) retryAgentBtn.style.display = "none";
       } else {
         turnBadge.className = "turn-indicator active-agent";
-        turnBadge.textContent = "Agent 正在思考中... (白子)";
+        turnBadge.textContent = `Agent 正在思考中... (${sideName(agentSide)})`;
         statusText.textContent = "AI Agent 正在思考并落子中...";
       }
     }
@@ -476,6 +498,8 @@
     const prevMove = lastMove;
     board = snapshot.board || board;
     turn = snapshot.turn ?? turn;
+    playerSide = snapshot.playerSide ?? playerSide;
+    agentSide = snapshot.agentSide ?? agentSide;
     status = snapshot.status || status;
     lastMove = snapshot.lastMove || null;
 
@@ -492,6 +516,7 @@
     }
     initialized = true;
 
+    updateSideLabels();
     updateUI();
     drawBoard();
   }
@@ -510,9 +535,15 @@
       updateAgentInfo(data.payload);
     } else if (data.type === "AGENT_CHAT") {
       speechText.textContent = data.payload?.message || "";
+    } else if (data.type === "MOVE_REJECTED") {
+      statusText.textContent =
+        "⚠ 落子被拒绝：" + (data.payload?.error || "非法落子") + " 正在恢复服务器棋面...";
+      // The gomoku board applies an optimistic local update on click; ask the
+      // host for the authoritative state so the stone is removed again.
+      window.parent.postMessage({ type: "REQUEST_SYNC" }, "*");
     } else if (data.type === "AGENT_STALLED") {
       const isStalled = Boolean(data.payload?.stalled);
-      if (isStalled && turn === 2 && status === "playing") {
+      if (isStalled && turn === agentSide && status === "playing") {
         if (retryAgentBtn) retryAgentBtn.style.display = "inline-block";
         statusText.textContent = "AI 回复结束但未落子，请点击【重试】";
       } else {
@@ -654,7 +685,9 @@
     sCtx.font = "14px -apple-system, sans-serif";
     sCtx.fillStyle = "#e2e8f0";
     sCtx.textAlign = "right";
-    sCtx.fillText(`⚫ 玩家 (黑)  VS  ⚪ ${agentDisplay} (白)`, cardWidth - 40, 138);
+    const playerStone = playerSide === 1 ? "⚫" : "⚪";
+    const agentStone = agentSide === 1 ? "⚫" : "⚪";
+    sCtx.fillText(`${playerStone} 玩家 (${playerSide === 1 ? "黑" : "白"})  VS  ${agentStone} ${agentDisplay} (${agentSide === 1 ? "黑" : "白"})`, cardWidth - 40, 138);
     sCtx.textAlign = "left";
 
     // 4. Draw Chessboard

--- a/public/games/gomoku/index.html
+++ b/public/games/gomoku/index.html
@@ -12,8 +12,8 @@
     <header class="game-header">
       <div class="player-col left">
         <div class="player-badge">
-          <span class="stone-dot black"></span>
-          <span>你 (黑棋)</span>
+          <span id="player-side-dot" class="stone-dot black"></span>
+          <span id="player-side-label">你 (黑棋)</span>
         </div>
       </div>
       <div id="turn-badge" class="turn-indicator active-player">
@@ -24,8 +24,8 @@
           <div class="player-badge">
             <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
             <span id="agent-name-label">AI Agent</span>
-            <span class="side-tag">(白棋)</span>
-            <span class="stone-dot white"></span>
+            <span id="agent-side-label" class="side-tag">(白棋)</span>
+            <span id="agent-side-dot" class="stone-dot white"></span>
           </div>
         </div>
       </div>

--- a/public/games/xiangqi/game.js
+++ b/public/games/xiangqi/game.js
@@ -11,13 +11,17 @@
 
   // State
   let board = createInitialBoard();
-  let turn = 1; // 1: Player (Red), 2: Agent (Black)
+  let turn = 1; // 1: Red, 2: Black
+  let playerSide = 1;
+  let agentSide = 2;
   let status = "playing";
   let lastMove = null;
   let selectedCoord = null;
   let legalTargets = [];
   let hoverCoord = null;
   let initialized = false;
+  let playerWasInCheck = false;
+  let agentWasInCheck = false;
 
   // DOM Elements
   const canvas = document.getElementById("xiangqi-canvas");
@@ -33,6 +37,34 @@
   const agentNameLabel = document.getElementById("agent-name-label");
   const agentAvatarIcon = document.getElementById("agent-avatar-icon");
   const speechAvatar = document.getElementById("speech-avatar");
+  const playerBadge = document.getElementById("player-badge");
+  const agentBadge = document.getElementById("agent-badge");
+  const playerPieceIndicator = document.getElementById("player-piece-indicator");
+  const agentPieceIndicator = document.getElementById("agent-piece-indicator");
+  const playerSideLabel = document.getElementById("player-side-label");
+  const agentSideLabel = document.getElementById("agent-side-label");
+
+  function sideName(side) {
+    return side === 1 ? "红方" : "黑方";
+  }
+
+  function updateSideLabels() {
+    const playerIsRed = playerSide === 1;
+    if (playerBadge) playerBadge.className = `player-badge ${playerIsRed ? "red" : "black"}`;
+    if (agentBadge) agentBadge.className = `player-badge ${playerIsRed ? "black" : "red"}`;
+    if (playerPieceIndicator) {
+      playerPieceIndicator.className = `piece-indicator ${playerIsRed ? "red" : "black"}`;
+      playerPieceIndicator.textContent = playerIsRed ? "帥" : "將";
+    }
+    if (agentPieceIndicator) {
+      agentPieceIndicator.className = `piece-indicator ${playerIsRed ? "black" : "red"}`;
+      agentPieceIndicator.textContent = playerIsRed ? "將" : "帥";
+    }
+    if (playerSideLabel) playerSideLabel.textContent = `你 (${sideName(playerSide)})`;
+    if (agentSideLabel) agentSideLabel.textContent = `(${sideName(agentSide)})`;
+    if (playerCapturedContainer) playerCapturedContainer.title = `你吃掉的${sideName(agentSide).slice(0, 1)}子`;
+    if (agentCapturedContainer) agentCapturedContainer.title = `AI 吃掉的${sideName(playerSide).slice(0, 1)}子`;
+  }
 
   function updateAgentInfo(info) {
     if (!info) return;
@@ -73,30 +105,33 @@
       }
     }
 
-    // Player captured (Missing Black pieces)
+    const playerCapturedOrder = playerSide === 1 ? BLACK_ORDER : RED_ORDER;
+    const agentCapturedOrder = playerSide === 1 ? RED_ORDER : BLACK_ORDER;
+
+    // Pieces captured by the player (missing opponent pieces).
     playerCapturedContainer.innerHTML = "";
-    for (const p of BLACK_ORDER) {
-      const init = INITIAL_BLACK_COUNTS[p] || 0;
+    for (const p of playerCapturedOrder) {
+      const init = (p > 0 ? INITIAL_RED_COUNTS : INITIAL_BLACK_COUNTS)[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
       for (let i = 0; i < capturedCount; i++) {
         const badge = document.createElement("span");
-        badge.className = "mini-piece-badge black";
+        badge.className = `mini-piece-badge ${p > 0 ? "red" : "black"}`;
         badge.textContent = PIECE_NAMES[p] || "";
         badge.title = PIECE_NAMES[p] || "";
         playerCapturedContainer.appendChild(badge);
       }
     }
 
-    // Agent captured (Missing Red pieces)
+    // Pieces captured by the Agent (missing player pieces).
     agentCapturedContainer.innerHTML = "";
-    for (const p of RED_ORDER) {
-      const init = INITIAL_RED_COUNTS[p] || 0;
+    for (const p of agentCapturedOrder) {
+      const init = (p > 0 ? INITIAL_RED_COUNTS : INITIAL_BLACK_COUNTS)[p] || 0;
       const live = liveCounts[p] || 0;
       const capturedCount = init - live;
       for (let i = 0; i < capturedCount; i++) {
         const badge = document.createElement("span");
-        badge.className = "mini-piece-badge red";
+        badge.className = `mini-piece-badge ${p > 0 ? "red" : "black"}`;
         badge.textContent = PIECE_NAMES[p] || "";
         badge.title = PIECE_NAMES[p] || "";
         agentCapturedContainer.appendChild(badge);
@@ -651,66 +686,80 @@
     }
   }
 
-  // Client-side quick legal move calculator for instant response
-  function getClientLegalMoves(fromX, fromY) {
+  function isSameSide(pieceA, pieceB) {
+    return pieceA !== 0 && pieceB !== 0 && (pieceA > 0) === (pieceB > 0);
+  }
+
+  // Generate piece-rule moves for either side. King safety is filtered by
+  // getClientLegalMoves below so the instant UI matches the backend rules.
+  function getClientPseudoLegalMoves(fromX, fromY) {
     const piece = board[fromY][fromX];
-    if (piece <= 0) return []; // Red pieces only for player
+    if (piece === 0) return [];
+    const isRed = piece > 0;
     const absPiece = Math.abs(piece);
     const moves = [];
 
     const addIfValid = (tx, ty) => {
       if (tx < 0 || tx >= BOARD_COLS || ty < 0 || ty >= BOARD_ROWS) return;
-      if (board[ty][tx] > 0) return; // Cannot capture own red pieces
+      if (isSameSide(piece, board[ty][tx])) return;
       moves.push({ toX: tx, toY: ty });
     };
 
     switch (absPiece) {
-      case 1: { // 帥 King
+      case 1: { // 帥/將 King
+        const minY = isRed ? 0 : 7;
+        const maxY = isRed ? 2 : 9;
         const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
         for (const [dx, dy] of dirs) {
           const nx = fromX + dx;
           const ny = fromY + dy;
-          if (nx >= 3 && nx <= 5 && ny >= 0 && ny <= 2) {
+          if (nx >= 3 && nx <= 5 && ny >= minY && ny <= maxY) {
             addIfValid(nx, ny);
           }
         }
         // Flying general
-        let cy = fromY + 1;
-        while (cy < BOARD_ROWS) {
+        const stepY = isRed ? 1 : -1;
+        const opponentKing = isRed ? -1 : 1;
+        let cy = fromY + stepY;
+        while (cy >= 0 && cy < BOARD_ROWS) {
           const p = board[cy][fromX];
           if (p !== 0) {
-            if (p === -1) moves.push({ toX: fromX, toY: cy });
+            if (p === opponentKing) moves.push({ toX: fromX, toY: cy });
             break;
           }
-          cy++;
+          cy += stepY;
         }
         break;
       }
-      case 2: { // 仕 Advisor
+      case 2: { // 仕/士 Advisor
+        const minY = isRed ? 0 : 7;
+        const maxY = isRed ? 2 : 9;
         const dirs = [[1, 1], [1, -1], [-1, 1], [-1, -1]];
         for (const [dx, dy] of dirs) {
           const nx = fromX + dx;
           const ny = fromY + dy;
-          if (nx >= 3 && nx <= 5 && ny >= 0 && ny <= 2) {
+          if (nx >= 3 && nx <= 5 && ny >= minY && ny <= maxY) {
             addIfValid(nx, ny);
           }
         }
         break;
       }
-      case 3: { // 相 Bishop
+      case 3: { // 相/象 Bishop
+        const minY = isRed ? 0 : 5;
+        const maxY = isRed ? 4 : 9;
         const dirs = [[2, 2], [2, -2], [-2, 2], [-2, -2]];
         for (const [dx, dy] of dirs) {
           const nx = fromX + dx;
           const ny = fromY + dy;
           const ex = fromX + dx / 2;
           const ey = fromY + dy / 2;
-          if (nx >= 0 && nx < BOARD_COLS && ny >= 0 && ny <= 4) {
+          if (nx >= 0 && nx < BOARD_COLS && ny >= minY && ny <= maxY) {
             if (board[ey][ex] === 0) addIfValid(nx, ny);
           }
         }
         break;
       }
-      case 4: { // 傌 Knight
+      case 4: { // 傌/馬 Knight
         const km = [
           { dx: 1, dy: 2, lx: 0, ly: 1 }, { dx: -1, dy: 2, lx: 0, ly: 1 },
           { dx: 1, dy: -2, lx: 0, ly: -1 }, { dx: -1, dy: -2, lx: 0, ly: -1 },
@@ -726,7 +775,7 @@
         }
         break;
       }
-      case 5: { // 俥 Rook
+      case 5: { // 俥/車 Rook
         const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
         for (const [dx, dy] of dirs) {
           let nx = fromX + dx, ny = fromY + dy;
@@ -735,7 +784,7 @@
             if (t === 0) {
               moves.push({ toX: nx, toY: ny });
             } else {
-              if (t < 0) moves.push({ toX: nx, toY: ny });
+              if (!isSameSide(piece, t)) moves.push({ toX: nx, toY: ny });
               break;
             }
             nx += dx; ny += dy;
@@ -743,7 +792,7 @@
         }
         break;
       }
-      case 6: { // 炮 Cannon
+      case 6: { // 炮/砲 Cannon
         const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
         for (const [dx, dy] of dirs) {
           let nx = fromX + dx, ny = fromY + dy;
@@ -755,7 +804,7 @@
               else jumped = true;
             } else {
               if (t !== 0) {
-                if (t < 0) moves.push({ toX: nx, toY: ny });
+                if (!isSameSide(piece, t)) moves.push({ toX: nx, toY: ny });
                 break;
               }
             }
@@ -764,9 +813,10 @@
         }
         break;
       }
-      case 7: { // 兵 Pawn
-        addIfValid(fromX, fromY + 1);
-        if (fromY >= 5) {
+      case 7: { // 兵/卒 Pawn
+        addIfValid(fromX, fromY + (isRed ? 1 : -1));
+        const crossedRiver = isRed ? fromY >= 5 : fromY <= 4;
+        if (crossedRiver) {
           addIfValid(fromX - 1, fromY);
           addIfValid(fromX + 1, fromY);
         }
@@ -777,14 +827,83 @@
     return moves;
   }
 
+  function isClientKingInCheck(redSide) {
+    const kingPiece = redSide ? 1 : -1;
+    let king = null;
+    for (let y = 0; y < BOARD_ROWS && !king; y++) {
+      for (let x = 0; x < BOARD_COLS; x++) {
+        if (board[y][x] === kingPiece) {
+          king = { x, y };
+          break;
+        }
+      }
+    }
+    if (!king) return true;
+
+    for (let y = 0; y < BOARD_ROWS; y++) {
+      for (let x = 0; x < BOARD_COLS; x++) {
+        const piece = board[y][x];
+        if (piece === 0 || (piece > 0) === redSide) continue;
+        const attacks = getClientPseudoLegalMoves(x, y);
+        if (attacks.some((move) => move.toX === king.x && move.toY === king.y)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // Player-facing targets must also resolve check. Previously this returned
+  // pseudo-legal moves, so the UI offered moves that the backend rejected and
+  // the optimistically moved piece appeared to bounce back.
+  function getClientLegalMoves(fromX, fromY) {
+    const piece = board[fromY][fromX];
+    const playerIsRed = playerSide === 1;
+    if (piece === 0 || (piece > 0) !== playerIsRed) return [];
+
+    return getClientPseudoLegalMoves(fromX, fromY).filter((move) => {
+      const captured = board[move.toY][move.toX];
+      board[move.toY][move.toX] = piece;
+      board[fromY][fromX] = 0;
+      const safe = !isClientKingInCheck(playerIsRed);
+      board[fromY][fromX] = piece;
+      board[move.toY][move.toX] = captured;
+      return safe;
+    });
+  }
+
+  function getClientKingSafetyRejectedMoves(fromX, fromY, legalMoves) {
+    const legalKeys = new Set(
+      legalMoves.map((move) => `${move.toX},${move.toY}`)
+    );
+    return getClientPseudoLegalMoves(fromX, fromY).filter(
+      (move) => !legalKeys.has(`${move.toX},${move.toY}`)
+    );
+  }
+
+  function describeKingSafetyRejection(piece, fromY, rejectedMoves) {
+    if (rejectedMoves.length === 0) return "";
+    const kingName = playerSide === 1 ? "帅" : "将";
+    const isPawnSideways = Math.abs(piece) === 7
+      && rejectedMoves.some((move) => move.toY === fromY);
+    return isPawnSideways
+      ? `兵的横走会让己方${kingName}被将军，不能走。`
+      : `另有 ${rejectedMoves.length} 个着法会让己方${kingName}被将军，不能走。`;
+  }
+
   function handleCanvasClick(e) {
+    if (!initialized) {
+      statusText.textContent = "正在同步服务器棋面，请稍候...";
+      window.parent.postMessage({ type: "REQUEST_SYNC" }, "*");
+      return;
+    }
     if (status !== "playing") {
       statusText.textContent = "本局已结束，请点击下方【重新开局】。";
       return;
     }
 
-    if (turn !== 1) {
-      statusText.textContent = "当前轮到 AI Agent (黑方) 走子，请稍候...";
+    if (turn !== playerSide) {
+      statusText.textContent = `当前轮到 AI Agent (${sideName(agentSide)}) 走子，请稍候...`;
       return;
     }
 
@@ -794,11 +913,17 @@
     const { x, y } = coord;
     const clickedPiece = board[y][x];
 
-    // Case 1: Clicking own Red piece -> Select it
-    if (clickedPiece > 0) {
+    // Case 1: Clicking a piece controlled by the player -> select it.
+    if (clickedPiece !== 0 && (clickedPiece > 0) === (playerSide === 1)) {
       selectedCoord = { x, y };
       legalTargets = getClientLegalMoves(x, y);
-      statusText.textContent = `已选择【${PIECE_NAMES[clickedPiece]}】，点击绿色标记点移动。`;
+      const rejectedMoves = getClientKingSafetyRejectedMoves(x, y, legalTargets);
+      const rejectionHint = describeKingSafetyRejection(clickedPiece, y, rejectedMoves);
+      statusText.textContent = legalTargets.length > 0
+        ? `已选择【${PIECE_NAMES[clickedPiece]}】，点击绿色标记点移动。${rejectionHint ? ` ${rejectionHint}` : ""}`
+        : isClientKingInCheck(playerSide === 1)
+          ? `【${PIECE_NAMES[clickedPiece]}】当前没有能解除将军的合法着法。`
+          : rejectionHint || `【${PIECE_NAMES[clickedPiece]}】当前没有合法着法。`;
       playSelectSound();
       drawBoard();
       return;
@@ -812,13 +937,13 @@
         const fromY = selectedCoord.y;
         const actionId = moveToString(fromX, fromY, x, y);
         const movingPiece = board[fromY][fromX];
-        const isCapture = board[y][x] < 0;
+        const isCapture = board[y][x] !== 0 && (board[y][x] > 0) !== (movingPiece > 0);
 
         // Apply local optimistic update
         board[y][x] = movingPiece;
         board[fromY][fromX] = 0;
-        lastMove = { fromX, fromY, toX: x, toY: y, actionId, player: 1 };
-        turn = 2;
+        lastMove = { fromX, fromY, toX: x, toY: y, actionId, player: playerSide };
+        turn = agentSide;
         selectedCoord = null;
         legalTargets = [];
 
@@ -832,6 +957,16 @@
           payload: { actionId, fromX, fromY, toX: x, toY: y }
         }, "*");
       } else {
+        const pseudoTarget = getClientPseudoLegalMoves(
+          selectedCoord.x,
+          selectedCoord.y
+        ).some((move) => move.toX === x && move.toY === y);
+        if (pseudoTarget) {
+          const kingName = playerSide === 1 ? "帅" : "将";
+          statusText.textContent = `这步会让己方${kingName}被将军，不能走。`;
+          drawBoard();
+          return;
+        }
         selectedCoord = null;
         legalTargets = [];
         drawBoard();
@@ -840,6 +975,18 @@
   }
 
   function updateUI() {
+    const playerInCheck =
+      status === "playing" && turn === playerSide && isClientKingInCheck(playerSide === 1);
+    const agentInCheck =
+      status === "playing" && turn === agentSide && isClientKingInCheck(agentSide === 1);
+    statusText.className = "status-text";
+
+    if ((playerInCheck && !playerWasInCheck) || (agentInCheck && !agentWasInCheck)) {
+      playCheckSound();
+    }
+    playerWasInCheck = playerInCheck;
+    agentWasInCheck = agentInCheck;
+
     if (status === "player_won") {
       if (!gameOverSoundPlayed) {
         gameOverSoundPlayed = true;
@@ -877,15 +1024,29 @@
       restartBtn.className = "btn";
       restartBtn.textContent = "重新开局";
       resignBtn.style.display = "inline-block";
-      if (turn === 1) {
-        turnBadge.className = "turn-indicator active-player";
-        turnBadge.textContent = "轮到你行动 (红方)";
-        statusText.textContent = "点击己方棋子，再点击目标位置移动";
+      if (turn === playerSide) {
+        if (playerInCheck) {
+          turnBadge.className = "turn-indicator in-check";
+          turnBadge.textContent = "⚠️ 将军！请立即应将";
+          statusText.className = "status-text in-check";
+          statusText.textContent = `${playerSide === 1 ? "红帅" : "黑将"}正被攻击，只能选择能够解除将军的绿色目标点。`;
+        } else {
+          turnBadge.className = "turn-indicator active-player";
+          turnBadge.textContent = `轮到你行动 (${sideName(playerSide)})`;
+          statusText.textContent = "点击己方棋子，再点击目标位置移动";
+        }
         if (retryAgentBtn) retryAgentBtn.style.display = "none";
       } else {
-        turnBadge.className = "turn-indicator active-agent";
-        turnBadge.textContent = "Agent 正在思考中... (黑方)";
-        statusText.textContent = "AI Agent 正在思考走子方案...";
+        if (agentInCheck) {
+          turnBadge.className = "turn-indicator in-check";
+          turnBadge.textContent = "⚔️ 你已将军！等待 Agent 应将";
+          statusText.className = "status-text in-check";
+          statusText.textContent = `${agentSide === 1 ? "红帅" : "黑将"}正被攻击，Agent 本回合必须解除将军。`;
+        } else {
+          turnBadge.className = "turn-indicator active-agent";
+          turnBadge.textContent = `Agent 正在思考中... (${sideName(agentSide)})`;
+          statusText.textContent = "AI Agent 正在思考走子方案...";
+        }
       }
     }
 
@@ -897,6 +1058,8 @@
     const prevMove = lastMove;
     board = snapshot.board || board;
     turn = snapshot.turn ?? turn;
+    playerSide = snapshot.playerSide ?? playerSide;
+    agentSide = snapshot.agentSide ?? agentSide;
     status = snapshot.status || status;
     lastMove = snapshot.lastMove || null;
 
@@ -914,6 +1077,7 @@
 
     selectedCoord = null;
     legalTargets = [];
+    updateSideLabels();
     updateUI();
     drawBoard();
   }
@@ -932,9 +1096,15 @@
       updateAgentInfo(data.payload);
     } else if (data.type === "AGENT_CHAT") {
       speechText.textContent = data.payload?.message || "";
+    } else if (data.type === "MOVE_REJECTED") {
+      selectedCoord = null;
+      legalTargets = [];
+      statusText.textContent =
+        "⚠ 着法被拒绝：" + (data.payload?.error || "非法着法") + " 棋面已恢复为服务器状态。";
+      drawBoard();
     } else if (data.type === "AGENT_STALLED") {
       const isStalled = Boolean(data.payload?.stalled);
-      if (isStalled && turn === 2 && status === "playing") {
+      if (isStalled && turn === agentSide && status === "playing") {
         if (retryAgentBtn) retryAgentBtn.style.display = "inline-block";
         statusText.textContent = "AI 回复结束但未走子，请点击【重试】";
       } else {
@@ -1071,7 +1241,9 @@
     sCtx.font = "14px -apple-system, sans-serif";
     sCtx.fillStyle = "#e2e8f0";
     sCtx.textAlign = "right";
-    sCtx.fillText(`🔴 玩家 (红)  VS  ⚫ ${agentDisplay} (黑)`, cardWidth - 40, 138);
+    const playerDot = playerSide === 1 ? "🔴" : "⚫";
+    const agentDot = agentSide === 1 ? "🔴" : "⚫";
+    sCtx.fillText(`${playerDot} 玩家 (${playerSide === 1 ? "红" : "黑"})  VS  ${agentDot} ${agentDisplay} (${agentSide === 1 ? "红" : "黑"})`, cardWidth - 40, 138);
     sCtx.textAlign = "left";
 
     // 4. Draw Chessboard (9:10 ratio)

--- a/public/games/xiangqi/index.html
+++ b/public/games/xiangqi/index.html
@@ -11,9 +11,9 @@
     <!-- Header -->
     <header class="game-header">
       <div class="player-col left">
-        <div class="player-badge red">
-          <span class="piece-indicator red">帥</span>
-          <span>你 (红方)</span>
+        <div id="player-badge" class="player-badge red">
+          <span id="player-piece-indicator" class="piece-indicator red">帥</span>
+          <span id="player-side-label">你 (红方)</span>
         </div>
         <div id="player-captured" class="captured-tray" title="你吃掉的黑子"></div>
       </div>
@@ -22,11 +22,11 @@
       </div>
       <div class="header-right">
         <div class="player-col right">
-          <div class="player-badge black">
+          <div id="agent-badge" class="player-badge black">
             <span id="agent-avatar-icon" class="agent-avatar-mini">🤖</span>
             <span id="agent-name-label">AI Agent</span>
-            <span class="side-tag">(黑方)</span>
-            <span class="piece-indicator black">將</span>
+            <span id="agent-side-label" class="side-tag">(黑方)</span>
+            <span id="agent-piece-indicator" class="piece-indicator black">將</span>
           </div>
           <div id="agent-captured" class="captured-tray right" title="AI 吃掉的红子"></div>
         </div>

--- a/public/games/xiangqi/style.css
+++ b/public/games/xiangqi/style.css
@@ -218,6 +218,14 @@ body {
   box-shadow: 0 0 10px rgba(99, 102, 241, 0.3);
 }
 
+.turn-indicator.in-check {
+  background: rgba(239, 68, 68, 0.28);
+  color: #fecaca;
+  border: 1px solid #f87171;
+  box-shadow: 0 0 14px rgba(239, 68, 68, 0.55);
+  animation: check-alert-pulse 1s infinite ease-in-out;
+}
+
 /* Agent Dialogue Bubble */
 .agent-speech-banner {
   position: relative;
@@ -298,6 +306,11 @@ body {
   color: var(--text-muted);
 }
 
+.status-text.in-check {
+  color: #fca5a5;
+  font-weight: 700;
+}
+
 .btn-group {
   display: flex;
   gap: 8px;
@@ -373,6 +386,11 @@ body {
 @keyframes pulse-glow {
   0%, 100% { box-shadow: 0 0 4px rgba(245, 158, 11, 0.3); }
   50% { box-shadow: 0 0 12px rgba(245, 158, 11, 0.6); }
+}
+
+@keyframes check-alert-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.04); }
 }
 
 /* Share Modal */
@@ -478,4 +496,3 @@ body {
   from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
 }
-

--- a/public/web-preload.js
+++ b/public/web-preload.js
@@ -466,6 +466,7 @@
         });
       },
       resetGame: function (conversationId) { return invoke("game:resetGame", conversationId); },
+      playerResign: function (conversationId) { return invoke("game:playerResign", conversationId); },
       onGameEvent: function (cb) { return subscribe("freebuddy://game-event", cb); }
     },
 

--- a/public/web-preload.js
+++ b/public/web-preload.js
@@ -465,6 +465,13 @@
           mood: mood
         });
       },
+      sendChat: function (conversationId, message, mood) {
+        return invoke("game:sendChat", {
+          conversationId: conversationId,
+          message: message,
+          mood: mood
+        });
+      },
       resetGame: function (conversationId) { return invoke("game:resetGame", conversationId); },
       playerResign: function (conversationId) { return invoke("game:playerResign", conversationId); },
       onGameEvent: function (cb) { return subscribe("freebuddy://game-event", cb); }

--- a/src/components/Browser/BrowserCanvas.tsx
+++ b/src/components/Browser/BrowserCanvas.tsx
@@ -196,6 +196,73 @@ function extractAgentMoveFromText(text: string): {
   return null;
 }
 
+function buildHardModeCommentaryPrompt(
+  snapshot: any,
+  t: (key: string, options?: any) => string
+): string {
+  const isXiangqi = snapshot?.gameType === "xiangqi";
+  const history = snapshot?.moveHistory || [];
+  const agentMove = snapshot?.lastMove || (history.length > 0 ? history[history.length - 1] : null);
+  if (!agentMove) return "";
+
+  const prevMove = history.length >= 2 ? history[history.length - 2] : null;
+
+  const formatMove = (m: any) => {
+    if (!m) return "";
+    if (isXiangqi && m.chineseMove) {
+      return `${m.chineseMove} (${m.actionId})`;
+    }
+    return String(m.actionId || "");
+  };
+
+  const cleanReason = (rawReason?: string, moveStr?: string) => {
+    if (!rawReason) return "";
+    let r = rawReason.trim();
+    if (moveStr && r.startsWith(moveStr)) {
+      r = r.slice(moveStr.length).replace(/^[，,\s]+/, "").trim();
+    } else if (r.includes("，")) {
+      r = r.split("，").slice(1).join("，").trim();
+    } else if (r.includes(",")) {
+      r = r.split(",").slice(1).join(",").trim();
+    }
+    return r ? `（${r}）` : "";
+  };
+
+  const agentMoveLabel = formatMove(agentMove);
+  const playerMoveLabel = formatMove(prevMove);
+  const reasonText = isXiangqi
+    ? cleanReason(agentMove.reason, agentMove.chineseMove)
+    : "";
+
+  if (snapshot.status === "agent_won") {
+    return isXiangqi
+      ? t("game.hardModeWonAgentXiangqi", { agentMove: agentMoveLabel })
+      : t("game.hardModeWonAgentGomoku", { agentMove: agentMoveLabel });
+  }
+
+  if (prevMove) {
+    return isXiangqi
+      ? t("game.hardModeTurnCommentaryXiangqi", {
+          playerMove: playerMoveLabel,
+          agentMove: agentMoveLabel,
+          reason: reasonText
+        })
+      : t("game.hardModeTurnCommentaryGomoku", {
+          playerMove: playerMoveLabel,
+          agentMove: agentMoveLabel
+        });
+  }
+
+  return isXiangqi
+    ? t("game.hardModeOpeningCommentaryXiangqi", {
+        agentMove: agentMoveLabel,
+        reason: reasonText
+      })
+    : t("game.hardModeOpeningCommentaryGomoku", {
+        agentMove: agentMoveLabel
+      });
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
   return (
@@ -420,11 +487,13 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
     stepCount: number;
   } | null>(null);
   const autoRemindCountRef = useRef(0);
+  const lastEngineCommentedStepRef = useRef<number>(-1);
 
   useEffect(() => {
     pendingGameTurnPromptRef.current = null;
     autoRemindCountRef.current = 0;
     processedMessageIdsRef.current.clear();
+    lastEngineCommentedStepRef.current = -1;
   }, [activeId]);
 
   const activeConversation = useConversationStore((s) =>
@@ -581,12 +650,39 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
 
     window.addEventListener("message", handleMessage);
     const unbindGameEvent = window.freebuddy?.game?.onGameEvent((event: any) => {
-      if (event?.conversationId && event.conversationId !== activeId) return;
+      if (!activeId || (event?.conversationId && event.conversationId !== activeId)) return;
       if (frameRef.current?.contentWindow && event?.payload) {
         frameRef.current.contentWindow.postMessage(
           { type: "FREEBUDDY_GAME_SYNC", payload: event.payload },
           "*"
         );
+      }
+
+      // If an engine move was performed in hard mode, prompt the AI agent to give a commentary
+      const snapshot = event?.payload;
+      if (
+        snapshot &&
+        snapshot.lastMove &&
+        snapshot.lastMove.player === snapshot.agentSide &&
+        lastEngineCommentedStepRef.current !== snapshot.stepCount &&
+        sendMessage
+      ) {
+        lastEngineCommentedStepRef.current = snapshot.stepCount;
+        const promptText = buildHardModeCommentaryPrompt(snapshot, t);
+        if (!promptText) return;
+
+        if (useConversationStore.getState().isRunning(activeId)) {
+          pendingGameTurnPromptRef.current = {
+            conversationId: activeId,
+            prompt: promptText,
+            stepCount: Number(snapshot.stepCount ?? 0)
+          };
+        } else {
+          void sendMessage({
+            conversationId: activeId,
+            prompt: promptText
+          });
+        }
       }
     });
 
@@ -596,7 +692,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
     };
   }, [activeId, agentInfo, sendMessage, t]);
 
-  // Observe assistant messages in game conversations to extract moves even without native MCP tool calling
+  // Observe assistant messages in game conversations to extract moves or commentary
   useEffect(() => {
     if (!activeId || !messages.length) return;
     const lastMsg = messages[messages.length - 1];

--- a/src/components/Browser/BrowserCanvas.tsx
+++ b/src/components/Browser/BrowserCanvas.tsx
@@ -414,6 +414,18 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
 
   // Bridge game canvas iframe with FreeBuddy Game Service and Agent session
   const processedMessageIdsRef = useRef<Set<string>>(new Set());
+  const pendingGameTurnPromptRef = useRef<{
+    conversationId: string;
+    prompt: string;
+    stepCount: number;
+  } | null>(null);
+  const autoRemindCountRef = useRef(0);
+
+  useEffect(() => {
+    pendingGameTurnPromptRef.current = null;
+    autoRemindCountRef.current = 0;
+    processedMessageIdsRef.current.clear();
+  }, [activeId]);
 
   const activeConversation = useConversationStore((s) =>
     activeId ? s.conversations.find((c) => c.id === activeId) : undefined
@@ -453,18 +465,52 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
   useEffect(() => {
     const handleMessage = async (event: MessageEvent) => {
       const data = event.data;
-      if (!data || typeof data !== "object" || !activeId) return;
+      if (
+        !data ||
+        typeof data !== "object" ||
+        !activeId ||
+        event.source !== frameRef.current?.contentWindow
+      ) return;
 
       if (data.type === "PLAYER_MOVE" && data.payload?.actionId) {
         const actionId = String(data.payload.actionId);
         try {
           const moveRes = await window.freebuddy?.game?.playerMove(activeId, actionId);
+
+          // Engine rejected the move (e.g. it does not resolve a check).
+          // Tell the board so it can revert, and never prompt the agent for
+          // an illegal move.
+          if (moveRes && moveRes.ok === false) {
+            if (frameRef.current?.contentWindow) {
+              frameRef.current.contentWindow.postMessage(
+                {
+                  type: "MOVE_REJECTED",
+                  payload: { actionId, error: String(moveRes.error || "") }
+                },
+                "*"
+              );
+              try {
+                const state = await window.freebuddy?.game?.getState(activeId);
+                if (state && frameRef.current?.contentWindow) {
+                  frameRef.current.contentWindow.postMessage(
+                    { type: "FREEBUDDY_GAME_SYNC", payload: { ...state, agentInfo } },
+                    "*"
+                  );
+                }
+              } catch {
+                /* best effort */
+              }
+            }
+            return;
+          }
+
           const legalMoves = moveRes?.gameState?.legalMoves;
           const candidateList = legalMoves && legalMoves.length > 0
             ? legalMoves.slice(0, 12).map((m: any) => `${m.coord}(${m.description || ""})`).join(", ")
             : "H8, G7, I9, H9";
           const suggestedCoord = legalMoves?.[0]?.coord || "H8";
 
+          if (moveRes?.agentAutoPlayScheduled === true) return;
           if (sendMessage) {
             const isXiangqi = moveRes?.gameState?.gameType === "xiangqi";
             const isWon = moveRes?.gameState?.status === "player_won";
@@ -472,10 +518,21 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
               ? (isXiangqi ? t("game.playerMoveWonXiangqi", { actionId }) : t("game.playerMoveWonGomoku", { actionId }))
               : (isXiangqi ? t("game.playerMoveXiangqi", { actionId }) : t("game.playerMoveGomoku", { actionId }));
 
-            void sendMessage({
-              conversationId: activeId,
-              prompt: promptText
-            });
+            // The agent may still be streaming its reply for the previous
+            // move; sendMessage drops prompts while a run is active, so queue
+            // the turn prompt and flush it when generation ends.
+            if (useConversationStore.getState().isRunning(activeId)) {
+              pendingGameTurnPromptRef.current = {
+                conversationId: activeId,
+                prompt: promptText,
+                stepCount: Number(moveRes?.gameState?.stepCount ?? 0)
+              };
+            } else {
+              void sendMessage({
+                conversationId: activeId,
+                prompt: promptText
+              });
+            }
           }
         } catch (err) {
           console.error("[FreeBuddy] Failed to process player game move:", err);
@@ -494,8 +551,8 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
         }
       } else if (data.type === "GAME_RESET") {
         try {
-          await window.freebuddy?.game?.resetGame(activeId);
-          if (sendMessage) {
+          const resetRes = await window.freebuddy?.game?.resetGame(activeId);
+          if (sendMessage && resetRes?.agentAutoPlayScheduled !== true) {
             void sendMessage({
               conversationId: activeId,
               prompt: t("game.promptGameReset")
@@ -512,7 +569,8 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
           });
         }
       } else if (data.type === "GAME_RESIGN") {
-        if (sendMessage) {
+        const resignRes = await window.freebuddy?.game?.playerResign(activeId);
+        if (resignRes?.ok !== false && sendMessage) {
           void sendMessage({
             conversationId: activeId,
             prompt: t("game.promptResign")
@@ -536,7 +594,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
       window.removeEventListener("message", handleMessage);
       unbindGameEvent?.();
     };
-  }, [activeId, sendMessage]);
+  }, [activeId, agentInfo, sendMessage, t]);
 
   // Observe assistant messages in game conversations to extract moves even without native MCP tool calling
   useEffect(() => {
@@ -549,17 +607,45 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
         const moveKey = `${lastMsg.id}:${move.action}`;
         if (!processedMessageIdsRef.current.has(moveKey)) {
           processedMessageIdsRef.current.add(moveKey);
-          void window.freebuddy?.game?.agentMove(
-            activeId,
-            move.action,
-            move.thought,
-            move.speech,
-            move.mood
-          );
+          void (async () => {
+            const moveRes = await window.freebuddy?.game?.agentMove(
+              activeId,
+              move.action,
+              move.thought,
+              move.speech,
+              move.mood
+            );
+            if (moveRes?.ok !== false) return;
+
+            const state = await window.freebuddy?.game?.getState(activeId);
+            if (!state || state.status !== "playing" || state.turn !== state.agentSide) return;
+            if (frameRef.current?.contentWindow) {
+              frameRef.current.contentWindow.postMessage(
+                { type: "FREEBUDDY_GAME_SYNC", payload: { ...state, agentInfo } },
+                "*"
+              );
+            }
+            const prompt = t("game.promptAgentMoveRejected", {
+              actionId: move.action,
+              error: String(moveRes.error || "illegal move"),
+              step: state.stepCount
+            });
+            if (useConversationStore.getState().isRunning(activeId)) {
+              pendingGameTurnPromptRef.current = {
+                conversationId: activeId,
+                prompt,
+                stepCount: state.stepCount
+              };
+            } else if (sendMessage) {
+              void sendMessage({ conversationId: activeId, prompt });
+            }
+          })().catch((err) => {
+            console.error("[FreeBuddy] Failed to recover rejected Agent move:", err);
+          });
         }
       }
     }
-  }, [activeId, messages]);
+  }, [activeId, agentInfo, messages, sendMessage, t]);
 
   // Monitor for abnormal stalls (Agent finished generation but turn is still White/2)
   useEffect(() => {
@@ -569,16 +655,43 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
     const checkStall = async () => {
       try {
         const state = await window.freebuddy?.game?.getState(activeId);
-        if (state && state.status === "playing" && state.turn === 2 && !isRunning) {
-          timer = setTimeout(() => {
-            if (frameRef.current?.contentWindow) {
-              frameRef.current.contentWindow.postMessage(
-                { type: "AGENT_STALLED", payload: { stalled: true } },
-                "*"
-              );
-            }
-          }, 2500);
+        if (
+          state &&
+          state.status === "playing" &&
+          state.turn === state.agentSide
+        ) {
+          if (frameRef.current?.contentWindow) {
+            frameRef.current.contentWindow.postMessage(
+              { type: "AGENT_STALLED", payload: { stalled: false } },
+              "*"
+            );
+          }
+          if (!isRunning) {
+            timer = setTimeout(() => {
+              // Auto-send one remind carrying step facts so replayed history
+              // cannot convince the agent it is not its turn. The counter only
+              // resets when the turn actually leaves the agent (real
+              // progress) - resetting it during a run would loop reminders.
+              if (autoRemindCountRef.current < 1 && sendMessage) {
+                autoRemindCountRef.current += 1;
+                void sendMessage({
+                  conversationId: activeId,
+                  prompt: t("game.promptRemindAgentWithTurn", {
+                    step: state.stepCount
+                  })
+                });
+                return;
+              }
+              if (frameRef.current?.contentWindow) {
+                frameRef.current.contentWindow.postMessage(
+                  { type: "AGENT_STALLED", payload: { stalled: true } },
+                  "*"
+                );
+              }
+            }, 2500);
+          }
         } else {
+          autoRemindCountRef.current = 0;
           if (frameRef.current?.contentWindow) {
             frameRef.current.contentWindow.postMessage(
               { type: "AGENT_STALLED", payload: { stalled: false } },
@@ -596,7 +709,56 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
     return () => {
       if (timer) clearTimeout(timer);
     };
-  }, [activeId, isRunning, messages]);
+  }, [activeId, isRunning, messages, sendMessage, t]);
+
+  // Flush a queued game-turn prompt once the agent finishes generating. This
+  // covers the race where the player moves while the agent is still streaming
+  // its reply for the previous move (sendMessage silently drops prompts while
+  // a run is active).
+  useEffect(() => {
+    if (!activeId || isRunning) return;
+    const pending = pendingGameTurnPromptRef.current;
+    if (!pending || pending.conversationId !== activeId) return;
+    pendingGameTurnPromptRef.current = null;
+    void (async () => {
+      try {
+        const state = await window.freebuddy?.game?.getState(activeId);
+        if (
+          !state ||
+          state.status !== "playing" ||
+          state.turn !== state.agentSide ||
+          state.stepCount !== pending.stepCount
+        ) return;
+        if (!sendMessage) return;
+        void sendMessage({ conversationId: activeId, prompt: pending.prompt });
+      } catch (err) {
+        console.error("[FreeBuddy] Failed to flush queued game turn prompt:", err);
+      }
+    })();
+  }, [activeId, isRunning, messages.length, sendMessage]);
+
+  // RUN_END_RESYNC: converge the board with backend truth whenever a
+  // generation run finishes. Protects the iframe from any missed broadcast
+  // leaving it stuck on a stale turn indicator.
+  useEffect(() => {
+    if (!activeId || isRunning) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const state = await window.freebuddy?.game?.getState(activeId);
+        if (cancelled || !state || !frameRef.current?.contentWindow) return;
+        frameRef.current.contentWindow.postMessage(
+          { type: "FREEBUDDY_GAME_SYNC", payload: { ...state, agentInfo } },
+          "*"
+        );
+      } catch {
+        /* best effort */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeId, isRunning, agentInfo]);
 
   useEffect(() => {
     if (!nativeBrowserAvailable || !isNativeRemote || !entry?.manualEntry) {

--- a/src/components/Games/GameSetupModal.tsx
+++ b/src/components/Games/GameSetupModal.tsx
@@ -63,6 +63,7 @@ export function GameSetupModal({ open, onClose }: GameSetupModalProps) {
   const [selectedAgentId, setSelectedAgentId] = useState<string>("");
   const [selectedModel, setSelectedModel] = useState<string>("");
   const [selectedHand, setSelectedHand] = useState<"player_first" | "agent_first">("player_first");
+  const [selectedDifficulty, setSelectedDifficulty] = useState<"easy" | "hard">("easy");
   const [isLaunching, setIsLaunching] = useState(false);
 
   // Model probing states
@@ -203,7 +204,8 @@ export function GameSetupModal({ open, onClose }: GameSetupModalProps) {
           gameType: gamePath,
           opponentAgentId: selectedMember.id,
           opponentModel: selectedModel || undefined,
-          hand: selectedHand
+          hand: selectedHand,
+          gameDifficulty: selectedDifficulty
         },
         configOptionOverrides: configOverrides,
         skillIds: ["game-arena"]
@@ -216,30 +218,33 @@ export function GameSetupModal({ open, onClose }: GameSetupModalProps) {
       useDetailLayoutStore.getState().setActiveTab("preview");
       useDetailLayoutStore.getState().setDetailCollapsed(false);
 
-      // Send opening welcome prompt
-      if (selectedGame === "chinese_chess") {
-        if (selectedHand === "player_first") {
-          void convStore.sendMessage({
-            conversationId: conv.id,
-            prompt: t("game.promptXiangqiPlayerFirst")
-          });
+      // Hard-mode Agent-first games are opened by the local engine as soon as
+      // the board requests its initial state; avoid racing it with an LLM run.
+      if (!(selectedDifficulty === "hard" && selectedHand === "agent_first")) {
+        if (selectedGame === "chinese_chess") {
+          if (selectedHand === "player_first") {
+            void convStore.sendMessage({
+              conversationId: conv.id,
+              prompt: t("game.promptXiangqiPlayerFirst")
+            });
+          } else {
+            void convStore.sendMessage({
+              conversationId: conv.id,
+              prompt: t("game.promptXiangqiAgentFirst")
+            });
+          }
         } else {
-          void convStore.sendMessage({
-            conversationId: conv.id,
-            prompt: t("game.promptXiangqiAgentFirst")
-          });
-        }
-      } else {
-        if (selectedHand === "player_first") {
-          void convStore.sendMessage({
-            conversationId: conv.id,
-            prompt: t("game.promptGomokuPlayerFirst")
-          });
-        } else {
-          void convStore.sendMessage({
-            conversationId: conv.id,
-            prompt: t("game.promptGomokuAgentFirst")
-          });
+          if (selectedHand === "player_first") {
+            void convStore.sendMessage({
+              conversationId: conv.id,
+              prompt: t("game.promptGomokuPlayerFirst")
+            });
+          } else {
+            void convStore.sendMessage({
+              conversationId: conv.id,
+              prompt: t("game.promptGomokuAgentFirst")
+            });
+          }
         }
       }
 
@@ -375,6 +380,30 @@ export function GameSetupModal({ open, onClose }: GameSetupModalProps) {
                 </button>
               </div>
             </div>
+          </div>
+
+          {/* Difficulty */}
+          <div className="game-setup-field">
+            <span className="game-setup-field-label">{t("game.difficulty")}</span>
+            <div className="game-setup-choice-group two-cols">
+              <button
+                type="button"
+                className={selectedDifficulty === "easy" ? "active" : ""}
+                onClick={() => setSelectedDifficulty("easy")}
+              >
+                {t("game.difficultyEasy")}
+              </button>
+              <button
+                type="button"
+                className={selectedDifficulty === "hard" ? "active" : ""}
+                onClick={() => setSelectedDifficulty("hard")}
+              >
+                {t("game.difficultyHard")}
+              </button>
+            </div>
+            {selectedDifficulty === "hard" ? (
+              <p className="game-setup-dialog-desc">{t("game.difficultyHardHint")}</p>
+            ) : null}
           </div>
         </div>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1870,6 +1870,10 @@
     "aiOpponent": "AI Opponent",
     "gameModel": "Model",
     "turnOrder": "Turn Order",
+    "difficulty": "Difficulty",
+    "difficultyEasy": "Easy · AI free play",
+    "difficultyHard": "Hard · Engine boosted",
+    "difficultyHardHint": "In hard mode the local engine replies automatically for the AI, offering the strongest play",
     "gomoku": "Gomoku",
     "xiangqi": "Chinese Chess",
     "go": "Go",
@@ -1889,6 +1893,8 @@
     "playerMoveGomoku": "Player placed stone: {{actionId}}",
     "promptGameReset": "[Restart Game] I have reset the board. Ready for a new match!",
     "promptRemindAgent": "It is your turn. Please make your move.",
+    "promptRemindAgentWithTurn": "[System reminder - move {{step}} - your turn] Call game_get_state immediately to verify the board. Once confirmed it is your turn you MUST call game_make_move. Never ask the player to move for you or keep waiting.",
+    "promptAgentMoveRejected": "Your attempted move {{actionId}} was rejected by the rules engine ({{error}}). It is still your turn after move {{step}}. Call game_get_state again and choose another legal safe move with game_make_move.",
     "promptResign": "I resign. Well played!",
     "promptXiangqiPlayerFirst": "[Chinese Chess Match Start] I play Red and move first. You play Black. Prepare for battle!",
     "promptXiangqiAgentFirst": "[Chinese Chess Match Start] You play Red and move first. Please make your move!",
@@ -1896,4 +1902,3 @@
     "promptGomokuAgentFirst": "[Gomoku Match Start] You play Black and move first. Please place your stone!"
   }
 }
-

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1899,6 +1899,12 @@
     "promptXiangqiPlayerFirst": "[Chinese Chess Match Start] I play Red and move first. You play Black. Prepare for battle!",
     "promptXiangqiAgentFirst": "[Chinese Chess Match Start] You play Red and move first. Please make your move!",
     "promptGomokuPlayerFirst": "[Gomoku Match Start] I play Black and move first. You play White. Prepare for the game!",
-    "promptGomokuAgentFirst": "[Gomoku Match Start] You play Black and move first. Please place your stone!"
+    "promptGomokuAgentFirst": "[Gomoku Match Start] You play Black and move first. Please place your stone!",
+    "hardModeTurnCommentaryXiangqi": "I played \"{{playerMove}}\", and you replied with \"{{agentMove}}\"{{reason}}.\n\n(Note: Both moves are placed on the board, and it is my turn now. Please share your in-character tactical commentary or reaction in chat. If you want to say something in the board speech bubble, call the game_send_chat tool.)",
+    "hardModeTurnCommentaryGomoku": "I placed a stone at \"{{playerMove}}\", and you replied with \"{{agentMove}}\".\n\n(Note: Both stones are placed on the board, and it is my turn now. Please share your in-character reaction in chat. If you want to say something in the board speech bubble, call the game_send_chat tool.)",
+    "hardModeOpeningCommentaryXiangqi": "You opened the game with \"{{agentMove}}\"{{reason}}.\n\n(Note: Your opening move is placed on the board, and it is my turn now. Please share your opening thoughts in chat. If you want to say something in the board speech bubble, call the game_send_chat tool.)",
+    "hardModeOpeningCommentaryGomoku": "You opened the game at \"{{agentMove}}\".\n\n(Note: Your opening move is placed on the board, and it is my turn now. Please share your opening thoughts in chat. If you want to say something in the board speech bubble, call the game_send_chat tool.)",
+    "hardModeWonAgentXiangqi": "You played \"{{agentMove}}\", checkmate win! You won this match - please share your victory thoughts in chat!",
+    "hardModeWonAgentGomoku": "You placed at \"{{agentMove}}\", five-in-a-row win! You won this match - please share your victory thoughts in chat!"
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1855,6 +1855,10 @@
     "aiOpponent": "AI 对手",
     "gameModel": "对弈模型",
     "turnOrder": "先后手",
+    "difficulty": "难度",
+    "difficultyEasy": "简单 · AI 自由对弈",
+    "difficultyHard": "困难 · 引擎加持",
+    "difficultyHardHint": "困难模式下，本地引擎将代替 AI 自动应答落子，棋力最强",
     "gomoku": "五子棋",
     "xiangqi": "中国象棋",
     "go": "围棋",
@@ -1874,6 +1878,8 @@
     "playerMoveGomoku": "玩家落子：{{actionId}}",
     "promptGameReset": "【重新开局】我已重置了棋盘，准备开始新一局！",
     "promptRemindAgent": "轮到你行动，请尽快出招。",
+    "promptRemindAgentWithTurn": "【系统催促·第 {{step}} 手·轮到你】请立即调用 game_get_state 核实当前局面；确认轮到你之后必须调用 game_make_move 落子。不要以任何理由让玩家代走或继续等待。",
+    "promptAgentMoveRejected": "你刚才尝试的走法 {{actionId}} 被规则引擎拒绝（{{error}}）。当前仍是第 {{step}} 手后的你的回合。请重新调用 game_get_state，并选择另一个合法安全着法调用 game_make_move。",
     "promptResign": "我认输了，这一局你下得漂亮！",
     "promptXiangqiPlayerFirst": "【中国象棋对局开始】我执红先行，你执黑后手。准备迎战！",
     "promptXiangqiAgentFirst": "【中国象棋对局开始】本局你执红先行，请出招！",
@@ -1881,4 +1887,3 @@
     "promptGomokuAgentFirst": "【五子棋对局开始】本局你执黑先行，请落子！"
   }
 }
-

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1884,6 +1884,12 @@
     "promptXiangqiPlayerFirst": "【中国象棋对局开始】我执红先行，你执黑后手。准备迎战！",
     "promptXiangqiAgentFirst": "【中国象棋对局开始】本局你执红先行，请出招！",
     "promptGomokuPlayerFirst": "【五子棋对局开始】我执黑先行，你执白后手。准备接招！",
-    "promptGomokuAgentFirst": "【五子棋对局开始】本局你执黑先行，请落子！"
+    "promptGomokuAgentFirst": "【五子棋对局开始】本局你执黑先行，请落子！",
+    "hardModeTurnCommentaryXiangqi": "我走了「{{playerMove}}」，你应了一步「{{agentMove}}」{{reason}}。\n\n（提示：棋盘上双方已完成落子，现轮到我走棋。请针对刚才的交手在聊天中进行生动点评或心理战；若想在棋盘气泡中向我喊话，请调用 game_send_chat 工具。）",
+    "hardModeTurnCommentaryGomoku": "我落子在「{{playerMove}}」，你应了一步「{{agentMove}}」。\n\n（提示：棋盘上双方已完成落子，现轮到我行动。请在聊天中进行生动点评或心理战；若想在棋盘气泡中向我喊话，请调用 game_send_chat 工具。）",
+    "hardModeOpeningCommentaryXiangqi": "你开局走了「{{agentMove}}」{{reason}}。\n\n（提示：棋盘上你已完成开局落子，现轮到我走棋。请在聊天中简述你的开局意图或发起互动；若想在棋盘气泡中向我喊话，请调用 game_send_chat 工具。）",
+    "hardModeOpeningCommentaryGomoku": "你开局落子在「{{agentMove}}」。\n\n（提示：棋盘上你已完成开局落子，现轮到我行动。请在聊天中发起互动；若想在棋盘气泡中向我喊话，请调用 game_send_chat 工具。）",
+    "hardModeWonAgentXiangqi": "你走了「{{agentMove}}」，绝杀获胜！本局你赢了，请在聊天中发表胜利感言！",
+    "hardModeWonAgentGomoku": "你落子在「{{agentMove}}」，五连珠获胜！本局你赢了，请在聊天中发表胜利感言！"
   }
 }

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -917,6 +917,11 @@ declare global {
       speech?: string,
       mood?: string
     ): Promise<any>;
+    sendChat(
+      conversationId: string,
+      message: string,
+      mood?: string
+    ): Promise<any>;
     resetGame(conversationId: string): Promise<any>;
     playerResign(conversationId: string): Promise<any>;
     onGameEvent(cb: (event: any) => void): () => void;

--- a/src/types/freebuddy.d.ts
+++ b/src/types/freebuddy.d.ts
@@ -918,6 +918,7 @@ declare global {
       mood?: string
     ): Promise<any>;
     resetGame(conversationId: string): Promise<any>;
+    playerResign(conversationId: string): Promise<any>;
     onGameEvent(cb: (event: any) => void): () => void;
   }
 

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -460,6 +460,9 @@ test("isDefaultDshAcpBinary treats npm-global shims as the stock demo", () => {
 
 test("buildCommand puts koffi --import on argv on Windows when the composition uses the native sandbox", () => {
   const { root, binJs } = writeManagedDshRuntime();
+  const sandbox = path.join(root, "node_modules", "@deepseek-ai", "dsh-sandbox-local");
+  fs.mkdirSync(sandbox, { recursive: true });
+  fs.writeFileSync(path.join(sandbox, "package.json"), "{}");
   // The managed cordis.yml must mount the native sandbox for the guard to apply.
   fs.writeFileSync(
     path.join(root, "cordis.yml"),

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { getAdapterDefinition, getCliCheckProbe, applyDshAcpNpmInstallEnv, dshAcpWindowsResiduePath, dshAcpInstallCommand, parseDshAcpCompositionPackages, bundledDshAcpConfigPath, dshAcpCompositionReady, dshAcpManagedDemoBin, resolveDshAcpDemoDirFromBinary, quoteForShell, resolveDshAcpDemoBinJs } from "../dist-electron/cli/adapters.js";
+import { getAdapterDefinition, getCliCheckProbe, applyDshAcpNpmInstallEnv, dshAcpWindowsResiduePath, dshAcpInstallCommand, parseDshAcpCompositionPackages, bundledDshAcpConfigPath, dshAcpCompositionReady, dshAcpManagedDemoBin, resolveDshAcpDemoDirFromBinary, quoteForShell, resolveDshAcpDemoBinJs, cleanupLegacyDshAcpManagedFiles } from "../dist-electron/cli/adapters.js";
 
 test("Codex ACP checks the new Agent Client Protocol package version", () => {
   assert.deepEqual(getCliCheckProbe("codex-acp"), {
@@ -176,4 +176,59 @@ test("resolveDshAcpDemoBinJs defaults to standalone binary instead of picking up
   });
   assert.equal(standalone, undefined);
 });
+
+test("cleanupLegacyDshAcpManagedFiles removes legacy granular package.json and lockfile", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-legacy-cleanup-"));
+  const legacyPkg = {
+    dependencies: {
+      "@deepseek-ai/dsh-acp-demo": "^0.1.0-rc.6",
+      "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.6"
+    }
+  };
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(legacyPkg));
+  fs.writeFileSync(path.join(root, "package-lock.json"), "{}");
+
+  cleanupLegacyDshAcpManagedFiles(root);
+  assert.equal(fs.existsSync(path.join(root, "package.json")), false);
+  assert.equal(fs.existsSync(path.join(root, "package-lock.json")), false);
+
+  const cleanPkg = {
+    dependencies: {
+      "deepseek-harness-acp": "^0.1.16"
+    }
+  };
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(cleanPkg));
+  cleanupLegacyDshAcpManagedFiles(root);
+  assert.equal(fs.existsSync(path.join(root, "package.json")), true);
+});
+
+test("dshAcpCompositionReady validates required plugins in cordis.yml", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dsh-ready-cfg-"));
+  const standalone = path.join(root, "node_modules", "deepseek-harness-acp");
+  fs.mkdirSync(path.join(standalone, "lib"), { recursive: true });
+  fs.writeFileSync(path.join(standalone, "package.json"), "{}");
+  const bin = path.join(standalone, "lib", "bin.js");
+  fs.writeFileSync(bin, "");
+
+  const probe = path.join(root, "node_modules", "@deepseek-ai", "dsh-llm-deepseek");
+  fs.mkdirSync(probe, { recursive: true });
+  fs.writeFileSync(path.join(probe, "package.json"), "{}");
+
+  const cordisYaml = path.join(root, "cordis.yml");
+  fs.writeFileSync(
+    cordisYaml,
+    "- name: '@deepseek-ai/dsh-llm-deepseek'\n- name: '@deepseek-ai/dsh-attachment-local'\n"
+  );
+
+  // Missing attachment-local
+  assert.equal(dshAcpCompositionReady(bin, cordisYaml), false);
+
+  // Add attachment-local
+  const attachment = path.join(root, "node_modules", "@deepseek-ai", "dsh-attachment-local");
+  fs.mkdirSync(attachment, { recursive: true });
+  fs.writeFileSync(path.join(attachment, "package.json"), "{}");
+
+  assert.equal(dshAcpCompositionReady(bin, cordisYaml), true);
+});
+
 

--- a/tests/conversation-isolation-wiring.test.mjs
+++ b/tests/conversation-isolation-wiring.test.mjs
@@ -99,7 +99,8 @@ test("game IPC handlers enforce conversation ownership", () => {
     "game:getState",
     "game:playerMove",
     "game:agentMove",
-    "game:resetGame"
+    "game:resetGame",
+    "game:playerResign"
   ]) {
     const start = main.indexOf(`"${channel}"`);
     assert.ok(start > 0, `${channel} is registered`);

--- a/tests/debug-log-day-filter.test.mjs
+++ b/tests/debug-log-day-filter.test.mjs
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  collapseAcpHistoryReplayLines,
   filterJsonlLinesByTimestamp,
+  groupSessionLogEntries,
   localDayRange
 } from "../dist-electron/shared/debugLogExportCore.js";
 
@@ -39,4 +41,59 @@ test("localDayRange spans from local midnight to the next local midnight", () =>
     [end.getFullYear(), end.getMonth(), end.getDate(), end.getHours()],
     [2026, 7, 20, 0]
   );
+});
+
+test("session logs are grouped by resumable ACP session and kept chronological", () => {
+  const entries = [
+    { taskId: "turn-1", name: "turn-1.jsonl", mtimeMs: 10 },
+    { taskId: "turn-2", name: "turn-2.jsonl", mtimeMs: 30 },
+    { taskId: "standalone", name: "standalone.jsonl", mtimeMs: 20 },
+    { taskId: "old", name: "old.jsonl", mtimeMs: 5 }
+  ];
+  const groups = groupSessionLogEntries(
+    entries,
+    new Map([
+      ["turn-1", "game-session"],
+      ["turn-2", "game-session"]
+    ]),
+    2
+  );
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      id: group.logicalSessionId,
+      tasks: group.entries.map((entry) => entry.taskId)
+    })),
+    [
+      { id: "game-session", tasks: ["turn-1", "turn-2"] },
+      { id: "standalone", tasks: ["standalone"] }
+    ]
+  );
+});
+
+test("ACP history replay is collapsed without dropping live or malformed lines", () => {
+  const acpLine = (meta, ts) => JSON.stringify({
+    ts,
+    type: "stdout",
+    content: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { update: { _meta: meta } }
+    })
+  });
+  const start = acpLine({
+    "codebuddy.ai/historyReplay": "start",
+    "codebuddy.ai/historyReplayTotalItems": 12
+  }, "2026-08-24T01:00:00.000Z");
+  const history = acpLine({ "codebuddy.ai": { mode: "history" } }, "2026-08-24T01:00:00.001Z");
+  const end = acpLine({ "codebuddy.ai/historyReplay": "end" }, "2026-08-24T01:00:00.002Z");
+  const live = acpLine({ "codebuddy.ai": { mode: "live" } }, "2026-08-24T01:00:01.000Z");
+
+  const result = collapseAcpHistoryReplayLines(["not-json", start, history, end, live]);
+
+  assert.equal(result.length, 3);
+  assert.equal(result[0], "not-json");
+  assert.match(result[1], /omitted 3 ACP history replay log lines/);
+  assert.match(result[1], /adapter reported 12 replay items/);
+  assert.equal(result[2], live);
 });

--- a/tests/debug-log-export.test.mjs
+++ b/tests/debug-log-export.test.mjs
@@ -65,13 +65,16 @@ test("app logs are limited to the local export day without changing session scop
   assert.match(exporter, /readSessionLogFiles\(mode, masks, conversationId\)/);
 });
 
-test("conversation-scoped export filters sessions by conversation_messages.task_id", () => {
-  assert.match(exporter, /function sessionIdsForConversation/);
+test("conversation-scoped export filters task logs and merges their resumable session", () => {
+  assert.match(exporter, /function sessionsForConversation/);
   assert.match(
     exporter,
-    /SELECT DISTINCT task_id FROM conversation_messages WHERE conversation_id = \? AND task_id IS NOT NULL/
+    /SELECT DISTINCT m\.task_id, t\.tool_session_id/
   );
-  assert.match(exporter, /allowed\.has\(n\.replace\(\/\\\.jsonl\$\/, ""\)\)/);
+  assert.match(exporter, /LEFT JOIN cli_tasks t ON t\.id = m\.task_id/);
+  assert.match(exporter, /selection\.taskIds\.has\(n\.replace\(\/\\\.jsonl\$\/, ""\)\)/);
+  assert.match(exporter, /groupSessionLogEntries/);
+  assert.match(exporter, /collapseAcpHistoryReplayLines/);
   assert.match(exporter, /exportScope: scope/);
   // IPC + preload thread the optional conversationId through to the exporter.
   assert.match(ipc, /"debugLogs:preview", \(_event, mode: unknown, conversationId: unknown\)/);

--- a/tests/game-ai-strength.test.mjs
+++ b/tests/game-ai-strength.test.mjs
@@ -231,6 +231,27 @@ test("xiangqi search returns a legal move with a factual reason", () => {
   assert.match(best.reason, /[进平退]/);
 });
 
+test("xiangqi quiescence search avoids sacrificing Rook for defended Pawn", () => {
+  // Red Rook at e3, defended Black Pawn at e6 defended by Black Cannon at e7
+  const board = Array.from({ length: 10 }, () => Array(9).fill(0));
+  board[0][4] = 1;   // Red King e0
+  board[9][4] = -1;  // Black King e9
+  board[2][4] = 5;   // Red Rook e2
+  board[6][4] = -7;  // Black Pawn e6
+  board[7][4] = -6;  // Black Cannon e7 (defends e6)
+
+  // Red to move: Taking e6 with Rook (e2e6) wins a pawn but loses the Rook to cannon (e7e6).
+  // With Q-search, Red should NOT play e2e6 (Rook takes Pawn).
+  const best = findBestXiangqiMove(board, 1, {
+    maxDepth: 2,
+    timeBudgetMs: 400
+  });
+
+  assert.ok(best);
+  assert.notEqual(best.actionId, "e2e6", "Rook should not sacrifice itself for a defended pawn");
+});
+
+
 test("hard difficulty triggers automatic engine reply after player move", async () => {
   const conversationId = `conv-hard-${Date.now()}`;
   initGamePersistence(

--- a/tests/game-ai-strength.test.mjs
+++ b/tests/game-ai-strength.test.mjs
@@ -1,0 +1,508 @@
+import fs from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BOARD_SIZE,
+  GomokuGameInstance,
+  PLAYER_BLACK,
+  PLAYER_WHITE,
+  createEmptyBoard
+} from "../dist-electron/games/gomokuEngine.js";
+import {
+  XiangqiGameInstance,
+  createInitialBoard
+} from "../dist-electron/games/xiangqiEngine.js";
+import {
+  evaluateBoard,
+  findBestMove,
+  patternScore,
+  pointScore
+} from "../dist-electron/games/gomokuSearch.js";
+import { findBestXiangqiMove } from "../dist-electron/games/xiangqiSearch.js";
+import {
+  renderGomokuBoardAscii,
+  renderXiangqiBoardAscii,
+  formatGameStateText
+} from "../dist-electron/games/boardDisplay.js";
+import {
+  ENGINE_AUTO_MOVE_DELAY_MS,
+  handleGetGameState,
+  handlePlayerMove,
+  handlePlayerResign,
+  getOrCreateGame,
+  initGamePersistence,
+  dispatchGameAction
+} from "../dist-electron/gameToolService.js";
+
+const SEARCH_OPTS = { maxDepth: 4, timeBudgetMs: 400 };
+
+function emptyGomokuBoard() {
+  return createEmptyBoard();
+}
+
+function placeStones(board, player, cells) {
+  for (const [x, y] of cells) {
+    board[y][x] = player;
+  }
+  return board;
+}
+
+test("gomoku search finds immediate winning move", () => {
+  // White has four in a row D8-G8; completing at C8 or H8 wins instantly
+  const board = placeStones(emptyGomokuBoard(), PLAYER_WHITE, [
+    [3, 7],
+    [4, 7],
+    [5, 7],
+    [6, 7]
+  ]);
+
+  const best = findBestMove(board, PLAYER_WHITE, SEARCH_OPTS);
+
+  assert.ok(best, "engine should return a move");
+  assert.ok(["C8", "H8"].includes(best.actionId), `expected winning move C8/H8, got ${best.actionId}`);
+});
+
+test("gomoku search blocks opponent's four-in-a-row", () => {
+  // Black has four in a row D8-G8; white must block C8 or H8
+  const board = placeStones(emptyGomokuBoard(), PLAYER_BLACK, [
+    [3, 7],
+    [4, 7],
+    [5, 7],
+    [6, 7]
+  ]);
+
+  const best = findBestMove(board, PLAYER_WHITE, SEARCH_OPTS);
+
+  assert.ok(best, "engine should return a move");
+  assert.ok(
+    ["C8", "H8"].includes(best.actionId),
+    `expected blocking move C8/H8, got ${best.actionId}`
+  );
+});
+
+test("gomoku search opens with center point on empty board", () => {
+  const best = findBestMove(emptyGomokuBoard(), PLAYER_BLACK, SEARCH_OPTS);
+
+  assert.equal(best.actionId, "H8");
+});
+
+test("gomoku search never returns an occupied cell", () => {
+  const board = placeStones(emptyGomokuBoard(), PLAYER_WHITE, [
+    [3, 7],
+    [4, 7],
+    [5, 7],
+    [6, 7]
+  ]);
+  board[7][2] = PLAYER_BLACK;
+
+  const best = findBestMove(board, PLAYER_WHITE, SEARCH_OPTS);
+
+  assert.equal(best.actionId, "H8", "only remaining completion is H8");
+  assert.equal(board[best.y][best.x], 0);
+});
+
+test("gomoku evaluator scores a two-ended live three as live, not sleeping", () => {
+  const board = placeStones(emptyGomokuBoard(), PLAYER_BLACK, [
+    [5, 7],
+    [6, 7],
+    [7, 7]
+  ]);
+
+  assert.ok(
+    evaluateBoard(board, PLAYER_BLACK) >= patternScore(3, 2),
+    "a row with both endpoints open must receive at least the live-three score"
+  );
+});
+
+test("gomoku point evaluator recognizes a one-gap winning shape", () => {
+  const board = placeStones(emptyGomokuBoard(), PLAYER_BLACK, [
+    [6, 7],
+    [8, 7],
+    [9, 7]
+  ]);
+
+  assert.ok(
+    pointScore(board, 5, 7, PLAYER_BLACK) > 1_000_000,
+    "placing at F8 creates XX_XX and must see the chain beyond the empty gap"
+  );
+});
+
+test("renderGomokuBoardAscii produces coordinate-framed grid", () => {
+  const board = placeStones(emptyGomokuBoard(), PLAYER_BLACK, [[7, 7]]);
+
+  const ascii = renderGomokuBoardAscii(board);
+  const lines = ascii.split("\n");
+
+  assert.equal(lines.length, BOARD_SIZE + 1, "header plus 15 rows");
+  assert.match(lines[0], /A B C.*O$/);
+  assert.match(lines[1], /^15\b/);
+  assert.match(lines[15], /^ 1\b/);
+  // Center stone rendered as X on row 8 (index 8 => line 15-8+1 = 8th row line)
+  assert.match(lines[8], /\bX\b/);
+});
+
+test("renderXiangqiBoardAscii renders red uppercase and black lowercase pieces", () => {
+  const ascii = renderXiangqiBoardAscii(createInitialBoard());
+  const lines = ascii.split("\n");
+
+  assert.equal(lines.length, 11, "header plus 10 ranks");
+  assert.match(lines[0], /a b c d e f g h i$/);
+  assert.match(lines[1], /\br n b a k a b n r\b/);
+  assert.match(lines[10], /\bR N B A K A B N R\b/);
+});
+
+test("formatGameStateText embeds board, turn info and candidate moves", () => {
+  const inst = new GomokuGameInstance("conv-format-test");
+  inst.applyMove("H8", PLAYER_BLACK);
+  inst.applyMove("I9", PLAYER_WHITE);
+  const snapshot = inst.getSnapshot();
+
+  const text = formatGameStateText(snapshot);
+
+  assert.match(text, /五子棋/);
+  assert.match(text, /轮到/);
+  assert.match(text, /A B C/, "should embed ascii board");
+  assert.match(text, /候选走法/, "should list candidate moves");
+  assert.match(text, /I9/, "last move should be mentioned");
+});
+
+test("formatGameStateText warns about opponent five-threat", () => {
+  const inst = new GomokuGameInstance("conv-threat-test");
+  placeStones(inst.board, PLAYER_BLACK, [
+    [3, 7],
+    [4, 7],
+    [5, 7],
+    [6, 7]
+  ]);
+  inst.turn = PLAYER_WHITE;
+  const snapshot = inst.getSnapshot();
+
+  const text = formatGameStateText(snapshot);
+
+  assert.match(text, /威胁/);
+  assert.match(text, /C8|H8/, "threat note should name blocking points");
+});
+
+test("formatGameStateText works for xiangqi snapshots", () => {
+  const inst = new XiangqiGameInstance("conv-xiangqi-format");
+  const snapshot = inst.getSnapshot();
+
+  const text = formatGameStateText(snapshot);
+
+  assert.match(text, /象棋/);
+  assert.match(text, /a b c d e f g h i/);
+  assert.match(text, /候选走法/);
+});
+
+test("formatted state identifies actors correctly when the Agent has the opening side", () => {
+  const gomoku = new GomokuGameInstance("agent-first-format", PLAYER_WHITE);
+  const text = formatGameStateText(gomoku.getSnapshot());
+
+  assert.match(text, /轮到 AI 执黑/);
+  assert.match(text, /X=黑棋\(AI\)/);
+  assert.match(text, /O=白棋\(玩家\)/);
+});
+
+test("terminal state text does not claim another side is to move", () => {
+  const inst = new XiangqiGameInstance("conv-xiangqi-terminal");
+  inst.status = "player_won";
+  inst.winner = 1;
+
+  const text = formatGameStateText(inst.getSnapshot());
+
+  assert.match(text, /玩家获胜/);
+  assert.doesNotMatch(text, /轮到/);
+});
+
+test("xiangqi search returns a legal move with a factual reason", () => {
+  const inst = new XiangqiGameInstance("xiangqi-search");
+  inst.applyMove("b2e2", 1);
+
+  const best = findBestXiangqiMove(inst.board, 2, {
+    maxDepth: 2,
+    timeBudgetMs: 300,
+    positionHistory: inst.positionHistory,
+    recentMoves: inst.moveHistory
+  });
+
+  assert.ok(best);
+  assert.ok(inst.getSnapshot().legalMoves.some((move) => move.actionId === best.actionId));
+  assert.match(best.reason, /[进平退]/);
+});
+
+test("hard difficulty triggers automatic engine reply after player move", async () => {
+  const conversationId = `conv-hard-${Date.now()}`;
+  initGamePersistence(
+    (id) => ({ metadata: { gameType: "gomoku", gameDifficulty: "hard" } }),
+    () => {}
+  );
+
+  const res = handlePlayerMove(conversationId, "H8");
+  assert.equal(res.ok, true);
+  assert.equal(res.agentAutoPlayScheduled, true, "hard mode should flag auto reply");
+
+  await new Promise((resolve) => setTimeout(resolve, ENGINE_AUTO_MOVE_DELAY_MS + 1_100));
+
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  const whiteStones = state.board.flat().filter((v) => v === PLAYER_WHITE).length;
+  assert.equal(whiteStones, 1, "engine should have replied with one white stone");
+  assert.equal(state.turn, PLAYER_BLACK);
+});
+
+test("hard difficulty also triggers Xiangqi engine reply", async () => {
+  const conversationId = `conv-hard-xiangqi-${Date.now()}`;
+  initGamePersistence(
+    () => ({ metadata: { gameType: "xiangqi", gameDifficulty: "hard" } }),
+    () => {}
+  );
+
+  const res = handlePlayerMove(conversationId, "b2e2");
+  assert.equal(res.ok, true);
+  assert.equal(res.agentAutoPlayScheduled, true);
+
+  await new Promise((resolve) => setTimeout(resolve, ENGINE_AUTO_MOVE_DELAY_MS + 950));
+
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  assert.equal(state.stepCount, 2, "the Xiangqi engine should have replied once");
+  assert.equal(state.turn, 1);
+});
+
+test("easy difficulty does not schedule automatic engine reply", async () => {
+  const conversationId = `conv-easy-${Date.now()}`;
+  initGamePersistence(
+    (id) => ({ metadata: { gameType: "gomoku", gameDifficulty: "easy" } }),
+    () => {}
+  );
+
+  const res = handlePlayerMove(conversationId, "H8");
+  assert.equal(res.ok, true);
+  assert.equal(res.agentAutoPlayScheduled, false, "easy mode must not auto reply");
+
+  await new Promise((resolve) => setTimeout(resolve, ENGINE_AUTO_MOVE_DELAY_MS + 500));
+
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  const whiteStones = state.board.flat().filter((v) => v === PLAYER_WHITE).length;
+  assert.equal(whiteStones, 0, "no white stone should appear in easy mode");
+  assert.equal(state.turn, PLAYER_WHITE);
+});
+
+test("player move handler rejects a second move while it is still the Agent turn", () => {
+  const conversationId = `conv-turn-guard-${Date.now()}`;
+  initGamePersistence(
+    () => ({ metadata: { gameType: "gomoku", gameDifficulty: "easy" } }),
+    () => {}
+  );
+
+  assert.equal(handlePlayerMove(conversationId, "H8").ok, true);
+  const second = handlePlayerMove(conversationId, "H9");
+  assert.equal(second.ok, false);
+
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  assert.equal(state.stepCount, 1);
+  assert.equal(state.board.flat().filter((value) => value === PLAYER_BLACK).length, 1);
+});
+
+test("Agent-first assigns the opening side to the Agent in both games", async () => {
+  const metadata = new Map([
+    ["agent-first-gomoku", { gameType: "gomoku", gameDifficulty: "easy", hand: "agent_first" }],
+    ["agent-first-xiangqi", { gameType: "xiangqi", gameDifficulty: "easy", hand: "agent_first" }]
+  ]);
+  initGamePersistence((id) => ({ metadata: metadata.get(id) }), () => {});
+
+  const gomokuBinding = {
+    token: "agent-first-g",
+    taskSessionId: "agent-first-g-session",
+    conversationId: "agent-first-gomoku",
+    gameType: "gomoku"
+  };
+  const gomoku = getOrCreateGame("agent-first-gomoku");
+  assert.equal(gomoku.agentSide, PLAYER_BLACK);
+  assert.equal(gomoku.playerSide, PLAYER_WHITE);
+  assert.equal((await dispatchGameAction(gomokuBinding, "make_move", { actionId: "H8" })).ok, true);
+  assert.equal(handlePlayerMove("agent-first-gomoku", "I9").ok, true);
+
+  const xiangqiBinding = {
+    token: "agent-first-x",
+    taskSessionId: "agent-first-x-session",
+    conversationId: "agent-first-xiangqi",
+    gameType: "xiangqi"
+  };
+  const xiangqi = getOrCreateGame("agent-first-xiangqi");
+  assert.equal(xiangqi.agentSide, 1);
+  assert.equal(xiangqi.playerSide, 2);
+  assert.equal((await dispatchGameAction(xiangqiBinding, "make_move", { actionId: "b2e2" })).ok, true);
+  assert.equal(handlePlayerMove("agent-first-xiangqi", "b7e7").ok, true);
+});
+
+test("player resign ends the game immediately and awards the Agent", () => {
+  const conversationId = `conv-player-resign-${Date.now()}`;
+  initGamePersistence(
+    () => ({
+      metadata: {
+        gameType: "xiangqi",
+        gameDifficulty: "easy",
+        hand: "agent_first"
+      }
+    }),
+    () => {}
+  );
+
+  const result = handlePlayerResign(conversationId);
+  assert.equal(result.ok, true);
+  assert.equal(result.gameState.status, "agent_won");
+  assert.equal(result.gameState.winner, result.gameState.agentSide);
+  assert.equal(handlePlayerResign(conversationId).ok, false, "resign must be idempotently rejected");
+});
+
+test("hard Agent-first game starts its opening move from initial state sync", async () => {
+  const conversationId = `conv-hard-agent-first-${Date.now()}`;
+  initGamePersistence(
+    () => ({
+      metadata: {
+        gameType: "gomoku",
+        gameDifficulty: "hard",
+        hand: "agent_first"
+      }
+    }),
+    () => {}
+  );
+
+  const initial = handleGetGameState(conversationId);
+  assert.equal(initial.turn, initial.agentSide);
+  await new Promise((resolve) => setTimeout(resolve, ENGINE_AUTO_MOVE_DELAY_MS + 1_100));
+
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  assert.equal(state.stepCount, 1);
+  assert.equal(state.lastMove?.player, state.agentSide);
+  assert.equal(state.turn, state.playerSide);
+});
+
+test("hard engine search runs outside the main event loop", async () => {
+  const conversationId = `conv-worker-responsive-${Date.now()}`;
+  initGamePersistence(
+    () => ({ metadata: { gameType: "gomoku", gameDifficulty: "hard" } }),
+    () => {}
+  );
+  handlePlayerMove(conversationId, "H8");
+
+  const started = Date.now();
+  await new Promise((resolve) => setTimeout(resolve, ENGINE_AUTO_MOVE_DELAY_MS + 120));
+  assert.ok(
+    Date.now() - started < ENGINE_AUTO_MOVE_DELAY_MS + 350,
+    "the 700ms search budget must not block a main-thread timer"
+  );
+  // Let the worker finish so it cannot leak into later tests.
+  await new Promise((resolve) => setTimeout(resolve, 900));
+});
+
+test("state polling does not postpone an already scheduled hard-mode reply", async () => {
+  const conversationId = `conv-worker-poll-${Date.now()}`;
+  initGamePersistence(
+    () => ({ metadata: { gameType: "gomoku", gameDifficulty: "hard" } }),
+    () => {}
+  );
+  handlePlayerMove(conversationId, "H8");
+
+  for (let i = 0; i < 6; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    handleGetGameState(conversationId);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 950));
+
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  assert.equal(state.stepCount, 2, "polling getState must reuse rather than restart the pending job");
+  assert.equal(state.turn, state.playerSide);
+});
+
+test("auto-move lifecycle is independent from MCP session unregister", () => {
+  const service = fs.readFileSync(
+    new URL("../electron/gameToolService.ts", import.meta.url),
+    "utf8"
+  );
+  const unregister = service.slice(
+    service.indexOf("export function unregisterGameToolSession"),
+    service.indexOf("export async function handleGameToolHttpRequest")
+  );
+  assert.doesNotMatch(unregister, /cancelAgentAutoMove/);
+  assert.match(service, /new Worker\(/);
+});
+
+test("make_move emits its reason as an agent chat message", async () => {
+  const conversationId = `conv-reason-${Date.now()}`;
+  initGamePersistence(
+    (id) => ({ metadata: { gameType: "gomoku", gameDifficulty: "easy" } }),
+    () => {}
+  );
+  const binding = {
+    token: "reason-token",
+    taskSessionId: `reason-session-${Date.now()}`,
+    conversationId,
+    gameType: "gomoku"
+  };
+
+  handlePlayerMove(conversationId, "H8");
+  const res = await dispatchGameAction(binding, "make_move", {
+    actionId: "I9",
+    reason: "抢占斜线要点，构建活三"
+  });
+
+  assert.equal(res.ok, true);
+  assert.ok(res.chat, "result should carry the emitted chat");
+  assert.equal(res.chat.sender, "agent");
+  assert.equal(res.chat.message, "抢占斜线要点，构建活三");
+
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  const lastChat = state.chatHistory[state.chatHistory.length - 1];
+  assert.ok(lastChat);
+  assert.equal(lastChat.message, "抢占斜线要点，构建活三");
+});
+
+test("make_move without reason emits no chat message", async () => {
+  const conversationId = `conv-noreason-${Date.now()}`;
+  initGamePersistence(
+    (id) => ({ metadata: { gameType: "gomoku", gameDifficulty: "easy" } }),
+    () => {}
+  );
+  const binding = {
+    token: "noreason-token",
+    taskSessionId: `noreason-session-${Date.now()}`,
+    conversationId,
+    gameType: "gomoku"
+  };
+
+  handlePlayerMove(conversationId, "H8");
+  const res = await dispatchGameAction(binding, "make_move", {
+    actionId: "I9"
+  });
+
+  assert.equal(res.ok, true);
+  assert.equal(res.chat, undefined);
+  const state = getOrCreateGame(conversationId).getSnapshot();
+  assert.equal(state.chatHistory.length, 0);
+});
+
+test("game lobby persists difficulty into conversation metadata", () => {
+  const modal = fs.readFileSync(
+    new URL("../src/components/Games/GameSetupModal.tsx", import.meta.url),
+    "utf8"
+  );
+  assert.match(modal, /gameDifficulty/);
+
+  const canvas = fs.readFileSync(
+    new URL("../src/components/Browser/BrowserCanvas.tsx", import.meta.url),
+    "utf8"
+  );
+  assert.match(canvas, /agentAutoPlayScheduled/);
+
+  const gomokuBoard = fs.readFileSync(
+    new URL("../public/games/gomoku/game.js", import.meta.url),
+    "utf8"
+  );
+  const xiangqiBoard = fs.readFileSync(
+    new URL("../public/games/xiangqi/game.js", import.meta.url),
+    "utf8"
+  );
+  assert.match(gomokuBoard, /snapshot\.playerSide/);
+  assert.match(xiangqiBoard, /snapshot\.playerSide/);
+});

--- a/tests/game-mcp.test.mjs
+++ b/tests/game-mcp.test.mjs
@@ -58,8 +58,11 @@ test("Game tool service dispatches actions correctly", async () => {
   });
   assert.equal(legalMoveRes.ok, true);
   assert.equal(legalMoveRes.actionId, "H9");
-  assert.equal(legalMoveRes.gameState.turn, PLAYER_BLACK);
-  assert.equal(legalMoveRes.gameState.board[6][7], PLAYER_WHITE);
+  assert.equal(legalMoveRes.gameState, undefined, "move acknowledgements should stay compact");
+  assert.equal(legalMoveRes.status, "playing");
+  const stateAfterMove = await dispatchGameAction(binding, "get_state", {});
+  assert.equal(stateAfterMove.gameState.turn, PLAYER_BLACK);
+  assert.equal(stateAfterMove.gameState.board[6][7], PLAYER_WHITE);
 
   // 5. Agent sends in-game chat
   const chatRes = await dispatchGameAction(binding, "send_chat", {
@@ -73,9 +76,17 @@ test("Game tool service dispatches actions correctly", async () => {
 
   // 6. Test get_history action
   const historyRes = await dispatchGameAction(binding, "get_history", {});
-  assert.equal(historyRes.ok, true);
   assert.equal(historyRes.moveHistory.length, 2, "Should have 2 moves in history");
-  assert.equal(historyRes.chatHistory.length, 1, "Should have 1 chat in history");
+  assert.equal(
+    historyRes.chatHistory.length,
+    2,
+    "Should have make_move reason chat + explicit send_chat"
+  );
+  assert.equal(
+    historyRes.chatHistory[0].message,
+    "抢占中路邻近要点",
+    "make_move reason should be emitted as an agent chat"
+  );
 
   // Verify lean snapshot in get_state does not contain full moveHistory
   assert.equal(stateRes.gameState.moveHistory, undefined, "Lean snapshot should omit moveHistory");
@@ -136,6 +147,7 @@ test("packaged and WebUI game wiring loads the board without a workspace", () =>
   assert.match(detail, /conv\?\.kind === "game" \? "preview" : "overview"/);
   assert.match(preload, /invoke\("game:getState"/);
   assert.match(preload, /invoke\("game:playerMove"/);
+  assert.match(preload, /invoke\("game:playerResign"/);
   assert.match(preload, /subscribe\("freebuddy:\/\/game-event"/);
   assert.match(acpRuntime, /registerGameToolSession/);
   const gameBlock = acpRuntime.slice(
@@ -149,4 +161,3 @@ test("packaged and WebUI game wiring loads the board without a workspace", () =>
   );
   assert.match(gameService, /conversationId: conversationId \|\| snapshot\.gameId/);
 });
-

--- a/tests/game-threat-awareness.test.mjs
+++ b/tests/game-threat-awareness.test.mjs
@@ -1,0 +1,449 @@
+import fs from "node:fs";
+import vm from "node:vm";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  XiangqiGameInstance,
+  PLAYER_RED,
+  PLAYER_BLACK,
+  PIECE_ROOK,
+  PIECE_CANNON,
+  PIECE_BISHOP,
+  PIECE_ADVISOR,
+  PIECE_KNIGHT,
+  PIECE_PAWN,
+  createInitialBoard,
+  getCandidateMoves,
+  getLegalMoves,
+  getPseudoLegalMoves,
+  isKingInCheck,
+  moveToString,
+  xiangqiPositionKey
+} from "../dist-electron/games/xiangqiEngine.js";
+import { getOpponentCaptureThreats } from "../dist-electron/games/xiangqiEngine.js";
+import { formatGameStateText } from "../dist-electron/games/boardDisplay.js";
+
+function blankBoard() {
+  return Array.from({ length: 10 }, () => Array(9).fill(0));
+}
+
+function replay(actions) {
+  const game = new XiangqiGameInstance("replay");
+  for (const actionId of actions) {
+    const result = game.applyMove(actionId, game.turn);
+    assert.equal(result.ok, true, `${actionId}: ${result.error ?? "failed"}`);
+  }
+  return game;
+}
+
+test("opponent capture threats lists attacked pieces with defense status", () => {
+  const board = blankBoard();
+  // Kings on DIFFERENT files (avoid flying-general face-off)
+  board[0][4] = 1; // red K e0
+  board[8][3] = -1; // black K d8
+  // Black advisor on f9 attacked by red rook f2, no defender
+  board[9][5] = -PIECE_ADVISOR;
+  board[2][5] = PIECE_ROOK;
+
+  const threats = getOpponentCaptureThreats(board, PLAYER_BLACK);
+
+  assert.equal(threats.length, 1);
+  const t = threats[0];
+  assert.equal(t.attackerCoord, "f2");
+  assert.equal(t.targetCoord, "f9");
+  assert.equal(t.defended, false);
+});
+
+test("opponent capture threats marks defended targets", () => {
+  const board = blankBoard();
+  board[0][4] = 1; // red K e0
+  board[8][3] = -1; // black K d8, orthogonally adjacent to d9 -> can recapture
+  board[9][3] = -PIECE_ADVISOR; // advisor d9
+  board[7][4] = PIECE_KNIGHT; // red knight e8 attacks d9 (and does NOT check K d8)
+
+  const threats = getOpponentCaptureThreats(board, PLAYER_BLACK);
+  const d9 = threats.find((t) => t.targetCoord === "d9");
+  assert.ok(d9, "should detect d9 threat");
+  assert.equal(d9.defended, true);
+});
+
+test("candidate moves get lose tags when landing on attacked squares", () => {
+  const board = blankBoard();
+  board[0][4] = 1; // red K e0
+  board[8][3] = -1; // black K d8 (not attacked by the knight below)
+  board[9][0] = -PIECE_ROOK; // black rook a9
+  board[8][6] = PIECE_KNIGHT; // red knight g8 attacks e9 (and does NOT check K d8)
+
+  const moves = new XiangqiGameInstance("t");
+  moves.board = board;
+  moves.turn = PLAYER_BLACK;
+  const cands = moves.getSnapshot().legalMoves;
+  const byId = new Map(cands.map((m) => [m.actionId, m]));
+
+  const hangMove = byId.get("a9e9");
+  assert.ok(hangMove, "a9e9 should be among candidates");
+  assert.equal(hangMove.safety, "lose", `expected lose tag, got ${hangMove.safety}`);
+  assert.match(hangMove.description ?? "", /丢/, "description should mention loss");
+
+  const safeMove = byId.get("a9b9");
+  assert.ok(safeMove, "a9b9 should be among candidates");
+  assert.notEqual(safeMove.safety, "lose", "safe retreat should not be tagged lose");
+});
+
+test("formatGameStateText renders opponent threat warnings", () => {
+  const inst = new XiangqiGameInstance("t-threat");
+  inst.board = blankBoard();
+  inst.board[0][4] = 1;
+  inst.board[8][3] = -1;
+  inst.board[9][5] = -PIECE_ADVISOR; // f9 advisor
+  inst.board[2][5] = PIECE_ROOK; // f2 rook attacks it
+  inst.turn = PLAYER_BLACK;
+  const snap = inst.getSnapshot();
+
+  const text = formatGameStateText(snap);
+
+  assert.match(text, /对方威胁/);
+  assert.match(text, /f9/);
+  assert.match(text, /f2/);
+  assert.match(text, /无保护/);
+});
+
+test("candidate safety uses relative baseline (no noisy trade tags)", () => {
+  const board = blankBoard();
+  board[0][4] = 1; // red K e0
+  board[8][3] = -1; // black K d8
+  board[9][0] = -PIECE_ROOK; // black rook a9
+  board[8][6] = PIECE_KNIGHT; // red knight g8 attacks e9
+
+  const inst = new XiangqiGameInstance("t");
+  inst.board = board;
+  inst.turn = PLAYER_BLACK;
+  const cands = inst.getSnapshot().legalMoves;
+  const byId = new Map(cands.map((m) => [m.actionId, m]));
+
+  // Quiet retreat creates no NEW loss -> untagged.
+  const quiet = byId.get("a9b9");
+  assert.ok(quiet);
+  assert.notEqual(quiet.safety, "lose");
+});
+
+test("candidates that allow opponent mate-in-1 get the doomed tag", () => {
+  // Reconstructed from a real lost game: black cannon sits on e3 guarding
+  // the middle; e3i3 abandons the file and allows b4e4 double-cannon mate.
+  const board = blankBoard();
+  board[9] = [-7, -5, -3, -2, -1, -2, -3, -5, -7]; // black back rank
+  board[8] = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+  board[7] = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+  board[6] = [7, 0, 7, 0, 6, 7, 0, 7, 0]; // red cannon e6
+  board[5] = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+  board[4] = [0, 6, 0, 0, 0, 0, 0, 0, 0]; // red cannon b4
+  board[3] = [7, 0, 7, 0, -6, 0, 7, 0, 7]; // black cannon e3 + pawns a3/c3/g3/i3
+  board[2] = [0, 0, 0, 0, 0, 0, 0, 0, 4]; // red knight i2
+  board[1] = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+  board[0] = [0, 5, 3, 2, 1, 2, 3, 0, 5]; // red back rank (rook b0)
+
+  const inst = new XiangqiGameInstance("t");
+  inst.board = board;
+  inst.turn = PLAYER_BLACK;
+  const cands = inst.getSnapshot().legalMoves;
+  const greedy = cands.find((m) => m.actionId === "e3i3");
+  assert.ok(greedy, "e3i3 should be among candidates");
+
+  assert.equal(greedy.safety, "lose");
+  assert.match(greedy.description ?? "", /招致绝杀/, "should flag incoming mate");
+});
+
+test("real-game cannon raid is a loss, not a trade", () => {
+  const game = replay(["b2e2", "b7e7", "b0c2"]);
+  const move = getCandidateMoves(game.board, PLAYER_BLACK, game.moveHistory, 100)
+    .find((candidate) => candidate.actionId === "e7e3");
+
+  assert.ok(move, "e7e3 should still be assessable below the displayed candidates");
+  assert.equal(move.safety, "lose");
+  assert.equal(move.lossPiece, "砲");
+  assert.match(move.description ?? "", /丢砲/);
+  assert.doesNotMatch(move.description ?? "", /兑子/);
+
+  const result = game.applyMove("e7e3", PLAYER_BLACK);
+  assert.equal(result.ok, true);
+  assert.equal(result.capturedPieceName, "兵");
+  assert.equal(result.isCheck, true, "the server should report the cannon check factually");
+  assert.equal(game.moveHistory.at(-1)?.capturedPieceName, "兵");
+});
+
+test("blocking check by sacrificing a Rook is tagged as a Rook loss", () => {
+  const game = replay([
+    "b2e2", "b7e7", "b0c2", "e7e3", "c2e3", "h7g7", "e2e6", "g7g3",
+    "e3f5", "g3e3", "f5e3", "b9c7", "e6e4", "a9b9", "e3g4", "b9b0",
+    "a0b0", "e9e8", "h2e2", "e8f8", "b0b7", "c7e6", "e2e6", "f9e8",
+    "e6a6", "i9i8", "g4f6", "e8f7", "f6d7", "f8f9", "e4f4"
+  ]);
+  const move = getCandidateMoves(game.board, PLAYER_BLACK, game.moveHistory, 100)
+    .find((candidate) => candidate.actionId === "i8f8");
+
+  assert.ok(move);
+  assert.equal(move.safety, "lose");
+  assert.equal(move.lossPiece, "車");
+  assert.match(move.description ?? "", /丢車/);
+});
+
+test("agent guard rejects avoidable mate-in-one moves", () => {
+  const game = replay([
+    "b2e2", "b7e7", "b0c2", "e7e3", "c2e3", "h7g7", "e2e6", "g7g3",
+    "e3f5", "g3e3", "f5e3", "b9c7", "e6e4", "a9b9", "e3g4"
+  ]);
+
+  const result = game.applyMove("b9b0", PLAYER_BLACK, undefined, {
+    rejectAvoidableMate: true
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error ?? "", /mate in one/);
+  assert.equal(game.turn, PLAYER_BLACK, "a rejected move must not mutate the turn");
+  assert.equal(game.board[9][1], -PIECE_ROOK, "a rejected move must not mutate the board");
+});
+
+test("three repetitions finish Xiangqi as a draw", () => {
+  const game = new XiangqiGameInstance("repetition");
+  game.board = blankBoard();
+  game.board[0][4] = 1;
+  game.board[9][4] = -1;
+  game.board[4][4] = PIECE_PAWN;
+  game.board[0][0] = PIECE_ROOK;
+  game.board[9][0] = -PIECE_ROOK;
+  game.turn = PLAYER_RED;
+  game.positionHistory = [xiangqiPositionKey(game.board, game.turn)];
+
+  for (const actionId of [
+    "a0b0", "a9b9", "b0a0", "b9a9",
+    "a0b0", "a9b9", "b0a0", "b9a9"
+  ]) {
+    const result = game.applyMove(actionId, game.turn);
+    assert.equal(result.ok, true, `${actionId}: ${result.error ?? "failed"}`);
+  }
+
+  assert.equal(game.status, "draw");
+  assert.equal(game.winner, null);
+});
+
+test("skill mandates winning as primary objective", () => {
+  const skill = fs.readFileSync(
+    new URL("../assets/skills/game-arena/SKILL.md", import.meta.url),
+    "utf8"
+  );
+  assert.match(skill, /首要目标|primary objective/i);
+  assert.match(skill, /送子|hanging|不要白白丢/i);
+});
+
+test("browser canvas queues turn prompts across the generation race", () => {
+  const canvas = fs.readFileSync(
+    new URL("../src/components/Browser/BrowserCanvas.tsx", import.meta.url),
+    "utf8"
+  );
+  // Player moves while agent is still streaming -> prompt must be queued and
+  // flushed when generation ends, not silently dropped by sendMessage guard.
+  assert.match(canvas, /pendingGameTurnPromptRef\.current = \{/);
+  assert.match(canvas, /pendingGameTurnPromptRef\.current = null/);
+  // Stall detector escalates to an automatic single remind.
+  assert.match(canvas, /autoRemindCount/);
+});
+
+test("rejected player moves bounce back to the board without prompting the agent", () => {
+  const read = (p) => fs.readFileSync(new URL(p, import.meta.url), "utf8");
+
+  const canvas = read("../src/components/Browser/BrowserCanvas.tsx");
+  assert.match(canvas, /MOVE_REJECTED/, "canvas must notify the board on rejection");
+  assert.match(
+    canvas,
+    /ok === false/,
+    "canvas must not send an agent prompt for failed moves"
+  );
+  assert.match(canvas, /RUN_END_RESYNC/, "canvas must resync board when a run ends");
+
+  assert.match(read("../public/games/gomoku/game.js"), /MOVE_REJECTED/);
+  assert.match(read("../public/games/xiangqi/game.js"), /MOVE_REJECTED/);
+});
+
+test("xiangqi client filters pseudo moves that do not answer check", () => {
+  // Reconstruct the reported position: black rook moved e5->f5, uncovering
+  // the e7 cannon's check through red advisor e1 onto red king e0.
+  const board = blankBoard();
+  board[9] = [-PIECE_ROOK, -PIECE_KNIGHT, -PIECE_BISHOP, -PIECE_ADVISOR, -1, -PIECE_ADVISOR, 0, 0, 0];
+  board[7][4] = -PIECE_CANNON;
+  board[7][8] = -PIECE_BISHOP;
+  board[6][0] = -7;
+  board[6][2] = 7;
+  board[6][8] = -7;
+  board[5][5] = -PIECE_ROOK;
+  board[3][0] = 7;
+  board[3][1] = PIECE_CANNON;
+  board[3][2] = 7;
+  board[3][8] = 7;
+  board[1][4] = PIECE_ADVISOR;
+  board[0][0] = PIECE_ROOK;
+  board[0][1] = PIECE_KNIGHT;
+  board[0][2] = PIECE_BISHOP;
+  board[0][4] = 1;
+  board[0][5] = PIECE_ADVISOR;
+
+  assert.equal(isKingInCheck(board, PLAYER_RED), true, "red should be in cannon check");
+  const legalIds = getLegalMoves(board, PLAYER_RED).map((move) =>
+    moveToString(move.fromX, move.fromY, move.toX, move.toY)
+  );
+  assert.deepEqual(legalIds, ["c0e2", "e0d0", "e1f2", "e1d2", "e1d0"]);
+
+  const client = fs.readFileSync(
+    new URL("../public/games/xiangqi/game.js", import.meta.url),
+    "utf8"
+  );
+  assert.match(client, /你已将军/, "the board should also announce when the player checks the Agent");
+  const rulesStart = client.indexOf("function isSameSide");
+  const rulesEnd = client.indexOf("function handleCanvasClick");
+  assert.ok(rulesStart >= 0 && rulesEnd > rulesStart, "client rules block should exist");
+
+  const sandbox = {
+    BOARD_COLS: 9,
+    BOARD_ROWS: 10,
+    board: board.map((row) => [...row]),
+    playerSide: PLAYER_RED,
+    legalIds: [],
+    clientInCheck: false
+  };
+  vm.runInNewContext(
+    `${client.slice(rulesStart, rulesEnd)}
+     const cols = "abcdefghi";
+     clientInCheck = isClientKingInCheck(true);
+     legalIds = [];
+     for (let y = 0; y < BOARD_ROWS; y++) {
+       for (let x = 0; x < BOARD_COLS; x++) {
+         if (board[y][x] <= 0) continue;
+         for (const move of getClientLegalMoves(x, y)) {
+           legalIds.push(cols[x] + y + cols[move.toX] + move.toY);
+         }
+       }
+     }`,
+    sandbox
+  );
+  assert.equal(sandbox.clientInCheck, true, "client should detect the check immediately");
+  assert.deepEqual(
+    [...sandbox.legalIds],
+    legalIds,
+    "instant client targets should exactly match authoritative legal replies"
+  );
+
+  assert.match(client, /将军！请立即应将/);
+  assert.match(client, /playCheckSound\(\)/);
+  const styles = fs.readFileSync(
+    new URL("../public/games/xiangqi/style.css", import.meta.url),
+    "utf8"
+  );
+  assert.match(styles, /\.turn-indicator\.in-check/);
+});
+
+test("crossed pawn explains sideways moves rejected by a cannon pin", () => {
+  // This is the central tactic from the reported game: the crossed red pawn
+  // on e5 is the second screen between the black cannon and red king. Moving
+  // sideways would leave the advisor on e1 as the cannon's only screen.
+  const board = blankBoard();
+  board[0][4] = 1;
+  board[1][4] = PIECE_ADVISOR;
+  board[5][4] = PIECE_PAWN;
+  board[5][5] = -PIECE_KNIGHT;
+  board[7][4] = -PIECE_CANNON;
+  board[9][3] = -1;
+
+  const pawnPseudoIds = getPseudoLegalMoves(board, 4, 5).map((move) =>
+    moveToString(4, 5, move.toX, move.toY)
+  );
+  assert.deepEqual(pawnPseudoIds, ["e5e6", "e5d5", "e5f5"]);
+
+  const pawnLegalIds = getLegalMoves(board, PLAYER_RED)
+    .filter((move) => move.fromX === 4 && move.fromY === 5)
+    .map((move) => moveToString(move.fromX, move.fromY, move.toX, move.toY));
+  assert.deepEqual(
+    pawnLegalIds,
+    ["e5e6"],
+    "sideways pawn moves must stay illegal when they expose a cannon check"
+  );
+
+  board[7][4] = 0;
+  const unpinnedIds = getLegalMoves(board, PLAYER_RED)
+    .filter((move) => move.fromX === 4 && move.fromY === 5)
+    .map((move) => moveToString(move.fromX, move.fromY, move.toX, move.toY));
+  assert.deepEqual(
+    unpinnedIds,
+    ["e5e6", "e5d5", "e5f5"],
+    "the crossed pawn may move sideways when the cannon pin is removed"
+  );
+
+  const client = fs.readFileSync(
+    new URL("../public/games/xiangqi/game.js", import.meta.url),
+    "utf8"
+  );
+  assert.match(client, /兵的横走会让己方\$\{kingName\}被将军，不能走/);
+  assert.match(client, /if \(pseudoTarget\)[\s\S]*这步会让己方\$\{kingName\}被将军，不能走/);
+});
+
+test("auto-remind counter only resets on real progress and carries turn facts", () => {
+  const canvas = fs.readFileSync(
+    new URL("../src/components/Browser/BrowserCanvas.tsx", import.meta.url),
+    "utf8"
+  );
+  // The reset must live in the turn!==2 branch (real progress), never in the
+  // isRunning branch - otherwise every run clears it and reminds loop forever.
+  const stallBlock = canvas.slice(
+    canvas.indexOf("const checkStall"),
+    canvas.indexOf("void checkStall()")
+  );
+  assert.ok(stallBlock.length > 100, "stall detector block should exist");
+  assert.match(stallBlock, /autoRemindCountRef\.current = 0/);
+  const resetIdx = stallBlock.indexOf("autoRemindCountRef.current = 0");
+  const runningBranchIdx = stallBlock.indexOf("if (!isRunning)");
+  const turnCheckIdx = stallBlock.indexOf("state.turn === state.agentSide");
+  assert.ok(turnCheckIdx >= 0, "Agent-side turn gate should exist");
+  // reset must appear AFTER the turn gate (i.e. in the turn!==2 else path)
+  // and the auto-remind send must be gated behind !isRunning.
+  assert.ok(resetIdx > turnCheckIdx, "counter reset belongs to the progress branch");
+
+  // Remind prompt must carry step/side facts so replayed history cannot
+  // convince the agent it is not its turn.
+  assert.match(canvas, /promptRemindAgentWithTurn/);
+  const en = fs.readFileSync(new URL("../src/locales/en.json", import.meta.url), "utf8");
+  const zh = fs.readFileSync(new URL("../src/locales/zh-CN.json", import.meta.url), "utf8");
+  assert.match(en, /promptRemindAgentWithTurn/);
+  assert.match(zh, /promptRemindAgentWithTurn/);
+});
+
+test("browser game prompt state is reset per active conversation", () => {
+  const canvas = fs.readFileSync(
+    new URL("../src/components/Browser/BrowserCanvas.tsx", import.meta.url),
+    "utf8"
+  );
+  assert.match(canvas, /pendingGameTurnPromptRef\.current = null/);
+  assert.match(canvas, /processedMessageIdsRef\.current\.clear\(\)/);
+  assert.match(canvas, /state\.stepCount !== pending\.stepCount/);
+  assert.match(canvas, /state\.turn !== state\.agentSide/);
+});
+
+test("rejected fallback Agent moves are resynced and retried", () => {
+  const canvas = fs.readFileSync(
+    new URL("../src/components/Browser/BrowserCanvas.tsx", import.meta.url),
+    "utf8"
+  );
+  assert.match(canvas, /moveRes\?\.ok !== false/);
+  assert.match(canvas, /promptAgentMoveRejected/);
+  assert.match(canvas, /Failed to recover rejected Agent move/);
+});
+
+test("Xiangqi search does not discard legal moves by a fixed branch cap", () => {
+  const search = fs.readFileSync(
+    new URL("../electron/games/xiangqiSearch.ts", import.meta.url),
+    "utf8"
+  );
+  const ordered = search.slice(
+    search.indexOf("function orderedMoves"),
+    search.indexOf("interface SearchState")
+  );
+  assert.doesNotMatch(ordered, /\.slice\(/);
+  assert.doesNotMatch(search, /captured \* 20 - mover \+/);
+});

--- a/tests/remote-channel-policy.test.mjs
+++ b/tests/remote-channel-policy.test.mjs
@@ -142,7 +142,8 @@ test("the chat surface the web client depends on stays callable", async () => {
     "game:getState",
     "game:playerMove",
     "game:agentMove",
-    "game:resetGame"
+    "game:resetGame",
+    "game:playerResign"
   ]) {
     assert.equal(
       isRemoteChannelCallable(channel, false),

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -24,9 +24,22 @@ const snapshot = (name, rootPath) => ({
 test("skill announcement exposes the selected catalog without replacing the prompt", () => {
   const result = buildSkillAnnouncement("Fix the bug", [snapshot("verify-change", "/tmp/skill")]);
   assert.match(result, /verify-change \(1\.2\.3\): verify-change instructions/);
+  assert.match(result, /freebuddy-skills MCP server/);
   assert.match(result, /skill_list and skill_load/);
   assert.match(result, /skill_read_resource/);
+  assert.match(result, /Do not call adapter-native skill commands/);
   assert.ok(result.endsWith("Fix the bug"));
+});
+
+test("skill announcement mentions native discovery only after skills were mounted", () => {
+  const result = buildSkillAnnouncement(
+    "Play the game",
+    [snapshot("game-arena", "/tmp/game-arena")],
+    { nativeSkillsMounted: true }
+  );
+  assert.match(result, /freebuddy-skills MCP tools/);
+  assert.match(result, /Adapter-native skill discovery may also expose the mounted copies/);
+  assert.doesNotMatch(result, /Do not call adapter-native skill commands/);
 });
 
 test("native skill mounting reconciles only FreeBuddy-owned symlinks", () => {
@@ -46,13 +59,14 @@ test("native skill mounting reconciles only FreeBuddy-owned symlinks", () => {
   );
   fs.mkdirSync(path.join(nativeDir, "user-owned"));
 
-  reconcileNativeSkillLinks(
+  const mounted = reconcileNativeSkillLinks(
     cwd,
     [".agents/skills"],
     [snapshot("selected", selectedRoot)],
     [selectedRoot, staleRoot]
   );
 
+  assert.equal(mounted, true);
   assert.equal(
     fs.realpathSync(path.join(nativeDir, "selected")),
     fs.realpathSync(selectedRoot)
@@ -74,6 +88,14 @@ test("skill persistence, IPC, MCP, and conversation snapshots stay wired", () =>
   assert.match(ipc, /skills:installFromMarket/);
   assert.match(acp, /registerSkillToolSession/);
   assert.match(conversations, /resolveSkillSnapshots/);
+});
+
+test("runtime reports native skill access only when it actually mounts the links", () => {
+  const runtime = fs.readFileSync(new URL("../electron/cli/runtime.ts", import.meta.url), "utf8");
+  assert.match(runtime, /let nativeSkillsMounted = false/);
+  assert.match(runtime, /nativeSkillsMounted = reconcileNativeSkillLinks/);
+  assert.match(runtime, /buildSkillAnnouncement\(args\.prompt, args\.skills, \{/);
+  assert.match(runtime, /nativeSkillsMounted/);
 });
 
 test("skill ZIP extraction accepts a normal Skill package", () => {

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -11,5 +11,5 @@
     "rootDir": "electron",
     "types": ["node"]
   },
-  "include": ["electron/main.ts", "electron/menu.ts", "electron/app-meta.ts", "electron/butlerBuddyState.ts", "electron/cli/**/*.ts", "electron/mcp/**/*.ts", "electron/shared/**/*.ts"]
+  "include": ["electron/main.ts", "electron/menu.ts", "electron/app-meta.ts", "electron/butlerBuddyState.ts", "electron/cli/**/*.ts", "electron/games/**/*.ts", "electron/mcp/**/*.ts", "electron/shared/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- strengthen Gomoku and Xiangqi hard mode with background search, threat awareness, legal-move validation, and Agent-first opening support
- improve board state prompts, check and threat feedback, turn synchronization, and game conversation isolation
- merge per-turn debug logs by resumable ACP session and collapse explicitly tagged CodeBuddy history replay records
- route selected skills through the freebuddy-skills MCP server when native skill links are not actually mounted

## Validation
- npm run typecheck
- npm test
- npm run build:renderer
- replay-compaction regression against the supplied 19-file game export: 1,809 tagged history replay lines removed without dropping live events