### PR TITLE
fix: resolve macOS cert import helper path on Windows

### DIFF
--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -143,6 +143,12 @@ test("macOS cert import test does not create a keychain during npm test on Darwi
     platformCheck < spawn,
     "spawnSync must be skipped on Darwin so npm test does not leave freebuddy-signing.keychain-db"
   );
+  assert.match(
+    darwinTest,
+    /fileURLToPath\(/,
+    "URL.pathname is /D:/... on Windows; bash cannot open that path (exit 127)"
+  );
+  assert.doesNotMatch(darwinTest, /\.pathname/);
 });
 
 test("macOS cert import is a no-op off Darwin", async () => {
@@ -150,11 +156,16 @@ test("macOS cert import is a no-op off Darwin", async () => {
     return;
   }
   const { spawnSync } = await import("node:child_process");
-  const result = spawnSync(
-    "bash",
-    [new URL("../scripts/import-macos-csc-cert.sh", import.meta.url).pathname],
-    { encoding: "utf8", env: { ...process.env, CSC_LINK: "dGVzdA==" } }
+  const { fileURLToPath } = await import("node:url");
+  const scriptPath = fileURLToPath(
+    new URL("../scripts/import-macos-csc-cert.sh", import.meta.url)
   );
-  assert.equal(result.status, 0, result.stderr);
+  const bashPath =
+    process.platform === "win32" ? scriptPath.replaceAll("\\", "/") : scriptPath;
+  const result = spawnSync("bash", [bashPath], {
+    encoding: "utf8",
+    env: { ...process.env, CSC_LINK: "dGVzdA==" },
+  });
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
   assert.match(result.stdout, /Skipping macOS certificate import/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#152 已经合入 `main`（并打了 v0.9.16），但 Windows 上这条测试仍会失败：

```
macOS cert import is a no-op off Darwin
/usr/bin/bash: /D:/a/freebuddy/freebuddy/scripts/import-macos-csc-cert.sh: No such file or directory
127 !== 0
```

Windows 的 `URL.pathname` 是 `/D:/...`，Git Bash 打不开。Linux 不受影响，所以 #152 合入时没覆盖到。

Windows 修复当时推到了已合并的 `cursor/macos-signing-keychain-leftover-bb73`，无法再写进已关闭的 #152。

## Fix

用 `fileURLToPath` 解析 helper 路径；win32 再把 `\` 换成 `/`，Git Bash 才能找到脚本。

合入后 Windows 的 `npm test` 应能过。若要重发已有 tag，Actions → Release → Use workflow from **`main`**，不要选旧 tag 当 workflow 源。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7d72d6c-30ed-426e-87a3-647a3b9dbb73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7d72d6c-30ed-426e-87a3-647a3b9dbb73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

