### PR TITLE
feat: restore codex BYOK chat wire API via local Responses bridge

### DIFF
--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -1231,8 +1231,17 @@ function codexMetaErrorToItems(meta: unknown): AcpStreamItem[] {
   const attemptMatch = message.match(/(\d+)\s*\/\s*\d+/);
   const attempt = attemptMatch ? attemptMatch[1] : undefined;
 
+  // Pull the provider's own reason ("Insufficient account balance", "content
+  // input null", …) out of `unexpected status <code> <phrase>: <reason>` so it
+  // lands in the headline instead of being buried in the collapsed log.
+  const reasonMatch = additionalDetails.match(
+    /^unexpected status \d+[^:]*: (.+?)(?:, url: .*)?$/
+  );
+  const reason = reasonMatch ? reasonMatch[1].trim().slice(0, 200) : "";
+
   const statusText = typeof httpStatus === "number" ? ` (HTTP ${httpStatus})` : "";
-  const headline = `Upstream gateway error${statusText}`;
+  const reasonText = reason ? `: ${reason}` : "";
+  const headline = `Upstream gateway error${statusText}${reasonText}`;
   const subline =
     e.willRetry === false
       ? "codex gave up after retries; the turn did not complete."

--- a/electron/cli/acpAuth.ts
+++ b/electron/cli/acpAuth.ts
@@ -21,6 +21,7 @@ import { killProcessTree } from "./process-kill.js";
 import { mergeBuiltEnv } from "./runtime.js";
 import {
   clearToolSessionsForAgent,
+  ensureCodexChatBridge,
   resolveCliByokEnv
 } from "./store.js";
 
@@ -65,6 +66,7 @@ async function withAcpAgent<T>(
   if (built.protocol !== "acp") {
     throw new Error("Authentication control requires an ACP agent.");
   }
+  await ensureCodexChatBridge();
   const env = mergeBuiltEnv(
     mergeBuiltEnv(
       { ...process.env, ...(args.env ?? {}) },

--- a/electron/cli/responsesBridge.ts
+++ b/electron/cli/responsesBridge.ts
@@ -1,0 +1,1247 @@
+/**
+ * Local Responses ↔ chat/completions protocol bridge for Codex BYOK.
+ *
+ * codex >= 0.146 removed `wire_api = "chat"` from ModelProviderInfo, so the
+ * codex binary only speaks the OpenAI Responses API. Most third-party BYOK
+ * providers (DeepSeek, Kimi, …) only serve `POST /chat/completions`. codex-acp
+ * cannot translate (model HTTP calls are made by the codex binary itself), so
+ * FreeBuddy hosts this tiny localhost bridge instead:
+ *
+ *   codex --wire_api responses --> bridge (/v1/<route>/responses)
+ *     --> upstream provider (/chat/completions)
+ *
+ * `resolveCodexByokEnv` points `model_providers.<id>.base_url` at the bridge
+ * route when the saved BYOK config selects `wireApi: "chat"`. The bridge is
+ * stateless: API keys are forwarded from the inbound request headers.
+ */
+
+import crypto from "node:crypto";
+import http from "node:http";
+import https from "node:https";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+type JsonObject = Record<string, unknown>;
+
+const MAX_BODY_BYTES = 128 * 1024 * 1024;
+const KEEPALIVE_INTERVAL_MS = 15_000;
+const MAX_ROUTES = 64;
+
+function asObject(value: unknown): JsonObject | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function genId(prefix: string): string {
+  return `${prefix}_${crypto.randomBytes(9).toString("hex")}`;
+}
+
+export function normalizeUpstreamBaseUrl(baseUrl: string): string | undefined {
+  try {
+    const parsed = new URL(baseUrl.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Responses API request → chat/completions request
+// ---------------------------------------------------------------------------
+
+export interface ChatToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | Array<JsonObject> | null;
+  tool_calls?: ChatToolCall[];
+  tool_call_id?: string;
+}
+
+function responsesContentToChatContent(
+  content: unknown
+): string | Array<JsonObject> {
+  if (typeof content === "string") return content;
+  const parts: Array<JsonObject> = [];
+  for (const raw of asArray(content)) {
+    const part = asObject(raw);
+    if (!part) {
+      if (typeof raw === "string" && raw) {
+        parts.push({ type: "text", text: raw });
+      }
+      continue;
+    }
+    const text = typeof part.text === "string" ? part.text : undefined;
+    if (
+      (part.type === "input_text" ||
+        part.type === "output_text" ||
+        part.type === "text" ||
+        part.type === "summary_text") &&
+      text !== undefined
+    ) {
+      if (text) parts.push({ type: "text", text });
+      continue;
+    }
+    if (part.type === "input_image" || part.type === "image_url") {
+      const url =
+        typeof part.image_url === "string"
+          ? part.image_url
+          : asObject(part.image_url)?.url;
+      if (typeof url === "string" && url) {
+        parts.push({ type: "image_url", image_url: { url } });
+      }
+      continue;
+    }
+    if (text !== undefined && text) {
+      parts.push({ type: "text", text });
+    }
+  }
+  if (parts.length === 1 && parts[0].type === "text") {
+    return String(parts[0].text);
+  }
+  return parts;
+}
+
+export function responsesInputToChatMessages(
+  body: JsonObject
+): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  if (typeof body.instructions === "string" && body.instructions.trim()) {
+    messages.push({ role: "system", content: body.instructions });
+  }
+
+  let items: unknown[];
+  if (typeof body.input === "string") {
+    items = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: body.input }] }
+    ];
+  } else if (Array.isArray(body.input)) {
+    items = body.input;
+  } else {
+    items = [];
+  }
+
+  let pendingToolCalls: ChatToolCall[] = [];
+  const flushToolCalls = () => {
+    if (!pendingToolCalls.length) return;
+    messages.push({
+      role: "assistant",
+      content: null,
+      tool_calls: pendingToolCalls
+    });
+    pendingToolCalls = [];
+  };
+
+  for (const raw of items) {
+    const item = asObject(raw);
+    if (!item) continue;
+    if (item.type === "function_call") {
+      const args =
+        typeof item.arguments === "string"
+          ? item.arguments
+          : JSON.stringify(item.arguments ?? {});
+      pendingToolCalls.push({
+        id: typeof item.call_id === "string" && item.call_id
+          ? item.call_id
+          : genId("call"),
+        type: "function",
+        function: {
+          name: typeof item.name === "string" ? item.name : "",
+          arguments: args
+        }
+      });
+      continue;
+    }
+    if (item.type === "function_call_output") {
+      flushToolCalls();
+      const output =
+        typeof item.output === "string"
+          ? item.output
+          : JSON.stringify(item.output ?? "");
+      messages.push({
+        role: "tool",
+        tool_call_id:
+          typeof item.call_id === "string" ? item.call_id : "",
+        content: output
+      });
+      continue;
+    }
+    if (item.type === "reasoning") {
+      continue;
+    }
+    if (item.type === "message" || (item.type === undefined && typeof item.role === "string")) {
+      flushToolCalls();
+      const role =
+        item.role === "developer"
+          ? "system"
+          : item.role === "assistant"
+            ? "assistant"
+            : item.role === "system"
+              ? "system"
+              : "user";
+      messages.push({
+        role,
+        content: responsesContentToChatContent(item.content)
+      });
+      continue;
+    }
+  }
+  flushToolCalls();
+  return messages;
+}
+
+export interface ChatTool {
+  type: "function";
+  function: {
+    name: string;
+    description?: unknown;
+    parameters?: unknown;
+    strict?: unknown;
+  };
+}
+
+export function responsesToolsToChatTools(
+  tools: unknown
+): { tools: ChatTool[]; customToolNames: string[] } {
+  const out: ChatTool[] = [];
+  const customToolNames: string[] = [];
+  for (const raw of asArray(tools)) {
+    const tool = asObject(raw);
+    if (!tool) continue;
+    if (tool.type === "function") {
+      if (typeof tool.name !== "string" || !tool.name) continue;
+      out.push({
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+          ...(tool.strict !== undefined ? { strict: tool.strict } : {})
+        }
+      });
+      continue;
+    }
+    // Responses "custom" (freeform) tools have no chat equivalent. Map them to
+    // a single-string function and unwrap `{"input": …}` on the way back so
+    // apply_patch keeps working through chat-only providers.
+    if (tool.type === "custom" && typeof tool.name === "string" && tool.name) {
+      customToolNames.push(tool.name);
+      out.push({
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: {
+            type: "object",
+            properties: { input: { type: "string" } },
+            required: ["input"]
+          }
+        }
+      });
+    }
+  }
+  return { tools: out, customToolNames };
+}
+
+export function mapToolChoice(
+  toolChoice: unknown
+): unknown {
+  if (typeof toolChoice === "string") return toolChoice;
+  const obj = asObject(toolChoice);
+  if (obj?.type === "function" && typeof obj.name === "string") {
+    return { type: "function", function: { name: obj.name } };
+  }
+  return undefined;
+}
+
+export interface ResponsesToChatResult {
+  chat: JsonObject;
+  customToolNames: string[];
+  stream: boolean;
+}
+
+export function translateResponsesRequestToChat(
+  body: unknown
+): ResponsesToChatResult | undefined {
+  const obj = asObject(body);
+  if (!obj || typeof obj.model !== "string" || !obj.model) return undefined;
+
+  const messages = responsesInputToChatMessages(obj);
+  const { tools, customToolNames } = responsesToolsToChatTools(obj.tools);
+
+  const chat: JsonObject = {
+    model: obj.model,
+    messages,
+    stream: obj.stream !== false
+  };
+  if (tools.length) chat.tools = tools;
+  const toolChoice = mapToolChoice(obj.tool_choice);
+  if (toolChoice !== undefined) chat.tool_choice = toolChoice;
+  if (typeof obj.parallel_tool_calls === "boolean") {
+    chat.parallel_tool_calls = obj.parallel_tool_calls;
+  }
+  if (num(obj.temperature) !== undefined) chat.temperature = obj.temperature;
+  if (num(obj.top_p) !== undefined) chat.top_p = obj.top_p;
+  const maxOutputTokens = num(obj.max_output_tokens);
+  if (maxOutputTokens !== undefined && maxOutputTokens > 0) {
+    chat.max_tokens = Math.floor(maxOutputTokens);
+  }
+  const reasoning = asObject(obj.reasoning);
+  const effort = reasoning?.effort;
+  if (typeof effort === "string" && ["low", "medium", "high"].includes(effort)) {
+    chat.reasoning_effort = effort;
+  }
+  if (chat.stream === true) {
+    chat.stream_options = { include_usage: true };
+  }
+  return { chat, customToolNames, stream: chat.stream === true };
+}
+
+/** Best-effort fallback when a provider rejects optional chat extensions. */
+export function stripOptionalChatFields(chat: JsonObject): JsonObject {
+  const stripped: JsonObject = { ...chat };
+  delete stripped.reasoning_effort;
+  delete stripped.stream_options;
+  delete stripped.parallel_tool_calls;
+  if (Array.isArray(stripped.tools)) {
+    stripped.tools = (stripped.tools as unknown[]).map((raw) => {
+      const tool = asObject(raw);
+      const fn = asObject(tool?.function);
+      if (!tool || !fn) return raw;
+      const { strict: _strict, ...restFn } = fn;
+      return { ...tool, function: restFn };
+    });
+  }
+  return stripped;
+}
+
+// ---------------------------------------------------------------------------
+// chat/completions SSE → Responses API SSE
+// ---------------------------------------------------------------------------
+
+export function normalizeResponsesUsage(usage: unknown): JsonObject {
+  const obj = asObject(usage);
+  const prompt = num(asObject(obj?.prompt_tokens_details)?.cached_tokens) ?? 0;
+  const reasoning =
+    num(asObject(obj?.completion_tokens_details)?.reasoning_tokens) ?? 0;
+  const input = num(obj?.prompt_tokens) ?? 0;
+  const output = num(obj?.completion_tokens) ?? 0;
+  return {
+    input_tokens: input,
+    input_tokens_details: { cached_tokens: prompt },
+    output_tokens: output,
+    output_tokens_details: { reasoning_tokens: reasoning },
+    total_tokens: num(obj?.total_tokens) ?? input + output
+  };
+}
+
+function serializeSse(event: JsonObject): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+export class ChatToResponsesStream {
+  readonly responseId = genId("resp");
+  private readonly model: string;
+  private readonly customToolNames: Set<string>;
+  private outputIndex = 0;
+  private usage: JsonObject | undefined;
+  private finished = false;
+
+  private reasoning: { id: string; text: string } | null = null;
+  private message: { id: string; text: string } | null = null;
+  private readonly toolCalls = new Map<
+    number,
+    { id?: string; name?: string; arguments: string }
+  >();
+
+  constructor(model: string, customToolNames: string[] = []) {
+    this.model = model;
+    this.customToolNames = new Set(customToolNames);
+  }
+
+  begin(): string[] {
+    return [
+      serializeSse({
+        type: "response.created",
+        response: {
+          id: this.responseId,
+          object: "response",
+          created_at: Math.floor(Date.now() / 1000),
+          model: this.model,
+          status: "in_progress",
+          output: [],
+          usage: null
+        }
+      })
+    ];
+  }
+
+  handleChatChunk(chunk: unknown): string[] {
+    if (this.finished) return [];
+    const events: string[] = [];
+    const obj = asObject(chunk);
+    if (asObject(obj?.usage)) {
+      this.usage = normalizeResponsesUsage(obj?.usage);
+    }
+    const choice = asObject(asArray(obj?.choices)[0]);
+    const delta = asObject(choice?.delta);
+    if (!delta) return events;
+
+    const reasoningDelta =
+      typeof delta.reasoning_content === "string"
+        ? delta.reasoning_content
+        : typeof delta.reasoning === "string"
+          ? delta.reasoning
+          : "";
+    if (reasoningDelta) {
+      events.push(...this.pushReasoningDelta(reasoningDelta));
+    }
+
+    if (typeof delta.content === "string" && delta.content) {
+      events.push(...this.pushTextDelta(delta.content));
+    } else if (Array.isArray(delta.content)) {
+      for (const raw of delta.content) {
+        const text = asObject(raw)?.text;
+        if (typeof text === "string" && text) {
+          events.push(...this.pushTextDelta(text));
+        }
+      }
+    }
+
+    for (const raw of asArray(delta.tool_calls)) {
+      const call = asObject(raw);
+      if (!call) continue;
+      const index =
+        num(call.index) ?? (this.toolCalls.size ? Math.max(...this.toolCalls.keys()) + 1 : 0);
+      const entry = this.toolCalls.get(index) ?? { arguments: "" };
+      if (typeof call.id === "string" && call.id) entry.id = call.id;
+      const fn = asObject(call.function);
+      if (typeof fn?.name === "string" && fn.name) {
+        entry.name =
+          entry.name === undefined ? fn.name : entry.name + fn.name;
+      }
+      if (typeof fn?.arguments === "string" && fn.arguments) {
+        entry.arguments += fn.arguments;
+      }
+      this.toolCalls.set(index, entry);
+    }
+    return events;
+  }
+
+  finish(): string[] {
+    if (this.finished) return [];
+    this.finished = true;
+    const events: string[] = [];
+    events.push(...this.closeReasoning());
+    events.push(...this.closeMessage());
+    const sorted = [...this.toolCalls.entries()].sort((a, b) => a[0] - b[0]);
+    for (const [, call] of sorted) {
+      if (!call.name) continue;
+      const itemId = genId("fc");
+      const callId = call.id ?? genId("call");
+      const args = this.unwrapCustomArguments(call.name, call.arguments);
+      const item = {
+        id: itemId,
+        type: "function_call",
+        status: "completed",
+        call_id: callId,
+        name: call.name,
+        arguments: args
+      };
+      events.push(
+        serializeSse({
+          type: "response.output_item.added",
+          output_index: this.outputIndex,
+          item: { ...item, status: "in_progress" }
+        })
+      );
+      events.push(
+        serializeSse({
+          type: "response.output_item.done",
+          output_index: this.outputIndex,
+          item
+        })
+      );
+      this.outputIndex += 1;
+    }
+    events.push(
+      serializeSse({
+        type: "response.completed",
+        response: {
+          id: this.responseId,
+          object: "response",
+          model: this.model,
+          status: "completed",
+          output: [],
+          usage: this.usage ?? {
+            input_tokens: 0,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 0,
+            output_tokens_details: { reasoning_tokens: 0 },
+            total_tokens: 0
+          }
+        }
+      }),
+      "data: [DONE]\n\n"
+    );
+    return events;
+  }
+
+  fail(message: string): string[] {
+    this.finished = true;
+    return [
+      serializeSse({
+        type: "response.failed",
+        response: {
+          id: this.responseId,
+          object: "response",
+          model: this.model,
+          status: "failed",
+          error: { code: "upstream_error", message }
+        }
+      }),
+      "data: [DONE]\n\n"
+    ];
+  }
+
+  private pushReasoningDelta(text: string): string[] {
+    if (!this.reasoning) {
+      this.reasoning = { id: genId("rs"), text: "" };
+      return [
+        serializeSse({
+          type: "response.output_item.added",
+          output_index: this.outputIndex,
+          item: {
+            id: this.reasoning.id,
+            type: "reasoning",
+            summary: [],
+            content: null,
+            status: "in_progress"
+          }
+        }),
+        serializeSse({
+          type: "response.reasoning_summary_text.delta",
+          item_id: this.reasoning.id,
+          output_index: this.outputIndex,
+          summary_index: 0,
+          delta: text
+        })
+      ];
+    }
+    return [
+      serializeSse({
+        type: "response.reasoning_summary_text.delta",
+        item_id: this.reasoning.id,
+        output_index: this.outputIndex,
+        summary_index: 0,
+        delta: text
+      })
+    ];
+  }
+
+  private closeReasoning(): string[] {
+    if (!this.reasoning) return [];
+    const { id, text } = this.reasoning;
+    this.reasoning = null;
+    const done = [
+      serializeSse({
+        type: "response.output_item.done",
+        output_index: this.outputIndex,
+        item: {
+          id,
+          type: "reasoning",
+          summary: [{ type: "summary_text", text }],
+          content: null,
+          status: "completed"
+        }
+      })
+    ];
+    this.outputIndex += 1;
+    return done;
+  }
+
+  private pushTextDelta(text: string): string[] {
+    const events: string[] = [];
+    if (this.reasoning) events.push(...this.closeReasoning());
+    if (!this.message) {
+      this.message = { id: genId("msg"), text: "" };
+      events.push(
+        serializeSse({
+          type: "response.output_item.added",
+          output_index: this.outputIndex,
+          item: {
+            id: this.message.id,
+            type: "message",
+            status: "in_progress",
+            role: "assistant",
+            content: []
+          }
+        })
+      );
+    }
+    this.message.text += text;
+    events.push(
+      serializeSse({
+        type: "response.output_text.delta",
+        item_id: this.message.id,
+        output_index: this.outputIndex,
+        content_index: 0,
+        delta: text
+      })
+    );
+    return events;
+  }
+
+  private closeMessage(): string[] {
+    if (!this.message) return [];
+    const { id, text } = this.message;
+    this.message = null;
+    const done = [
+      serializeSse({
+        type: "response.output_text.done",
+        item_id: id,
+        output_index: this.outputIndex,
+        content_index: 0,
+        text
+      }),
+      serializeSse({
+        type: "response.output_item.done",
+        output_index: this.outputIndex,
+        item: {
+          id,
+          type: "message",
+          status: "completed",
+          role: "assistant",
+          content: [{ type: "output_text", text, annotations: [] }]
+        }
+      })
+    ];
+    this.outputIndex += 1;
+    return done;
+  }
+
+  private unwrapCustomArguments(name: string, args: string): string {
+    if (!this.customToolNames.has(name)) return args;
+    try {
+      const parsed = JSON.parse(args);
+      if (
+        asObject(parsed) &&
+        Object.keys(parsed as JsonObject).length === 1 &&
+        typeof (parsed as JsonObject).input === "string"
+      ) {
+        return (parsed as JsonObject).input as string;
+      }
+    } catch {
+      /* keep raw arguments */
+    }
+    return args;
+  }
+}
+
+/** Non-stream chat JSON → Responses response object. */
+export function translateChatResponseToResponses(
+  chat: unknown,
+  fallbackModel?: string
+): JsonObject | undefined {
+  const obj = asObject(chat);
+  const choice = asObject(asArray(obj?.choices)[0]);
+  const message = asObject(choice?.message);
+  if (!obj || !message) return undefined;
+
+  const output: JsonObject[] = [];
+  const reasoning = message.reasoning_content ?? message.reasoning;
+  if (typeof reasoning === "string" && reasoning) {
+    output.push({
+      id: genId("rs"),
+      type: "reasoning",
+      summary: [{ type: "summary_text", text: reasoning }],
+      content: null,
+      status: "completed"
+    });
+  }
+  if (typeof message.content === "string" && message.content) {
+    output.push({
+      id: genId("msg"),
+      type: "message",
+      status: "completed",
+      role: "assistant",
+      content: [
+        { type: "output_text", text: message.content, annotations: [] }
+      ]
+    });
+  }
+  for (const raw of asArray(message.tool_calls)) {
+    const call = asObject(raw);
+    const fn = asObject(call?.function);
+    if (!call || !fn || typeof fn.name !== "string") continue;
+    output.push({
+      id: genId("fc"),
+      type: "function_call",
+      status: "completed",
+      call_id: typeof call.id === "string" ? call.id : genId("call"),
+      name: fn.name,
+      arguments: typeof fn.arguments === "string" ? fn.arguments : ""
+    });
+  }
+
+  return {
+    id: typeof obj.id === "string" ? obj.id : genId("resp"),
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    model: typeof obj.model === "string" ? obj.model : fallbackModel,
+    status: "completed",
+    output,
+    usage: normalizeResponsesUsage(obj.usage)
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Incremental SSE parser (upstream side)
+// ---------------------------------------------------------------------------
+
+export interface SseFrame {
+  event?: string;
+  data: string;
+}
+
+export class SseParser {
+  private buffer = "";
+
+  push(text: string): SseFrame[] {
+    this.buffer += text;
+    const frames: SseFrame[] = [];
+    for (;;) {
+      const boundary = SseParser.findBoundary(this.buffer);
+      if (boundary === -1) break;
+      const raw = this.buffer.slice(0, boundary.index);
+      this.buffer = this.buffer.slice(boundary.index + boundary.length);
+      const frame = SseParser.parseFrame(raw);
+      if (frame) frames.push(frame);
+    }
+    return frames;
+  }
+
+  flush(): SseFrame[] {
+    if (!this.buffer.trim()) {
+      this.buffer = "";
+      return [];
+    }
+    const frame = SseParser.parseFrame(this.buffer);
+    this.buffer = "";
+    return frame ? [frame] : [];
+  }
+
+  private static findBoundary(
+    buffer: string
+  ): { index: number; length: number } | -1 {
+    const lf = buffer.indexOf("\n\n");
+    const crlf = buffer.indexOf("\r\n\r\n");
+    if (lf === -1 && crlf === -1) return -1;
+    if (crlf !== -1 && (lf === -1 || crlf < lf)) {
+      return { index: crlf, length: 4 };
+    }
+    return { index: lf, length: 2 };
+  }
+
+  private static parseFrame(raw: string): SseFrame | undefined {
+    let data: string | undefined;
+    let event: string | undefined;
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line || line.startsWith(":")) continue;
+      if (line.startsWith("data:")) {
+        const value = line.slice(5).trimStart();
+        data = data === undefined ? value : `${data}\n${value}`;
+      } else if (line.startsWith("event:")) {
+        event = line.slice(6).trim();
+      }
+    }
+    if (data === undefined) return undefined;
+    return { event, data };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local HTTP server
+// ---------------------------------------------------------------------------
+
+interface BridgeState {
+  server: http.Server;
+  port: number;
+  routes: Map<string, string>;
+}
+
+let bridgeState: BridgeState | undefined;
+let bridgeStarting: Promise<number | undefined> | undefined;
+
+export function isResponsesBridgeRunning(): boolean {
+  return bridgeState !== undefined;
+}
+
+export function getResponsesBridgePort(): number | undefined {
+  return bridgeState?.port;
+}
+
+export function registerCodexChatBridgeRoute(
+  upstreamBaseUrl: string
+): { port: number; routeId: string } | undefined {
+  const base = normalizeUpstreamBaseUrl(upstreamBaseUrl);
+  if (!base || !bridgeState) return undefined;
+  const routeId = `chat${crypto
+    .createHash("sha256")
+    .update(base)
+    .digest("hex")
+    .slice(0, 12)}`;
+  if (!bridgeState.routes.has(routeId) && bridgeState.routes.size >= MAX_ROUTES) {
+    const oldest = bridgeState.routes.keys().next().value;
+    if (oldest !== undefined) bridgeState.routes.delete(oldest);
+  }
+  bridgeState.routes.set(routeId, base);
+  return { port: bridgeState.port, routeId };
+}
+
+export function startResponsesBridge(): Promise<number | undefined> {
+  if (bridgeState) return Promise.resolve(bridgeState.port);
+  if (bridgeStarting) return bridgeStarting;
+  const starting: Promise<number | undefined> = new Promise((resolve) => {
+    let settled = false;
+    const done = (value: number | undefined) => {
+      if (settled) return;
+      settled = true;
+      if (bridgeStarting === starting) bridgeStarting = undefined;
+      resolve(value);
+    };
+    const routes = new Map<string, string>();
+    const server = http.createServer((req, res) => {
+      void handleBridgeRequest(req, res, routes).catch(() => {
+        try {
+          res.destroy();
+        } catch {
+          /* socket already gone */
+        }
+      });
+    });
+    server.requestTimeout = 0;
+    server.headersTimeout = 60_000;
+    server.timeout = 0;
+    server.keepAliveTimeout = 65_000;
+    server.on("error", () => done(undefined));
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port =
+        address !== null && typeof address === "object" ? address.port : undefined;
+      if (!port) {
+        server.close();
+        done(undefined);
+        return;
+      }
+      bridgeState = { server, port, routes };
+      done(port);
+    });
+  });
+  bridgeStarting = starting;
+  return starting;
+}
+
+export function closeResponsesBridge(): Promise<void> {
+  const state = bridgeState;
+  bridgeState = undefined;
+  bridgeStarting = undefined;
+  if (!state) return Promise.resolve();
+  const server = state.server as http.Server & {
+    closeAllConnections?: () => void;
+    closeIdleConnections?: () => void;
+  };
+  // Tear connections down before close(): on Windows libuv asserts when
+  // keep-alive sockets outlive a closing server handle.
+  server.closeIdleConnections?.();
+  server.closeAllConnections?.();
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error("request body too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown
+): void {
+  if (res.destroyed || res.headersSent || res.writableEnded) return;
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload)
+  });
+  res.end(payload);
+}
+
+async function handleBridgeRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  routes: Map<string, string>
+): Promise<void> {
+  res.on("error", () => {});
+  req.on("error", () => {});
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+  if (req.method === "GET" && (url.pathname === "/healthz" || url.pathname === "/v1/healthz")) {
+    sendJson(res, 200, { ok: true, routes: routes.size });
+    return;
+  }
+
+  const match =
+    req.method === "POST"
+      ? /^\/v1\/([A-Za-z0-9]+)\/responses$/.exec(url.pathname)
+      : null;
+  if (!match) {
+    sendJson(res, 404, { error: { message: "unknown bridge endpoint" } });
+    return;
+  }
+  const upstreamBase = routes.get(match[1]);
+  if (!upstreamBase) {
+    sendJson(res, 404, {
+      error: { message: "unknown bridge route (BYOK provider not registered)" }
+    });
+    return;
+  }
+
+  let rawBody: string;
+  try {
+    rawBody = await readBody(req);
+  } catch (error) {
+    sendJson(res, 413, {
+      error: { message: `bridge read failed: ${(error as Error).message}` }
+    });
+    return;
+  }
+
+  let responsesBody: unknown;
+  try {
+    responsesBody = JSON.parse(rawBody);
+  } catch {
+    sendJson(res, 400, { error: { message: "invalid JSON body" } });
+    return;
+  }
+
+  const translated = translateResponsesRequestToChat(responsesBody);
+  if (!translated) {
+    sendJson(res, 400, {
+      error: { message: "unsupported Responses request (missing model)" }
+    });
+    return;
+  }
+
+  const authorization = req.headers.authorization;
+  const controller = new AbortController();
+  res.on("close", () => {
+    if (!res.writableEnded) controller.abort();
+  });
+
+  const requestModel =
+    typeof asObject(responsesBody)?.model === "string"
+      ? (asObject(responsesBody)?.model as string)
+      : undefined;
+
+  let upstream: IncomingMessage;
+  try {
+    upstream = await requestChatCompletions(
+      upstreamBase,
+      translated.chat,
+      authorization,
+      controller.signal
+    );
+  } catch (error) {
+    sendJson(res, 502, {
+      error: { message: `bridge upstream failed: ${(error as Error).message}` }
+    });
+    return;
+  }
+
+  let status = upstream.statusCode ?? 0;
+  if (status >= 400) {
+    const text = await readUpstreamBody(upstream);
+    const stripped = stripOptionalChatFields(translated.chat);
+    if (
+      looksLikeUnknownFieldError(status, text) &&
+      JSON.stringify(stripped) !== JSON.stringify(translated.chat)
+    ) {
+      try {
+        upstream = await requestChatCompletions(
+          upstreamBase,
+          stripped,
+          authorization,
+          controller.signal
+        );
+      } catch (error) {
+        sendJson(res, 502, {
+          error: {
+            message: `bridge upstream failed: ${(error as Error).message}`
+          }
+        });
+        return;
+      }
+      status = upstream.statusCode ?? 0;
+      if (status >= 400) {
+        sendJson(res, status, safeErrorBody(await readUpstreamBody(upstream)));
+        return;
+      }
+    } else {
+      sendJson(res, status, safeErrorBody(text));
+      return;
+    }
+  }
+
+  const contentType = String(upstream.headers["content-type"] ?? "");
+  if (translated.stream && contentType.includes("text/event-stream")) {
+    await pipeUpstreamSse(upstream, res, translated, requestModel);
+    return;
+  }
+
+  const chatJson = parseJsonObject(await readUpstreamBody(upstream));
+  if (chatJson && asObject(chatJson.error)) {
+    sendJson(res, 502, { error: asObject(chatJson.error) });
+    return;
+  }
+  const responseObj = translateChatResponseToResponses(chatJson, requestModel);
+  if (!responseObj) {
+    sendJson(res, 502, {
+      error: { message: "bridge could not parse upstream chat response" }
+    });
+    return;
+  }
+  if (translated.stream) {
+    writeSseHead(res);
+    for (const event of responsesObjectToSseEvents(responseObj)) {
+      res.write(event);
+    }
+    res.end();
+    return;
+  }
+  sendJson(res, 200, responseObj);
+}
+
+function requestChatCompletions(
+  upstreamBase: string,
+  chatBody: JsonObject,
+  authorization: string | undefined,
+  signal: AbortSignal
+): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    let url: URL;
+    try {
+      url = new URL(`${upstreamBase}/chat/completions`);
+    } catch (error) {
+      reject(error as Error);
+      return;
+    }
+    const transport = url.protocol === "https:" ? https : http;
+    const payload = Buffer.from(JSON.stringify(chatBody), "utf8");
+    const request = transport.request(
+      {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === "https:" ? 443 : 80),
+        path: `${url.pathname}${url.search}`,
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": payload.length,
+          accept: "text/event-stream, application/json",
+          ...(authorization ? { authorization } : {})
+        }
+      },
+      (response) => resolve(response)
+    );
+    request.on("error", reject);
+    signal.addEventListener(
+      "abort",
+      () => request.destroy(new Error("client connection closed")),
+      { once: true }
+    );
+    request.end(payload);
+  });
+}
+
+function readUpstreamBody(upstream: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    upstream.on("data", (chunk: Buffer) => chunks.push(chunk));
+    upstream.on("end", () =>
+      resolve(Buffer.concat(chunks).toString("utf8"))
+    );
+    upstream.on("error", reject);
+  });
+}
+
+async function pipeUpstreamSse(
+  upstream: IncomingMessage,
+  res: ServerResponse,
+  translated: ResponsesToChatResult,
+  requestModel: string | undefined
+): Promise<void> {
+  writeSseHead(res);
+  const stream = new ChatToResponsesStream(
+    requestModel ?? translated.chat.model as string,
+    translated.customToolNames
+  );
+  for (const event of stream.begin()) res.write(event);
+
+  const parser = new SseParser();
+  const keepalive = setInterval(() => {
+    if (!res.writableEnded) res.write(": keepalive\n\n");
+  }, KEEPALIVE_INTERVAL_MS);
+
+  const drainToClient = (text: string): boolean => {
+    for (const frame of parser.push(text)) {
+      if (frame.data === "[DONE]") return false;
+      const chunk = parseJsonObject(frame.data);
+      if (!chunk) continue;
+      for (const event of stream.handleChatChunk(chunk)) {
+        res.write(event);
+      }
+    }
+    return true;
+  };
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      clearInterval(keepalive);
+      if (!res.writableEnded) {
+        for (const event of stream.finish()) res.write(event);
+        res.end();
+      }
+      resolve();
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearInterval(keepalive);
+      if (!res.writableEnded) {
+        for (const event of stream.fail(error.message)) res.write(event);
+        res.end();
+      }
+      resolve();
+    };
+
+    upstream.setEncoding("utf8");
+    upstream.on("data", (text: string) => {
+      if (!drainToClient(text)) done();
+    });
+    upstream.on("end", () => {
+      for (const frame of parser.flush()) {
+        if (frame.data === "[DONE]") break;
+        const chunk = parseJsonObject(frame.data);
+        if (chunk) {
+          for (const event of stream.handleChatChunk(chunk)) res.write(event);
+        }
+      }
+      done();
+    });
+    upstream.on("error", (error: Error) => fail(error));
+  });
+}
+
+function looksLikeUnknownFieldError(status: number, body: string): boolean {
+  if (status !== 400 && status !== 404 && status !== 422) return false;
+  return /unknown|unrecognized|unexpected|unsupported|extra_forbidden|invalid_request/i.test(
+    body
+  );
+}
+
+function safeErrorBody(text: string): unknown {
+  const parsed = parseJsonObject(text);
+  if (asObject(parsed?.error) || asObject(parsed)?.detail !== undefined) {
+    return parsed;
+  }
+  return {
+    error: { message: (text || "upstream request failed").slice(0, 2000) }
+  };
+}
+
+function parseJsonObject(text: string): JsonObject | undefined {
+  try {
+    const parsed = JSON.parse(text);
+    return asObject(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeSseHead(res: ServerResponse): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache",
+    connection: "keep-alive"
+  });
+  if (typeof (res as unknown as { flushHeaders?: () => void }).flushHeaders === "function") {
+    (res as unknown as { flushHeaders: () => void }).flushHeaders();
+  }
+}
+
+function responsesObjectToSseEvents(responseObj: JsonObject): string[] {
+  const events: string[] = [];
+  events.push(
+    serializeSse({
+      type: "response.created",
+      response: { ...responseObj, status: "in_progress", output: [] }
+    })
+  );
+  const output = asArray(responseObj.output);
+  output.forEach((item, index) => {
+    const obj = asObject(item);
+    if (!obj) return;
+    events.push(
+      serializeSse({
+        type: "response.output_item.added",
+        output_index: index,
+        item: { ...obj, status: "in_progress" }
+      })
+    );
+    events.push(
+      serializeSse({
+        type: "response.output_item.done",
+        output_index: index,
+        item: obj
+      })
+    );
+  });
+  events.push(
+    serializeSse({ type: "response.completed", response: responseObj }),
+    "data: [DONE]\n\n"
+  );
+  return events;
+}

--- a/electron/cli/responsesBridge.ts
+++ b/electron/cli/responsesBridge.ts
@@ -364,6 +364,7 @@ export class ChatToResponsesStream {
 
   private reasoning: { id: string; text: string } | null = null;
   private message: { id: string; text: string } | null = null;
+  private upstreamError: string | undefined;
   private readonly toolCalls = new Map<
     number,
     { id?: string; name?: string; arguments: string }
@@ -372,6 +373,15 @@ export class ChatToResponsesStream {
   constructor(model: string, customToolNames: string[] = []) {
     this.model = model;
     this.customToolNames = new Set(customToolNames);
+  }
+
+  hasUpstreamError(): boolean {
+    return this.upstreamError !== undefined;
+  }
+
+  /** Stream-level provider error (`data: {"error": …}` before/instead of chunks). */
+  getUpstreamError(): string | undefined {
+    return this.upstreamError;
   }
 
   begin(): string[] {
@@ -397,6 +407,13 @@ export class ChatToResponsesStream {
     const obj = asObject(chunk);
     if (asObject(obj?.usage)) {
       this.usage = normalizeResponsesUsage(obj?.usage);
+    }
+    if (obj && !asArray(obj.choices).length) {
+      const message = extractUpstreamErrorMessage(obj);
+      if (message !== undefined && this.upstreamError === undefined) {
+        this.upstreamError = message;
+      }
+      return events;
     }
     const choice = asObject(asArray(obj?.choices)[0]);
     const delta = asObject(choice?.delta);
@@ -782,7 +799,7 @@ export class SseParser {
 interface BridgeState {
   server: http.Server;
   port: number;
-  routes: Map<string, string>;
+  routes: Map<string, BridgeRoute>;
 }
 
 let bridgeState: BridgeState | undefined;
@@ -794,6 +811,13 @@ export function isResponsesBridgeRunning(): boolean {
 
 export function getResponsesBridgePort(): number | undefined {
   return bridgeState?.port;
+}
+
+export interface BridgeRoute {
+  /** Normalized provider base URL, e.g. https://cli.example.com */
+  base: string;
+  /** Chat endpoint path under base; auto-upgraded to /v1/… for gateways. */
+  chatPath: string;
 }
 
 export function registerCodexChatBridgeRoute(
@@ -810,7 +834,8 @@ export function registerCodexChatBridgeRoute(
     const oldest = bridgeState.routes.keys().next().value;
     if (oldest !== undefined) bridgeState.routes.delete(oldest);
   }
-  bridgeState.routes.set(routeId, base);
+  const existing = bridgeState.routes.get(routeId);
+  bridgeState.routes.set(routeId, existing ?? { base, chatPath: "/chat/completions" });
   return { port: bridgeState.port, routeId };
 }
 
@@ -825,7 +850,7 @@ export function startResponsesBridge(): Promise<number | undefined> {
       if (bridgeStarting === starting) bridgeStarting = undefined;
       resolve(value);
     };
-    const routes = new Map<string, string>();
+    const routes = new Map<string, BridgeRoute>();
     const server = http.createServer((req, res) => {
       void handleBridgeRequest(req, res, routes).catch(() => {
         try {
@@ -910,7 +935,7 @@ function sendJson(
 async function handleBridgeRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  routes: Map<string, string>
+  routes: Map<string, BridgeRoute>
 ): Promise<void> {
   res.on("error", () => {});
   req.on("error", () => {});
@@ -929,8 +954,8 @@ async function handleBridgeRequest(
     sendJson(res, 404, { error: { message: "unknown bridge endpoint" } });
     return;
   }
-  const upstreamBase = routes.get(match[1]);
-  if (!upstreamBase) {
+  const route = routes.get(match[1]);
+  if (!route) {
     sendJson(res, 404, {
       error: { message: "unknown bridge route (BYOK provider not registered)" }
     });
@@ -977,7 +1002,7 @@ async function handleBridgeRequest(
   let upstream: IncomingMessage;
   try {
     upstream = await requestChatCompletions(
-      upstreamBase,
+      route,
       translated.chat,
       authorization,
       controller.signal
@@ -989,7 +1014,43 @@ async function handleBridgeRequest(
     return;
   }
 
+  // Some relay gateways host their API under /v1 while serving the web UI
+  // (200 text/html) or a 404 at the bare /chat/completions path. Retry once
+  // under /v1 and remember the working path on the route.
   let status = upstream.statusCode ?? 0;
+  let contentType = String(upstream.headers["content-type"] ?? "");
+  if (
+    route.chatPath === "/chat/completions" &&
+    !basePathHasVersionSegment(route.base) &&
+    (status === 404 || (status < 400 && contentType.includes("text/html")))
+  ) {
+    upstream.resume();
+    try {
+      const fallback: BridgeRoute = {
+        base: route.base,
+        chatPath: "/v1/chat/completions"
+      };
+      const retried = await requestChatCompletions(
+        fallback,
+        translated.chat,
+        authorization,
+        controller.signal
+      );
+      const retriedStatus = retried.statusCode ?? 0;
+      const retriedType = String(retried.headers["content-type"] ?? "");
+      if (retriedStatus !== 404 && !(retriedStatus < 400 && retriedType.includes("text/html"))) {
+        route.chatPath = "/v1/chat/completions";
+        upstream = retried;
+        status = retriedStatus;
+        contentType = retriedType;
+      } else {
+        retried.resume();
+      }
+    } catch {
+      /* keep the original response for error handling below */
+    }
+  }
+
   if (status >= 400) {
     const text = await readUpstreamBody(upstream);
     const stripped = stripOptionalChatFields(translated.chat);
@@ -999,7 +1060,7 @@ async function handleBridgeRequest(
     ) {
       try {
         upstream = await requestChatCompletions(
-          upstreamBase,
+          route,
           stripped,
           authorization,
           controller.signal
@@ -1022,22 +1083,46 @@ async function handleBridgeRequest(
       return;
     }
   }
+  contentType = String(upstream.headers["content-type"] ?? "");
 
-  const contentType = String(upstream.headers["content-type"] ?? "");
   if (translated.stream && contentType.includes("text/event-stream")) {
     await pipeUpstreamSse(upstream, res, translated, requestModel);
     return;
   }
 
-  const chatJson = parseJsonObject(await readUpstreamBody(upstream));
-  if (chatJson && asObject(chatJson.error)) {
-    sendJson(res, 502, { error: asObject(chatJson.error) });
+  const bodyText = await readUpstreamBody(upstream);
+
+  // A few gateways stream SSE but label it application/json; sniff it.
+  if (translated.stream && bodyText.trimStart().startsWith("data:")) {
+    writeSseHead(res);
+    for (const event of synthesizeSseFromChatText(
+      bodyText,
+      requestModel ?? translated.chat.model as string,
+      translated.customToolNames
+    )) {
+      res.write(event);
+    }
+    res.end();
+    return;
+  }
+
+  const chatJson = parseJsonObject(bodyText);
+  const upstreamError = chatJson
+    ? extractUpstreamErrorMessage(chatJson)
+    : undefined;
+  if (!chatJson || upstreamError !== undefined || !asArray(chatJson.choices).length) {
+    const message =
+      upstreamError ??
+      `bridge could not parse upstream chat response (status ${status}, content-type ${contentType || "unknown"}, body: ${bodySnippet(bodyText)})`;
+    sendJson(res, 502, { error: { message } });
     return;
   }
   const responseObj = translateChatResponseToResponses(chatJson, requestModel);
   if (!responseObj) {
     sendJson(res, 502, {
-      error: { message: "bridge could not parse upstream chat response" }
+      error: {
+        message: `bridge could not parse upstream chat response (status ${status}, content-type ${contentType || "unknown"}, body: ${bodySnippet(bodyText)})`
+      }
     });
     return;
   }
@@ -1052,8 +1137,41 @@ async function handleBridgeRequest(
   sendJson(res, 200, responseObj);
 }
 
+function basePathHasVersionSegment(base: string): boolean {
+  try {
+    const pathname = new URL(base).pathname.replace(/\/+$/, "");
+    return /\/v\d+$/.test(pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** Replay a full chat SSE payload (possibly mislabeled) as Responses SSE events. */
+function synthesizeSseFromChatText(
+  text: string,
+  model: string,
+  customToolNames: string[]
+): string[] {
+  const stream = new ChatToResponsesStream(model, customToolNames);
+  const parser = new SseParser();
+  const events = [...stream.begin()];
+  const feed = (frames: SseFrame[]) => {
+    for (const frame of frames) {
+      if (frame.data === "[DONE]") return;
+      const chunk = parseJsonObject(frame.data);
+      if (chunk) events.push(...stream.handleChatChunk(chunk));
+    }
+  };
+  feed(parser.push(text));
+  feed(parser.flush());
+  if (stream.hasUpstreamError()) {
+    return [...events, ...stream.fail(stream.getUpstreamError() ?? "upstream error")];
+  }
+  return [...events, ...stream.finish()];
+}
+
 function requestChatCompletions(
-  upstreamBase: string,
+  route: BridgeRoute,
   chatBody: JsonObject,
   authorization: string | undefined,
   signal: AbortSignal
@@ -1061,7 +1179,7 @@ function requestChatCompletions(
   return new Promise((resolve, reject) => {
     let url: URL;
     try {
-      url = new URL(`${upstreamBase}/chat/completions`);
+      url = new URL(`${route.base}${route.chatPath}`);
     } catch (error) {
       reject(error as Error);
       return;
@@ -1141,7 +1259,12 @@ async function pipeUpstreamSse(
       settled = true;
       clearInterval(keepalive);
       if (!res.writableEnded) {
-        for (const event of stream.finish()) res.write(event);
+        const failure = stream.getUpstreamError();
+        const closing =
+          failure !== undefined
+            ? stream.fail(failure)
+            : stream.finish();
+        for (const event of closing) res.write(event);
         res.end();
       }
       resolve();
@@ -1180,6 +1303,28 @@ function looksLikeUnknownFieldError(status: number, body: string): boolean {
   return /unknown|unrecognized|unexpected|unsupported|extra_forbidden|invalid_request/i.test(
     body
   );
+}
+
+/**
+ * Pull a human-readable message out of standard and gateway-specific error
+ * bodies: {"error":{"message":…}}, {"message":…}, {"msg":…}, {"detail":…}.
+ */
+function extractUpstreamErrorMessage(obj: JsonObject | undefined): string | undefined {
+  if (!obj) return undefined;
+  const err = asObject(obj.error);
+  if (err) {
+    if (typeof err.message === "string" && err.message) return err.message;
+    return JSON.stringify(err).slice(0, 500);
+  }
+  for (const key of ["message", "msg", "detail"]) {
+    const value = obj[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+function bodySnippet(text: string, max = 300): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, max);
 }
 
 function safeErrorBody(text: string): unknown {

--- a/electron/cli/runtime.ts
+++ b/electron/cli/runtime.ts
@@ -37,6 +37,7 @@ import {
 } from "./runtimeShared.js";
 import { killProcessTree } from "./process-kill.js";
 import {
+  ensureCodexChatBridge,
   resolveClaudeByokSessionOptions,
   resolveCliByokEnv
 } from "./store.js";
@@ -329,6 +330,7 @@ export async function cliRun(
     return;
   }
 
+  await ensureCodexChatBridge();
   const env = mergeBuiltEnv(
     mergeBuiltEnv(
       { ...process.env, ...(effectiveArgs.env || {}) },

--- a/electron/cli/sessionConfigProbe.ts
+++ b/electron/cli/sessionConfigProbe.ts
@@ -20,6 +20,7 @@ import { killProcessTree } from "./process-kill.js";
 import { mergeBuiltEnv } from "./runtime.js";
 import {
   cliByokModelSignature,
+  ensureCodexChatBridge,
   mergeCliByokModelOption,
   resolveCliByokEnv
 } from "./store.js";
@@ -155,6 +156,7 @@ export async function inspectSessionConfigOptions(
   if (input.adapter === "dsh-acp") patchDshAcpRuntimeFromCommand(built);
   if (built.protocol !== "acp") return [];
 
+  await ensureCodexChatBridge();
   const env = mergeBuiltEnv(
     mergeBuiltEnv(
       { ...process.env, ...(input.env ?? {}) },

--- a/electron/cli/store.ts
+++ b/electron/cli/store.ts
@@ -8,6 +8,10 @@ import {
   resolveNodeBinaryHint
 } from "./codexBinaryHint.js";
 import { buildCodexAppServerWrapperContent } from "./codexByokWrapper.js";
+import {
+  registerCodexChatBridgeRoute,
+  startResponsesBridge
+} from "./responsesBridge.js";
 import { getDataDir, getDb } from "./db.js";
 import { getCallerUserId, isCallerAdmin } from "./callerContext.js";
 
@@ -381,11 +385,38 @@ function readDeepSeekByokPrivate(id: string): CLIDeepSeekByokConfig | undefined 
   return readPrivateByok<CLIDeepSeekByokConfig>(id, "deepseek_byok");
 }
 
-// codex >= 0.146 removed `wire_api = "chat"` support, so "responses" is the only
-// valid wire protocol. Coerce legacy/stale values (e.g. old DeepSeek BYOK configs
-// persisted as "chat") so they keep working instead of crashing codex at startup.
-function normalizeWireApi(value: CLICodexByokConfig["wireApi"]): "responses" {
-  return value === "chat" || !value ? "responses" : value;
+// codex >= 0.146 removed `wire_api = "chat"` support: the codex binary only
+// speaks the Responses API. Keep the user's "chat" selection in storage —
+// resolveCodexByokEnv serves it through the local Responses↔chat bridge — and
+// coerce anything else (legacy/stale values) to "responses".
+function normalizeWireApi(
+  value: CLICodexByokConfig["wireApi"]
+): "responses" | "chat" {
+  return value === "chat" ? "chat" : "responses";
+}
+
+function hasCodexChatWireByok(): boolean {
+  try {
+    const row = getDb()
+      .prepare(
+        `SELECT 1 FROM cli_executor_overrides
+         WHERE codex_byok LIKE '%"wireApi":"chat"%' LIMIT 1`
+      )
+      .get();
+    return row !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pre-start the local Responses↔chat bridge so resolveCodexByokEnv can point
+ * codex at a bridge route. Session runners await this before resolving BYOK
+ * env; it is a no-op unless some codex BYOK config selects wireApi "chat".
+ */
+export async function ensureCodexChatBridge(): Promise<void> {
+  if (!hasCodexChatWireByok()) return;
+  await startResponsesBridge();
 }
 
 function normalizeByokForStorage(
@@ -667,15 +698,25 @@ export function resolveCodexByokEnv(
   const codexPath = modelCatalogPath
     ? createCodexAppServerWrapper(modelCatalogPath)
     : undefined;
+  const wireApi = normalizeWireApi(byok.wireApi);
+  let baseUrl = byok.baseUrl?.trim();
+  if (wireApi === "chat" && baseUrl) {
+    // codex itself no longer speaks chat/completions; hand codex a local
+    // bridge route that translates Responses ↔ chat/completions instead.
+    // Without a running bridge fall back to direct "responses" (previous
+    // behavior) so codex still starts.
+    const route = registerCodexChatBridgeRoute(baseUrl);
+    if (route) baseUrl = `http://127.0.0.1:${route.port}/v1/${route.routeId}`;
+  }
   const config: Record<string, unknown> = {
     model_provider: providerId,
     model_supports_reasoning_summaries: true,
     model_providers: {
       [providerId]: {
         name: byok.providerName?.trim() || "BYOK provider",
-        base_url: byok.baseUrl?.trim(),
+        base_url: baseUrl,
         env_key: envKey,
-        wire_api: normalizeWireApi(byok.wireApi)
+        wire_api: wireApi === "chat" ? "responses" : wireApi
       }
     },
     ...(modelCatalogPath ? { model_catalog_json: modelCatalogPath } : {})

--- a/src/components/Settings/CLIAdaptersTab.tsx
+++ b/src/components/Settings/CLIAdaptersTab.tsx
@@ -981,11 +981,9 @@ function EditOverridePanel({
   const [codexWireApi, setCodexWireApi] = useState<
     NonNullable<NonNullable<CLIExecutorOverride["codexByok"]>["wireApi"]>
   >(
-    // codex >= 0.146 dropped `wire_api = "chat"`; coerce stale saved values so the
-    // <select> (which only offers "responses") never sits in an invalid state.
-    savedCodexByok?.wireApi === "chat"
-      ? "responses"
-      : savedCodexByok?.wireApi ?? "responses"
+    // "chat" is served through the local Responses↔chat bridge (see
+    // responsesBridge.ts) because codex >= 0.146 dropped the chat wire API.
+    savedCodexByok?.wireApi ?? "responses"
   );
   const [deepseekWireApi, setDeepseekWireApi] = useState<"chat" | "responses">(
     savedDeepSeekByok?.wireApi ?? "chat"
@@ -1654,7 +1652,8 @@ function EditOverridePanel({
                           setCodexWireApi(e.target.value as typeof codexWireApi)
                         }
                       >
-                        <option value="responses">responses</option>
+                        <option value="responses">responses (/v1/responses)</option>
+                        <option value="chat">chat (/v1/chat/completions · local bridge)</option>
                       </select>
                     </label>
                   )}

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -1362,7 +1362,8 @@ test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors
     },
     {
       kind: "error",
-      message: "Upstream gateway error (HTTP 422) — codex is retrying the request…",
+      message:
+        "Upstream gateway error (HTTP 422): content input null — codex is retrying the request…",
       details: [
         "Retry attempt 1.",
         "Reconnecting... 1/5",
@@ -1400,6 +1401,47 @@ test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors
       ]
     }
   ]);
+
+  // Provider reasons surface in the headline instead of the collapsed log,
+  // including gateway-specific bodies relayed by the local bridge (url suffix
+  // stripped, reason stable across retries so dedupe still collapses them).
+  const balance = acpUpdateToItems({
+    sessionUpdate: "session_info_update",
+    _meta: {
+      codex: {
+        error: {
+          message: "Reconnecting... 1/5",
+          additionalDetails:
+            "unexpected status 403 Forbidden: Insufficient account balance, url: http://127.0.0.1:61874/v1/chat81e2eadc6030/responses",
+          codexErrorInfo: {
+            responseStreamDisconnected: { httpStatusCode: 403 }
+          },
+          willRetry: true
+        }
+      }
+    }
+  });
+  assert.equal(
+    balance[0].message,
+    "Upstream gateway error (HTTP 403): Insufficient account balance — codex is retrying the request…"
+  );
+  const balanceRetry = acpUpdateToItems({
+    sessionUpdate: "session_info_update",
+    _meta: {
+      codex: {
+        error: {
+          message: "Reconnecting... 2/5",
+          additionalDetails:
+            "unexpected status 403 Forbidden: Insufficient account balance, url: http://127.0.0.1:61874/v1/chat81e2eadc6030/responses",
+          codexErrorInfo: {
+            responseStreamDisconnected: { httpStatusCode: 403 }
+          },
+          willRetry: true
+        }
+      }
+    }
+  });
+  assert.equal(balance[0].message, balanceRetry[0].message);
 
   // Stable headline across retry attempts: attempt 1 and 2 produce the same
   // message so downstream adjacent-error dedupe collapses them into one entry.

--- a/tests/codex-responses-bridge.test.mjs
+++ b/tests/codex-responses-bridge.test.mjs
@@ -526,6 +526,158 @@ test("bridge retries optional-field rejections and relays other errors", async (
   }
 });
 
+test("bridge auto-upgrades bare gateways from /chat/completions to /v1", async (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+
+  const hits = [];
+  const upstream = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => (raw += chunk));
+    req.on("end", () => {
+      hits.push(req.url);
+      if (req.url === "/chat/completions") {
+        // gateway serves its web UI at the bare path, with status 200
+        res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        res.end("<!doctype html><html>gateway ui</html>");
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          choices: [{ delta: { content: "via /v1" } }]
+        })}\n\n`
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          choices: [{ delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+        })}\n\n`
+      );
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+  });
+  await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  const upstreamPort = upstream.address().port;
+
+  try {
+    const port = await bridge.startResponsesBridge();
+    const route = bridge.registerCodexChatBridgeRoute(
+      `http://127.0.0.1:${upstreamPort}`
+    );
+
+    const first = await postJson(
+      `http://127.0.0.1:${port}/v1/${route.routeId}/responses`,
+      { model: "gpt-5.6-luna", input: "hi", stream: true }
+    );
+    assert.equal(first.status, 200);
+    const events = sseEvents(first.raw);
+    assert.equal(
+      events.find((event) => event.type === "response.output_item.done").item
+        .content[0].text,
+      "via /v1"
+    );
+
+    const second = await postJson(
+      `http://127.0.0.1:${port}/v1/${route.routeId}/responses`,
+      { model: "gpt-5.6-luna", input: "again", stream: true }
+    );
+    assert.equal(second.status, 200);
+    // fallback happened once, then the working path was remembered
+    assert.deepEqual(hits, [
+      "/chat/completions",
+      "/v1/chat/completions",
+      "/v1/chat/completions"
+    ]);
+  } finally {
+    await bridge.closeResponsesBridge();
+    await closeServer(upstream);
+  }
+});
+
+test("bridge reports a diagnostic snippet when the upstream body is unusable", async (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+
+  const upstream = http.createServer((req, res) => {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("this is not json at all");
+  });
+  await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  const upstreamPort = upstream.address().port;
+
+  try {
+    const port = await bridge.startResponsesBridge();
+    // base without /v1 so the fallback also runs and fails, ending at the
+    // original unusable response
+    const route = bridge.registerCodexChatBridgeRoute(
+      `http://127.0.0.1:${upstreamPort}`
+    );
+    const response = await postJson(
+      `http://127.0.0.1:${port}/v1/${route.routeId}/responses`,
+      { model: "m", input: "hi", stream: false }
+    );
+    assert.equal(response.status, 502);
+    const message = response.json().error.message;
+    assert.match(message, /could not parse upstream chat response/);
+    assert.match(message, /this is not json at all/);
+  } finally {
+    await bridge.closeResponsesBridge();
+    await closeServer(upstream);
+  }
+});
+
+test("bridge sniffs SSE bodies mislabeled as application/json", async (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+
+  const upstream = http.createServer((req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.write(
+      `data: ${JSON.stringify({
+        choices: [{ delta: { content: "sniffed" } }]
+      })}\n\n`
+    );
+    res.write("data: [DONE]\n\n");
+    res.end();
+  });
+  await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  const upstreamPort = upstream.address().port;
+
+  try {
+    const port = await bridge.startResponsesBridge();
+    const route = bridge.registerCodexChatBridgeRoute(
+      `http://127.0.0.1:${upstreamPort}/v1`
+    );
+    const response = await postJson(
+      `http://127.0.0.1:${port}/v1/${route.routeId}/responses`,
+      { model: "m", input: "hi", stream: true }
+    );
+    assert.equal(response.status, 200);
+    const events = sseEvents(response.raw);
+    assert.equal(
+      events.find((event) => event.type === "response.output_item.done").item
+        .content[0].text,
+      "sniffed"
+    );
+    assert.equal(
+      events.at(-1).type,
+      "response.completed",
+      "sniffed stream still terminates with completed"
+    );
+  } finally {
+    await bridge.closeResponsesBridge();
+    await closeServer(upstream);
+  }
+});
+
 test("bridge rejects unknown routes and serves healthz", async (t) => {
   if (!bridge) {
     t.skip("dist-electron bridge not built yet");

--- a/tests/codex-responses-bridge.test.mjs
+++ b/tests/codex-responses-bridge.test.mjs
@@ -1,0 +1,548 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs";
+
+// node:http instead of fetch(): undici keep-alive sockets + --test-force-exit
+// trip a libuv assertion on Windows at process exit.
+function postJson(url, body, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: target.hostname,
+        port: target.port,
+        path: target.pathname,
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(payload),
+          ...headers
+        }
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode,
+            contentType: res.headers["content-type"] ?? "",
+            raw: Buffer.concat(chunks).toString("utf8"),
+            json: () => JSON.parse(Buffer.concat(chunks).toString("utf8"))
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
+const bridgeSource = fs.readFileSync(
+  new URL("../electron/cli/responsesBridge.ts", import.meta.url),
+  "utf8"
+);
+const storeSource = fs.readFileSync(
+  new URL("../electron/cli/store.ts", import.meta.url),
+  "utf8"
+);
+
+let bridge;
+try {
+  bridge = await import("../dist-electron/cli/responsesBridge.js");
+} catch {
+  bridge = undefined;
+}
+
+function getJson(url) {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    http
+      .get(
+        {
+          hostname: target.hostname,
+          port: target.port,
+          path: target.pathname
+        },
+        (res) => {
+          const chunks = [];
+          res.on("data", (chunk) => chunks.push(chunk));
+          res.on("end", () => {
+            resolve({
+              status: res.statusCode,
+              json: () => JSON.parse(Buffer.concat(chunks).toString("utf8"))
+            });
+          });
+        }
+      )
+      .on("error", reject);
+  });
+}
+
+function sseDataChunks(raw) {
+  return raw
+    .split("\n\n")
+    .filter((frame) => frame.startsWith("data: "))
+    .map((frame) => frame.slice("data: ".length));
+}
+
+function sseEvents(raw) {
+  return sseDataChunks(raw)
+    .filter((line) => line !== "[DONE]")
+    .map((line) => JSON.parse(line));
+}
+
+test("codex BYOK chat wire API is routed through the local bridge", () => {
+  assert.match(
+    storeSource,
+    /registerCodexChatBridgeRoute/,
+    "resolveCodexByokEnv must register a bridge route for chat wire APIs"
+  );
+  assert.match(
+    storeSource,
+    /ensureCodexChatBridge/,
+    "store must expose ensureCodexChatBridge for session runners"
+  );
+  assert.match(
+    bridgeSource,
+    /chat\/completions/,
+    "bridge module must document the chat/completions translation"
+  );
+});
+
+test("session runners pre-start the codex chat bridge", () => {
+  for (const file of [
+    "../electron/cli/runtime.ts",
+    "../electron/cli/acpAuth.ts",
+    "../electron/cli/sessionConfigProbe.ts"
+  ]) {
+    const source = fs.readFileSync(new URL(file, import.meta.url), "utf8");
+    assert.match(
+      source,
+      /await ensureCodexChatBridge\(\)/,
+      `${file} must await ensureCodexChatBridge before resolving BYOK env`
+    );
+  }
+});
+
+test("translateResponsesRequestToChat maps instructions, input and tools", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const { translateResponsesRequestToChat } = bridge;
+  const result = translateResponsesRequestToChat({
+    model: "deepseek-chat",
+    instructions: "You are a coder.",
+    stream: true,
+    max_output_tokens: 1234,
+    temperature: 0.2,
+    reasoning: { effort: "high", summary: "auto" },
+    parallel_tool_calls: false,
+    tool_choice: { type: "function", name: "shell" },
+    input: [
+      { type: "message", role: "developer", content: [{ type: "input_text", text: "be nice" }] },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+      { type: "reasoning", summary: [] },
+      { type: "function_call", call_id: "call_a", name: "shell", arguments: "{\"cmd\":\"ls\"}" },
+      { type: "function_call", call_id: "call_b", name: "shell", arguments: "{\"cmd\":\"pwd\"}" },
+      { type: "function_call_output", call_id: "call_a", output: "ok" },
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] }
+    ],
+    tools: [
+      {
+        type: "function",
+        name: "shell",
+        description: "run shell",
+        strict: false,
+        parameters: { type: "object" }
+      },
+      { type: "web_search" },
+      { type: "custom", name: "apply_patch", description: "patch" }
+    ]
+  });
+
+  assert.ok(result);
+  const chat = result.chat;
+  assert.equal(chat.model, "deepseek-chat");
+  assert.equal(chat.stream, true);
+  assert.deepEqual(chat.stream_options, { include_usage: true });
+  assert.equal(chat.max_tokens, 1234);
+  assert.equal(chat.temperature, 0.2);
+  assert.equal(chat.reasoning_effort, "high");
+  assert.equal(chat.parallel_tool_calls, false);
+  assert.deepEqual(chat.tool_choice, {
+    type: "function",
+    function: { name: "shell" }
+  });
+  assert.deepEqual(result.customToolNames, ["apply_patch"]);
+
+  const messages = chat.messages;
+  assert.equal(messages[0].role, "system");
+  assert.equal(messages[0].content, "You are a coder.");
+  assert.equal(messages[1].role, "system");
+  assert.equal(messages[1].content, "be nice");
+  assert.equal(messages[2].role, "user");
+  assert.equal(messages[2].content, "hello");
+  // consecutive function_calls merge into one assistant tool_calls message
+  assert.deepEqual(
+    messages[3].tool_calls.map((call) => call.id),
+    ["call_a", "call_b"]
+  );
+  assert.equal(messages[4].role, "tool");
+  assert.equal(messages[4].tool_call_id, "call_a");
+  assert.equal(messages[4].content, "ok");
+  assert.equal(messages[5].role, "assistant");
+  assert.equal(messages[5].content, "done");
+
+  assert.equal(chat.tools.length, 2);
+  assert.deepEqual(chat.tools[0].function.parameters, { type: "object" });
+  assert.equal(chat.tools[0].function.strict, false);
+  assert.deepEqual(chat.tools[1].function.parameters.required, ["input"]);
+
+  // string input becomes a single user message
+  const simple = translateResponsesRequestToChat({
+    model: "m",
+    input: "hi",
+    stream: false
+  });
+  assert.equal(simple.chat.stream, false);
+  assert.equal(simple.chat.stream_options, undefined);
+  assert.equal(simple.chat.messages[0].role, "user");
+  assert.equal(simple.chat.messages[0].content, "hi");
+});
+
+test("stripOptionalChatFields removes chat extensions providers reject", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const stripped = bridge.stripOptionalChatFields({
+    model: "m",
+    messages: [],
+    reasoning_effort: "high",
+    stream_options: { include_usage: true },
+    parallel_tool_calls: false,
+    tools: [
+      { type: "function", function: { name: "shell", strict: true } }
+    ]
+  });
+  assert.equal(stripped.reasoning_effort, undefined);
+  assert.equal(stripped.stream_options, undefined);
+  assert.equal(stripped.parallel_tool_calls, undefined);
+  assert.equal(stripped.tools[0].function.strict, undefined);
+  assert.equal(stripped.tools[0].function.name, "shell");
+});
+
+test("ChatToResponsesStream translates chat SSE chunks into Responses events", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const stream = new bridge.ChatToResponsesStream("deepseek-chat", ["apply_patch"]);
+  const chunks = [];
+  for (const raw of stream.begin()) chunks.push(...sseDataChunks(raw));
+  for (const chunk of [
+    { choices: [{ delta: { role: "assistant" } }] },
+    { choices: [{ delta: { reasoning_content: "thinking" } }] },
+    { choices: [{ delta: { content: "Hello" } }] },
+    { choices: [{ delta: { content: " world" } }] },
+    {
+      choices: [
+        {
+          delta: {
+            tool_calls: [
+              { index: 0, id: "call_z", function: { name: "apply_patch", arguments: "{\"in" } },
+              { index: 0, function: { arguments: "put\": \"*** Begin Patch\"}" } }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      choices: [{ delta: {}, finish_reason: "tool_calls" }],
+      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 }
+    }
+  ]) {
+    for (const raw of stream.handleChatChunk(chunk)) chunks.push(...sseDataChunks(raw));
+  }
+  for (const raw of stream.finish()) chunks.push(...sseDataChunks(raw));
+
+  const events = chunks
+    .filter((line) => line !== "[DONE]")
+    .map((line) => JSON.parse(line));
+  assert.equal(chunks.at(-1), "[DONE]");
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      "response.created",
+      "response.output_item.added",
+      "response.reasoning_summary_text.delta",
+      "response.output_item.done",
+      "response.output_item.added",
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.output_item.done",
+      "response.output_item.added",
+      "response.output_item.done",
+      "response.completed"
+    ]
+  );
+
+  const completed = events.find((event) => event.type === "response.completed");
+  assert.equal(completed.response.usage.input_tokens, 11);
+  assert.equal(completed.response.usage.output_tokens, 7);
+  assert.equal(completed.response.usage.total_tokens, 18);
+
+  const messageDone = events.find(
+    (event) =>
+      event.type === "response.output_item.done" && event.item.type === "message"
+  );
+  assert.equal(messageDone.item.content[0].text, "Hello world");
+
+  const callDone = events.find(
+    (event) =>
+      event.type === "response.output_item.done" &&
+      event.item.type === "function_call"
+  );
+  assert.equal(callDone.item.call_id, "call_z");
+  assert.equal(callDone.item.name, "apply_patch");
+  assert.equal(
+    callDone.item.arguments,
+    "*** Begin Patch",
+    "custom (freeform) tool arguments must be unwrapped from {input: …}"
+  );
+});
+
+test("SseParser handles split frames, CRLF and comments", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const parser = new bridge.SseParser();
+  const frames = [
+    ...parser.push('data: {"a":1}\n\ndata: {"b":'),
+    ...parser.push('2}\n\n: keepalive\n\ndata: [DONE]\r\n\r\n')
+  ];
+  assert.deepEqual(
+    frames.map((frame) => frame.data),
+    ['{"a":1}', '{"b":2}', "[DONE]"]
+  );
+});
+
+test("bridge server proxies /v1/<route>/responses to upstream chat/completions", async (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+
+  const captured = { headers: {}, path: "", body: null };
+  const upstreamChunks = [
+    { choices: [{ delta: { reasoning_content: "hmm" } }] },
+    { choices: [{ delta: { content: "Hi " } }] },
+    { choices: [{ delta: { content: "there" } }] },
+    {
+      choices: [{ delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 }
+    }
+  ];
+  const upstream = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => (raw += chunk));
+    req.on("end", () => {
+      captured.path = req.url;
+      captured.headers = req.headers;
+      captured.body = JSON.parse(raw);
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      for (const chunk of upstreamChunks) {
+        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      }
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+  });
+  await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  const upstreamPort = upstream.address().port;
+
+  try {
+    const port = await bridge.startResponsesBridge();
+    assert.ok(port, "bridge must start");
+    const route = bridge.registerCodexChatBridgeRoute(
+      `http://127.0.0.1:${upstreamPort}/v1`
+    );
+    assert.ok(route);
+
+    const response = await postJson(
+      `http://127.0.0.1:${port}/v1/${route.routeId}/responses`,
+      {
+        model: "deepseek-chat",
+        instructions: "sys",
+        stream: true,
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "hey" }]
+          }
+        ]
+      },
+      { authorization: "Bearer sk-test" }
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(response.contentType, /text\/event-stream/);
+    const raw = response.raw;
+    const events = sseEvents(raw);
+    assert.equal(events[0].type, "response.created");
+    assert.equal(
+      events.find(
+        (event) =>
+          event.type === "response.output_item.done" &&
+          event.item.type === "message"
+      ).item.content[0].text,
+      "Hi there"
+    );
+    const completed = events.find((event) => event.type === "response.completed");
+    assert.equal(completed.response.usage.input_tokens, 5);
+    assert.equal(completed.response.usage.output_tokens, 2);
+    assert.equal(raw.trimEnd().endsWith("data: [DONE]"), true);
+
+    assert.equal(captured.path, "/v1/chat/completions");
+    assert.equal(captured.headers.authorization, "Bearer sk-test");
+    assert.equal(captured.body.model, "deepseek-chat");
+    assert.deepEqual(captured.body.stream_options, { include_usage: true });
+    assert.equal(captured.body.messages[0].content, "sys");
+    assert.equal(captured.body.messages[1].content, "hey");
+  } finally {
+    await bridge.closeResponsesBridge();
+    await closeServer(upstream);
+  }
+});
+
+function closeServer(server) {
+  server.closeAllConnections?.();
+  return new Promise((resolve) => server.close(resolve));
+}
+
+test("bridge retries optional-field rejections and relays other errors", async (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+
+  const requests = [];
+  const upstream = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => (raw += chunk));
+    req.on("end", () => {
+      const body = JSON.parse(raw);
+      requests.push(body);
+      if (
+        body.reasoning_effort !== undefined ||
+        body.stream_options !== undefined
+      ) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({ error: { message: "unknown field: stream_options" } })
+        );
+        return;
+      }
+      if (body.stream === false) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({ error: { message: "provider exploded" } })
+        );
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: "chatcmpl-1",
+          model: "deepseek-chat",
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { role: "assistant", content: "plain" }
+            }
+          ],
+          usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 }
+        })
+      );
+    });
+  });
+  await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  const upstreamPort = upstream.address().port;
+
+  try {
+    const port = await bridge.startResponsesBridge();
+    const route = bridge.registerCodexChatBridgeRoute(
+      `http://127.0.0.1:${upstreamPort}/v1`
+    );
+    const endpoint = `http://127.0.0.1:${port}/v1/${route.routeId}/responses`;
+
+    // nothing to strip → upstream error is relayed untouched
+    const relayed = await postJson(endpoint, {
+      model: "m",
+      input: "hi",
+      stream: false
+    });
+    assert.equal(relayed.status, 400);
+    assert.deepEqual(relayed.json(), {
+      error: { message: "provider exploded" }
+    });
+
+    // optional fields rejected → one retry without them succeeds
+    const ok = await postJson(endpoint, {
+      model: "deepseek-chat",
+      input: "hi",
+      stream: true,
+      reasoning: { effort: "low" }
+    });
+    assert.equal(ok.status, 200);
+    const lastTwo = requests.slice(-2);
+    assert.equal(lastTwo[0].reasoning_effort, "low");
+    assert.notEqual(lastTwo[0].stream_options, undefined);
+    assert.equal(lastTwo[1].reasoning_effort, undefined);
+    assert.equal(lastTwo[1].stream_options, undefined);
+
+    const events = sseEvents(ok.raw);
+    assert.equal(events[0].type, "response.created");
+    assert.equal(
+      events.find((event) => event.type === "response.output_item.done").item
+        .content[0].text,
+      "plain"
+    );
+    assert.equal(
+      events.find((event) => event.type === "response.completed").response
+        .usage.total_tokens,
+      4
+    );
+  } finally {
+    await bridge.closeResponsesBridge();
+    await closeServer(upstream);
+  }
+});
+
+test("bridge rejects unknown routes and serves healthz", async (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const port = await bridge.startResponsesBridge();
+  try {
+    const missing = await postJson(
+      `http://127.0.0.1:${port}/v1/unknown123/responses`,
+      {}
+    );
+    assert.equal(missing.status, 404);
+
+    const health = await getJson(`http://127.0.0.1:${port}/healthz`);
+    assert.equal(health.status, 200);
+    assert.deepEqual(health.json(), { ok: true, routes: 0 });
+  } finally {
+    await bridge.closeResponsesBridge();
+  }
+});


### PR DESCRIPTION
## Summary

codex >= 0.146 removed `wire_api = "chat"` from `ModelProviderInfo` (the binary now only speaks the Responses API), which broke FreeBuddy's codex BYOK support for chat/completions-only providers (DeepSeek, Kimi, etc.). codex-acp cannot fix this itself — it only spawns the codex binary via app-server and never sits on the model HTTP path.

This PR adds a local Responses ↔ chat/completions bridge inside FreeBuddy:

- codex keeps using `wire_api = "responses"`, pointed at `http://127.0.0.1:<port>/v1/<routeId>`
- the bridge translates to the provider's `/chat/completions` and back, SSE streaming both ways

## Changes

- **`electron/cli/responsesBridge.ts`** (new): the bridge server + pure translation logic
  - instructions → system message, Responses input items → chat messages (consecutive `function_call` items merged into one `tool_calls` assistant message, `function_call_output` → tool message)
  - tools: flat Responses function tools → nested chat tools; Responses "custom"/freeform tools (apply_patch) → single-`input` function tools, with `{"input": …}` unwrapped back to raw freeform arguments on return
  - `reasoning.effort` → `reasoning_effort`, `max_output_tokens` → `max_tokens`
  - chat SSE → Responses SSE: `response.created`, `output_item.added/done` (message / function_call / reasoning), `output_text.delta`, `reasoning_summary_text.delta` (from `reasoning_content`), `response.completed` with full usage mapping, `[DONE]`
  - SSE keepalive comments while waiting for the first upstream token
  - one retry without optional fields (`reasoning_effort`, `stream_options`, `parallel_tool_calls`, `strict`) when a strict provider rejects them; other upstream errors relayed untouched
  - API key forwarded from the inbound `Authorization` header (no secrets stored); server binds 127.0.0.1 only; node:http/https upstream client (no undici)
- **`electron/cli/store.ts`**: `normalizeWireApi` now preserves `"chat"` in storage; `resolveCodexByokEnv` routes `base_url` through the bridge when `wireApi === "chat"` (falls back to direct responses if the bridge is not running); new `ensureCodexChatBridge()` pre-starts the bridge only when a chat-wire BYOK config exists
- **`electron/cli/runtime.ts`, `acpAuth.ts`, `sessionConfigProbe.ts`**: `await ensureCodexChatBridge()` before resolving BYOK env
- **`src/components/Settings/CLIAdaptersTab.tsx`**: re-offers the `chat (/v1/chat/completions · local bridge)` option for codex BYOK
- **`tests/codex-responses-bridge.test.mjs`**: unit tests for request/response/stream translation, SSE parsing, plus end-to-end tests through the real server (upstream request shape, auth forwarding, error relay, retry, healthz)

## Validation

- `npm run typecheck` ✅
- full `node --test --test-force-exit tests/*.mjs`: 1176 pass / 0 fail (127 pre-existing env skips) ✅
- real-binary smoke test: codex 0.150.1 (`codex exec`, custom provider → bridge → mock chat upstream) streamed the reply back and reported correct token usage ✅

## Notes

- Users re-enable chat providers from Settings → CLI adapter → codex BYOK → wire API: `chat`.
- `wire_api` written to `CODEX_CONFIG` is always `responses`; the bridge URL is injected as `base_url`, so codex upgrades remain transparent.