### PR TITLE
fix: verify draft runtime assets via API

### DIFF
--- a/scripts/publish-runtime-release.mjs
+++ b/scripts/publish-runtime-release.mjs
@@ -6,6 +6,7 @@ import {
   decideImmutableAsset,
   decideReleaseMutation,
   normalizeSha256,
+  runtimeAssetDownloadUrl,
   resolveRuntimePackVersion,
   runtimeReleaseRepo,
   runtimeReleaseTag
@@ -240,11 +241,11 @@ if (zipDecision.action === "upload") {
     throw new Error(`upload ${zipName} failed: ${uploaded.status} ${await uploaded.text()}`);
   }
   const asset = await uploaded.json();
-  await assertRemoteZipMatches(asset.browser_download_url || asset.url);
+  await assertRemoteZipMatches(runtimeAssetDownloadUrl(asset));
 } else if (zipDecision.action === "compare-bytes") {
   await assertRemoteZipMatches(zipDecision.url);
 } else if (zipDecision.action === "reuse") {
-  const url = zipAsset.browser_download_url || zipAsset.url;
+  const url = runtimeAssetDownloadUrl(zipAsset);
   await assertRemoteZipMatches(url);
 }
 

--- a/scripts/runtime-release-lib.mjs
+++ b/scripts/runtime-release-lib.mjs
@@ -87,6 +87,14 @@ export function assetSha256(asset) {
   return normalizeSha256(asset.digest) || normalizeSha256(asset.sha256) || null;
 }
 
+export function runtimeAssetDownloadUrl(asset) {
+  if (!asset) return null;
+  // The browser URL of an asset attached to a draft release returns 404 even
+  // with authentication. The API asset URL supports authenticated downloads
+  // for both draft and published releases.
+  return asset.url || asset.browser_download_url || null;
+}
+
 /**
  * Immutable release assets: reuse when the digest matches, fail when it differs,
  * upload only when the named asset is absent.
@@ -108,7 +116,7 @@ export function decideImmutableAsset({ existingAsset, localSha256 }) {
       action: "compare-bytes",
       localSha256: local,
       assetId: existingAsset.id,
-      url: existingAsset.browser_download_url || existingAsset.url
+      url: runtimeAssetDownloadUrl(existingAsset)
     };
   }
   return {

--- a/tests/runtime-release.test.mjs
+++ b/tests/runtime-release.test.mjs
@@ -7,6 +7,7 @@ import {
   isRuntimeTag,
   resolveRuntimePackVersion,
   runtimeChannelBaseUrl,
+  runtimeAssetDownloadUrl,
   runtimeReleaseRepo,
   runtimeReleaseTag,
   versionFromRuntimeTag,
@@ -96,6 +97,25 @@ test("published runtime assets are immutable", () => {
       localSha256
     }).action,
     "fail"
+  );
+  assert.equal(
+    runtimeAssetDownloadUrl({
+      url: "https://api.github.com/repos/acme/runtime/releases/assets/1",
+      browser_download_url: "https://github.com/acme/runtime/releases/download/untagged/pack.zip"
+    }),
+    "https://api.github.com/repos/acme/runtime/releases/assets/1"
+  );
+  assert.equal(
+    decideImmutableAsset({
+      existingAsset: {
+        id: 1,
+        name: "pack.zip",
+        url: "https://api.github.com/repos/acme/runtime/releases/assets/1",
+        browser_download_url: "https://github.com/acme/runtime/releases/download/untagged/pack.zip"
+      },
+      localSha256
+    }).url,
+    "https://api.github.com/repos/acme/runtime/releases/assets/1"
   );
   assert.equal(
     decideReleaseMutation({ release: null, zipName: "pack.zip", localSha256 }).action,


### PR DESCRIPTION
## Summary

- download uploaded draft Release assets through the authenticated GitHub API URL
- keep browser download URLs as a fallback for published assets
- cover URL selection and immutable byte-comparison behavior

The first runtime publish exposed this issue after build, signing, verification, probing, packaging, and upload had all passed: GitHub returns 404 for a draft asset browser URL even with authentication.

## Verification

- node --test tests/runtime-release.test.mjs
- npm run typecheck:packages
- npm run github:preflight