### PR TITLE
fix: recover stalled DeepSeek delegation turns

### DIFF
--- a/electron/cli/acp.ts
+++ b/electron/cli/acp.ts
@@ -21,6 +21,53 @@ export interface AcpMessage {
   error?: { code: number; message: string; data?: any };
 }
 
+/** Keep the inactivity watchdog aware of a silent, in-flight ACP tool call. */
+export function updateActiveAcpToolCalls(
+  activeToolCallIds: Set<string>,
+  update: any
+): void {
+  const type = String(update?.sessionUpdate ?? "");
+  if (type !== "tool_call" && type !== "tool_call_update") return;
+  if (update?.toolCallId == null) return;
+  const toolCallId = String(update.toolCallId);
+  if (!toolCallId) return;
+  const status = String(update?.status ?? "").toLowerCase();
+  if (["completed", "failed", "cancelled", "done", "error"].includes(status)) {
+    activeToolCallIds.delete(toolCallId);
+    return;
+  }
+  activeToolCallIds.add(toolCallId);
+}
+
+export function shouldRetryEmptyResumedDshTurn(input: {
+  adapter: string;
+  resumed: boolean;
+  promptHadContent: boolean;
+  resetAttempted: boolean;
+}): boolean {
+  return (
+    input.adapter === "dsh-acp" &&
+    input.resumed &&
+    !input.promptHadContent &&
+    !input.resetAttempted
+  );
+}
+
+export function shouldDiscardAcpToolSession(input: {
+  adapter: string;
+  status: "done" | "failed" | "killed";
+  promptStarted: boolean;
+  promptHadContent: boolean;
+  turnHadTerminalError: boolean;
+}): boolean {
+  return (
+    input.adapter === "dsh-acp" &&
+    (input.status !== "done" ||
+      input.turnHadTerminalError ||
+      (input.promptStarted && !input.promptHadContent))
+  );
+}
+
 /** An ACP authentication method advertised by an agent in `initialize`.
  *  Stable ACP v1 supports agent-driven authentication. Draft agents may also
  *  advertise richer method types, which are kept here so we can reject them

--- a/electron/cli/acpRuntime.ts
+++ b/electron/cli/acpRuntime.ts
@@ -28,7 +28,10 @@ import {
   shouldDropReplayPhaseAgentChunk,
   shouldEmitAcpUpdate,
   shouldSkipUserMessageChunk,
+  shouldDiscardAcpToolSession,
+  shouldRetryEmptyResumedDshTurn,
   textFromContent,
+  updateActiveAcpToolCalls,
   isMissingSavedSessionError,
   type AcpAuthMethod,
   type AcpMessage,
@@ -142,6 +145,12 @@ function contextResetInstruction(): string {
   return "The previous agent session reached its context limit. Continue from the current workspace state; do not repeat completed work. Re-check the current files and finish the request.";
 }
 
+function emptySessionResetInstruction(): string {
+  // Agent-facing recovery instruction. The original prompt is retained before
+  // this suffix so a newly created session can safely resume the same task.
+  return "The previous agent session ended without producing output. Continue from the current workspace state; do not repeat completed work. Re-check the current files and finish the request.";
+}
+
 function contextWindowExceededAfterResetError(err: unknown): Error {
   const detail = (err as Error)?.message || String(err);
   return getLanguage() === "zh-CN"
@@ -209,11 +218,14 @@ export async function runAcpAgent({
   let inactivityFired = false;
   let inactivityReprieves = 0;
   let promptHadContent = false;
+  let turnHadTerminalError = false;
   let turnHadLiveAgentChunk = false;
   let sessionWasResumed = false;
   let mcpServers: AcpStdioMcpServer[] = [];
   let contextResetAttempted = false;
+  let emptySessionResetAttempted = false;
   let nonRetryableUpstreamError: string | undefined;
+  const activeToolCallIds = new Set<string>();
   let activePrompt = args.prompt;
   const sessionMeta: AcpSessionMeta | undefined = claudeAcpSessionOptions
     ? { claudeCode: { options: claudeAcpSessionOptions } }
@@ -351,12 +363,20 @@ export async function runAcpAgent({
     const alive = await probeAgentLiveness();
     if (finished) return;
     const minutes = Math.round(INACTIVITY_TIMEOUT_MS / 60000);
-    if (alive && inactivityReprieves < MAX_INACTIVITY_REPRIEVES) {
+    const hasActiveToolCall = activeToolCallIds.size > 0;
+    if (
+      (alive || hasActiveToolCall) &&
+      inactivityReprieves < MAX_INACTIVITY_REPRIEVES
+    ) {
       inactivityReprieves += 1;
       appendLog(
         logStream,
         "system",
-        `inactivity after ${INACTIVITY_TIMEOUT_MS}ms; agent responded to liveness probe; continuing (reprieve ${inactivityReprieves}/${MAX_INACTIVITY_REPRIEVES})`
+        `inactivity after ${INACTIVITY_TIMEOUT_MS}ms; ${
+          alive
+            ? "agent responded to liveness probe"
+            : `ACP tool call still active (${activeToolCallIds.size})`
+        }; continuing (reprieve ${inactivityReprieves}/${MAX_INACTIVITY_REPRIEVES})`
       );
       inactivityFired = false;
       disarmInactivityTimer();
@@ -372,7 +392,9 @@ export async function runAcpAgent({
     finish(
       "failed",
       -1,
-      alive
+      hasActiveToolCall
+        ? `Agent's active tool call produced no output for ${minutes} minutes and remained silent after ${MAX_INACTIVITY_REPRIEVES} watchdog reprieves.`
+        : alive
         ? `Agent produced no output for ${minutes} minutes and was still silent after ${MAX_INACTIVITY_REPRIEVES} liveness probes. This usually means a tool spawned a long-running process (for example a dev server or sub-agent) that held the agent's output stream open.`
         : `Agent produced no output for ${minutes} minutes and did not respond to a liveness probe. This usually means a tool spawned a long-running process (for example a dev server) that held the agent's output stream open.`
     );
@@ -435,7 +457,20 @@ export async function runAcpAgent({
     clearSessionOwner(args.sessionId);
     updateTaskStatus(args.sessionId, status, exitCode, errorMessage);
     updateRuntimeRun(args.adapter, status === "failed" ? errorMessage : undefined);
-    if (activeAcpSessionId && toolSessionScope) {
+    const discardToolSession = shouldDiscardAcpToolSession({
+      adapter: args.adapter,
+      status,
+      promptStarted,
+      promptHadContent,
+      turnHadTerminalError
+    });
+    if (discardToolSession && toolSessionScope) {
+      try {
+        clearToolSession(args.agentId, toolSessionScope);
+      } catch {
+        /* best-effort */
+      }
+    } else if (activeAcpSessionId && toolSessionScope) {
       saveToolSession(args.agentId, toolSessionScope, args.adapter, activeAcpSessionId);
       setTaskToolSessionId(args.sessionId, activeAcpSessionId);
     }
@@ -501,6 +536,9 @@ export async function runAcpAgent({
         capturedSessions.set(args.sessionId, sessionId);
       }
       const updateType = String(msg.params?.update?.sessionUpdate ?? "");
+      if (promptStarted) {
+        updateActiveAcpToolCalls(activeToolCallIds, msg.params?.update);
+      }
       const upstreamFailure = acpNonRetryableUpstreamError(msg.params?.update);
       if (!nonRetryableUpstreamError && upstreamFailure) {
         nonRetryableUpstreamError = upstreamFailure;
@@ -576,6 +614,13 @@ export async function runAcpAgent({
         return;
       }
       const items = acpUpdateToItems(msg.params?.update, sessionId);
+      if (
+        items.some(
+          (item) => item.kind === "error" && item.terminal === true
+        )
+      ) {
+        turnHadTerminalError = true;
+      }
       if (items.length) emit({ type: "items", items });
       return;
     }
@@ -1104,8 +1149,10 @@ export async function runAcpAgent({
     });
     promptStarted = true;
     promptHadContent = false;
+    turnHadTerminalError = false;
     turnHadLiveAgentChunk = false;
     inactivityReprieves = 0;
+    activeToolCallIds.clear();
     // Live generation begins here. Replay suppression (sessionWasResumed) must
     // be confined to the pre-prompt replay phase; keeping it enabled would drop
     // live agent chunks whose text matches a persisted history signature.
@@ -1470,6 +1517,7 @@ export async function runAcpAgent({
     };
 
     await applyConfigOptionOverrides();
+    const initialPromptResumedSession = sessionWasResumed;
     try {
       await runPromptOnSession();
     } catch (promptErr) {
@@ -1530,6 +1578,52 @@ export async function runAcpAgent({
     }
     if (nonRetryableUpstreamError) {
       throw new Error(nonRetryableUpstreamError);
+    }
+
+    if (
+      !finished &&
+      shouldRetryEmptyResumedDshTurn({
+        adapter: args.adapter,
+        resumed: initialPromptResumedSession,
+        promptHadContent,
+        resetAttempted: emptySessionResetAttempted
+      })
+    ) {
+      emptySessionResetAttempted = true;
+      const emptySessionId = activeAcpSessionId;
+      appendLog(
+        logStream,
+        "system",
+        `saved DeepSeek ACP session returned an empty turn; starting a fresh session${
+          emptySessionId ? ` from ${emptySessionId}` : ""
+        }`
+      );
+      emit({
+        type: "stderr",
+        content:
+          "Previous DeepSeek session returned no output; retrying once in a fresh session."
+      });
+      if (toolSessionScope) {
+        try {
+          clearToolSession(args.agentId, toolSessionScope);
+        } catch {
+          /* best-effort */
+        }
+      }
+      requestedToolSessionId = undefined;
+      activeAcpSessionId = undefined;
+      sessionWasResumed = false;
+      activePrompt = [
+        args.prompt.trimEnd(),
+        "",
+        emptySessionResetInstruction()
+      ].join("\n");
+      await establishSession();
+      await applyConfigOptionOverrides();
+      await runPromptOnSession();
+      if (nonRetryableUpstreamError) {
+        throw new Error(nonRetryableUpstreamError);
+      }
     }
     await syncSessionMetadataFromList();
 

--- a/electron/cli/delegation/protocol/text.ts
+++ b/electron/cli/delegation/protocol/text.ts
@@ -1,4 +1,5 @@
 export {
+  buildDelegateFollowUpTask,
   buildDelegateTaskPrompt,
   buildDelegateWakePrompt,
   buildDelegationRosterPrompt,

--- a/electron/cli/delegationPrompt.ts
+++ b/electron/cli/delegationPrompt.ts
@@ -1,5 +1,6 @@
 /** Thin facade — canonical protocol text lives in delegation/protocol/text.ts */
 export {
+  buildDelegateFollowUpTask,
   buildDelegationRosterPrompt,
   buildDelegateTaskPrompt,
   buildDelegateWakePrompt,

--- a/electron/cli/delegationRuntime.ts
+++ b/electron/cli/delegationRuntime.ts
@@ -33,7 +33,10 @@ import {
   type DelegateExecArgs,
   type DelegateExecResult
 } from "./delegationDispatch.js";
-import { buildDelegateTaskPrompt } from "./delegation/protocol/text.js";
+import {
+  buildDelegateFollowUpTask,
+  buildDelegateTaskPrompt
+} from "./delegation/protocol/text.js";
 import type { DelegateAgentRunner } from "./delegationRunner.js";
 import {
   classifyNewDelegationChildren,
@@ -428,11 +431,17 @@ export class DelegationRuntime {
     const orch = this.ensureOrchestrator(ctx);
     if (!orch.state) orch.bindEntry(root.id);
 
+    const followUpTask = buildDelegateFollowUpTask(
+      root.taskText,
+      userPrompt,
+      root.status
+    );
+
     // Reset root to running for the follow-up turn.
     transitionDelegationEvent(root.id, "running", null, { allowReopen: true });
 
     const prompt = buildDelegateTaskPrompt(
-      userPrompt,
+      followUpTask,
       ctx.roster,
       entry.id,
       0,

--- a/packages/delegation-core/src/index.ts
+++ b/packages/delegation-core/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from "./protocol/guards.js";
 export type { DelegationEventRoleRef } from "./protocol/guards.js";
 export {
+  buildDelegateFollowUpTask,
   buildDelegateTaskPrompt,
   buildDelegateWakePrompt,
   buildDelegationRosterPrompt,

--- a/packages/delegation-core/src/protocol/text.ts
+++ b/packages/delegation-core/src/protocol/text.ts
@@ -156,6 +156,39 @@ export function buildDelegateTaskPrompt(
   ].join("\n");
 }
 
+/**
+ * Restore enough task context when a failed entry turn is retried in a fresh
+ * tool session. Terse continuation prompts need the same protection even when
+ * the prior event was marked done, because its persisted ACP session may have
+ * disappeared between app launches.
+ */
+export function buildDelegateFollowUpTask(
+  originalTask: string,
+  userPrompt: string,
+  previousStatus?: string
+): string {
+  const original = originalTask.trim();
+  const followUp = userPrompt.trim();
+  const failedTurn = ["failed", "timeout", "cancelled"].includes(
+    String(previousStatus ?? "").toLowerCase()
+  );
+  const terseContinuation = /^(?:继续(?:执行|处理|完成|推进)?(?:吧|下去)?|接着(?:做|执行|处理|完成|推进)?(?:吧)?|continue|resume|go on)[\s.!。！]*$/iu.test(
+    followUp
+  );
+  if (!original || original === followUp || (!failedTurn && !terseContinuation)) {
+    return followUp;
+  }
+  return [
+    "Continue the existing delegation task from the current workspace state.",
+    "",
+    "Original task:",
+    original,
+    "",
+    "Latest user instruction:",
+    followUp
+  ].join("\n");
+}
+
 export interface DelegateWakeInfo {
   taskText: string;
   roleLabel: string;

--- a/packages/delegation-runtime/src/memory.ts
+++ b/packages/delegation-runtime/src/memory.ts
@@ -102,13 +102,22 @@ export function createMemoryDelegationRepository(): DelegationRunRepository & {
         if (!allowed) return false;
       }
       const terminal = isTerminalDelegationStatus(to);
+      const transitionedAt = nowIso();
+      const reopeningTerminal =
+        options?.allowReopen === true &&
+        to === "running" &&
+        isTerminalDelegationStatus(current.status);
       events.set(eventId, {
         ...current,
         status: to,
         resultSummary: resultSummary ?? current.resultSummary,
         startedAt:
-          to === "running" ? (current.startedAt ?? nowIso()) : current.startedAt,
-        endedAt: terminal ? nowIso() : current.endedAt
+          to === "running"
+            ? reopeningTerminal
+              ? transitionedAt
+              : (current.startedAt ?? transitionedAt)
+            : current.startedAt,
+        endedAt: terminal ? transitionedAt : to === "running" ? null : current.endedAt
       });
       return true;
     },

--- a/packages/delegation-runtime/src/runtime.ts
+++ b/packages/delegation-runtime/src/runtime.ts
@@ -10,7 +10,10 @@ import type {
   DelegationRosterEntry
 } from "@freebuddy/protocol/delegation";
 import { effectiveDelegationRoleCanWrite } from "@freebuddy/protocol/delegation";
-import { buildDelegateTaskPrompt } from "@freebuddy/delegation-core";
+import {
+  buildDelegateFollowUpTask,
+  buildDelegateTaskPrompt
+} from "@freebuddy/delegation-core";
 import type { DelegationRuntimePorts } from "./ports.js";
 import { DelegationOrchestrator } from "./orchestrator.js";
 
@@ -298,9 +301,14 @@ export class DelegationRuntime {
     if (!root) throw new Error("delegation root event missing");
     ctx.rootEventId = root.id;
     const orch = this.ensureOrchestrator(ctx);
+    const followUpTask = buildDelegateFollowUpTask(
+      root.taskText,
+      userPrompt,
+      root.status
+    );
     this.ports.repository.transitionEvent(root.id, "running", null, { allowReopen: true });
     const prompt = buildDelegateTaskPrompt(
-      userPrompt,
+      followUpTask,
       ctx.roster,
       entry.id,
       0,

--- a/packages/storage-sqlite/src/delegation-runs.ts
+++ b/packages/storage-sqlite/src/delegation-runs.ts
@@ -371,8 +371,18 @@ export function transitionDelegationEvent(
   const terminal = isTerminalDelegationStatus(status);
   const transitionedAt = nowIso(ctx);
   const current = ctx.db
-    .prepare("SELECT verdict, verdict_summary FROM delegation_events WHERE id = ?")
-    .get(id) as { verdict?: DelegationVerdict | null; verdict_summary?: string | null } | undefined;
+    .prepare("SELECT status, verdict, verdict_summary FROM delegation_events WHERE id = ?")
+    .get(id) as
+      | {
+          status?: DelegationEventStatus;
+          verdict?: DelegationVerdict | null;
+          verdict_summary?: string | null;
+        }
+      | undefined;
+  const resetAttemptStart =
+    options?.allowReopen === true &&
+    status === "running" &&
+    isTerminalDelegationStatus(current?.status ?? "");
   const structuredResult = terminal
     ? {
         ...(options?.result ??
@@ -391,7 +401,11 @@ export function transitionDelegationEvent(
     .prepare(
       `UPDATE delegation_events
        SET status = ?, result_summary = ?, result_json = ?,
-           started_at = CASE WHEN ? = 'running' THEN COALESCE(started_at, ?) ELSE started_at END,
+           started_at = CASE
+             WHEN ? = 'running' AND ? = 1 THEN ?
+             WHEN ? = 'running' THEN COALESCE(started_at, ?)
+             ELSE started_at
+           END,
            ended_at = ?
        WHERE id = ? AND status IN (${placeholders})`
     )
@@ -399,6 +413,9 @@ export function transitionDelegationEvent(
       status,
       resultSummary ?? null,
       structuredResult ? JSON.stringify(structuredResult) : null,
+      status,
+      resetAttemptStart ? 1 : 0,
+      transitionedAt,
       status,
       transitionedAt,
       terminal ? transitionedAt : null,

--- a/tests/acp-runtime-contract.test.mjs
+++ b/tests/acp-runtime-contract.test.mjs
@@ -144,6 +144,26 @@ test("ACP inactivity watchdog probes liveness before cancelling and caps repriev
   );
 });
 
+test("ACP watchdog grants bounded time to an explicitly active tool call", () => {
+  assert.match(acpRuntimeSource, /updateActiveAcpToolCalls/);
+  assert.match(acpRuntimeSource, /const activeToolCallIds = new Set<string>\(\)/);
+  assert.match(acpRuntimeSource, /alive \|\| hasActiveToolCall/);
+  assert.match(acpRuntimeSource, /MAX_INACTIVITY_REPRIEVES/);
+});
+
+test("DeepSeek empty resumed turns retry fresh once and unhealthy sessions are evicted", () => {
+  assert.match(acpRuntimeSource, /shouldRetryEmptyResumedDshTurn/);
+  assert.match(acpRuntimeSource, /emptySessionResetAttempted = true/);
+  assert.match(acpRuntimeSource, /Previous DeepSeek session returned no output/);
+  assert.match(acpRuntimeSource, /emptySessionResetInstruction\(\)/);
+  assert.match(acpRuntimeSource, /shouldDiscardAcpToolSession/);
+  const finishBody = acpRuntimeSource.slice(
+    acpRuntimeSource.indexOf("const finish ="),
+    acpRuntimeSource.indexOf("const cancelRun")
+  );
+  assert.match(finishBody, /clearToolSession\(args\.agentId, toolSessionScope\)/);
+});
+
 test("CLI runtime records the approval mode with each task start", () => {
   assert.match(runtimeSource, /approvalMode: args\.approvalMode \?\? "default"/);
 });

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -48,9 +48,12 @@ import {
   parseAcpLine,
   selectAcpAuthMethod,
   selectAcpSessionStartMode,
+  shouldDiscardAcpToolSession,
   shouldEmitAcpUpdate,
+  shouldRetryEmptyResumedDshTurn,
   shouldSkipUserMessageChunk,
-  shouldDropReplayPhaseAgentChunk
+  shouldDropReplayPhaseAgentChunk,
+  updateActiveAcpToolCalls
 } from "../dist-electron/cli/acp.js";
 
 const acpRuntimeSource = fs.readFileSync(
@@ -1174,6 +1177,85 @@ test("ACP runtime starts a fresh session once when a prompt exceeds context", ()
   assert.match(
     acpRuntimeSource,
     /buildSessionNewRequest\(nextId\(\), args\.cwd, mcpServers, sessionMeta\)/
+  );
+});
+
+test("ACP tool-call activity tracks silent in-flight tools until terminal updates", () => {
+  const active = new Set();
+  updateActiveAcpToolCalls(active, {
+    sessionUpdate: "tool_call",
+    toolCallId: "job-1",
+    status: "in_progress"
+  });
+  assert.deepEqual([...active], ["job-1"]);
+  updateActiveAcpToolCalls(active, {
+    sessionUpdate: "tool_call_update",
+    toolCallId: "job-1",
+    status: "completed"
+  });
+  assert.equal(active.size, 0);
+});
+
+test("DeepSeek session health policy retries one empty resume and discards unhealthy sessions", () => {
+  assert.equal(
+    shouldRetryEmptyResumedDshTurn({
+      adapter: "dsh-acp",
+      resumed: true,
+      promptHadContent: false,
+      resetAttempted: false
+    }),
+    true
+  );
+  assert.equal(
+    shouldRetryEmptyResumedDshTurn({
+      adapter: "dsh-acp",
+      resumed: true,
+      promptHadContent: false,
+      resetAttempted: true
+    }),
+    false,
+    "a second empty fresh turn must not start an infinite retry loop"
+  );
+  assert.equal(
+    shouldDiscardAcpToolSession({
+      adapter: "dsh-acp",
+      status: "failed",
+      promptStarted: true,
+      promptHadContent: true,
+      turnHadTerminalError: false
+    }),
+    true
+  );
+  assert.equal(
+    shouldDiscardAcpToolSession({
+      adapter: "dsh-acp",
+      status: "done",
+      promptStarted: true,
+      promptHadContent: false,
+      turnHadTerminalError: false
+    }),
+    true
+  );
+  assert.equal(
+    shouldDiscardAcpToolSession({
+      adapter: "dsh-acp",
+      status: "done",
+      promptStarted: true,
+      promptHadContent: true,
+      turnHadTerminalError: false
+    }),
+    false
+  );
+  assert.equal(
+    shouldDiscardAcpToolSession({
+      adapter: "codex-acp",
+      status: "failed",
+      promptStarted: true,
+      promptHadContent: false,
+      turnHadTerminalError: false
+    }),
+    false,
+    "the compatibility policy is intentionally limited to DeepSeek Harness"
   );
 });
 

--- a/tests/delegation-followup-wake.test.mjs
+++ b/tests/delegation-followup-wake.test.mjs
@@ -236,6 +236,38 @@ test("followUp after completed entry reopens without reusing entry sessionId", a
   });
 });
 
+test("followUp after a failed entry restores the original task for a fresh session", async (t) => {
+  if (!bindingAvailable) { t.skip(); return; }
+  await withDb(async () => {
+    const { DelegationRuntime } = await import("../dist-electron/cli/delegationRuntime.js");
+    const prompts = [];
+    let turn = 0;
+    const rt = new DelegationRuntime({
+      webContents: undefined,
+      resolveAgent: () => ({ adapter: "dsh-acp", agentName: "DeepSeek", skillIds: [] }),
+      runAgent: async (args) => {
+        prompts.push(args.prompt);
+        turn += 1;
+        return turn === 1
+          ? { summary: "", exitCode: 0, error: "Agent returned no output.", hasOutput: false }
+          : { summary: "done", exitCode: 0, error: null, hasOutput: true };
+      }
+    });
+
+    const runId = await rt.start({
+      goal: "制作五张短视频封面并完成验收",
+      teamId: "t",
+      teamSnapshot: snap,
+      cwd: "/r"
+    });
+    await rt.followUp(runId, "继续");
+
+    assert.equal(prompts.length, 2);
+    assert.match(prompts[1], /Original task:\n制作五张短视频封面并完成验收/);
+    assert.match(prompts[1], /Latest user instruction:\n继续/);
+  });
+});
+
 test("followUp during an initial park is queued without prematurely completing the run", async (t) => {
   if (!bindingAvailable) { t.skip(); return; }
   await withDb(async () => {

--- a/tests/delegation-prompt.test.mjs
+++ b/tests/delegation-prompt.test.mjs
@@ -23,6 +23,23 @@ test("task prompt wraps the task with the roster header", async () => {
   assert.match(p, /协作团队/);
 });
 
+test("failed and terse delegation follow-ups restore the original task context", async () => {
+  const { buildDelegateFollowUpTask } = await import(
+    "../dist-electron/cli/delegationPrompt.js"
+  );
+  const failed = buildDelegateFollowUpTask("制作宣传片", "继续", "failed");
+  assert.match(failed, /Original task:\n制作宣传片/);
+  assert.match(failed, /Latest user instruction:\n继续/);
+
+  const terse = buildDelegateFollowUpTask("制作宣传片", "continue", "done");
+  assert.match(terse, /Original task:\n制作宣传片/);
+
+  assert.equal(
+    buildDelegateFollowUpTask("制作宣传片", "把片尾延长两秒", "done"),
+    "把片尾延长两秒"
+  );
+});
+
 test("task and wake prompts separate routing capability from execution instructions", async () => {
   const { buildDelegateTaskPrompt, buildDelegateWakePrompt } = await import(
     "../dist-electron/cli/delegationPrompt.js"

--- a/tests/delegation-runtime-memory.test.mjs
+++ b/tests/delegation-runtime-memory.test.mjs
@@ -512,6 +512,53 @@ test("crash recovery marks active events failed via repository transitions", () 
   assert.equal(repository.setStatus(run.id, "failed"), true);
 });
 
+test("reopening a terminal delegation event starts a new visible attempt", () => {
+  const repository = createMemoryDelegationRepository();
+  const run = repository.createRun({
+    goal: "g",
+    status: "running",
+    teamId: "t",
+    teamSnapshotJson: "{}"
+  });
+  repository.hydrateEvent({
+    id: "root",
+    runId: run.id,
+    parentEventId: null,
+    agentId: "a",
+    agentName: "a",
+    roleLabel: "a",
+    taskText: "g",
+    depth: 0,
+    status: "failed",
+    resultSummary: "failed",
+    result: null,
+    canWrite: true,
+    acceptedAt: "2026-01-01T00:00:00.000Z",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    endedAt: "2026-01-01T00:10:00.000Z",
+    verdict: null,
+    verdictSummary: null
+  });
+
+  assert.equal(
+    repository.transitionEvent("root", "running", null, { allowReopen: true }),
+    true
+  );
+  const reopened = repository.getEvent("root");
+  assert.notEqual(reopened?.startedAt, "2026-01-01T00:00:00.000Z");
+  assert.equal(reopened?.endedAt, null);
+  const attemptStartedAt = reopened?.startedAt;
+  assert.equal(
+    repository.transitionEvent("root", "running", null, { allowReopen: true }),
+    true
+  );
+  assert.equal(
+    repository.getEvent("root")?.startedAt,
+    attemptStartedAt,
+    "a follow-up queued while the event is already running must not reset its timer"
+  );
+});
+
 test("memory delegation ids are UUIDs and unique across fresh repositories", () => {
   const first = createMemoryDelegationRepository();
   const second = createMemoryDelegationRepository();

--- a/tests/storage-sqlite-contract.test.mjs
+++ b/tests/storage-sqlite-contract.test.mjs
@@ -220,3 +220,79 @@ test("sqlite insertDelegationEvent rethrows foreign key failures", async (t) => 
   assert.equal(getDelegationEvent(ctx, "dup-event")?.runId, runId);
   db.close();
 });
+
+test("sqlite delegation reopen resets attempt start time and clears end time", async (t) => {
+  let Database;
+  try {
+    Database = (await import("better-sqlite3")).default;
+    new Database(":memory:").close();
+  } catch {
+    t.skip("better-sqlite3 native binding unavailable");
+    return;
+  }
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE workflow_runs (
+      id TEXT PRIMARY KEY, conversation_id TEXT, name TEXT, goal TEXT, status TEXT,
+      cwd TEXT, template TEXT, loop_index INTEGER, max_loops INTEGER, plan_json TEXT,
+      team_id TEXT, team_snapshot_json TEXT, plan_version INTEGER, kind TEXT,
+      runtime_version TEXT, runtime_api_version TEXT, summary TEXT,
+      created_at TEXT, updated_at TEXT, ended_at TEXT
+    );
+    CREATE TABLE delegation_events (
+      id TEXT PRIMARY KEY, run_id TEXT NOT NULL, parent_event_id TEXT, agent_id TEXT,
+      agent_name TEXT, role_label TEXT, task_text TEXT, depth INTEGER, status TEXT,
+      result_summary TEXT, result_json TEXT, can_write INTEGER, accepted_at TEXT,
+      started_at TEXT, ended_at TEXT, verdict TEXT, verdict_summary TEXT
+    );
+  `);
+  const {
+    createDelegationRun,
+    getDelegationEvent,
+    insertDelegationEvent,
+    transitionDelegationEvent
+  } = await import("../packages/storage-sqlite/dist/index.js");
+  let now = "2026-09-02T10:00:00.000Z";
+  const ctx = {
+    db,
+    owner: { ownerUserId: null, isAdmin: true },
+    nowIso: () => now
+  };
+  const runId = createDelegationRun(ctx, {
+    goal: "g",
+    teamId: "t",
+    teamSnapshotJson: "{}"
+  });
+  const eventId = insertDelegationEvent(ctx, {
+    runId,
+    parentEventId: null,
+    agentId: "a",
+    agentName: "a",
+    roleLabel: "a",
+    taskText: "g",
+    depth: 0,
+    canWrite: true,
+    status: "running"
+  });
+  now = "2026-09-02T10:10:00.000Z";
+  assert.equal(transitionDelegationEvent(ctx, eventId, "failed", "empty"), true);
+  now = "2026-09-02T15:00:00.000Z";
+  assert.equal(
+    transitionDelegationEvent(ctx, eventId, "running", null, { allowReopen: true }),
+    true
+  );
+  const reopened = getDelegationEvent(ctx, eventId);
+  assert.equal(reopened?.startedAt, "2026-09-02T15:00:00.000Z");
+  assert.equal(reopened?.endedAt, null);
+  now = "2026-09-02T16:00:00.000Z";
+  assert.equal(
+    transitionDelegationEvent(ctx, eventId, "running", null, { allowReopen: true }),
+    true
+  );
+  assert.equal(
+    getDelegationEvent(ctx, eventId)?.startedAt,
+    "2026-09-02T15:00:00.000Z",
+    "a queued follow-up must not reset an already-running attempt"
+  );
+  db.close();
+});


### PR DESCRIPTION
## Summary

- grant bounded watchdog reprieves while an ACP tool call is explicitly active
- evict failed, terminal-error, and empty DeepSeek Harness sessions, and retry one empty resumed turn in a fresh session
- restore the original delegation task when recovering a failed or terse follow-up such as 继续
- reset the root-event timer when a terminal delegation attempt is reopened

## Root cause

User follow-ups created new FreeBuddy task ids but reused the same unhealthy DeepSeek ACP tool-session scope. That session returned end_turn with zero tokens and no agent output, so the empty-output guard correctly failed every follow-up. The earlier long-running tool call could also collide with the ten-minute inactivity watchdog.

## Verification

- npm run typecheck
- 124 focused ACP/delegation runtime tests passed
- 8 focused Electron/SQLite integration tests passed with no skips
- full Node suite completed with 1226 passing and 132 platform/native skips; its 8 sandbox-only PTY/loopback failures all passed when rerun with the required system permissions
- full Electron DB suite completed with 147 passing and 4 Windows-only skips; its 5 sandbox-runtime smoke failures all passed when rerun with the required system permissions
- npm run github:preflight