### PR TITLE
Fix Codex BYOK model selection and ACP failure handling

### DIFF
--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -206,7 +206,7 @@ export type AcpStreamItem =
       size?: number;
       text?: string;
     }
-  | { kind: "error"; message: string; details?: string[] }
+  | { kind: "error"; message: string; details?: string[]; terminal?: boolean }
   | { kind: "done"; exitCode?: number }
   | { kind: "raw"; content: string };
 
@@ -1237,20 +1237,63 @@ function codexMetaErrorToItems(meta: unknown): AcpStreamItem[] {
   const reasonMatch = additionalDetails.match(
     /^unexpected status \d+[^:]*: (.+?)(?:, url: .*)?$/
   );
-  const reason = reasonMatch ? reasonMatch[1].trim().slice(0, 200) : "";
+  const reason = reasonMatch
+    ? reasonMatch[1]
+        .replace(
+          /\s*(?:\(|\[|,\s*)request(?:[_ -]?id)?\s*[:=]\s*[^\])\],;]+(?:\)|\])?/gi,
+          ""
+        )
+        .trim()
+        .slice(0, 200)
+    : "";
 
   const statusText = typeof httpStatus === "number" ? ` (HTTP ${httpStatus})` : "";
   const reasonText = reason ? `: ${reason}` : "";
   const headline = `Upstream gateway error${statusText}${reasonText}`;
+  const nonRetryableHttpError =
+    typeof httpStatus === "number" &&
+    httpStatus >= 400 &&
+    httpStatus < 500 &&
+    ![408, 409, 425, 429].includes(httpStatus);
+  const terminal = nonRetryableHttpError || e.willRetry === false;
   const subline =
-    e.willRetry === false
+    nonRetryableHttpError
+      ? "the request was rejected; the turn did not complete."
+      : e.willRetry === false
       ? "codex gave up after retries; the turn did not complete."
       : "codex is retrying the request…";
   const details: string[] = [];
   if (attempt) details.push(`Retry attempt ${attempt}.`);
   if (message) details.push(message);
   if (additionalDetails) details.push(additionalDetails);
-  return [{ kind: "error", message: `${headline} — ${subline}`, details }];
+  return [
+    {
+      kind: "error",
+      message: `${headline} — ${subline}`,
+      details,
+      ...(terminal ? { terminal: true } : {})
+    }
+  ];
+}
+
+/** Return a stable failure message when retrying cannot make a 4xx succeed. */
+export function acpNonRetryableUpstreamError(update: any): string | undefined {
+  const status =
+    update?._meta?.codex?.error?.codexErrorInfo?.responseStreamDisconnected
+      ?.httpStatusCode;
+  if (
+    typeof status !== "number" ||
+    status < 400 ||
+    status >= 500 ||
+    [408, 409, 425, 429].includes(status)
+  ) {
+    return undefined;
+  }
+  const error = codexMetaErrorToItems(update?._meta).find(
+    (item): item is Extract<AcpStreamItem, { kind: "error" }> =>
+      item.kind === "error"
+  );
+  return error?.message;
 }
 
 export function acpUpdateToItems(
@@ -1262,6 +1305,19 @@ export function acpUpdateToItems(
     case "user_message_chunk":
       return [];
     case "agent_message_chunk":
+      {
+        const text = textFromContent(update.content).trim();
+        if (/^(?:unexpected status \d{3}\b|exceeded retry limit\b)/i.test(text)) {
+          return [
+            {
+              kind: "error",
+              message: "The upstream model request failed; the turn did not complete.",
+              details: [text],
+              terminal: true
+            }
+          ];
+        }
+      }
       return contentBlockToItems(update.content, {
         role: "assistant",
         append: true,
@@ -1351,7 +1407,18 @@ export function acpUpdateToItems(
         if (updatedAt) item.updatedAt = updatedAt;
         items.push(item);
       }
-      items.push(...codexMetaErrorToItems(update?._meta));
+      const codexErrors = codexMetaErrorToItems(update?._meta);
+      items.push(...codexErrors);
+      if (
+        codexErrors.length === 0 &&
+        update?._meta?.codex?.threadStatus?.type === "systemError"
+      ) {
+        items.push({
+          kind: "error",
+          message: "Codex reported a system error; the turn did not complete.",
+          terminal: true
+        });
+      }
       return items;
     }
     case "usage_update":

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -7,6 +7,7 @@ import type { WebContents } from "electron";
 
 import {
   acpPromptResultToItems,
+  acpNonRetryableUpstreamError,
   acpSessionListToItems,
   acpSessionSetupToItems,
   acpUpdateToItems,
@@ -212,6 +213,7 @@ export async function runAcpAgent({
   let sessionWasResumed = false;
   let mcpServers: AcpStdioMcpServer[] = [];
   let contextResetAttempted = false;
+  let nonRetryableUpstreamError: string | undefined;
   let activePrompt = args.prompt;
   const sessionMeta: AcpSessionMeta | undefined = claudeAcpSessionOptions
     ? { claudeCode: { options: claudeAcpSessionOptions } }
@@ -499,6 +501,18 @@ export async function runAcpAgent({
         capturedSessions.set(args.sessionId, sessionId);
       }
       const updateType = String(msg.params?.update?.sessionUpdate ?? "");
+      const upstreamFailure = acpNonRetryableUpstreamError(msg.params?.update);
+      if (!nonRetryableUpstreamError && upstreamFailure) {
+        nonRetryableUpstreamError = upstreamFailure;
+        appendLog(
+          logStream,
+          "system",
+          `non-retryable upstream error; cancelling ACP turn: ${upstreamFailure}`
+        );
+        if (activeAcpSessionId) {
+          notify(buildSessionCancelNotification(activeAcpSessionId));
+        }
+      }
       if (updateType === "agent_message_chunk" || updateType === "agent_thought_chunk") {
         const chunkText = textFromContent(msg.params?.update?.content);
         if (chunkText) {
@@ -1397,10 +1411,30 @@ export async function runAcpAgent({
               value
             )
           );
-          const items = acpSessionSetupToItems(activeAcpSessionId, {
+          const setupItems = acpSessionSetupToItems(activeAcpSessionId, {
             sessionId: activeAcpSessionId,
             ...(result && typeof result === "object" ? result : {})
-          })
+          });
+          if (configId === "model") {
+            const actualModel = setupItems
+              .find((item) => item.kind === "config-options")
+              ?.options.find(
+                (option) => option.id === "model" || option.category === "model"
+              )?.currentValue;
+            const normalizeModel = (model: string) =>
+              model
+                .trim()
+                .replace(/\[(?:none|low|medium|high|xhigh|max)\]$/i, "");
+            if (
+              actualModel &&
+              normalizeModel(actualModel) !== normalizeModel(value)
+            ) {
+              throw new Error(
+                `agent kept ${actualModel} after selecting ${value}`
+              );
+            }
+          }
+          const items = setupItems
             .filter((item) => item.kind === "config-options")
             .map((item) => item.kind === "config-options"
               ? {
@@ -1416,16 +1450,21 @@ export async function runAcpAgent({
             );
           if (items.length) emit({ type: "items", items });
         } catch (err) {
+          const message = (err as Error)?.message || String(err);
           appendLog(
             logStream,
             "system",
-            `set_config_option failed id=${configId}: ${(err as Error)?.message || String(err)}`
+            `set_config_option failed id=${configId}: ${message}`
           );
           emit({
             type: "stderr",
-            content: `Failed to set config option ${configId}: ${(err as Error)?.message || String(err)}`
+            content: `Failed to set config option ${configId}: ${message}`
           });
-          // do not block prompt
+          // A failed model switch would send the prompt to the wrong provider
+          // model. Other optional config controls remain best-effort.
+          if (configId === "model") {
+            throw new Error(`Failed to select model ${value}: ${message}`);
+          }
         }
       }
     };
@@ -1437,6 +1476,8 @@ export async function runAcpAgent({
       if (yieldRequested) {
         // session/cancel rejects the outstanding prompt request. This is an
         // intentional park, not an agent failure or a context/auth retry.
+      } else if (nonRetryableUpstreamError) {
+        throw new Error(nonRetryableUpstreamError);
       } else if (!finished && !contextResetAttempted && isContextWindowError(promptErr)) {
         contextResetAttempted = true;
         const exhaustedSessionId = activeAcpSessionId;
@@ -1486,6 +1527,9 @@ export async function runAcpAgent({
       } else {
         throw promptErr;
       }
+    }
+    if (nonRetryableUpstreamError) {
+      throw new Error(nonRetryableUpstreamError);
     }
     await syncSessionMetadataFromList();
 

--- a/electron/cli/store.ts
+++ b/electron/cli/store.ts
@@ -717,7 +717,8 @@ export function resetOverride(id: string): void {
 
 export function resolveCodexByokEnv(
   agentId: string,
-  adapter: string
+  adapter: string,
+  selectedModel?: string
 ): Record<string, string> | undefined {
   if (adapter !== "codex-acp") return undefined;
   const overrideId = agentId.startsWith("cli-") ? agentId.slice(4) : agentId;
@@ -726,8 +727,11 @@ export function resolveCodexByokEnv(
   const apiKey = decryptSecret(byok.apiKeyEncrypted);
   const providerId = byok.providerId?.trim() || "proxy";
   const envKey = byok.envKey?.trim() || "OPENAI_API_KEY";
-  const model = extractModelArg(readOverrideExtraArgs(overrideId));
   const configuredModels = normalizeByokModels(byok.models);
+  const model =
+    selectedModel?.trim() ||
+    extractModelArg(readOverrideExtraArgs(overrideId)) ||
+    configuredModels[0]?.id;
   // The catalog must cover configured models, any explicitly selected model,
   // and — because the in-session picker selects models via ACP after env
   // resolution — every cached codex model slug. Without a matching catalog
@@ -757,6 +761,7 @@ export function resolveCodexByokEnv(
   }
   const config: Record<string, unknown> = {
     model_provider: providerId,
+    ...(model ? { model } : {}),
     model_supports_reasoning_summaries: true,
     model_providers: {
       [providerId]: {
@@ -907,7 +912,7 @@ export function resolveCliByokEnv(
   selectedModel?: string
 ): Record<string, string> | undefined {
   return (
-    resolveCodexByokEnv(agentId, adapter) ??
+    resolveCodexByokEnv(agentId, adapter, selectedModel) ??
     resolveClaudeByokEnv(agentId, adapter, selectedModel) ??
     resolveDeepSeekByokEnv(agentId, adapter, selectedModel)
   );
@@ -973,12 +978,16 @@ export function mergeCliByokModelOption<T extends {
   );
   const existing = existingIndex >= 0 ? options[existingIndex] : undefined;
   const requested = selectedModel?.trim();
-  const currentValue = models.some((model) => model.id === requested)
-    ? requested
-    : existing?.currentValue &&
-        models.some((model) => model.id === existing.currentValue)
-      ? existing.currentValue
-      : models[0].id;
+  const existingCurrent = existing?.currentValue?.trim();
+  const currentValue =
+    adapter === "codex-acp" && existingCurrent
+      ? existingCurrent
+      : models.some((model) => model.id === requested)
+        ? requested
+        : existingCurrent &&
+            models.some((model) => model.id === existingCurrent)
+          ? existingCurrent
+          : models[0].id;
   const modelOption = {
     ...(existing ?? {}),
     id: existing?.id || "model",

--- a/electron/shared/logSanitize.ts
+++ b/electron/shared/logSanitize.ts
@@ -19,6 +19,14 @@ export function redactedLengthMarker(length: number): string {
 }
 
 const secret_RULES: Array<[RegExp, (...args: string[]) => string]> = [
+  [
+    /(\\"name\\"\s*:\s*\\"[^"\\]*(?:token|key|secret|password)[^"\\]*\\"\s*,\s*\\"value\\"\s*:\s*\\")((?:\\.|[^"\\])*)(\\")/gi,
+    (_m, prefix, _value, suffix) => `${prefix}<redacted>${suffix}`
+  ],
+  [
+    /("name"\s*:\s*"[^"]*(?:token|key|secret|password)[^"]*"\s*,\s*"value"\s*:\s*")([^"]*)(")/gi,
+    (_m, prefix, _value, suffix) => `${prefix}<redacted>${suffix}`
+  ],
   [/Authorization(["'\s:=]+)[^\s"',\]}]{8,}/gi, (_m, sep) => `Authorization${sep}<redacted>`],
   [/Bearer\s+[A-Za-z0-9._~+/=-]{8,}/g, () => "Bearer <redacted>"],
   [/sk-[A-Za-z0-9_-]{8,}/g, (m) => `${m.slice(0, 6)}…<redacted>`],

--- a/packages/protocol/src/cli.ts
+++ b/packages/protocol/src/cli.ts
@@ -142,7 +142,7 @@ export type CliStreamItem =
       size?: number;
       text?: string;
     }
-  | { kind: "error"; message: string; details?: string[] }
+  | { kind: "error"; message: string; details?: string[]; terminal?: boolean }
   | { kind: "done"; exitCode?: number }
   | { kind: "raw"; content: string };
 

--- a/src/components/Settings/CLIAdaptersTab.tsx
+++ b/src/components/Settings/CLIAdaptersTab.tsx
@@ -1044,6 +1044,11 @@ function EditOverridePanel({
       .split(/\r?\n/)
       .map((l) => l.trim())
       .filter(Boolean);
+    // Keep accepting --model in Advanced arguments, but normalize it into the
+    // first-class Model field. Previously the parser silently removed it when
+    // the dedicated field was blank, so the saved override lost the model.
+    const modelFromExtraArgs = extractModelArg(cleanedExtraArgs).model.trim();
+    const effectiveModel = model.trim() || modelFromExtraArgs;
     const env: Record<string, string> = {};
     envText
       .split(/\r?\n/)
@@ -1126,7 +1131,7 @@ function EditOverridePanel({
         binary.trim() && binary.trim() !== ex.defaultBinary
           ? binary.trim()
           : undefined,
-      extraArgs: withModelArg(cleanedExtraArgs, model),
+      extraArgs: withModelArg(cleanedExtraArgs, effectiveModel),
       env: Object.keys(env).length ? env : undefined,
       icon: icon || undefined,
       codexByok: codexByokConfig,
@@ -1138,6 +1143,8 @@ function EditOverridePanel({
     try {
       await upsert(override);
       refreshMembers();
+      setModel(effectiveModel);
+      setExtraArgs(extractModelArg(cleanedExtraArgs).args.join("\n"));
       setCodexApiKey("");
       setDeepseekOfficialApiKey("");
       setSaveStatus("saved");

--- a/src/store/conversationHandlers.ts
+++ b/src/store/conversationHandlers.ts
@@ -79,6 +79,10 @@ function hasUserFacingError(items: CliStreamItem[]) {
   return items.some((item) => item.kind === "error");
 }
 
+function hasTerminalUserFacingError(items: CliStreamItem[]) {
+  return items.some((item) => item.kind === "error" && item.terminal === true);
+}
+
 function failureSummaryFor(exitCode: number, parseCtx: ParseContext): CliStreamItem {
   const details = parseCtx.diagnosticLogs?.slice(-30);
   return {
@@ -92,7 +96,8 @@ function failureSummaryFor(exitCode: number, parseCtx: ParseContext): CliStreamI
               ? i18next.t("errors.rawLogCollapsed")
               : i18next.t("errors.cliNoStructured")
           }),
-    details
+    details,
+    terminal: true
   };
 }
 
@@ -247,7 +252,7 @@ export function handleStreamEvent(
       ]);
     } else if (e.type === "error") {
       nextItems = appendItems(nextItems, [
-        { kind: "error", message: e.message }
+        { kind: "error", message: e.message, terminal: true }
       ] as CliStreamItem[]);
       errorMessage = e.message;
     } else if (e.type === "done") {
@@ -255,7 +260,10 @@ export function handleStreamEvent(
       if (status === "killed") {
         // keep status
       } else {
-        status = e.exitCode === 0 ? "done" : "failed";
+        status =
+          e.exitCode === 0 && !hasTerminalUserFacingError(nextItems)
+            ? "done"
+            : "failed";
       }
       exitCode = e.exitCode;
       // Some adapters (e.g. codebuddy/Hy3) abandon an in-progress tool call and
@@ -316,7 +324,7 @@ export function handleStreamEvent(
     const live = get().live[conversationId];
     const reason = live?.status === "killed" ? "killed" : "done";
     if (reason !== "killed") {
-      const success = (e.exitCode ?? 0) === 0;
+      const success = live?.status === "done" && (e.exitCode ?? 0) === 0;
       get().markConversationCompletedUnread(
         conversationId,
         success ? "success" : "failure"
@@ -409,7 +417,7 @@ async function finalizeRun(
   const finalStatus =
     reason === "killed"
       ? "killed"
-      : live.exitCode === 0
+      : live.status === "done" && live.exitCode === 0
         ? "done"
         : "failed";
   const finalContent = JSON.stringify(live.items);

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -877,6 +877,17 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     skillIds
   }) {
     const id = nanoid();
+    const resolvedExecutor = useCliExecutorStore
+      .getState()
+      .resolve(member.cli.adapter);
+    const defaultCodexByokModel =
+      member.cli.adapter === "codex-acp" && resolvedExecutor?.codexByok?.enabled
+        ? resolvedExecutor.codexByok.models?.[0]?.id?.trim()
+        : undefined;
+    const persistedConfigOptionOverrides = {
+      ...(defaultCodexByokModel ? { model: defaultCodexByokModel } : {}),
+      ...(configOptionOverrides ?? {})
+    };
     const conv = await cliClient.createConversation({
       id,
       title: title ?? defaultTitleFor(member, cwd),
@@ -888,8 +899,8 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       cwd,
       projectId,
       approvalMode: approvalMode ?? member.cli.approvalMode,
-      ...(configOptionOverrides && Object.keys(configOptionOverrides).length > 0
-        ? { configOptionOverrides }
+      ...(Object.keys(persistedConfigOptionOverrides).length > 0
+        ? { configOptionOverrides: persistedConfigOptionOverrides }
         : {}),
       skillIds: mergeMemberSkillIds(
         skillIds ?? member.cli.skillIds,
@@ -1286,6 +1297,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       configOptions
     );
     const combinedOverrides = {
+      ...(member.cli.adapter === "codex-acp" && resolved?.codexByok?.enabled
+        ? { model: resolved.codexByok.models?.[0]?.id?.trim() }
+        : {}),
       ...(overridesToSend ?? {}),
       ...(configOptionOverrides ?? {})
     };

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -32,6 +32,7 @@ import {
   acpSessionListToItems,
   acpSessionSetupToItems,
   acpUpdateToItems,
+  acpNonRetryableUpstreamError,
   buildAuthenticateRequest,
   buildInitializeRequest,
   buildLogoutRequest,
@@ -1335,7 +1336,7 @@ test("acpUpdateToItems maps session metadata, commands and config options", () =
   );
 });
 
-test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors", () => {
+test("acpUpdateToItems surfaces codex gateway errors and marks permanent 4xx terminal", () => {
   // Real shape from codex-acp 1.1.7 when an upstream gateway returns HTTP 422
   // and codex begins its Reconnecting 1..5 retry loop (issues #340 / #355).
   const retrying = acpUpdateToItems({
@@ -1363,12 +1364,13 @@ test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors
     {
       kind: "error",
       message:
-        "Upstream gateway error (HTTP 422): content input null — codex is retrying the request…",
+        "Upstream gateway error (HTTP 422): content input null — the request was rejected; the turn did not complete.",
       details: [
         "Retry attempt 1.",
         "Reconnecting... 1/5",
         "unexpected status 422 Unprocessable Entity: content input null"
-      ]
+      ],
+      terminal: true
     }
   ]);
 
@@ -1393,12 +1395,13 @@ test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors
     {
       kind: "error",
       message:
-        "Upstream gateway error (HTTP 422) — codex gave up after retries; the turn did not complete.",
+        "Upstream gateway error (HTTP 422) — the request was rejected; the turn did not complete.",
       details: [
         "Retry attempt 5.",
         "Reconnecting... 5/5",
         "unexpected status 422 Unprocessable Entity"
-      ]
+      ],
+      terminal: true
     }
   ]);
 
@@ -1423,8 +1426,9 @@ test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors
   });
   assert.equal(
     balance[0].message,
-    "Upstream gateway error (HTTP 403): Insufficient account balance — codex is retrying the request…"
+    "Upstream gateway error (HTTP 403): Insufficient account balance — the request was rejected; the turn did not complete."
   );
+  assert.equal(balance[0].terminal, true);
   const balanceRetry = acpUpdateToItems({
     sessionUpdate: "session_info_update",
     _meta: {
@@ -1442,6 +1446,26 @@ test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors
     }
   });
   assert.equal(balance[0].message, balanceRetry[0].message);
+
+  assert.equal(
+    acpNonRetryableUpstreamError({
+      ...balanceRetry[0],
+      _meta: {
+        codex: {
+          error: {
+            message: "Reconnecting... 2/5",
+            additionalDetails:
+              "unexpected status 403 Forbidden: Insufficient account balance (request id: req-secret)",
+            codexErrorInfo: {
+              responseStreamDisconnected: { httpStatusCode: 403 }
+            },
+            willRetry: true
+          }
+        }
+      }
+    }),
+    "Upstream gateway error (HTTP 403): Insufficient account balance — the request was rejected; the turn did not complete."
+  );
 
   // Stable headline across retry attempts: attempt 1 and 2 produce the same
   // message so downstream adjacent-error dedupe collapses them into one entry.
@@ -1486,6 +1510,39 @@ test("acpUpdateToItems surfaces codex _meta.codex.error retryable gateway errors
       sessionId: "s1"
     }),
     [{ kind: "session", sessionId: "s1" }]
+  );
+});
+
+test("acpUpdateToItems never renders terminal Codex failures as assistant text", () => {
+  assert.deepEqual(
+    acpUpdateToItems({
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: "unexpected status 403 Forbidden: deposit required"
+      }
+    }),
+    [
+      {
+        kind: "error",
+        message: "The upstream model request failed; the turn did not complete.",
+        details: ["unexpected status 403 Forbidden: deposit required"],
+        terminal: true
+      }
+    ]
+  );
+  assert.deepEqual(
+    acpUpdateToItems({
+      sessionUpdate: "session_info_update",
+      _meta: { codex: { threadStatus: { type: "systemError" } } }
+    }),
+    [
+      {
+        kind: "error",
+        message: "Codex reported a system error; the turn did not complete.",
+        terminal: true
+      }
+    ]
   );
 });
 

--- a/tests/conversation-terminal-errors.test.mjs
+++ b/tests/conversation-terminal-errors.test.mjs
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync(
+  new URL("../src/store/conversationHandlers.ts", import.meta.url),
+  "utf8"
+);
+
+test("terminal stream errors override an ACP zero exit code", () => {
+  assert.match(
+    source,
+    /e\.exitCode === 0 && !hasTerminalUserFacingError\(nextItems\)/
+  );
+  assert.match(
+    source,
+    /live\.status === "done" && live\.exitCode === 0/
+  );
+  assert.match(source, /message: e\.message, terminal: true/);
+});

--- a/tests/log-sanitize.test.mjs
+++ b/tests/log-sanitize.test.mjs
@@ -64,6 +64,33 @@ test("filterSessionLogLine full mode only redacts secrets", async () => {
   assert.equal(out.type, "stdin");
 });
 
+test("full logs redact ACP environment tokens in plain and escaped JSON", async () => {
+  const { redactsecrets, filterSessionLogLine } = await load();
+  const token = "browser-token-value-123456";
+  const envEntry = JSON.stringify({
+    name: "FREEBUDDY_BROWSER_TOKEN",
+    value: token
+  });
+  const plain = redactsecrets(envEntry);
+  assert.ok(!plain.includes(token));
+  assert.match(plain, /"value":"<redacted>"/);
+
+  const line = JSON.stringify({
+    ts: "t",
+    type: "stdin",
+    content: JSON.stringify({
+      method: "session/new",
+      params: { env: [{ name: "FREEBUDDY_BROWSER_TOKEN", value: token }] }
+    })
+  });
+  const filtered = filterSessionLogLine(line, "full", []);
+  assert.ok(!filtered.includes(token));
+  assert.equal(
+    JSON.parse(JSON.parse(filtered).content).params.env[0].value,
+    "<redacted>"
+  );
+});
+
 test("filterSessionLogLine standard keeps system/stderr with path masks", async () => {
   const { filterSessionLogLine, buildPathMasks } = await load();
   const masks = buildPathMasks({ home: "/h", userData: "/h/app", workspaces: ["/h/w"] });

--- a/tests/new-task-model-picker.test.mjs
+++ b/tests/new-task-model-picker.test.mjs
@@ -10,6 +10,8 @@ const probe = read("../electron/cli/sessionConfigProbe.ts");
 const ipc = read("../electron/cli/ipc.ts");
 const preload = read("../electron/preload.ts");
 const conversations = read("../electron/cli/conversations.ts");
+const conversationStore = read("../src/store/conversationStore.ts");
+const electronStore = read("../electron/cli/store.ts");
 
 test("new-task model picker discovers ACP options before creating a conversation", () => {
   assert.match(chatView, /inspectSessionConfigOptions\(probeInput\)/);
@@ -18,6 +20,19 @@ test("new-task model picker discovers ACP options before creating a conversation
   assert.match(newTaskHome, /options=\{configOptions\}/);
   assert.match(newTaskHome, /onChange=\{onConfigOptionOverrides\}/);
   assert.match(newTaskHome, /!teamMode/);
+});
+
+test("Codex BYOK materializes its configured default model end to end", () => {
+  assert.match(
+    electronStore,
+    /resolveCodexByokEnv\(agentId, adapter, selectedModel\)/
+  );
+  assert.match(electronStore, /\.\.\.\(model \? \{ model \} : \{\}\)/);
+  assert.match(conversationStore, /defaultCodexByokModel/);
+  assert.match(
+    conversationStore,
+    /configOptionOverrides: persistedConfigOptionOverrides/
+  );
 });
 
 test("new-task model overrides are persisted before the first prompt", () => {

--- a/tests/settings-ui.test.mjs
+++ b/tests/settings-ui.test.mjs
@@ -43,6 +43,14 @@ test("coding agent settings expose model as a first-class field", () => {
   assert.equal(settingsSource.includes("Model"), true);
   assert.equal(settingsSource.includes("extractModelArg"), true);
   assert.equal(settingsSource.includes("withModelArg"), true);
+  assert.match(
+    settingsSource,
+    /const effectiveModel = model\.trim\(\) \|\| modelFromExtraArgs/
+  );
+  assert.match(
+    settingsSource,
+    /extraArgs: withModelArg\(cleanedExtraArgs, effectiveModel\)/
+  );
 });
 
 test("coding agent settings expose Codex BYOK without echoing saved keys", () => {
@@ -381,4 +389,3 @@ test("coding agent settings allow manual typing of model context window without 
     /parseByokContextWindow\(entry\.contextWindow\)/
   );
 });
-


### PR DESCRIPTION
## Summary

- preserve model values entered through the dedicated field or --model extra arguments
- materialize the configured Codex BYOK model into startup and conversation overrides, and fail closed when ACP cannot apply it
- stop permanent upstream 4xx retries and mark terminal ACP errors as failures even when the process exits with code 0
- redact token-bearing ACP environment entries from full diagnostic logs

## Validation

- npm run typecheck
- npm run build
- npm test
- npm run github:preflight