### PR TITLE
fix(test): 修复设置 Tab 断言导致的发版 CI 失败

### DIFF
--- a/tests/feed-feature.test.mjs
+++ b/tests/feed-feature.test.mjs
@@ -136,8 +136,9 @@ test("feed bridge is exposed across ipc preload types and client", () => {
 });
 
 test("settings modal mounts the feed management tab", () => {
-  assert.match(settingsModal, /"feed" \| "remote" \| "about"/);
-  assert.match(settingsModal, /settings\.tabs\.feed/);
+  assert.match(settingsModal, /SettingsTab = [^;]*"feed"/);
+  assert.match(settingsModal, /key: "feed", labelKey: "settings.tabs.feed"/);
+  assert.match(settingsModal, /activeTab === "feed"/);
   assert.match(settingsModal, /<InfoCardsTab \/>/);
   assert.match(infoCardsTab, /<FeedTab \/>/);
   assert.match(feedTab, /addSource/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

[v0.9.19 Release](https://github.com/maojindao55/freebuddy/actions/runs/34423113087) 在 Test 步骤失败，四个平台构建都停在这里，后续 Electron 打包没有跑到。

失败用例：`settings modal mounts the feed management tab`（`tests/feed-feature.test.mjs`）

```
The input did not match the regular expression /"feed" \| "remote" \| "about"/
```

## 根因

#155 把 usage 从侧栏挪进设置页，`SettingsTab` 变成：

```ts
"general" | "cli" | "skills" | "plugins" | "feed" | "usage" | "remote" | "about"
```

feed 测试仍要求 `"feed" | "remote" | "about"` 三个字面量连续出现。usage 插在中间后断言失效。生产代码本身没问题。

## 修复

把断言改成不依赖相邻顺序，与 `tests/agent-usage-page.test.mjs` 同一风格：

- `SettingsTab` 联合类型包含 `"feed"`
- 导航里有 `key: "feed"`
- 内容区按 `activeTab === "feed"` 挂载 `InfoCardsTab`

## 验证

本地已复现原失败，修复后：

```
node --test --test-force-exit tests/*.mjs
# tests 1401
# pass 1265
# fail 0
# skipped 136
```

合并后需要重新跑 v0.9.19 发版工作流（或再打一次 tag），这次失败的 Test 步骤才会放行打包。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d2ffab8-a9e1-407b-a535-ba39ad9b596b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d2ffab8-a9e1-407b-a535-ba39ad9b596b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

