### PR TITLE
feat: split runtime release into artifact repository

### DIFF
--- a/.github/workflows/runtime-release.yml
+++ b/.github/workflows/runtime-release.yml
@@ -1,8 +1,4 @@
-name: Runtime Pack
-
-# Secrets on maojindao55/freebuddy:
-#   RUNTIME_SIGNING_PRIVATE_KEY
-#   FREEBUDDY_RUNTIME_RELEASE_TOKEN (contents:write on maojindao55/freebuddy-runtime)
+name: Runtime Source Validation
 
 on:
   push:
@@ -15,10 +11,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      RUNTIME_PACK_VERSION: ${{ github.ref_name }}
-      RUNTIME_SIGNING_KEY_ID: runtime-prod
-      RUNTIME_REQUIRE_PRODUCTION_VERSION: "1"
     steps:
       - name: Require production runtime tag
         run: |
@@ -32,27 +24,16 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run typecheck:packages
       - run: node --test tests/package-boundaries.test.mjs tests/protocol-fixtures.test.mjs tests/runtime-state-store.test.mjs tests/runtime-cli-host-conformance.test.mjs tests/runtime-release.test.mjs tests/runtime-updater.test.mjs tests/runtime-signature.test.mjs tests/delegation-runtime-process-wiring.test.mjs
       - run: echo "RUNTIME_PACK_PUBLISHED_AT=$(git log -1 --format=%cI)" >> "$GITHUB_ENV"
       - run: npm run runtime:build
         env:
-          RUNTIME_SIGNING_PRIVATE_KEY: ${{ secrets.RUNTIME_SIGNING_PRIVATE_KEY }}
-      - run: npm run runtime:sign
-        env:
-          RUNTIME_SIGNING_PRIVATE_KEY: ${{ secrets.RUNTIME_SIGNING_PRIVATE_KEY }}
-      - run: npm run runtime:verify
-      - run: npm run runtime:package
-        env:
-          RUNTIME_SIGNING_PRIVATE_KEY: ${{ secrets.RUNTIME_SIGNING_PRIVATE_KEY }}
+          RUNTIME_PACK_VERSION: ${{ github.ref_name }}
+          RUNTIME_REQUIRE_PRODUCTION_VERSION: "1"
+      - run: npm run runtime:probe
       - uses: actions/upload-artifact@v4
         with:
-          name: runtime-pack
-          path: .build/runtime-release/
-      - name: Publish to maojindao55/freebuddy-runtime
-        env:
-          FREEBUDDY_RUNTIME_RELEASE_TOKEN: ${{ secrets.FREEBUDDY_RUNTIME_RELEASE_TOKEN }}
-          RUNTIME_RELEASE_REPO: maojindao55/freebuddy-runtime
-          RUNTIME_SIGNING_PRIVATE_KEY: ${{ secrets.RUNTIME_SIGNING_PRIVATE_KEY }}
-        run: npm run runtime:publish
+          name: unsigned-runtime-pack-${{ github.ref_name }}
+          path: .build/runtime-pack/

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The AppImage uses a static runtime and runs on current Ubuntu releases without i
 
 ### Build from Source
 
-Prerequisites: Node.js 18+, npm 9+
+Prerequisites: Node.js 20.20+ or 22.22+, npm 9+
 
 ```bash
 # Clone the repository

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,7 +109,7 @@ AppImage 使用静态运行时，当前 Ubuntu 版本无需安装 FUSE 2 即可�
 
 ### 从源码构建
 
-前置要求：Node.js 18+, npm 9+
+前置要求：Node.js 20.20+ 或 22.22+, npm 9+
 
 ```bash
 # 克隆仓库

--- a/docs/runtime-release.md
+++ b/docs/runtime-release.md
@@ -9,16 +9,16 @@ Runtime Packs are published independently of desktop installers, to a dedicated 
 
 Desktop clients never `npm install` Runtime packages. Workspace packages stay `private: true`. The distribution unit is one signed `freebuddy-runtime-<version>.zip`.
 
-## What CI publishes
+## Release topology
 
-Pushing a `runtime-vX.Y.Z` tag on `maojindao55/freebuddy` runs `.github/workflows/runtime-release.yml`. That workflow:
+Runtime publishing runs in `maojindao55/freebuddy-runtime`, not in the Desktop source repository. This lets the artifact repository use its own short-lived `GITHUB_TOKEN` with `contents:write`; no cross-repository PAT is stored.
 
-1. Builds and Ed25519-signs the pack with a deterministic `publishedAt` from the git commit time.
-2. Stages `freebuddy-runtime-X.Y.Z.zip`, `stable.json`, and `stable.json.sig`.
-3. Creates a **draft** GitHub Release on `maojindao55/freebuddy-runtime` and uploads the zip.
-4. Re-downloads the zip, verifies the outer SHA-256 and inner `manifest.sig` / `checksums.json` / Host API compatibility.
-5. Publishes the Release.
-6. Atomically commits `channels/stable.json` and `channels/stable.json.sig` in **one** git commit.
+1. Push `runtime-vX.Y.Z` in `maojindao55/freebuddy`. The source workflow typechecks, tests, builds, and probes an unsigned pack in isolation.
+2. Run the `Publish Runtime` workflow in `maojindao55/freebuddy-runtime` with version `X.Y.Z`.
+3. The artifact workflow checks out the matching source tag, builds and Ed25519-signs the pack with a deterministic `publishedAt`, and stages `freebuddy-runtime-X.Y.Z.zip`, `stable.json`, and `stable.json.sig`.
+4. It creates a **draft** GitHub Release in the artifact repository and uploads the zip.
+5. It re-downloads the zip, verifies the outer SHA-256 and inner signature/checksums/Host API compatibility, then runs the isolated process probe.
+6. It publishes the Release and atomically commits `channels/stable.json` and `channels/stable.json.sig` in **one** git commit.
 
 If a `runtime-vX.Y.Z` zip already exists, the publisher compares SHA-256. Identical bytes succeed idempotently. Different bytes fail; the publisher never deletes or overwrites a published asset.
 
@@ -32,14 +32,13 @@ The zip is downloaded from the matching GitHub Release. The downloader follows a
 
 Desktop Runtime auto-update stays **disabled** until the production public key is shipped with the app. Checking for updates in Settings will not download a pack while `update.enabled` is false.
 
-## Secrets (set on `maojindao55/freebuddy`)
+## Secret (set on `maojindao55/freebuddy-runtime`)
 
-Add these repository Actions secrets before pushing a `runtime-v*` tag:
+Add this repository Actions secret before publishing:
 
-1. `RUNTIME_SIGNING_PRIVATE_KEY` — Ed25519 PKCS#8 PEM. GitHub secrets may use `\n` for newlines.
-2. `FREEBUDDY_RUNTIME_RELEASE_TOKEN` — PAT (or GitHub App token) with `contents:write` on `maojindao55/freebuddy-runtime`. The default `GITHUB_TOKEN` cannot create releases in a different repository.
+`RUNTIME_SIGNING_PRIVATE_KEY` — Ed25519 PKCS#8 PEM. GitHub secrets may use `\n` for newlines.
 
-Do not print token values or persist `GH_TOKEN` / `GITHUB_TOKEN` in local shell profiles.
+The workflow maps its repository-scoped `github.token` to the publisher process. Do not copy a personal `GH_TOKEN` into repository secrets or shell profiles.
 
 Generate a one-time key pair:
 
@@ -52,7 +51,7 @@ console.log(publicKey.export({ type: 'spki', format: 'pem' }).toString());
 "
 ```
 
-Store the private PEM in `RUNTIME_SIGNING_PRIVATE_KEY`. Commit the matching public PEM as `electron/runtime/keys/runtime-release.pub` (see that directory's README) in a **desktop** release before turning Runtime auto-update on.
+Store the private PEM in the artifact repository's `RUNTIME_SIGNING_PRIVATE_KEY`. Commit the matching public PEM as `electron/runtime/keys/runtime-release.pub` (see that directory's README) in a **desktop** release before turning Runtime auto-update on.
 
 ## Local development
 
@@ -60,11 +59,14 @@ Store the private PEM in `RUNTIME_SIGNING_PRIVATE_KEY`. Commit the matching publ
 npm run runtime:build
 npm run runtime:sign
 npm run runtime:verify
+npm run runtime:probe
 npm run runtime:package
 ```
 
 Development keys are written to `.build/runtime-keys/` and are not production keys. `npm run runtime:publish` talks to GitHub and requires `FREEBUDDY_RUNTIME_RELEASE_TOKEN`; do not run it against the desktop repository.
 
+For a local production-key rehearsal, point `RUNTIME_SIGNING_PRIVATE_KEY_FILE` at a protected PEM file instead of placing the key in shell history.
+
 ## First publish to the empty artifact repo
 
-The first successful tagged run creates `README.md` and `channels/` on `maojindao55/freebuddy-runtime` if they are missing, then uploads the zip. After that, GitHub Latest in the artifact repo may point at Runtime. Desktop Latest stays on `maojindao55/freebuddy`.
+The artifact repository is initialized with its publishing workflow and public verification key before the first release. The first successful publish creates `channels/` and uploads the zip. After that, GitHub Latest in the artifact repo may point at Runtime. Desktop Latest stays on `maojindao55/freebuddy`.

--- a/electron/runtime/keys/README.md
+++ b/electron/runtime/keys/README.md
@@ -6,6 +6,6 @@ Place the production Ed25519 public key at `runtime-release.pub` in this directo
 - `process.resourcesPath/runtime-keys/runtime-release.pub` in packaged apps
 - `electron/runtime/keys/runtime-release.pub` during development
 
-Leave the file absent until the matching private key is stored in the
-`maojindao55/freebuddy` Actions secret `RUNTIME_SIGNING_PRIVATE_KEY`. Runtime
-auto-update stays disabled until that public key ships with a desktop release.
+The matching private key is stored only in the `maojindao55/freebuddy-runtime`
+Actions secret `RUNTIME_SIGNING_PRIVATE_KEY`. Never commit or print the private key.
+Runtime auto-update stays disabled until this public key ships with a desktop release.

--- a/electron/runtime/keys/runtime-release.pub
+++ b/electron/runtime/keys/runtime-release.pub
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAGlTpRaCQ6KWs2b8fnusLphhdYp99slTofIrnIPIgX0M=
+-----END PUBLIC KEY-----

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "runtime:verify": "node scripts/verify-runtime-pack.mjs",
     "runtime:package": "node scripts/package-runtime-release.mjs",
     "runtime:publish": "node scripts/publish-runtime-release.mjs",
-    "runtime:probe": "node scripts/verify-runtime-pack.mjs",
+    "runtime:probe": "node scripts/probe-runtime-pack.mjs",
     "star-history:generate": "node scripts/generate-star-history.mjs",
     "start": "npm run build && node scripts/start-electron.mjs",
     "preview": "vite preview --host 127.0.0.1"

--- a/packages/runtime-host/src/index.ts
+++ b/packages/runtime-host/src/index.ts
@@ -13,7 +13,12 @@ export type {
   RuntimeVersionRoute
 } from "./ports.js";
 export { readRuntimeState, writeRuntimeState, withInstallLock } from "./runtimeStateStore.js";
-export { verifyRuntimeArtifact, verifyRuntimePackFiles, sha256 } from "./runtimeVerifier.js";
+export {
+  verifyRuntimeArtifact,
+  verifyRuntimePackFiles,
+  runtimePackSignaturePayload,
+  sha256
+} from "./runtimeVerifier.js";
 export { installRuntimeArchive } from "./runtimeInstaller.js";
 export { createNodeRuntimeProcessLauncher } from "./node/nodeRuntimeProcessLauncher.js";
 export { RuntimeRpcSession, createLoopbackPair } from "./rpc/session.js";

--- a/packages/runtime-host/src/runtimeVerifier.ts
+++ b/packages/runtime-host/src/runtimeVerifier.ts
@@ -1,11 +1,21 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createHash, verify } from "node:crypto";
-import type { RuntimeManifest } from "@freebuddy/protocol/runtime";
+import {
+  RUNTIME_MANIFEST_SCHEMA_VERSION,
+  RUNTIME_RPC_VERSION,
+  type RuntimeManifest
+} from "@freebuddy/protocol/runtime";
 import { hostApiCompatible, hostCapabilitiesSatisfied } from "./hostApiRange.js";
+
+const MAX_MANIFEST_BYTES = 64 * 1024;
+const MAX_CHECKSUM_BYTES = 256 * 1024;
+const MAX_SIGNATURE_BYTES = 1024;
+const SIGNATURE_DOMAIN = "freebuddy-runtime-pack-signature-v1";
 
 export interface VerifyInput {
   manifestBytes: Buffer;
+  checksumBytes: Buffer;
   signature: Buffer;
   publicKey: Buffer | string;
   archiveSha256: string;
@@ -25,6 +35,25 @@ export interface VerifyPackFilesInput {
 
 export function sha256(buf: Buffer | string): string {
   return createHash("sha256").update(buf).digest("hex");
+}
+
+export function runtimePackSignaturePayload(
+  manifestBytes: Buffer,
+  checksumBytes: Buffer
+): Buffer {
+  const header = Buffer.from(
+    `${SIGNATURE_DOMAIN}\n${manifestBytes.byteLength}\n${checksumBytes.byteLength}\n`,
+    "utf8"
+  );
+  return Buffer.concat([header, manifestBytes, checksumBytes]);
+}
+
+function isSafePackPath(name: string): boolean {
+  if (!name || name.includes("\\") || name.startsWith("/") || path.isAbsolute(name)) {
+    return false;
+  }
+  const normalized = path.posix.normalize(name);
+  return normalized === name && normalized !== ".." && !normalized.startsWith("../");
 }
 
 export function readRuntimePackDirectory(dir: string): Record<string, Buffer> {
@@ -48,10 +77,33 @@ export function verifyRuntimePackFiles(
   const manifestBytes = input.files["manifest.json"];
   const signature = input.files["manifest.sig"];
   const checksumBytes = input.files["checksums.json"];
-  const entry = input.files["runtime/index.mjs"];
   if (!manifestBytes) return { ok: false, error: "missing manifest.json" };
   if (!checksumBytes) return { ok: false, error: "missing checksums.json" };
-  if (!entry) return { ok: false, error: "missing runtime/index.mjs" };
+  if (manifestBytes.byteLength > MAX_MANIFEST_BYTES) {
+    return { ok: false, error: "manifest too large" };
+  }
+  if (checksumBytes.byteLength > MAX_CHECKSUM_BYTES) {
+    return { ok: false, error: "checksums too large" };
+  }
+  if (signature && signature.byteLength > MAX_SIGNATURE_BYTES) {
+    return { ok: false, error: "signature too large" };
+  }
+
+  if (!signature) {
+    if (!input.allowUnsigned) return { ok: false, error: "missing manifest.sig" };
+  } else {
+    if (!input.publicKey) return { ok: false, error: "unknown pack key" };
+    if (
+      !verify(
+        null,
+        runtimePackSignaturePayload(manifestBytes, checksumBytes),
+        input.publicKey,
+        signature
+      )
+    ) {
+      return { ok: false, error: "invalid signature" };
+    }
+  }
 
   let checksums: { files?: Record<string, string> };
   try {
@@ -59,20 +111,8 @@ export function verifyRuntimePackFiles(
   } catch {
     return { ok: false, error: "invalid checksums json" };
   }
-  for (const [name, expected] of Object.entries(checksums.files ?? {})) {
-    const bytes = input.files[name];
-    if (!bytes) return { ok: false, error: `missing checksum file ${name}` };
-    if (sha256(bytes) !== expected) return { ok: false, error: `checksum mismatch ${name}` };
-  }
-
-  if (!signature) {
-    if (!input.allowUnsigned) return { ok: false, error: "missing manifest.sig" };
-  } else if (input.publicKey) {
-    if (!verify(null, manifestBytes, input.publicKey, signature)) {
-      return { ok: false, error: "invalid signature" };
-    }
-  } else if (!input.allowUnsigned) {
-    return { ok: false, error: "unknown pack key" };
+  if (!checksums.files || typeof checksums.files !== "object") {
+    return { ok: false, error: "missing checksum files" };
   }
 
   let manifest: RuntimeManifest;
@@ -80,6 +120,38 @@ export function verifyRuntimePackFiles(
     manifest = JSON.parse(manifestBytes.toString("utf8")) as RuntimeManifest;
   } catch {
     return { ok: false, error: "invalid manifest json" };
+  }
+  if (manifest.schemaVersion !== RUNTIME_MANIFEST_SCHEMA_VERSION) {
+    return { ok: false, error: "unsupported manifest schema" };
+  }
+  if (manifest.rpcVersion !== RUNTIME_RPC_VERSION) {
+    return { ok: false, error: "incompatible runtime rpc" };
+  }
+  if (!isSafePackPath(manifest.entry) || manifest.entry !== "runtime/index.mjs") {
+    return { ok: false, error: "invalid runtime entry" };
+  }
+  if (!input.files[manifest.entry]) {
+    return { ok: false, error: `missing ${manifest.entry}` };
+  }
+  if (!checksums.files["manifest.json"] || !checksums.files[manifest.entry]) {
+    return { ok: false, error: "required file missing from checksums" };
+  }
+
+  for (const [name, expected] of Object.entries(checksums.files)) {
+    if (!isSafePackPath(name)) return { ok: false, error: `illegal checksum path ${name}` };
+    if (!/^[a-f0-9]{64}$/.test(expected)) {
+      return { ok: false, error: `invalid checksum ${name}` };
+    }
+    const bytes = input.files[name];
+    if (!bytes) return { ok: false, error: `missing checksum file ${name}` };
+    if (sha256(bytes) !== expected) return { ok: false, error: `checksum mismatch ${name}` };
+  }
+
+  for (const name of Object.keys(input.files)) {
+    if (name === "checksums.json" || name === "manifest.sig") continue;
+    if (!checksums.files[name]) {
+      return { ok: false, error: `unchecked pack file ${name}` };
+    }
   }
   if (manifest.bundleId !== input.expectedBundleId) {
     return { ok: false, error: "bundle id mismatch" };
@@ -105,7 +177,12 @@ export function verifyRuntimeArtifact(input: VerifyInput): { ok: true } | { ok: 
   if (archiveHash !== input.archiveSha256) {
     return { ok: false, error: "archive hash mismatch" };
   }
-  const valid = verify(null, input.manifestBytes, input.publicKey, input.signature);
+  const valid = verify(
+    null,
+    runtimePackSignaturePayload(input.manifestBytes, input.checksumBytes),
+    input.publicKey,
+    input.signature
+  );
   if (!valid) return { ok: false, error: "invalid signature" };
   let manifest: RuntimeManifest;
   try {

--- a/scripts/build-runtime-pack.mjs
+++ b/scripts/build-runtime-pack.mjs
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
-import { spawnSync } from "node:child_process";
+import { builtinModules } from "node:module";
 import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
 import { resolveRuntimePackVersion } from "./runtime-release-lib.mjs";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -14,23 +15,36 @@ const publishedAt = process.env.RUNTIME_PACK_PUBLISHED_AT || new Date().toISOStr
 fs.rmSync(outDir, { recursive: true, force: true });
 fs.mkdirSync(path.join(outDir, "runtime"), { recursive: true });
 
-const packTsconfig = {
-  files: [],
-  references: [{ path: path.join(root, "tsconfig.packages.json") }]
-};
-void packTsconfig;
-
-const build = spawnSync("npx", ["esbuild", "packages/runtime-entry/src/bootstrap.ts", "--bundle", "--platform=node", "--format=esm", "--outfile=.build/runtime-pack/runtime/index.mjs"], {
-  cwd: root,
-  stdio: "inherit"
+const buildResult = await build({
+  absWorkingDir: root,
+  entryPoints: ["packages/runtime-entry/src/bootstrap.ts"],
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  format: "esm",
+  outfile: ".build/runtime-pack/runtime/index.mjs",
+  metafile: true,
+  logLevel: "info"
 });
-if (build.status !== 0) {
-  // Fallback: copy compiled runtime-entry bootstrap when esbuild cannot resolve workspace graph yet.
-  const entry = path.join(root, "packages/runtime-entry/dist/bootstrap.js");
-  if (!fs.existsSync(entry)) {
-    process.exit(build.status ?? 1);
-  }
-  fs.copyFileSync(entry, path.join(outDir, "runtime/index.mjs"));
+
+const builtins = new Set(
+  builtinModules.flatMap((name) => [name, name.startsWith("node:") ? name : `node:${name}`])
+);
+const externalImports = Object.values(buildResult.metafile.outputs)
+  .flatMap((output) => output.imports)
+  .filter((item) => item.external && !builtins.has(item.path));
+if (externalImports.length > 0) {
+  throw new Error(
+    `runtime pack contains external package imports: ${externalImports
+      .map((item) => item.path)
+      .join(", ")}`
+  );
+}
+const forbiddenInputs = Object.keys(buildResult.metafile.inputs).filter(
+  (name) => /(^|\/)electron\//.test(name) || /(^|\/)better-sqlite3(\/|$)/.test(name)
+);
+if (forbiddenInputs.length > 0) {
+  throw new Error(`runtime pack contains forbidden host inputs: ${forbiddenInputs.join(", ")}`);
 }
 
 const bundle = fs.readFileSync(path.join(outDir, "runtime/index.mjs"), "utf8");
@@ -59,8 +73,11 @@ const manifest = {
 
 const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
 fs.writeFileSync(path.join(outDir, "manifest.json"), manifestText);
+const licensesText = "FreeBuddy runtime pack. See repository LICENSE.\n";
+fs.writeFileSync(path.join(outDir, "LICENSES.txt"), licensesText);
 const checksums = {
   files: {
+    "LICENSES.txt": createHash("sha256").update(licensesText).digest("hex"),
     "manifest.json": createHash("sha256").update(manifestText).digest("hex"),
     "runtime/index.mjs": createHash("sha256")
       .update(fs.readFileSync(path.join(outDir, "runtime/index.mjs")))
@@ -68,5 +85,4 @@ const checksums = {
   }
 };
 fs.writeFileSync(path.join(outDir, "checksums.json"), `${JSON.stringify(checksums, null, 2)}\n`);
-fs.writeFileSync(path.join(outDir, "LICENSES.txt"), "FreeBuddy runtime pack. See repository LICENSE.\n");
 console.log(`runtime pack written to ${outDir}`);

--- a/scripts/package-runtime-release.mjs
+++ b/scripts/package-runtime-release.mjs
@@ -55,18 +55,26 @@ const descriptorText = `${JSON.stringify(descriptor, null, 2)}\n`;
 fs.writeFileSync(path.join(outDir, `${channel}.json`), descriptorText);
 
 const fromEnv = process.env.RUNTIME_SIGNING_PRIVATE_KEY?.replace(/\\n/g, "\n")?.trim();
+const fromFile = process.env.RUNTIME_SIGNING_PRIVATE_KEY_FILE?.trim();
 if (
   !fromEnv &&
+  !fromFile &&
   process.env.CI &&
   /^runtime-v\d+\.\d+\.\d+$/.test(process.env.GITHUB_REF_NAME ?? "")
 ) {
-  throw new Error("RUNTIME_SIGNING_PRIVATE_KEY is required to package tagged runtime releases");
+  throw new Error(
+    "RUNTIME_SIGNING_PRIVATE_KEY or RUNTIME_SIGNING_PRIVATE_KEY_FILE is required to package tagged runtime releases"
+  );
 }
 const localPem = path.join(root, ".build", "runtime-keys", "runtime-dev.pem");
-if (!fromEnv && !fs.existsSync(localPem)) {
-  throw new Error("missing RUNTIME_SIGNING_PRIVATE_KEY and local development key");
+if (!fromEnv && !fromFile && !fs.existsSync(localPem)) {
+  throw new Error("missing Runtime signing key and local development key");
 }
-const keyPem = fromEnv || fs.readFileSync(localPem, "utf8");
+const keyPem =
+  fromEnv ||
+  (fromFile
+    ? fs.readFileSync(path.resolve(fromFile), "utf8")
+    : fs.readFileSync(localPem, "utf8"));
 const signature = sign(null, Buffer.from(descriptorText), createPrivateKey(keyPem));
 fs.writeFileSync(path.join(outDir, `${channel}.json.sig`), signature);
 

--- a/scripts/probe-runtime-pack.mjs
+++ b/scripts/probe-runtime-pack.mjs
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const packDir = path.join(root, ".build", "runtime-pack");
+const probeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "freebuddy-runtime-probe-"));
+const isolatedPack = path.join(probeRoot, "runtime-pack");
+const dataDir = path.join(probeRoot, "host-data");
+
+const { createNodeRuntimeProcessLauncher, probeRuntimeVersion } = await import(
+  "../packages/runtime-host/dist/index.js"
+);
+
+try {
+  fs.cpSync(packDir, isolatedPack, { recursive: true });
+  const result = await probeRuntimeVersion(
+    {
+      hostId: "freebuddy-cli",
+      hostVersion: "0.0.0-probe",
+      hostApiVersion: "1.0.0",
+      hostCapabilities: [
+        "agent.execute.v1",
+        "workflow.repository.v1",
+        "delegation.repository.v1",
+        "events.publish.v1"
+      ],
+      dataDir,
+      bundledRuntimePath: isolatedPack,
+      allowUnsignedDevelopmentRuntime: false,
+      launcher: createNodeRuntimeProcessLauncher(),
+      http: { fetch },
+      trustedKeys: { get: () => undefined, list: () => [] },
+      clock: { now: () => new Date(), nowIso: () => new Date().toISOString() }
+    },
+    "bundled"
+  );
+  if (!result.ok) throw new Error(result.reason ?? "runtime probe failed");
+  console.log("runtime pack probe passed");
+} finally {
+  fs.rmSync(probeRoot, { recursive: true, force: true });
+}

--- a/scripts/sign-runtime-pack.mjs
+++ b/scripts/sign-runtime-pack.mjs
@@ -7,6 +7,9 @@ const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const packDir = path.join(root, ".build", "runtime-pack");
 const keyDir = path.join(root, ".build", "runtime-keys");
 fs.mkdirSync(keyDir, { recursive: true });
+const { runtimePackSignaturePayload } = await import(
+  "../packages/runtime-host/dist/runtimeVerifier.js"
+);
 
 const privPath = path.join(keyDir, "runtime-dev.pem");
 const pubPath = path.join(keyDir, "current.pub");
@@ -17,8 +20,14 @@ function loadPrivateKey() {
   if (fromEnv && fromEnv.trim()) {
     return fromEnv.replace(/\\n/g, "\n");
   }
+  const fromFile = process.env.RUNTIME_SIGNING_PRIVATE_KEY_FILE;
+  if (fromFile && fromFile.trim()) {
+    return fs.readFileSync(path.resolve(fromFile));
+  }
   if (process.env.CI && /^runtime-v\d+\.\d+\.\d+$/.test(process.env.GITHUB_REF_NAME ?? "")) {
-    throw new Error("RUNTIME_SIGNING_PRIVATE_KEY is required to sign tagged runtime releases");
+    throw new Error(
+      "RUNTIME_SIGNING_PRIVATE_KEY or RUNTIME_SIGNING_PRIVATE_KEY_FILE is required to sign tagged runtime releases"
+    );
   }
   if (!fs.existsSync(privPath)) {
     const { publicKey, privateKey } = generateKeyPairSync("ed25519");
@@ -36,8 +45,10 @@ fs.writeFileSync(pubPath, publicKeyPem);
 if (!fs.existsSync(legacyPubPath)) fs.writeFileSync(legacyPubPath, publicKeyPem);
 
 const manifest = fs.readFileSync(path.join(packDir, "manifest.json"));
-const signature = sign(null, manifest, privateKey);
+const checksums = fs.readFileSync(path.join(packDir, "checksums.json"));
+const signaturePayload = runtimePackSignaturePayload(manifest, checksums);
+const signature = sign(null, signaturePayload, privateKey);
 fs.writeFileSync(path.join(packDir, "manifest.sig"), signature);
-const ok = verify(null, manifest, publicKeyPem, signature);
+const ok = verify(null, signaturePayload, publicKeyPem, signature);
 if (!ok) throw new Error("failed to sign runtime manifest");
 console.log("signed", path.join(packDir, "manifest.sig"));

--- a/scripts/verify-runtime-pack.mjs
+++ b/scripts/verify-runtime-pack.mjs
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { verify } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -8,14 +7,21 @@ const packDir = path.join(root, ".build", "runtime-pack");
 const currentPub = path.join(root, ".build", "runtime-keys", "current.pub");
 const legacyPub = path.join(root, ".build", "runtime-keys", "runtime-dev.pub");
 const pubPath = fs.existsSync(currentPub) ? currentPub : legacyPub;
-const manifest = fs.readFileSync(path.join(packDir, "manifest.json"));
-const signature = fs.readFileSync(path.join(packDir, "manifest.sig"));
 const publicKey = fs.readFileSync(pubPath);
-if (!verify(null, manifest, publicKey, signature)) {
-  throw new Error("runtime pack signature invalid");
-}
-const parsed = JSON.parse(manifest.toString("utf8"));
-if (parsed.bundleId !== "dev.freebuddy.runtime") {
-  throw new Error("unexpected bundle id");
-}
-console.log("verified runtime pack", parsed.version);
+const { readRuntimePackDirectory, verifyRuntimePackFiles } = await import(
+  "../packages/runtime-host/dist/runtimeVerifier.js"
+);
+const verified = verifyRuntimePackFiles({
+  files: readRuntimePackDirectory(packDir),
+  publicKey,
+  expectedBundleId: "dev.freebuddy.runtime",
+  hostApiVersion: "1.0.0",
+  hostCapabilities: [
+    "agent.execute.v1",
+    "workflow.repository.v1",
+    "delegation.repository.v1",
+    "events.publish.v1"
+  ]
+});
+if (!verified.ok) throw new Error(`runtime pack verification failed: ${verified.error}`);
+console.log("verified runtime pack", verified.manifest.version);

--- a/tests/package-boundaries.test.mjs
+++ b/tests/package-boundaries.test.mjs
@@ -150,6 +150,57 @@ function collectGraph() {
   return graph;
 }
 
+function collectSourceViolations(name, file, source) {
+  const rule = RULES[name];
+  assert.ok(rule, `missing boundary rule for package ${name}`);
+  const violations = [];
+  const rel = path.relative(rootDir, file);
+  const packageRoot = path.join(packagesDir, name);
+
+  for (const spec of extractImports(source)) {
+    if (spec.startsWith(".")) {
+      const resolved = path.resolve(path.dirname(file), spec);
+      if (resolved !== packageRoot && !resolved.startsWith(`${packageRoot}${path.sep}`)) {
+        violations.push(`${rel} escapes its package with ${spec}`);
+      }
+    }
+    if (spec.includes("/src/") && spec.startsWith("@freebuddy/")) {
+      violations.push(`${rel} deep-imports ${spec}`);
+    }
+    if (spec.startsWith("@freebuddy/")) {
+      const pkg = spec.split("/").slice(0, 2).join("/");
+      if (pkg !== `@freebuddy/${name}` && !rule.allowPackages.includes(pkg)) {
+        violations.push(`${rel} imports forbidden package ${pkg}`);
+      }
+    }
+    for (const forbid of rule.forbid) {
+      if (forbid.test(spec)) {
+        violations.push(`${rel} imports forbidden specifier ${spec}`);
+      }
+    }
+    if (/from\s+['"]electron['"]/.test(source) && name !== "storage-sqlite") {
+      violations.push(`${rel} imports electron`);
+    }
+  }
+  if (name !== "storage-sqlite") {
+    if (/\bbetter-sqlite3\b/.test(source)) {
+      violations.push(`${rel} references better-sqlite3`);
+    }
+    if (/\bgetDb\s*\(/.test(source)) {
+      violations.push(`${rel} calls getDb(`);
+    }
+    if (/\bWebContents\b/.test(source) || /\bipcSend\b/.test(source)) {
+      violations.push(`${rel} references Electron transport types`);
+    }
+  }
+  if (name === "protocol" || name === "workflow-core" || name === "delegation-core") {
+    if (/\bfrom\s+['"]node:fs['"]/.test(source) || /\bfrom\s+['"]fs['"]/.test(source)) {
+      violations.push(`${rel} uses filesystem APIs`);
+    }
+  }
+  return violations;
+}
+
 test("workspace packages obey dependency boundaries", () => {
   const names = packageList();
   const violations = [];
@@ -160,50 +211,7 @@ test("workspace packages obey dependency boundaries", () => {
     const files = walkTsFiles(path.join(packagesDir, name, "src"));
     for (const file of files) {
       const source = fs.readFileSync(file, "utf8");
-      const rel = path.relative(rootDir, file);
-      for (const spec of extractImports(source)) {
-        if (spec.includes("/src/") && spec.startsWith("@freebuddy/")) {
-          violations.push(`${rel} deep-imports ${spec}`);
-        }
-        if (spec.startsWith("@freebuddy/")) {
-          const pkg = spec.split("/").slice(0, 2).join("/");
-          if (pkg === `@freebuddy/${name}`) continue;
-          if (!rule.allowPackages.includes(pkg)) {
-            violations.push(`${rel} imports forbidden package ${pkg}`);
-          }
-        }
-        for (const forbid of rule.forbid) {
-          if (forbid.test(spec) || forbid.test(source)) {
-            if (spec.match(forbid) || (typeof forbid.source === "string" && source.includes(forbid.source.replace(/[\\^$]/g, "")))) {
-              if (forbid.test(spec)) {
-                violations.push(`${rel} imports forbidden specifier ${spec}`);
-              }
-            }
-          }
-        }
-        if (
-          /from\s+['"]electron['"]/.test(source) &&
-          name !== "storage-sqlite"
-        ) {
-          violations.push(`${rel} imports electron`);
-        }
-      }
-      if (name !== "storage-sqlite") {
-        if (/\bbetter-sqlite3\b/.test(source)) {
-          violations.push(`${rel} references better-sqlite3`);
-        }
-        if (/\bgetDb\s*\(/.test(source)) {
-          violations.push(`${rel} calls getDb(`);
-        }
-        if (/\bWebContents\b/.test(source) || /\bipcSend\b/.test(source)) {
-          violations.push(`${rel} references Electron transport types`);
-        }
-      }
-      if (name === "protocol" || name === "workflow-core" || name === "delegation-core") {
-        if (/\bfrom\s+['"]node:fs['"]/.test(source) || /\bfrom\s+['"]fs['"]/.test(source)) {
-          violations.push(`${rel} uses filesystem APIs`);
-        }
-      }
+      violations.push(...collectSourceViolations(name, file, source));
     }
   }
 
@@ -235,8 +243,19 @@ test("workspace packages have no dependency cycles", () => {
 });
 
 test("boundary fixture rejects electron import into a runtime package", () => {
+  const file = path.join(packagesDir, "workflow-runtime", "src", "fixture.ts");
   const fixture = `import { app } from "electron";\nexport const leaked = app;\n`;
-  assert.match(fixture, /from\s+["']electron["']/);
-  const wouldFail = /from\s+['"]electron['"]/.test(fixture);
-  assert.equal(wouldFail, true);
+  assert.match(
+    collectSourceViolations("workflow-runtime", file, fixture).join("\n"),
+    /imports forbidden specifier electron/
+  );
+});
+
+test("boundary fixture rejects a relative import that escapes a runtime package", () => {
+  const file = path.join(packagesDir, "workflow-runtime", "src", "fixture.ts");
+  const fixture = `import { app } from "../../../electron/main.js";\nexport const leaked = app;\n`;
+  assert.match(
+    collectSourceViolations("workflow-runtime", file, fixture).join("\n"),
+    /escapes its package/
+  );
 });

--- a/tests/runtime-signature.test.mjs
+++ b/tests/runtime-signature.test.mjs
@@ -2,13 +2,17 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { generateKeyPairSync, sign } from "node:crypto";
 
-const { verifyRuntimeArtifact, sha256 } = await import(
+const {
+  runtimePackSignaturePayload,
+  verifyRuntimeArtifact,
+  verifyRuntimePackFiles,
+  sha256
+} = await import(
   "../packages/runtime-host/dist/runtimeVerifier.js"
 );
 
-test("valid signature verifies", () => {
-  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
-  const manifestBytes = Buffer.from(
+function runtimeManifest() {
+  return Buffer.from(
     JSON.stringify({
       schemaVersion: 1,
       bundleId: "dev.freebuddy.runtime",
@@ -23,10 +27,32 @@ test("valid signature verifies", () => {
       requiresHostCapabilities: []
     })
   );
+}
+
+function runtimeChecksums(manifestBytes, entryBytes) {
+  return Buffer.from(
+    JSON.stringify({
+      files: {
+        "manifest.json": sha256(manifestBytes),
+        "runtime/index.mjs": sha256(entryBytes)
+      }
+    })
+  );
+}
+
+test("valid signature verifies", () => {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const manifestBytes = runtimeManifest();
+  const checksumBytes = runtimeChecksums(manifestBytes, Buffer.from("entry"));
   const archiveBytes = Buffer.from("archive");
-  const signature = sign(null, manifestBytes, privateKey);
+  const signature = sign(
+    null,
+    runtimePackSignaturePayload(manifestBytes, checksumBytes),
+    privateKey
+  );
   const result = verifyRuntimeArtifact({
     manifestBytes,
+    checksumBytes,
     signature,
     publicKey,
     archiveSha256: sha256(archiveBytes),
@@ -39,18 +65,17 @@ test("valid signature verifies", () => {
 
 test("modified archive is rejected", () => {
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
-  const manifestBytes = Buffer.from(
-    JSON.stringify({
-      schemaVersion: 1,
-      bundleId: "dev.freebuddy.runtime",
-      version: "1.0.0",
-      hostApi: ">=1.0.0 <2.0.0"
-    })
-  );
+  const manifestBytes = runtimeManifest();
+  const checksumBytes = runtimeChecksums(manifestBytes, Buffer.from("entry"));
   const archiveBytes = Buffer.from("archive");
-  const signature = sign(null, manifestBytes, privateKey);
+  const signature = sign(
+    null,
+    runtimePackSignaturePayload(manifestBytes, checksumBytes),
+    privateKey
+  );
   const result = verifyRuntimeArtifact({
     manifestBytes,
+    checksumBytes,
     signature,
     publicKey,
     archiveSha256: sha256(archiveBytes),
@@ -59,6 +84,33 @@ test("modified archive is rejected", () => {
     hostApiVersion: "1.0.0"
   });
   assert.equal(result.ok, false);
+});
+
+test("rewriting runtime bytes and checksums cannot preserve a valid pack signature", () => {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const manifestBytes = runtimeManifest();
+  const originalEntry = Buffer.from("export const trusted = true;\n");
+  const originalChecksums = runtimeChecksums(manifestBytes, originalEntry);
+  const signature = sign(
+    null,
+    runtimePackSignaturePayload(manifestBytes, originalChecksums),
+    privateKey
+  );
+  const tamperedEntry = Buffer.from("export const trusted = false;\n");
+  const rewrittenChecksums = runtimeChecksums(manifestBytes, tamperedEntry);
+  const result = verifyRuntimePackFiles({
+    files: {
+      "manifest.json": manifestBytes,
+      "manifest.sig": signature,
+      "checksums.json": rewrittenChecksums,
+      "runtime/index.mjs": tamperedEntry
+    },
+    publicKey,
+    expectedBundleId: "dev.freebuddy.runtime",
+    hostApiVersion: "1.0.0"
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /invalid signature/);
 });
 
 test("sanitized runtime env drops secrets and debug flags", async () => {

--- a/tests/runtime-updater.test.mjs
+++ b/tests/runtime-updater.test.mjs
@@ -277,7 +277,9 @@ test("installer verifies inner manifest signature, checksums, and compatibility"
   const dir = dataDir();
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
   const { default: AdmZip } = await import("adm-zip");
-  const { sha256 } = await import("../packages/runtime-host/dist/runtimeVerifier.js");
+  const { runtimePackSignaturePayload, sha256 } = await import(
+    "../packages/runtime-host/dist/runtimeVerifier.js"
+  );
   const entry = Buffer.from("export {}\n");
   const manifest = Buffer.from(
     `${JSON.stringify({
@@ -304,7 +306,10 @@ test("installer verifies inner manifest signature, checksums, and compatibility"
   );
   const zip = new AdmZip();
   zip.addFile("manifest.json", manifest);
-  zip.addFile("manifest.sig", sign(null, manifest, privateKey));
+  zip.addFile(
+    "manifest.sig",
+    sign(null, runtimePackSignaturePayload(manifest, checksums), privateKey)
+  );
   zip.addFile("checksums.json", checksums);
   zip.addFile("runtime/index.mjs", entry);
   const installed = installRuntimeArchive(dir, "1.2.3", zip.toBuffer(), {
@@ -316,7 +321,10 @@ test("installer verifies inner manifest signature, checksums, and compatibility"
 
   const tampered = new AdmZip();
   tampered.addFile("manifest.json", manifest);
-  tampered.addFile("manifest.sig", sign(null, manifest, privateKey));
+  tampered.addFile(
+    "manifest.sig",
+    sign(null, runtimePackSignaturePayload(manifest, checksums), privateKey)
+  );
   tampered.addFile("checksums.json", checksums);
   tampered.addFile("runtime/index.mjs", Buffer.from("export const x = 1\n"));
   const bad = installRuntimeArchive(dir, "1.2.4", tampered.toBuffer(), {
@@ -326,6 +334,27 @@ test("installer verifies inner manifest signature, checksums, and compatibility"
   });
   assert.equal(bad.ok, false);
   assert.match(bad.error, /checksum mismatch/);
+
+  const rewrittenChecksums = Buffer.from(
+    `${JSON.stringify({
+      files: {
+        "manifest.json": sha256(manifest),
+        "runtime/index.mjs": sha256(Buffer.from("export const x = 1\n"))
+      }
+    })}\n`
+  );
+  const rewritten = new AdmZip();
+  rewritten.addFile("manifest.json", manifest);
+  rewritten.addFile("manifest.sig", sign(null, runtimePackSignaturePayload(manifest, checksums), privateKey));
+  rewritten.addFile("checksums.json", rewrittenChecksums);
+  rewritten.addFile("runtime/index.mjs", Buffer.from("export const x = 1\n"));
+  const rewrittenBad = installRuntimeArchive(dir, "1.2.5", rewritten.toBuffer(), {
+    publicKey: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    hostApiVersion: "1.0.0",
+    hostCapabilities: ["agent.execute.v1"]
+  });
+  assert.equal(rewrittenBad.ok, false);
+  assert.match(rewrittenBad.error, /invalid signature/);
 });
 
 test("installer rejects path escape", async () => {


### PR DESCRIPTION
## Summary

- harden runtime pack verification by binding signatures to both manifest and checksums
- reject unchecked files, unsafe paths, invalid manifests, and forbidden bundled dependencies
- add a real out-of-tree runtime launch probe and production-key rehearsal support
- make the source repository validate runtime tags while the artifact repository signs and publishes releases
- document the two-repository release flow and production public-key fingerprint

## Verification

- npm run typecheck
- npm test (1435 tests total; 1306 passed, 129 skipped)
- npm run build
- production-key build/sign/verify/probe/package rehearsal
- npm run github:preflight

## Companion repository

Initialized https://github.com/maojindao55/freebuddy-runtime with its artifact-only README, public key, scoped signing secret, and publish workflow.