### PR TITLE
fix: make delegation wake recovery reliable

### DIFF
--- a/electron/cli/delegationIpc.ts
+++ b/electron/cli/delegationIpc.ts
@@ -19,12 +19,14 @@ import {
   conversationHasDelegationRun,
   handleDelegationFollowUp
 } from "./delegation/adapter/ipcFollowUp.js";
-import { createDelegationRuntimeHandle } from "../runtime/delegationRuntimeClient.js";
+import {
+  createDelegationRuntimeHandle,
+  shouldUseDelegationRuntimeProcess
+} from "../runtime/delegationRuntimeClient.js";
 import {
   listHostPendingApprovals,
   resolveHostWriteApproval
 } from "../runtime/runtimeHostApi.js";
-import { shouldUseRuntimeProcess } from "../runtime/workflowRuntimeClient.js";
 
 let runtime: DelegationRuntime | null = null;
 
@@ -119,7 +121,7 @@ export function registerDelegationIpc(): void {
     "workflow:approveDelegateWrite",
     (event, args: { runId: string; approvalId: string; approved: boolean }) => {
       if (!callerCanAccessDelegationRun(args.runId)) return false;
-      if (shouldUseRuntimeProcess()) {
+      if (shouldUseDelegationRuntimeProcess()) {
         return resolveHostWriteApproval(args.approvalId, args.approved);
       }
       const rt = ensureDelegationRuntime(event);
@@ -141,7 +143,7 @@ export function registerDelegationIpc(): void {
     "delegation:listPendingApprovals",
     (event, runId: string) => {
       if (!callerCanAccessDelegationRun(runId)) return [];
-      if (shouldUseRuntimeProcess()) {
+      if (shouldUseDelegationRuntimeProcess()) {
         return listHostPendingApprovals(runId);
       }
       return ensureDelegationRuntime(event)

--- a/electron/cli/delegationRuntime.ts
+++ b/electron/cli/delegationRuntime.ts
@@ -450,6 +450,7 @@ export class DelegationRuntime {
       prompt
     });
 
+    if (result.parked) return;
     if (this.killedRunIds.has(runId)) return;
     const status: DelegationEventStatus = result.error ? "failed" : "done";
     updateDelegationEvent(root.id, {

--- a/electron/runtime/delegationRuntimeClient.ts
+++ b/electron/runtime/delegationRuntimeClient.ts
@@ -15,6 +15,18 @@ export type DelegationRuntimeHandle = {
   followUp: (runId: string, prompt: string) => void | Promise<void>;
 };
 
+/**
+ * Delegation tools still execute in the desktop host and need the in-process
+ * runtime's queue/orchestrator callbacks. Keep delegation local by default
+ * until the runtime-process bridge forwards enqueue, settle, and yield events.
+ */
+export function shouldUseDelegationRuntimeProcess(): boolean {
+  return (
+    process.env.FREEBUDDY_DELEGATION_RUNTIME_PROCESS === "1" &&
+    shouldUseRuntimeProcess()
+  );
+}
+
 async function invokeDelegationRpc(
   event: IpcMainInvokeEvent,
   runId: string | undefined,
@@ -39,7 +51,7 @@ export function createDelegationRuntimeHandle(
   event: IpcMainInvokeEvent,
   getLocal: () => DelegationRuntime
 ): DelegationRuntimeHandle {
-  const useProcess = shouldUseRuntimeProcess();
+  const useProcess = shouldUseDelegationRuntimeProcess();
 
   function call<T>(
     runId: string | undefined,

--- a/electron/runtime/electronRuntimeProcessLauncher.ts
+++ b/electron/runtime/electronRuntimeProcessLauncher.ts
@@ -15,7 +15,10 @@ export function createElectronRuntimeProcessLauncher(): RuntimeProcessLauncher {
           child.postMessage(message);
         },
         onMessage(handler) {
-          const listener = (event: { data: unknown }) => handler(event.data);
+          // UtilityProcess emits the deserialized message itself. Unlike a
+          // MessagePort "message" event, there is no wrapping `{ data }`
+          // object on the host side.
+          const listener = (message: unknown) => handler(message);
           child.on("message", listener);
           return () => child.off("message", listener);
         },

--- a/packages/delegation-runtime/src/orchestrator.ts
+++ b/packages/delegation-runtime/src/orchestrator.ts
@@ -15,6 +15,8 @@ import { isTerminalDelegationStatus } from "./status.js";
 export interface OrchestratorTurnResult {
   summary: string;
   error: string | null;
+  /** The node is still waiting for active delegates; callers must not finalize it. */
+  parked?: boolean;
   /** False only when the executor positively observed no assistant text or artifact. */
   hasOutput?: boolean;
   /** Most useful tool/runtime detail to show when an otherwise empty turn is rejected. */
@@ -100,7 +102,12 @@ export interface OrchestratorSpawnArgs {
  */
 export class DelegationOrchestrator {
   private bus: BusState | null = null;
-  private eventWaiters = new Map<string, Array<(e: DelegationEvent | undefined) => void>>();
+  private eventWaiters = new Map<
+    string,
+    Set<(event: DelegationEvent | undefined) => void>
+  >();
+  private recoveryWakeDrives = new Map<string, Promise<void>>();
+  private queuedFollowUps = new Map<string, string[]>();
   private killed = false;
 
   constructor(
@@ -159,9 +166,10 @@ export class DelegationOrchestrator {
   onEventSettled(eventId: string): void {
     const evt = this.opts.repository.getEvent(eventId);
     const waiters = this.eventWaiters.get(eventId);
-    if (waiters) {
+    const hadWaiters = Boolean(waiters?.size);
+    if (hadWaiters) {
       this.eventWaiters.delete(eventId);
-      for (const resolve of waiters) resolve(evt);
+      for (const resolve of [...waiters!]) resolve(evt);
     }
     if (!this.bus || !evt?.parentEventId) return;
     const { state, effects } = reduce(this.bus, {
@@ -177,6 +185,100 @@ export class DelegationOrchestrator {
     });
     this.bus = state;
     this.applyEffects(effects.filter((e) => e.type !== "SpawnWake"));
+    if (!hadWaiters) {
+      for (const effect of effects) {
+        if (effect.type === "SpawnWake") this.scheduleRecoveryWake(effect);
+      }
+    }
+  }
+
+  /**
+   * Normal park/wake resumes through an in-memory event waiter. If that
+   * volatile waiter disappears while the persisted parent is still parked,
+   * the FSM's SpawnWake effect is the recovery path instead of dropping the
+   * completed child notification.
+   */
+  private scheduleRecoveryWake(effect: Extract<BusEffect, { type: "SpawnWake" }>): void {
+    if (this.recoveryWakeDrives.has(effect.nodeId) || this.killed) return;
+    const node = this.bus?.nodes[effect.nodeId];
+    const parent = this.opts.repository.getEvent(effect.nodeId);
+    const child = this.opts.repository.getEvent(effect.childId);
+    if (!node || !parent || !child) return;
+    const role =
+      this.opts.roster.find(
+        (candidate) =>
+          candidate.agentId === parent.agentId && candidate.label === parent.roleLabel
+      ) ??
+      this.opts.roster.find((candidate) => candidate.agentId === parent.agentId) ??
+      this.opts.roster.find((candidate) => candidate.id === this.opts.entryRoleId) ??
+      this.opts.roster[0];
+    if (!role) return;
+
+    const effective = resolveEffectiveWakeVerdict(
+      child,
+      this.opts.repository.listEvents(this.opts.runId)
+    );
+    const prompt = this.appendQueuedFollowUps(effect.nodeId, buildDelegateWakePrompt(
+      {
+        taskText: effect.taskText,
+        roleLabel: effect.roleLabel,
+        status: effect.childStatus,
+        resultSummary: effect.resultSummary,
+        verdict: effective.verdict,
+        verdictSummary: effective.verdictSummary
+      },
+      this.opts.roster,
+      role.id,
+      node.depth,
+      this.opts.policy.maxDepth,
+      {
+        sharedInstructions: this.opts.sharedInstructions,
+        roleInstructions: role.instructions,
+        selfLabel: role.label
+      }
+    ));
+
+    let drive: Promise<void>;
+    drive = Promise.resolve()
+      .then(async () => {
+        await this.runNodeLoop({
+          nodeId: effect.nodeId,
+          depth: node.depth,
+          selfAgentId: role.id,
+          selfLabel: role.label,
+          initialPrompt: prompt,
+          kind: "wake"
+        });
+      })
+      .catch((error) => {
+        const message = (error as Error)?.message ?? String(error);
+        this.opts.repository.updateEvent(effect.nodeId, {
+          status: "failed",
+          resultSummary: message
+        });
+        if (node.isEntry) this.opts.repository.setStatus(this.opts.runId, "failed");
+      })
+      .finally(() => {
+        if (this.recoveryWakeDrives.get(effect.nodeId) === drive) {
+          this.recoveryWakeDrives.delete(effect.nodeId);
+        }
+      });
+    this.recoveryWakeDrives.set(effect.nodeId, drive);
+  }
+
+  private queueFollowUp(nodeId: string, prompt: string): void {
+    const queued = this.queuedFollowUps.get(nodeId) ?? [];
+    queued.push(prompt);
+    this.queuedFollowUps.set(nodeId, queued);
+  }
+
+  private appendQueuedFollowUps(nodeId: string, prompt: string): string {
+    const queued = this.queuedFollowUps.get(nodeId);
+    if (!queued?.length) return prompt;
+    this.queuedFollowUps.delete(nodeId);
+    return `${prompt}\n\n用户在等待委派期间补充了以下要求，请一并处理：\n${queued
+      .map((item, index) => `${index + 1}. ${item}`)
+      .join("\n")}`;
   }
 
   awaitEventSettle(eventId: string): Promise<DelegationEvent | undefined> {
@@ -185,16 +287,47 @@ export class DelegationOrchestrator {
       return Promise.resolve(existing);
     }
     return new Promise((resolve) => {
-      const arr = this.eventWaiters.get(eventId) ?? [];
-      arr.push(resolve);
-      this.eventWaiters.set(eventId, arr);
+      const waiters = this.eventWaiters.get(eventId) ?? new Set();
+      waiters.add(resolve);
+      this.eventWaiters.set(eventId, waiters);
     });
   }
 
   raceAnySettle(eventIds: string[]): Promise<DelegationEvent | undefined> {
     if (eventIds.length === 0) throw new Error("raceAnySettle: empty id list");
     if (eventIds.length === 1) return this.awaitEventSettle(eventIds[0]!);
-    return Promise.race(eventIds.map((id) => this.awaitEventSettle(id)));
+    const alreadySettled = eventIds
+      .map((id) => this.opts.repository.getEvent(id))
+      .find((event) => event && isTerminalDelegationStatus(event.status));
+    if (alreadySettled) return Promise.resolve(alreadySettled);
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const registrations: Array<{
+        eventId: string;
+        waiter: (event: DelegationEvent | undefined) => void;
+      }> = [];
+      const cleanup = () => {
+        for (const registration of registrations) {
+          const waiters = this.eventWaiters.get(registration.eventId);
+          waiters?.delete(registration.waiter);
+          if (waiters?.size === 0) this.eventWaiters.delete(registration.eventId);
+        }
+      };
+      const finish = (event: DelegationEvent | undefined) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(event);
+      };
+      for (const eventId of eventIds) {
+        const waiter = (event: DelegationEvent | undefined) => finish(event);
+        registrations.push({ eventId, waiter });
+        const waiters = this.eventWaiters.get(eventId) ?? new Set();
+        waiters.add(waiter);
+        this.eventWaiters.set(eventId, waiters);
+      }
+    });
   }
 
   private applyEffects(effects: BusEffect[]): void {
@@ -246,7 +379,7 @@ export class DelegationOrchestrator {
     selfAgentId: string;
     selfLabel: string;
     initialPrompt: string;
-    kind?: "task" | "followUp";
+    kind?: "task" | "wake" | "followUp";
   }): Promise<OrchestratorTurnResult> {
     if (!this.bus) throw new Error("orchestrator not bound");
     let prompt = opts.initialPrompt;
@@ -297,7 +430,7 @@ export class DelegationOrchestrator {
                 this.opts.repository.listEvents(this.opts.runId)
               )
             : { verdict: null, verdictSummary: null };
-        prompt = buildDelegateWakePrompt(
+        prompt = this.appendQueuedFollowUps(opts.nodeId, buildDelegateWakePrompt(
           { ...immediateWake, ...effectiveVerdict },
           this.opts.roster,
           opts.selfAgentId,
@@ -309,7 +442,7 @@ export class DelegationOrchestrator {
               ?.instructions,
             selfLabel: opts.selfLabel
           }
-        );
+        ));
         kind = "wake";
         continue;
       }
@@ -371,7 +504,7 @@ export class DelegationOrchestrator {
         this.bus = state;
       }
 
-      prompt = buildDelegateWakePrompt(
+      prompt = this.appendQueuedFollowUps(opts.nodeId, buildDelegateWakePrompt(
         {
           taskText: settled?.taskText ?? "",
           roleLabel: settled?.roleLabel ?? "",
@@ -396,7 +529,7 @@ export class DelegationOrchestrator {
             ?.instructions,
           selfLabel: opts.selfLabel
         }
-      );
+      ));
       kind = "wake";
     }
 
@@ -410,6 +543,14 @@ export class DelegationOrchestrator {
   }): Promise<OrchestratorTurnResult> {
     if (!this.bus) {
       this.bindEntry(opts.entryNodeId);
+    }
+    const entry = this.bus!.nodes[opts.entryNodeId];
+    if (
+      entry?.status === "parked" &&
+      this.opts.repository.listPendingChildEvents(this.opts.runId, opts.entryNodeId).length > 0
+    ) {
+      this.queueFollowUp(opts.entryNodeId, opts.prompt);
+      return { summary: "follow-up queued while delegates are running", error: null, parked: true };
     }
     this.killed = false;
     const { state, effects } = reduce(this.bus!, {

--- a/packages/delegation-runtime/src/runtime.ts
+++ b/packages/delegation-runtime/src/runtime.ts
@@ -316,6 +316,7 @@ export class DelegationRuntime {
       entry,
       prompt
     });
+    if (result.parked) return;
     if (this.killedRunIds.has(runId)) return;
     const status: DelegationEventStatus = result.error ? "failed" : "done";
     this.ports.repository.updateEvent(root.id, {

--- a/tests/delegation-followup-wake.test.mjs
+++ b/tests/delegation-followup-wake.test.mjs
@@ -235,3 +235,74 @@ test("followUp after completed entry reopens without reusing entry sessionId", a
     assert.equal(scopes[1], scopes[0], "tool session scope stays stable for resume");
   });
 });
+
+test("followUp during an initial park is queued without prematurely completing the run", async (t) => {
+  if (!bindingAvailable) { t.skip(); return; }
+  await withDb(async () => {
+    const { DelegationRuntime } = await import("../dist-electron/cli/delegationRuntime.js");
+    const { dispatchDelegateAction } = await import("../dist-electron/cli/delegationDispatch.js");
+    const { getDelegationRun, listDelegationEvents } = await import(
+      "../dist-electron/cli/delegationRuns.js"
+    );
+
+    const entryPrompts = [];
+    let releaseChild;
+    const childGate = new Promise((resolve) => { releaseChild = resolve; });
+    const rt = new DelegationRuntime({
+      webContents: undefined,
+      resolveAgent: (id) => ({
+        adapter: id.includes("claude") ? "claude-agent-acp" : "codex-acp",
+        agentName: id,
+        skillIds: []
+      }),
+      runAgent: async (args) => {
+        if (args.delegation.depth === 0) {
+          entryPrompts.push(args.prompt);
+          if (entryPrompts.length === 1) {
+            await dispatchDelegateAction(
+              {
+                token: "t",
+                taskSessionId: "s",
+                runId: args.delegation.runId,
+                parentEventId: args.delegation.parentEventId,
+                depth: 0,
+                selfAgentId: "r-impl",
+                selfLabel: "实现"
+              },
+              "delegate",
+              { teammate_id: "r-rev", task: "review the initial change" }
+            );
+          }
+          return { summary: "entry", exitCode: 0, error: null };
+        }
+        await childGate;
+        return { summary: "review complete", exitCode: 0, error: null };
+      }
+    });
+
+    const runId = rt.prepareRun({
+      goal: "implement",
+      teamId: "t",
+      teamSnapshot: snap,
+      cwd: "/r"
+    });
+    const entryDrive = rt.runEntry(runId, "implement");
+    await tick(30);
+
+    await rt.followUp(runId, "also verify the release notes");
+    assert.equal(entryPrompts.length, 1, "parked follow-up must not re-enter the entry agent");
+    assert.equal(getDelegationRun(runId).status, "running");
+    assert.equal(
+      listDelegationEvents(runId).find((event) => event.depth === 0)?.status,
+      "running"
+    );
+
+    releaseChild();
+    await entryDrive;
+
+    assert.equal(entryPrompts.length, 2);
+    assert.match(entryPrompts[1], /review complete/);
+    assert.match(entryPrompts[1], /also verify the release notes/);
+    assert.equal(getDelegationRun(runId).status, "completed");
+  });
+});

--- a/tests/delegation-runtime-memory.test.mjs
+++ b/tests/delegation-runtime-memory.test.mjs
@@ -273,6 +273,221 @@ test("a child that fails before the parent turn ends triggers a wake instead of 
   assert.equal(repository.getEvent(rootId)?.status, "failed");
 });
 
+test("a settled child schedules a recovery wake when the parked waiter's memory is lost", async () => {
+  const repository = createMemoryDelegationRepository();
+  const run = repository.createRun({
+    goal: "g",
+    status: "running",
+    teamId: "t",
+    teamSnapshotJson: "{}"
+  });
+  const rootId = repository.insertEvent({
+    runId: run.id,
+    parentEventId: null,
+    agentId: "agent-a",
+    agentName: "A",
+    roleLabel: "实现",
+    taskText: "g",
+    depth: 0,
+    canWrite: false,
+    status: "running"
+  });
+  let childId;
+  let calls = 0;
+  let orchestrator;
+  orchestrator = new DelegationOrchestrator({
+    runId: run.id,
+    roster,
+    policy,
+    entryRoleId: "r-impl",
+    repository,
+    async spawnTurn({ prompt }) {
+      calls += 1;
+      if (calls === 1) {
+        childId = repository.insertEvent({
+          runId: run.id,
+          parentEventId: rootId,
+          agentId: "agent-b",
+          agentName: "B",
+          roleLabel: "评审",
+          taskText: "review",
+          depth: 1,
+          canWrite: false,
+          status: "running"
+        });
+        orchestrator.noteChildEnqueued({
+          childEventId: childId,
+          parentEventId: rootId,
+          depth: 1
+        });
+        orchestrator.noteChildStarted(childId);
+        return { summary: "delegated", error: null, hasOutput: true };
+      }
+      assert.match(prompt, /review complete/);
+      return { summary: "integrated", error: null, hasOutput: true };
+    }
+  });
+  orchestrator.bindEntry(rootId);
+
+  void orchestrator.runNodeLoop({
+    nodeId: rootId,
+    depth: 0,
+    selfAgentId: "r-impl",
+    selfLabel: "实现",
+    initialPrompt: "go"
+  });
+
+  const deadline = Date.now() + 500;
+  while (!orchestrator.eventWaiters?.get(childId)?.size && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.equal(orchestrator.state.nodes[rootId].status, "parked");
+  assert.ok(orchestrator.eventWaiters?.get(childId)?.size, "park waiter must exist first");
+
+  // Simulate the volatile waiter being lost while the persisted parent remains parked.
+  orchestrator.eventWaiters.clear();
+  repository.updateEvent(childId, {
+    status: "done",
+    resultSummary: "review complete"
+  });
+  orchestrator.onEventSettled(childId);
+
+  const wakeDeadline = Date.now() + 500;
+  while (calls < 2 && Date.now() < wakeDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.equal(calls, 2, "settlement must start a recovery wake without a live waiter");
+  assert.equal(repository.getEvent(rootId)?.status, "done");
+  assert.equal(repository.getRun(run.id)?.status, "completed");
+});
+
+test("follow-up while parked is folded into the next wake instead of starting a concurrent turn", async () => {
+  const repository = createMemoryDelegationRepository();
+  const run = repository.createRun({
+    goal: "g",
+    status: "running",
+    teamId: "t",
+    teamSnapshotJson: "{}"
+  });
+  const rootId = repository.insertEvent({
+    runId: run.id,
+    parentEventId: null,
+    agentId: "agent-a",
+    agentName: "A",
+    roleLabel: "实现",
+    taskText: "g",
+    depth: 0,
+    canWrite: false,
+    status: "running"
+  });
+  let childId;
+  const prompts = [];
+  let orchestrator;
+  orchestrator = new DelegationOrchestrator({
+    runId: run.id,
+    roster,
+    policy,
+    entryRoleId: "r-impl",
+    repository,
+    async spawnTurn({ prompt }) {
+      prompts.push(prompt);
+      if (prompts.length === 1) {
+        childId = repository.insertEvent({
+          runId: run.id,
+          parentEventId: rootId,
+          agentId: "agent-b",
+          agentName: "B",
+          roleLabel: "评审",
+          taskText: "review",
+          depth: 1,
+          canWrite: false,
+          status: "running"
+        });
+        orchestrator.noteChildEnqueued({
+          childEventId: childId,
+          parentEventId: rootId,
+          depth: 1
+        });
+        orchestrator.noteChildStarted(childId);
+      }
+      return { summary: "ok", error: null, hasOutput: true };
+    }
+  });
+  orchestrator.bindEntry(rootId);
+
+  const drive = orchestrator.runNodeLoop({
+    nodeId: rootId,
+    depth: 0,
+    selfAgentId: "r-impl",
+    selfLabel: "实现",
+    initialPrompt: "go"
+  });
+  const deadline = Date.now() + 500;
+  while (orchestrator.state.nodes[rootId].status !== "parked" && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  const followUp = await orchestrator.followUp({
+    entryNodeId: rootId,
+    entry: roster[0],
+    prompt: "also verify the release notes"
+  });
+  assert.equal(followUp.parked, true);
+  assert.equal(prompts.length, 1, "parked follow-up must not start a second root turn");
+
+  repository.updateEvent(childId, {
+    status: "done",
+    resultSummary: "review complete"
+  });
+  orchestrator.onEventSettled(childId);
+  await drive;
+
+  assert.equal(prompts.length, 2);
+  assert.match(prompts[1], /review complete/);
+  assert.match(prompts[1], /also verify the release notes/);
+});
+
+test("raceAnySettle removes losing waiters so stale registrations cannot swallow a later wake", async () => {
+  const repository = createMemoryDelegationRepository();
+  const run = repository.createRun({
+    goal: "g",
+    status: "running",
+    teamId: "t",
+    teamSnapshotJson: "{}"
+  });
+  const eventIds = ["a", "b"].map((taskText) =>
+    repository.insertEvent({
+      runId: run.id,
+      parentEventId: null,
+      agentId: "agent-b",
+      agentName: "B",
+      roleLabel: "评审",
+      taskText,
+      depth: 1,
+      canWrite: false,
+      status: "running"
+    })
+  );
+  const orchestrator = new DelegationOrchestrator({
+    runId: run.id,
+    roster,
+    policy,
+    entryRoleId: "r-impl",
+    repository,
+    async spawnTurn() {
+      return { summary: "unused", error: null };
+    }
+  });
+
+  const race = orchestrator.raceAnySettle(eventIds);
+  assert.equal(orchestrator.eventWaiters.get(eventIds[1])?.size, 1);
+  repository.updateEvent(eventIds[0], { status: "done", resultSummary: "first" });
+  orchestrator.onEventSettled(eventIds[0]);
+
+  assert.equal((await race)?.id, eventIds[0]);
+  assert.equal(orchestrator.eventWaiters.has(eventIds[1]), false);
+});
+
 test("crash recovery marks active events failed via repository transitions", () => {
   const repository = createMemoryDelegationRepository();
   const run = repository.createRun({

--- a/tests/electron-runtime-process-launcher.test.mjs
+++ b/tests/electron-runtime-process-launcher.test.mjs
@@ -1,0 +1,59 @@
+import "./fixtures/electron-stub.mjs";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+
+test("Electron utility-process messages reach the runtime host unchanged", async () => {
+  const child = new EventEmitter();
+  child.pid = 4242;
+  child.postMessage = () => {};
+  child.kill = () => {};
+  globalThis.__freebuddyElectronUtilityProcessFork = () => child;
+
+  try {
+    const { createElectronRuntimeProcessLauncher } = await import(
+      "../dist-electron/runtime/electronRuntimeProcessLauncher.js"
+    );
+    const handle = createElectronRuntimeProcessLauncher().launch({
+      entryPath: "/runtime/index.mjs",
+      env: {}
+    });
+    const received = [];
+    handle.onMessage((message) => received.push(message));
+
+    const hello = { rpcVersion: "1.0.0", id: "hello", kind: "response" };
+    child.emit("message", hello);
+
+    assert.deepEqual(received, [hello]);
+  } finally {
+    delete globalThis.__freebuddyElectronUtilityProcessFork;
+  }
+});
+
+test("delegation stays in-process unless its runtime bridge is explicitly enabled", async () => {
+  const previousRuntimeProcess = process.env.FREEBUDDY_RUNTIME_PROCESS;
+  const previousDelegationProcess = process.env.FREEBUDDY_DELEGATION_RUNTIME_PROCESS;
+  const previousInProcess = process.env.FREEBUDDY_RUNTIME_IN_PROCESS;
+  process.env.FREEBUDDY_RUNTIME_PROCESS = "1";
+  delete process.env.FREEBUDDY_RUNTIME_IN_PROCESS;
+  delete process.env.FREEBUDDY_DELEGATION_RUNTIME_PROCESS;
+
+  try {
+    const { shouldUseDelegationRuntimeProcess } = await import(
+      "../dist-electron/runtime/delegationRuntimeClient.js"
+    );
+    assert.equal(shouldUseDelegationRuntimeProcess(), false);
+    process.env.FREEBUDDY_DELEGATION_RUNTIME_PROCESS = "1";
+    assert.equal(shouldUseDelegationRuntimeProcess(), true);
+  } finally {
+    if (previousRuntimeProcess === undefined) delete process.env.FREEBUDDY_RUNTIME_PROCESS;
+    else process.env.FREEBUDDY_RUNTIME_PROCESS = previousRuntimeProcess;
+    if (previousDelegationProcess === undefined) {
+      delete process.env.FREEBUDDY_DELEGATION_RUNTIME_PROCESS;
+    } else {
+      process.env.FREEBUDDY_DELEGATION_RUNTIME_PROCESS = previousDelegationProcess;
+    }
+    if (previousInProcess === undefined) delete process.env.FREEBUDDY_RUNTIME_IN_PROCESS;
+    else process.env.FREEBUDDY_RUNTIME_IN_PROCESS = previousInProcess;
+  }
+});

--- a/tests/fixtures/electron-stub.mjs
+++ b/tests/fixtures/electron-stub.mjs
@@ -36,6 +36,9 @@ const electronStubUrl =
      export const protocol = any;
      export const safeStorage = any;
      export const shell = any;
+     export const utilityProcess = {
+       fork: (...args) => globalThis.__freebuddyElectronUtilityProcessFork?.(...args)
+     };
      export const webUtils = any;
     `
   );


### PR DESCRIPTION
## Summary
- forward Electron utility-process messages without incorrectly unwrapping data, fixing runtime.hello timeouts
- keep delegation in-process by default until its external runtime bridge can forward enqueue, settle, and yield events
- recover parked parents when an in-memory settle waiter is missing and clean stale Promise.race waiters
- fold user follow-ups received while parked into the next wake turn instead of re-entering the coordinator

## Verification
- npm run typecheck
- delegation/runtime targeted Node tests: 20 tests, 19 passed and 1 Node ABI skip
- Electron delegation regression suite: 50 passed
- npm run test:handoff-db delegation/runtime coverage passed; sandbox-only failures rerun with system permissions and passed
- full Node suite: 6 local HTTP listener failures under restricted sandbox; the failing file passed 15/15 with system permissions
- git diff --check