### PR TITLE
fix: isolate self-organizing team status when roles share a CLI adapter

### DIFF
--- a/electron/cli/delegation/protocol/guards.ts
+++ b/electron/cli/delegation/protocol/guards.ts
@@ -1,8 +1,11 @@
 export {
   ancestorRosterIds,
+  eventsForRosterRole,
   isWholeTaskRedelegate,
   normalizeTaskText,
+  resolveActiveDelegationRoleId,
   rosterIdForEvent,
   taskSimilarity,
   WHOLE_TASK_SIMILARITY_THRESHOLD
 } from "@freebuddy/delegation-core";
+export type { DelegationEventRoleRef } from "@freebuddy/delegation-core";

--- a/packages/delegation-core/src/index.ts
+++ b/packages/delegation-core/src/index.ts
@@ -23,12 +23,15 @@ export type {
 export { createInitialBusState, ensureChildNode, markChildTurning, reduce } from "./bus/stateMachine.js";
 export {
   ancestorRosterIds,
+  eventsForRosterRole,
   isWholeTaskRedelegate,
   normalizeTaskText,
+  resolveActiveDelegationRoleId,
   rosterIdForEvent,
   taskSimilarity,
   WHOLE_TASK_SIMILARITY_THRESHOLD
 } from "./protocol/guards.js";
+export type { DelegationEventRoleRef } from "./protocol/guards.js";
 export {
   buildDelegateTaskPrompt,
   buildDelegateWakePrompt,

--- a/packages/delegation-core/src/protocol/guards.ts
+++ b/packages/delegation-core/src/protocol/guards.ts
@@ -43,9 +43,11 @@ export function isWholeTaskRedelegate(
   return taskSimilarity(childTask, parentOrRootTask) >= threshold;
 }
 
+export type DelegationEventRoleRef = Pick<DelegationEvent, "agentId" | "roleLabel">;
+
 /** Map a persisted event to a roster role id (best-effort). */
 export function rosterIdForEvent(
-  event: DelegationEventRow,
+  event: DelegationEventRoleRef,
   roster: DelegationRosterEntry[]
 ): string | undefined {
   const exact = roster.find(
@@ -55,6 +57,42 @@ export function rosterIdForEvent(
   const byAgent = roster.filter((r) => r.agentId === event.agentId);
   if (byAgent.length === 1) return byAgent[0]!.id;
   return undefined;
+}
+
+/** Events that belong to one roster role, even when several roles share an agentId. */
+export function eventsForRosterRole<T extends DelegationEventRoleRef>(
+  events: T[],
+  role: Pick<DelegationRosterEntry, "id">,
+  roster: DelegationRosterEntry[]
+): T[] {
+  return events.filter((event) => rosterIdForEvent(event, roster) === role.id);
+}
+
+/**
+ * Which roster role currently owns the live slot.
+ * Keyed by role id so two roles sharing a CLI adapter (e.g. Codex) do not
+ * inherit each other's running state.
+ */
+export function resolveActiveDelegationRoleId(opts: {
+  roster: DelegationRosterEntry[];
+  entryRoleId: string;
+  events: Array<Pick<DelegationEvent, "agentId" | "roleLabel" | "status" | "depth">>;
+  runStatus?: string;
+  liveStatus?: string;
+}): string | undefined {
+  const runningChild = opts.events.find(
+    (event) => event.status === "running" && event.depth > 0
+  );
+  if (runningChild) {
+    return rosterIdForEvent(runningChild, opts.roster);
+  }
+  const runLive = opts.runStatus === "running" || opts.runStatus === "blocked";
+  const isLive =
+    runLive || opts.liveStatus === "running" || opts.liveStatus === "starting";
+  if (!isLive) return undefined;
+  const entry =
+    opts.roster.find((role) => role.id === opts.entryRoleId) ?? opts.roster[0];
+  return entry?.id;
 }
 
 /**

--- a/src/components/Workflows/DelegationTeamCard.tsx
+++ b/src/components/Workflows/DelegationTeamCard.tsx
@@ -9,6 +9,10 @@ import {
 } from "lucide-react";
 
 import {
+  eventsForRosterRole,
+  resolveActiveDelegationRoleId
+} from "@freebuddy/delegation-core";
+import {
   delegationClient,
   type DelegationEventRow,
   type DelegationEventStatus
@@ -46,7 +50,7 @@ export function DelegationTeamCard({
   const members = useConversationStore((s) => s.members);
   const liveStatus = useConversationStore((s) => s.live[conversationId]?.status);
   const [team, setTeam] = useState<DelegationTeam | undefined>(undefined);
-  const [activeAgentId, setActiveAgentId] = useState<string | undefined>(undefined);
+  const [activeRoleId, setActiveRoleId] = useState<string | undefined>(undefined);
   const [runStatus, setRunStatus] = useState<string | undefined>(undefined);
   const [runId, setRunId] = useState<string | undefined>(undefined);
   const [events, setEvents] = useState<DelegationEventRow[]>([]);
@@ -110,7 +114,7 @@ export function DelegationTeamCard({
         if (!run || !run.teamId) {
           if (!cancelled) {
             setTeam(undefined);
-            setActiveAgentId(undefined);
+            setActiveRoleId(undefined);
             setRunStatus(undefined);
             setRunId(undefined);
             setEvents([]);
@@ -121,32 +125,36 @@ export function DelegationTeamCard({
           setRunStatus(run.status);
           setRunId(run.id);
         }
-        if (!team) {
+        let currentTeam = team;
+        if (!currentTeam) {
           const loaded = await delegationClient.get(run.teamId);
           if (!cancelled) setTeam(loaded ?? undefined);
+          currentTeam = loaded ?? undefined;
         }
 
-        // Determine the active agent from run + events (bus is source of truth):
-        // 1. Child event (depth>0) "running" → that child
-        // 2. Else if run is running/blocked → entry is active (turning or parked)
+        // Determine the active role from run + events (bus is source of truth):
+        // 1. Child event (depth>0) "running" → that child's roster role
+        // 2. Else if run is running/blocked → entry role is active (turning or parked)
+        // Roles that share a CLI adapter must not inherit each other's live slot.
         const events = await delegationClient.listEvents(run.id);
         if (cancelled) return;
         setEvents(events);
-        const runningChild = events.find(
-          (e) => e.status === "running" && e.depth > 0
-        );
-        if (runningChild?.agentId) {
-          setActiveAgentId(runningChild.agentId);
-        } else {
-          const runLive = run.status === "running" || run.status === "blocked";
-          const isLive =
-            runLive || liveStatus === "running" || liveStatus === "starting";
-          const entry = team?.roster.find((r) => r.id === team.entryRoleId) ?? team?.roster[0];
-          setActiveAgentId(isLive && entry ? entry.agentId : undefined);
+        if (!currentTeam) {
+          setActiveRoleId(undefined);
+          return;
         }
+        setActiveRoleId(
+          resolveActiveDelegationRoleId({
+            roster: currentTeam.roster,
+            entryRoleId: currentTeam.entryRoleId,
+            events,
+            runStatus: run.status,
+            liveStatus
+          })
+        );
       } catch {
         if (!cancelled) {
-          setActiveAgentId(undefined);
+          setActiveRoleId(undefined);
           setRunStatus(undefined);
         }
       }
@@ -304,15 +312,8 @@ export function DelegationTeamCard({
       <div className="delegation-member-list" aria-live="polite">
       {team.roster.map((r) => {
         const isEntry = r.id === team.entryRoleId;
-        const isActive = activeAgentId === r.agentId;
-        const duplicateAgentRoles = team.roster.filter(
-          (candidate) => candidate.agentId === r.agentId
-        ).length;
-        const memberEvents = events.filter(
-          (event) =>
-            event.agentId === r.agentId &&
-            (duplicateAgentRoles === 1 || event.roleLabel === r.label)
-        );
+        const isActive = activeRoleId === r.id;
+        const memberEvents = eventsForRosterRole(events, r, team.roster);
         const newestFirst = [...memberEvents].reverse();
         const activeEvent = newestFirst.find(
           (event) => event.status === "running" || event.status === "pending"
@@ -326,7 +327,7 @@ export function DelegationTeamCard({
             : [];
         // Entry is parked when the run is live but a child agent owns the active slot.
         const parkedEntry =
-          isEntry && runStatus === "running" && Boolean(activeAgentId) && !isActive;
+          isEntry && runStatus === "running" && Boolean(activeRoleId) && !isActive;
         const badge = isActive
           ? t("status.running")
           : parkedEntry

--- a/tests/delegation-member-activity.test.mjs
+++ b/tests/delegation-member-activity.test.mjs
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const roster = [
+  {
+    id: "role-coord",
+    label: "总协调与集成",
+    agentId: "cli-codex-acp",
+    capability: "协调",
+    canWrite: false
+  },
+  {
+    id: "role-host",
+    label: "ELECTRON HOST 负责人",
+    agentId: "cli-codex-acp",
+    capability: "桌面宿主",
+    canWrite: true
+  },
+  {
+    id: "role-protocol",
+    label: "协议负责人",
+    agentId: "cli-cursor-acp",
+    capability: "协议",
+    canWrite: false
+  }
+];
+
+function event(overrides) {
+  return {
+    id: "evt",
+    runId: "run-1",
+    parentEventId: null,
+    agentId: "cli-codex-acp",
+    agentName: "Codex",
+    roleLabel: "总协调与集成",
+    taskText: "work",
+    depth: 0,
+    status: "done",
+    resultSummary: null,
+    result: null,
+    canWrite: false,
+    acceptedAt: null,
+    startedAt: null,
+    endedAt: null,
+    verdict: null,
+    verdictSummary: null,
+    ...overrides
+  };
+}
+
+async function load() {
+  return import("../packages/delegation-core/dist/index.js");
+}
+
+test("shared CLI adapter: only the running child role is live, not sibling roles", async () => {
+  const { resolveActiveDelegationRoleId, eventsForRosterRole } = await load();
+  const events = [
+    event({
+      id: "e-coord",
+      roleLabel: "总协调与集成",
+      status: "done",
+      depth: 0
+    }),
+    event({
+      id: "e-host",
+      roleLabel: "ELECTRON HOST 负责人",
+      status: "running",
+      depth: 1,
+      canWrite: true
+    })
+  ];
+
+  const activeRoleId = resolveActiveDelegationRoleId({
+    roster,
+    entryRoleId: "role-coord",
+    events,
+    runStatus: "running"
+  });
+
+  assert.equal(activeRoleId, "role-host");
+  assert.deepEqual(
+    eventsForRosterRole(events, roster.find((r) => r.id === "role-coord"), roster).map(
+      (row) => row.id
+    ),
+    ["e-coord"]
+  );
+  assert.deepEqual(
+    eventsForRosterRole(events, roster.find((r) => r.id === "role-host"), roster).map(
+      (row) => row.id
+    ),
+    ["e-host"]
+  );
+});
+
+test("shared CLI adapter: a live entry turn does not mark idle sibling roles running", async () => {
+  const { resolveActiveDelegationRoleId } = await load();
+  const events = [
+    event({
+      id: "e-coord",
+      roleLabel: "总协调与集成",
+      status: "running",
+      depth: 0
+    }),
+    event({
+      id: "e-host",
+      roleLabel: "ELECTRON HOST 负责人",
+      status: "done",
+      depth: 1,
+      canWrite: true
+    })
+  ];
+
+  const activeRoleId = resolveActiveDelegationRoleId({
+    roster,
+    entryRoleId: "role-coord",
+    events,
+    runStatus: "running",
+    liveStatus: "running"
+  });
+
+  assert.equal(activeRoleId, "role-coord");
+});
+
+test("shared CLI adapter: completed sibling keeps its own done events", async () => {
+  const { resolveActiveDelegationRoleId, eventsForRosterRole } = await load();
+  const events = [
+    event({
+      id: "e-host",
+      roleLabel: "ELECTRON HOST 负责人",
+      status: "done",
+      depth: 1,
+      canWrite: true
+    })
+  ];
+
+  const host = roster.find((r) => r.id === "role-host");
+  const coord = roster.find((r) => r.id === "role-coord");
+  assert.equal(eventsForRosterRole(events, host, roster).length, 1);
+  assert.equal(eventsForRosterRole(events, coord, roster).length, 0);
+  assert.equal(
+    resolveActiveDelegationRoleId({
+      roster,
+      entryRoleId: "role-coord",
+      events,
+      runStatus: "completed"
+    }),
+    undefined
+  );
+});
+
+test("distinct adapters still mark a running child and park the entry", async () => {
+  const { resolveActiveDelegationRoleId } = await load();
+  const activeRoleId = resolveActiveDelegationRoleId({
+    roster,
+    entryRoleId: "role-coord",
+    events: [
+      event({
+        id: "e-proto",
+        agentId: "cli-cursor-acp",
+        agentName: "Cursor",
+        roleLabel: "协议负责人",
+        status: "running",
+        depth: 1
+      })
+    ],
+    runStatus: "running"
+  });
+  assert.equal(activeRoleId, "role-protocol");
+});

--- a/tests/delegation-team-card-design.test.mjs
+++ b/tests/delegation-team-card-design.test.mjs
@@ -10,7 +10,7 @@ const styles = fs.readFileSync(new URL("../styles.css", import.meta.url), "utf8"
 
 test("delegation activity is grouped into member cards instead of a separate timeline", () => {
   assert.match(source, /team\.roster\.map/);
-  assert.match(source, /const memberEvents = events\.filter/);
+  assert.match(source, /const memberEvents = eventsForRosterRole\(events, r, team\.roster\)/);
   assert.match(source, /className=\{`side-card delegation-member-card/);
   assert.match(source, /className="delegation-member-activity"/);
   assert.doesNotMatch(source, /delegation-timeline-card/);
@@ -49,6 +49,14 @@ test("status remains readable without relying on timeline colors", () => {
   assert.match(source, /delegation-member-state \$\{memberState\}/);
   assert.match(source, /delegation-event-status \$\{event\.status\}/);
   assert.match(styles, /\.delegation-event-status\s*\{/);
+});
+
+test("member running state is keyed by roster role id, not shared CLI adapter", () => {
+  assert.match(source, /resolveActiveDelegationRoleId/);
+  assert.match(source, /eventsForRosterRole\(events, r, team\.roster\)/);
+  assert.match(source, /const isActive = activeRoleId === r\.id/);
+  assert.doesNotMatch(source, /activeAgentId === r\.agentId/);
+  assert.doesNotMatch(source, /setActiveAgentId/);
 });
 
 test("failed delegation events show their upstream error without expanding details", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

自组织团队的「成员动态」用 CLI 适配器的 `agentId` 判断谁在运行。当多个角色共用同一个适配器（例如都选 Codex）时，只要其中一个角色在跑，其他角色也会显示「运行中」。

截图里的典型情况：入口角色正在执行，另一个同样用 Codex 的角色任务已经完成，卡片顶部仍是「运行中」。

## 原因

`DelegationTeamCard` 把 live slot 记成 `activeAgentId`，再用 `activeAgentId === r.agentId` 给每个角色打「运行中」。共用适配器的角色会共享这个状态。运行时侧本来就用 `rosterIdForEvent`（`agentId` + `roleLabel`）区分角色，UI 没有跟上。

## 修复

- 新增 `resolveActiveDelegationRoleId` / `eventsForRosterRole`，按花名册 **role id** 解析当前活动角色和每个角色自己的事件
- 成员动态卡片用 `activeRoleId === r.id` 显示状态
- 完成态角色保留自己的任务状态，不再被同适配器的运行中角色带跑

## 测试

- `tests/delegation-member-activity.test.mjs`：共用 Codex 时只有真正在跑的角色为 live
- `tests/delegation-team-card-design.test.mjs`：卡片按 role id 而不是 agentId 绑定运行态
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06a057f6-20fa-4895-8abb-fd9a454ebd85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06a057f6-20fa-4895-8abb-fd9a454ebd85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

