### PR TITLE
feat: allow isolated browser to load remote HTTP URLs

### DIFF
--- a/electron/browserCollector.ts
+++ b/electron/browserCollector.ts
@@ -48,8 +48,8 @@ function isBlockedHostname(rawHostname: string): boolean {
 
 function validateRemoteUrl(value: string): URL {
   const url = new URL(value.trim());
-  if (url.protocol !== "https:") {
-    throw new Error("Browser collection only supports HTTPS sources.");
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Browser collection only supports HTTP and HTTPS sources.");
   }
   if (url.username || url.password) {
     throw new Error("Browser collection URLs cannot contain credentials.");

--- a/electron/nativeBrowserViewService.ts
+++ b/electron/nativeBrowserViewService.ts
@@ -44,8 +44,8 @@ let pendingNavigationUrl: string | null = null;
 
 function parseAllowedUrl(rawUrl: string): URL {
   const url = new URL(rawUrl.trim());
-  if (url.protocol !== "https:") {
-    throw new Error("The isolated browser only supports HTTPS pages.");
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("The isolated browser only supports HTTP and HTTPS pages.");
   }
   if (url.username || url.password) {
     throw new Error("Browser URLs cannot contain credentials.");
@@ -220,7 +220,7 @@ function ensureBrowserView(win: BrowserWindow): WebContentsView {
       const target = parseAllowedUrl(url);
       void contents.loadURL(target.toString());
     } catch {
-      // Block non-HTTPS popups and unsupported schemes.
+      // Block non-HTTP/HTTPS popups and unsupported schemes.
     }
     return { action: "deny" };
   });

--- a/src/components/Browser/BrowserCanvas.tsx
+++ b/src/components/Browser/BrowserCanvas.tsx
@@ -419,7 +419,7 @@ export function BrowserCanvas({ onClose }: { onClose?: () => void }) {
     nativeBrowserAvailable && isNativeRemoteBrowserTarget(entry?.manualEntry);
   const isExternalOnly =
     (!isNativeRemote && isExternalOnlyBrowserTarget(entry?.manualEntry)) ||
-    isInsecureRemoteBrowserTarget(entry?.manualEntry);
+    (!nativeBrowserAvailable && isInsecureRemoteBrowserTarget(entry?.manualEntry));
   const pdfUrl = isPdf && entry?.url ? `${entry.url}#view=FitH&navpanes=0` : "";
   const documentExtension = browserTargetExtension(entry?.manualEntry, entry?.url);
   const frameWidth = FRAME_WIDTH[viewport];

--- a/src/store/browserStore.ts
+++ b/src/store/browserStore.ts
@@ -97,7 +97,7 @@ export function isAbsoluteLocalPath(target: string): boolean {
 }
 
 export function remoteBrowserOrigin(value: string | undefined): string | null {
-  if (!value || !/^https:\/\//i.test(value)) return null;
+  if (!value || !/^https?:\/\//i.test(value)) return null;
   try {
     const url = new URL(value);
     const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");

--- a/tests/browser-file-preview.test.mjs
+++ b/tests/browser-file-preview.test.mjs
@@ -314,6 +314,15 @@ test("Browser preview keeps remote article URLs inside the preview target", asyn
   assert.equal(parsed.searchParams.get("from"), "rss");
 });
 
+test("Browser preview keeps remote HTTP URLs exact inside the preview target", async () => {
+  const { composeBrowserUrl, remoteBrowserOrigin } = await loadBrowserStoreModule();
+  const source = "http://w.gangpeitong.cloud:2011/dashboard";
+  assert.equal(remoteBrowserOrigin(source), "http://w.gangpeitong.cloud:2011");
+
+  const url = composeBrowserUrl("/Users/me/workspace", source, 11);
+  assert.equal(url, "http://w.gangpeitong.cloud:2011/dashboard");
+});
+
 test("Browser preview supports remote URLs but not relative files without a workspace", async () => {
   const { composeBrowserUrl } = await loadBrowserStoreModule();
   const remote = composeBrowserUrl("", "https://example.com/article", 4);

--- a/tests/native-browser-view.test.mjs
+++ b/tests/native-browser-view.test.mjs
@@ -29,9 +29,10 @@ test("native browser configures a browser-compatible UA before creating web cont
   assert.ok(configureIndex >= 0 && configureIndex < createIndex);
 });
 
-test("native browser accepts HTTPS only", () => {
+test("native browser accepts HTTP and HTTPS", () => {
   const source = read("electron/nativeBrowserViewService.ts");
   assert.match(source, /url\.protocol !== "https:"/);
+  assert.match(source, /url\.protocol !== "http:"/);
   assert.match(source, /Browser URLs cannot contain credentials/);
   assert.doesNotMatch(source, /clearNativeBrowserData|clearData\(/);
 });


### PR DESCRIPTION
## Summary

- Allow `remoteBrowserOrigin` in `browserStore` to recognize remote HTTP URLs (`^https?://`) alongside HTTPS so remote HTTP sites are treated as valid remote browser targets and preserved without development query nonces.
- Update `BrowserCanvas` so that remote HTTP URLs are rendered in the native isolated browser view (`WebContentsView`) when available on Desktop, only falling back to the external browser recommendation in non-native environments (such as web mode).
- Permit `http:` in addition to `https:` in `nativeBrowserViewService.ts` (`parseAllowedUrl`) for isolated navigation and redirects.
- Allow `http:` in `browserCollector.ts` (`validateRemoteUrl`) for headless collection.
- Update unit tests in `tests/native-browser-view.test.mjs` and add a remote HTTP resolution test case in `tests/browser-file-preview.test.mjs`.

## Verification

- `npm run typecheck`: Passed without errors.
- `npm run build:electron`: Succeeded.
- `npm run build:renderer`: Succeeded.
- Targeted tests: `node --test tests/native-browser-view.test.mjs tests/browser-file-preview.test.mjs tests/browser-info-cards.test.mjs` passed (36/36).
- Full test suite: `npm test` passed (152 passed, 4 Windows-only skips).
- `npm run github:preflight`: Passed.