### PR TITLE
fix: 桌面 v* 发版不再把 Runtime 当成 runtime-v* 正式包

### DIFF
--- a/scripts/runtime-release-lib.mjs
+++ b/scripts/runtime-release-lib.mjs
@@ -36,9 +36,9 @@ export function resolveRuntimePackVersion(env = process.env) {
 
   const provided = providedReleaseRefs(env);
   const invalidTag = provided.find((value) => value.startsWith("runtime-v"));
-  const taggedCi =
-    env.CI === "true" && (env.GITHUB_REF_TYPE === "tag" || Boolean(invalidTag));
-  if (invalidTag || taggedCi || env.RUNTIME_REQUIRE_PRODUCTION_VERSION === "1") {
+  // Desktop tags (vMAJOR.MINOR.PATCH) bundle a local 0.0.0-dev runtime pack.
+  // Fail closed only for runtime-v* refs or an explicit production requirement.
+  if (invalidTag || env.RUNTIME_REQUIRE_PRODUCTION_VERSION === "1") {
     throw new Error(
       `invalid runtime release tag ${invalidTag || provided[0] || "(empty)"}; expected runtime-vMAJOR.MINOR.PATCH`
     );

--- a/tests/runtime-release.test.mjs
+++ b/tests/runtime-release.test.mjs
@@ -29,6 +29,14 @@ test("runtime pack version comes from env, then runtime-v tag", () => {
     "2.0.1"
   );
   assert.equal(resolveRuntimePackVersion({}), "0.0.0-dev");
+  assert.equal(
+    resolveRuntimePackVersion({
+      CI: "true",
+      GITHUB_REF_TYPE: "tag",
+      GITHUB_REF_NAME: "v0.9.0"
+    }),
+    "0.0.0-dev"
+  );
   assert.equal(versionFromRuntimeTag("runtime-v1.0.1"), "1.0.1");
   assert.equal(versionFromRuntimeTag("v1.0.1"), null);
   assert.equal(isRuntimeTag("runtime-v1.0.1"), true);
@@ -45,6 +53,16 @@ test("runtime pack version comes from env, then runtime-v tag", () => {
         CI: "true",
         GITHUB_REF_TYPE: "tag",
         GITHUB_REF_NAME: "runtime-vtest"
+      }),
+    /invalid runtime release tag/
+  );
+  assert.throws(
+    () =>
+      resolveRuntimePackVersion({
+        CI: "true",
+        RUNTIME_REQUIRE_PRODUCTION_VERSION: "1",
+        GITHUB_REF_TYPE: "tag",
+        GITHUB_REF_NAME: "v0.9.0"
       }),
     /invalid runtime release tag/
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

[Release `v0.9.0` (run 33028515111)](https://github.com/maojindao55/freebuddy/actions/runs/33028515111) 在合并 Runtime Pack 到 `main` 后失败：

- Windows 构建成功
- macOS x64 / macOS arm64 / Linux 在 **Build Electron app** 失败

```
Error: invalid runtime release tag v0.9.0; expected runtime-vMAJOR.MINOR.PATCH
    at resolveRuntimePackVersion (scripts/runtime-release-lib.mjs)
    at scripts/build-runtime-pack.mjs
```

`npm run build` 现在会跑 `runtime:build`。`resolveRuntimePackVersion()` 在 `CI=true` 且 `GITHUB_REF_TYPE=tag` 时直接抛错，把桌面标签 `v0.9.0` 误当成 Runtime 生产标签 `runtime-v*`。

## 修复

- 桌面 `v*` CI：内嵌 bundled Runtime 版本 `0.0.0-dev`（与本地未打 Runtime 标签一致）
- 仅在以下情况 fail-closed：
  - 非法 / 非生产的 `runtime-v*` 引用
  - `RUNTIME_REQUIRE_PRODUCTION_VERSION=1`（Runtime Pack workflow 已设置）

不改 `update.enabled`，不打 `runtime-v*` 标签。

## 发版注意

Release workflow 按 **tag ref** checkout。合入本 PR 后，直接 `workflow_dispatch` 重建 `v0.9.0` 仍会编到旧 commit。需要任选其一：

1. 把 `v0.9.0` 移到含本修复的 commit，再触发 Release（当前 draft 未完整发布，Windows 资源可能已上传）
2. 打补丁版 `v0.9.1` 再发

## 测试

`node --test tests/runtime-release.test.mjs` 已覆盖：

- `CI=true` + `GITHUB_REF_NAME=v0.9.0` → `0.0.0-dev`
- `runtime-v*` / `RUNTIME_REQUIRE_PRODUCTION_VERSION=1` 仍 fail-closed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c4d62df-7138-481f-810a-0457ba9b2b79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c4d62df-7138-481f-810a-0457ba9b2b79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

