### PR TITLE
fix: replace leftover macOS signing keychain before import

### DIFF
--- a/scripts/import-macos-csc-cert.sh
+++ b/scripts/import-macos-csc-cert.sh
@@ -39,14 +39,22 @@ else:
     dest.write_bytes(base64.b64decode(raw))
 PY
 
+# npm test on macOS previously invoked this script with a dummy CSC_LINK and
+# left this keychain behind. create-keychain then fails with exit 48
+# (SecKeychainCreate: A keychain with the same name already exists).
+security delete-keychain "${keychain_path}" >/dev/null 2>&1 || true
+rm -f "${keychain_path}"
+
 security create-keychain -p "${keychain_password}" "${keychain_path}"
 security set-keychain-settings -lut 21600 "${keychain_path}"
 security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+# Import the PKCS12 identity (cert + private key). Do not set the import
+# type to certificate-only: that drops the private key and find-identity
+# reports 0 identities.
 security import "${certificate_path}" \
   -k "${keychain_path}" \
   -P "${CSC_KEY_PASSWORD:-}" \
   -A \
-  -t cert \
   -f pkcs12 \
   -T /usr/bin/codesign \
   -T /usr/bin/security \
@@ -62,11 +70,12 @@ while IFS= read -r line; do
   trimmed="${line#"${line%%[![:space:]]*}"}"
   trimmed="${trimmed%\"}"
   trimmed="${trimmed#\"}"
-  if [[ -n "${trimmed}" ]]; then
+  if [[ -n "${trimmed}" && "${trimmed}" != "${keychain_path}" ]]; then
     existing_keychains+=("${trimmed}")
   fi
-done < <(security list-keychain -d user)
-security list-keychain -d user -s "${keychain_path}" "${existing_keychains[@]+"${existing_keychains[@]}"}"
+done < <(security list-keychains -d user)
+security list-keychains -d user -s "${keychain_path}" "${existing_keychains[@]+"${existing_keychains[@]}"}"
+security default-keychain -s "${keychain_path}"
 
 identities="$(security find-identity -v -p codesigning "${keychain_path}")"
 printf '%s\n' "${identities}"

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -107,17 +107,54 @@ test("macOS cert import uses the keychain password for set-key-partition-list", 
   assert.match(script, /-P "\$\{CSC_KEY_PASSWORD:-\}"/);
 });
 
+test("macOS cert import replaces a leftover keychain before create-keychain", () => {
+  const script = fs.readFileSync(
+    new URL("../scripts/import-macos-csc-cert.sh", import.meta.url),
+    "utf8"
+  );
+  const deleteAt = script.search(/security delete-keychain/);
+  const createAt = script.search(/security create-keychain/);
+  assert.ok(deleteAt >= 0, "must delete any leftover keychain (npm test on Darwin leaves one)");
+  assert.ok(createAt >= 0);
+  assert.ok(
+    deleteAt < createAt,
+    "delete-keychain must run before create-keychain to avoid SecKeychainCreate exit 48"
+  );
+  assert.match(script, /security list-keychains -d user/);
+  assert.doesNotMatch(script, /security list-keychain /);
+  assert.doesNotMatch(
+    script,
+    /-t cert/,
+    "PKCS12 import must include the private key; -t cert drops the identity"
+  );
+});
+
+test("macOS cert import test does not create a keychain during npm test on Darwin", () => {
+  const source = fs.readFileSync(new URL(import.meta.url), "utf8");
+  const marker = 'test("macOS cert import is a no-op off Darwin", async () => {';
+  const start = source.lastIndexOf(marker);
+  assert.ok(start >= 0, "expected the Darwin no-op test");
+  const darwinTest = source.slice(start);
+  const platformCheck = darwinTest.indexOf('process.platform === "darwin"');
+  const spawn = darwinTest.indexOf("spawnSync(");
+  assert.ok(platformCheck >= 0, "expected a Darwin platform guard");
+  assert.ok(spawn >= 0, "expected spawnSync of the import script");
+  assert.ok(
+    platformCheck < spawn,
+    "spawnSync must be skipped on Darwin so npm test does not leave freebuddy-signing.keychain-db"
+  );
+});
+
 test("macOS cert import is a no-op off Darwin", async () => {
+  if (process.platform === "darwin") {
+    return;
+  }
   const { spawnSync } = await import("node:child_process");
   const result = spawnSync(
     "bash",
     [new URL("../scripts/import-macos-csc-cert.sh", import.meta.url).pathname],
     { encoding: "utf8", env: { ...process.env, CSC_LINK: "dGVzdA==" } }
   );
-  if (process.platform === "darwin") {
-    assert.ok(true);
-    return;
-  }
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Skipping macOS certificate import/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v0.9.15 的 macOS Release 仍然失败：https://github.com/maojindao55/freebuddy/actions/runs/34238647291/job/102102908412

失败点已经从 electron-builder 签名变成了 **Import macOS signing certificate**，退出码 **48**（`SecKeychainCreate: A keychain with the same name already exists`）。

## 原因

Release job 会先跑 `npm test`。其中「macOS cert import is a no-op off Darwin」这条测试在 Darwin 上**仍然会执行**导入脚本（用假的 `CSC_LINK=dGVzdA==`），于是在 `RUNNER_TEMP` 里留下了 `freebuddy-signing.keychain-db`。

正式导入步骤随后对**同一路径**调用 `create-keychain`，macOS 返回 exit 48。步骤在一秒内失败，所以看起来像证书 secret 仍有问题，其实钥匙串文件已经存在。

#151 合入后的 workaround 本身会被跑到，但被这条测试残留挡住了。

## 修复

- 创建钥匙串前先 `delete-keychain`（幂等，避免 exit 48）
- PKCS12 按 identity 导入，不再使用 certificate-only 类型（否则只有证书没有私钥）
- Darwin 上的 `npm test` 不再 spawn 导入脚本
- Windows：用 `fileURLToPath` 解析 helper 路径。`URL.pathname` 在 win32 上是 `/D:/...`，Git Bash 打不开（exit 127）

## 如何重发 v0.9.15

合入本 PR 后：Actions → **Release** → Run workflow

- **Use workflow from: `main`**（不要选 `v0.9.15` 标签当 workflow 源，否则会用到旧 helper）
- Tag: `v0.9.15`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7d72d6c-30ed-426e-87a3-647a3b9dbb73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7d72d6c-30ed-426e-87a3-647a3b9dbb73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

