### PR TITLE
fix(codex): chat 桥接转译 tool_search，恢复 MCP 工具发现

### DIFF
--- a/electron/cli/responsesBridge.ts
+++ b/electron/cli/responsesBridge.ts
@@ -211,6 +211,35 @@ export function responsesInputToChatMessages(
       });
       continue;
     }
+    if (item.type === "tool_search_call") {
+      pendingToolCalls.push({
+        id: typeof item.call_id === "string" && item.call_id
+          ? item.call_id
+          : genId("call"),
+        type: "function",
+        function: {
+          name:
+            typeof item.name === "string" && item.name
+              ? item.name
+              : "tool_search",
+          arguments: stringifyToolSearchArguments(item.arguments)
+        }
+      });
+      continue;
+    }
+    if (
+      item.type === "tool_search_output" ||
+      item.type === "tool_search_call_output"
+    ) {
+      flushToolCalls();
+      messages.push({
+        role: "tool",
+        tool_call_id:
+          typeof item.call_id === "string" ? item.call_id : "",
+        content: JSON.stringify(asArray(item.tools))
+      });
+      continue;
+    }
     if (item.type === "reasoning") {
       continue;
     }
@@ -307,17 +336,116 @@ function buildLocalShellCallItem(call: {
   };
 }
 
+const DEFAULT_TOOL_SEARCH_PARAMETERS: JsonObject = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      description: "Search query for deferred tools."
+    },
+    limit: {
+      type: "number",
+      description: "Maximum number of tools to return."
+    }
+  },
+  required: ["query"]
+};
+
+function stringifyToolSearchArguments(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value ?? {});
+}
+
+/** Parse a chat tool_search function call back into a JSON object. */
+function parseToolSearchArguments(args: string): JsonObject {
+  try {
+    const parsed = JSON.parse(args);
+    const obj = asObject(parsed);
+    if (obj) return obj;
+    if (typeof parsed === "string" && parsed.trim()) {
+      return { query: parsed };
+    }
+  } catch {
+    /* fall through */
+  }
+  return args.trim() ? { query: args } : {};
+}
+
+/**
+ * Build a Responses `tool_search_call` item from a chat function call named
+ * `tool_search`. Codex only dispatches client-executed searches, and it
+ * requires `arguments` as a JSON object (not a string).
+ */
+function buildToolSearchCallItem(call: {
+  id: string;
+  arguments: string;
+}): JsonObject {
+  const itemId = genId("tsc");
+  const callId = call.id || genId("call");
+  return {
+    id: itemId,
+    type: "tool_search_call",
+    status: "completed",
+    call_id: callId,
+    execution: "client",
+    arguments: parseToolSearchArguments(call.arguments)
+  };
+}
+
+function collectDiscoveredChatTools(input: unknown): {
+  tools: ChatTool[];
+  namespaces: Record<string, string>;
+} {
+  const tools: ChatTool[] = [];
+  const namespaces: Record<string, string> = {};
+  const seen = new Set<string>();
+  const visit = (raw: unknown, namespace?: string) => {
+    const tool = asObject(raw);
+    if (!tool) return;
+    if (tool.type === "namespace" || tool.type === "mcp") {
+      const ns = typeof tool.name === "string" && tool.name ? tool.name : namespace;
+      for (const child of asArray(tool.tools)) visit(child, ns);
+      return;
+    }
+    if (typeof tool.name !== "string" || !tool.name) return;
+    if (tool.type && tool.type !== "function" && tool.type !== "custom") return;
+    if (seen.has(tool.name)) return;
+    seen.add(tool.name);
+    if (namespace) namespaces[tool.name] = namespace;
+    tools.push({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters ?? { type: "object", properties: {} }
+      }
+    });
+  };
+  for (const raw of asArray(input)) {
+    const item = asObject(raw);
+    if (
+      item?.type === "tool_search_output" ||
+      item?.type === "tool_search_call_output"
+    ) {
+      for (const tool of asArray(item.tools)) visit(tool);
+    }
+  }
+  return { tools, namespaces };
+}
+
 export function responsesToolsToChatTools(
   tools: unknown
 ): {
   tools: ChatTool[];
   customToolNames: string[];
   localShellToolNames: string[];
+  toolSearchToolNames: string[];
   droppedToolTypes: string[];
 } {
   const out: ChatTool[] = [];
   const customToolNames: string[] = [];
   const localShellToolNames: string[] = [];
+  const toolSearchToolNames: string[] = [];
   const droppedToolTypes: string[] = [];
   for (const raw of asArray(tools)) {
     const tool = asObject(raw);
@@ -385,9 +513,36 @@ export function responsesToolsToChatTools(
       });
       continue;
     }
+    // Codex defers MCP tools behind a Responses `tool_search` tool. Chat
+    // providers only understand `function` tools, so expose it as a
+    // `tool_search` function and restore `tool_search_call` on the return
+    // path. Dropping this type silently hides every deferred MCP tool.
+    if (tool.type === "tool_search") {
+      const name =
+        typeof tool.name === "string" && tool.name ? tool.name : "tool_search";
+      toolSearchToolNames.push(name);
+      out.push({
+        type: "function",
+        function: {
+          name,
+          description:
+            typeof tool.description === "string" && tool.description
+              ? tool.description
+              : "Search for deferred MCP tools. Always use tool_search to discover MCP tools instead of list_mcp_resources.",
+          parameters: asObject(tool.parameters) ?? DEFAULT_TOOL_SEARCH_PARAMETERS
+        }
+      });
+      continue;
+    }
     droppedToolTypes.push(String(tool.type ?? "unknown"));
   }
-  return { tools: out, customToolNames, localShellToolNames, droppedToolTypes };
+  return {
+    tools: out,
+    customToolNames,
+    localShellToolNames,
+    toolSearchToolNames,
+    droppedToolTypes
+  };
 }
 
 export function mapToolChoice(
@@ -405,6 +560,8 @@ export interface ResponsesToChatResult {
   chat: JsonObject;
   customToolNames: string[];
   localShellToolNames: string[];
+  toolSearchToolNames: string[];
+  toolNamespaces: Record<string, string>;
   droppedToolTypes: string[];
   stream: boolean;
 }
@@ -416,8 +573,17 @@ export function translateResponsesRequestToChat(
   if (!obj || typeof obj.model !== "string" || !obj.model) return undefined;
 
   const messages = responsesInputToChatMessages(obj);
-  const { tools, customToolNames, localShellToolNames, droppedToolTypes } =
+  const { tools, customToolNames, localShellToolNames, toolSearchToolNames, droppedToolTypes } =
     responsesToolsToChatTools(obj.tools);
+  const discovered = collectDiscoveredChatTools(obj.input);
+  const existingNames = new Set(
+    tools.map((tool) => tool.function.name).filter((name) => name)
+  );
+  for (const tool of discovered.tools) {
+    if (existingNames.has(tool.function.name)) continue;
+    existingNames.add(tool.function.name);
+    tools.push(tool);
+  }
 
   const chat: JsonObject = {
     model: obj.model,
@@ -448,6 +614,8 @@ export function translateResponsesRequestToChat(
     chat,
     customToolNames,
     localShellToolNames,
+    toolSearchToolNames,
+    toolNamespaces: discovered.namespaces,
     droppedToolTypes,
     stream: chat.stream === true
   };
@@ -500,6 +668,8 @@ export class ChatToResponsesStream {
   private readonly model: string;
   private readonly customToolNames: Set<string>;
   private readonly localShellToolNames: Set<string>;
+  private readonly toolSearchToolNames: Set<string>;
+  private readonly toolNamespaces: Map<string, string>;
   private outputIndex = 0;
   private usage: JsonObject | undefined;
   private finished = false;
@@ -515,11 +685,15 @@ export class ChatToResponsesStream {
   constructor(
     model: string,
     customToolNames: string[] = [],
-    localShellToolNames: string[] = []
+    localShellToolNames: string[] = [],
+    toolSearchToolNames: string[] = [],
+    toolNamespaces: Record<string, string> = {}
   ) {
     this.model = model;
     this.customToolNames = new Set(customToolNames);
     this.localShellToolNames = new Set(localShellToolNames);
+    this.toolSearchToolNames = new Set(toolSearchToolNames);
+    this.toolNamespaces = new Map(Object.entries(toolNamespaces));
   }
 
   hasUpstreamError(): boolean {
@@ -640,15 +814,39 @@ export class ChatToResponsesStream {
         this.outputIndex += 1;
         continue;
       }
+      if (this.toolSearchToolNames.has(call.name)) {
+        const item = buildToolSearchCallItem({
+          id: callId,
+          arguments: call.arguments
+        });
+        events.push(
+          serializeSse({
+            type: "response.output_item.added",
+            output_index: this.outputIndex,
+            item: { ...item, status: "in_progress" }
+          })
+        );
+        events.push(
+          serializeSse({
+            type: "response.output_item.done",
+            output_index: this.outputIndex,
+            item
+          })
+        );
+        this.outputIndex += 1;
+        continue;
+      }
       const itemId = genId("fc");
       const args = this.unwrapCustomArguments(call.name, call.arguments);
+      const namespace = this.toolNamespaces.get(call.name);
       const item = {
         id: itemId,
         type: "function_call",
         status: "completed",
         call_id: callId,
         name: call.name,
-        arguments: args
+        arguments: args,
+        ...(namespace ? { namespace } : {})
       };
       events.push(
         serializeSse({
@@ -844,7 +1042,9 @@ export class ChatToResponsesStream {
 export function translateChatResponseToResponses(
   chat: unknown,
   fallbackModel?: string,
-  localShellToolNames: string[] = []
+  localShellToolNames: string[] = [],
+  toolSearchToolNames: string[] = [],
+  toolNamespaces: Record<string, string> = {}
 ): JsonObject | undefined {
   const obj = asObject(chat);
   const choice = asObject(asArray(obj?.choices)[0]);
@@ -852,6 +1052,8 @@ export function translateChatResponseToResponses(
   if (!obj || !message) return undefined;
 
   const localShellNames = new Set(localShellToolNames);
+  const toolSearchNames = new Set(toolSearchToolNames);
+  const namespaces = new Map(Object.entries(toolNamespaces));
   const output: JsonObject[] = [];
   const reasoning = message.reasoning_content ?? message.reasoning;
   if (typeof reasoning === "string" && reasoning) {
@@ -888,13 +1090,24 @@ export function translateChatResponseToResponses(
       );
       continue;
     }
+    if (toolSearchNames.has(fn.name)) {
+      output.push(
+        buildToolSearchCallItem({
+          id: typeof call.id === "string" ? call.id : "",
+          arguments: typeof fn.arguments === "string" ? fn.arguments : ""
+        })
+      );
+      continue;
+    }
+    const namespace = namespaces.get(fn.name);
     output.push({
       id: genId("fc"),
       type: "function_call",
       status: "completed",
       call_id: typeof call.id === "string" ? call.id : genId("call"),
       name: fn.name,
-      arguments: typeof fn.arguments === "string" ? fn.arguments : ""
+      arguments: typeof fn.arguments === "string" ? fn.arguments : "",
+      ...(namespace ? { namespace } : {})
     });
   }
 
@@ -1008,6 +1221,7 @@ export interface BridgeRequestLog {
   toolNames: string[];
   customToolNames: string[];
   localShellToolNames: string[];
+  toolSearchToolNames: string[];
   droppedToolTypes: string[];
 }
 
@@ -1205,6 +1419,7 @@ async function handleBridgeRequest(
       .filter((name): name is string => typeof name === "string"),
     customToolNames: translated.customToolNames,
     localShellToolNames: translated.localShellToolNames,
+    toolSearchToolNames: translated.toolSearchToolNames,
     droppedToolTypes: translated.droppedToolTypes
   });
 
@@ -1319,7 +1534,9 @@ async function handleBridgeRequest(
       bodyText,
       requestModel ?? translated.chat.model as string,
       translated.customToolNames,
-      translated.localShellToolNames
+      translated.localShellToolNames,
+      translated.toolSearchToolNames,
+      translated.toolNamespaces
     )) {
       res.write(event);
     }
@@ -1341,7 +1558,9 @@ async function handleBridgeRequest(
   const responseObj = translateChatResponseToResponses(
     chatJson,
     requestModel,
-    translated.localShellToolNames
+    translated.localShellToolNames,
+    translated.toolSearchToolNames,
+    translated.toolNamespaces
   );
   if (!responseObj) {
     sendJson(res, 502, {
@@ -1376,9 +1595,17 @@ function synthesizeSseFromChatText(
   text: string,
   model: string,
   customToolNames: string[],
-  localShellToolNames: string[] = []
+  localShellToolNames: string[] = [],
+  toolSearchToolNames: string[] = [],
+  toolNamespaces: Record<string, string> = {}
 ): string[] {
-  const stream = new ChatToResponsesStream(model, customToolNames, localShellToolNames);
+  const stream = new ChatToResponsesStream(
+    model,
+    customToolNames,
+    localShellToolNames,
+    toolSearchToolNames,
+    toolNamespaces
+  );
   const parser = new SseParser();
   const events = [...stream.begin()];
   const feed = (frames: SseFrame[]) => {
@@ -1458,7 +1685,9 @@ async function pipeUpstreamSse(
   const stream = new ChatToResponsesStream(
     requestModel ?? translated.chat.model as string,
     translated.customToolNames,
-    translated.localShellToolNames
+    translated.localShellToolNames,
+    translated.toolSearchToolNames,
+    translated.toolNamespaces
   );
   for (const event of stream.begin()) res.write(event);
 

--- a/electron/cli/store.ts
+++ b/electron/cli/store.ts
@@ -480,6 +480,7 @@ export async function ensureCodexChatBridge(): Promise<void> {
       tools: log.toolNames,
       localShell: log.localShellToolNames,
       custom: log.customToolNames,
+      toolSearch: log.toolSearchToolNames,
       droppedToolTypes: log.droppedToolTypes
     });
   });

--- a/tests/codex-responses-bridge.test.mjs
+++ b/tests/codex-responses-bridge.test.mjs
@@ -109,6 +109,11 @@ test("codex BYOK chat wire API is routed through the local bridge", () => {
     /chat\/completions/,
     "bridge module must document the chat/completions translation"
   );
+  assert.match(
+    bridgeSource,
+    /tool\.type === "tool_search"/,
+    "bridge must map Codex tool_search so deferred MCP tools are not dropped"
+  );
 });
 
 test("session runners pre-start the codex chat bridge", () => {
@@ -357,6 +362,251 @@ test("translateChatResponseToResponses emits local_shell_call for non-stream res
   assert.ok(item);
   assert.equal(item.call_id, "call_shell_3");
   assert.deepEqual(item.action, { type: "exec", command: ["bash", "-lc", "pwd"] });
+});
+
+test("translateResponsesRequestToChat maps tool_search tools and call history", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const { translateResponsesRequestToChat } = bridge;
+  const result = translateResponsesRequestToChat({
+    model: "agnes-3.0-flash",
+    stream: true,
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "open github" }] },
+      {
+        type: "tool_search_call",
+        call_id: "call_search_1",
+        execution: "client",
+        arguments: { query: "browser navigate", limit: 8 }
+      },
+      {
+        type: "tool_search_output",
+        call_id: "call_search_1",
+        status: "completed",
+        execution: "client",
+        tools: [
+          {
+            type: "namespace",
+            name: "mcp__freebuddy-browser",
+            description: "Browser automation",
+            tools: [
+              {
+                type: "function",
+                name: "browser_navigate",
+                description: "Navigate the browser to a URL.",
+                parameters: {
+                  type: "object",
+                  properties: { url: { type: "string" } },
+                  required: ["url"]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    tools: [
+      {
+        type: "tool_search",
+        execution: "client",
+        description: "For MCP tool discovery, always use tool_search.",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Search query for deferred tools." },
+            limit: { type: "number" }
+          },
+          required: ["query"]
+        }
+      },
+      { type: "web_search" }
+    ]
+  });
+
+  assert.ok(result);
+  assert.deepEqual(result.toolSearchToolNames, ["tool_search"]);
+  assert.deepEqual(result.toolNamespaces, {
+    browser_navigate: "mcp__freebuddy-browser"
+  });
+  assert.deepEqual(result.droppedToolTypes, ["web_search"]);
+
+  const chat = result.chat;
+  const searchTool = chat.tools.find((tool) => tool.function?.name === "tool_search");
+  assert.ok(searchTool, "tool_search must be exposed as a chat function");
+  assert.equal(searchTool.type, "function");
+  assert.deepEqual(searchTool.function.parameters.required, ["query"]);
+  assert.equal(
+    searchTool.function.description,
+    "For MCP tool discovery, always use tool_search."
+  );
+
+  const discovered = chat.tools.find((tool) => tool.function?.name === "browser_navigate");
+  assert.ok(
+    discovered,
+    "tools loaded by tool_search_output must be callable on the next chat turn"
+  );
+  assert.equal(discovered.function.description, "Navigate the browser to a URL.");
+
+  const messages = chat.messages;
+  assert.equal(messages[0].role, "user");
+  assert.equal(messages[1].role, "assistant");
+  assert.equal(messages[1].tool_calls[0].id, "call_search_1");
+  assert.equal(messages[1].tool_calls[0].function.name, "tool_search");
+  assert.deepEqual(JSON.parse(messages[1].tool_calls[0].function.arguments), {
+    query: "browser navigate",
+    limit: 8
+  });
+  assert.equal(messages[2].role, "tool");
+  assert.equal(messages[2].tool_call_id, "call_search_1");
+  const outputTools = JSON.parse(messages[2].content);
+  assert.equal(outputTools[0].name, "mcp__freebuddy-browser");
+  assert.equal(outputTools[0].tools[0].name, "browser_navigate");
+});
+
+test("ChatToResponsesStream emits tool_search_call items for tool_search function calls", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const stream = new bridge.ChatToResponsesStream("agnes-3.0-flash", [], [], ["tool_search"]);
+  const chunks = [];
+  for (const raw of stream.begin()) chunks.push(...sseDataChunks(raw));
+  for (const chunk of [
+    {
+      choices: [
+        {
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_search_2",
+                function: {
+                  name: "tool_search",
+                  arguments: "{\"query\":\"browser click\",\"limit\":8}"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    { choices: [{ delta: {}, finish_reason: "tool_calls" }] }
+  ]) {
+    for (const raw of stream.handleChatChunk(chunk)) chunks.push(...sseDataChunks(raw));
+  }
+  for (const raw of stream.finish()) chunks.push(...sseDataChunks(raw));
+
+  const events = chunks
+    .filter((line) => line !== "[DONE]")
+    .map((line) => JSON.parse(line));
+
+  const callDone = events.find(
+    (event) =>
+      event.type === "response.output_item.done" &&
+      event.item.type === "tool_search_call"
+  );
+  assert.ok(callDone, "expected a tool_search_call output item");
+  assert.equal(callDone.item.call_id, "call_search_2");
+  assert.equal(callDone.item.execution, "client");
+  assert.equal(callDone.item.status, "completed");
+  assert.deepEqual(callDone.item.arguments, { query: "browser click", limit: 8 });
+  assert.equal(
+    typeof callDone.item.arguments,
+    "object",
+    "Codex requires tool_search_call.arguments as a JSON object, not a string"
+  );
+});
+
+test("translateChatResponseToResponses emits tool_search_call for non-stream responses", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const responseObj = bridge.translateChatResponseToResponses(
+    {
+      id: "chat_search",
+      model: "agnes-3.0-flash",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_search_3",
+                function: {
+                  name: "tool_search",
+                  arguments: "{\"query\":\"freebuddy-browser\"}"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "agnes-3.0-flash",
+    [],
+    ["tool_search"]
+  );
+  assert.ok(responseObj);
+  const item = responseObj.output.find((entry) => entry.type === "tool_search_call");
+  assert.ok(item);
+  assert.equal(item.call_id, "call_search_3");
+  assert.equal(item.execution, "client");
+  assert.deepEqual(item.arguments, { query: "freebuddy-browser" });
+});
+
+test("ChatToResponsesStream adds namespace when calling a tool loaded by tool_search", (t) => {
+  if (!bridge) {
+    t.skip("dist-electron bridge not built yet");
+    return;
+  }
+  const stream = new bridge.ChatToResponsesStream(
+    "agnes-3.0-flash",
+    [],
+    [],
+    ["tool_search"],
+    { browser_navigate: "mcp__freebuddy-browser" }
+  );
+  const chunks = [];
+  for (const raw of stream.begin()) chunks.push(...sseDataChunks(raw));
+  for (const chunk of [
+    {
+      choices: [
+        {
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_nav_1",
+                function: {
+                  name: "browser_navigate",
+                  arguments: "{\"url\":\"https://github.com\"}"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]) {
+    for (const raw of stream.handleChatChunk(chunk)) chunks.push(...sseDataChunks(raw));
+  }
+  for (const raw of stream.finish()) chunks.push(...sseDataChunks(raw));
+
+  const events = chunks
+    .filter((line) => line !== "[DONE]")
+    .map((line) => JSON.parse(line));
+  const callDone = events.find(
+    (event) =>
+      event.type === "response.output_item.done" &&
+      event.item.type === "function_call"
+  );
+  assert.ok(callDone);
+  assert.equal(callDone.item.name, "browser_navigate");
+  assert.equal(callDone.item.namespace, "mcp__freebuddy-browser");
+  assert.equal(callDone.item.call_id, "call_nav_1");
 });
 
 test("stripOptionalChatFields removes chat extensions providers reject", (t) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

`wireApi: "chat"` 时，Codex 不会把 MCP 工具（如 `freebuddy-browser`）平铺成 `function` 塞进请求，而是提供一个 Responses 专属的 `type: "tool_search"`。`responsesBridge` 原先只白名单放行 `function` / `custom` / `local_shell`，因此 `tool_search` 被记入 `droppedToolTypes` 后静默丢弃。模型只能看到 `list_mcp_resources` 这类静态 Resource 工具，永远检索不到可执行的 MCP Tools。

## 修复

在 `responsesBridge` 中按 `local_shell` 的同一模式打通双向转译：

1. **请求**：把 `tool.type === "tool_search"` 映射为名为 `tool_search` 的标准 chat `function`（保留 Codex 下发的 description / parameters）。
2. **响应**：把模型返回的 `tool_search` 函数调用还原为 Codex 期望的 `tool_search_call`（`execution: "client"`，`arguments` 为 JSON **对象** 而非字符串）。
3. **历史**：把后续请求里的 `tool_search_call` / `tool_search_output` 转成 chat 的 assistant `tool_calls` + tool 结果。
4. **可调用性**：把 `tool_search_output` 里加载到的工具（含 namespace 子工具）挂回下一轮 `tools` 列表，并在后续 `function_call` 上带回 `namespace`，让 Codex 能路由到对应 MCP server。

`web_search` 仍按原样丢弃（chat 中转无法托管该能力）。

## 验证

```
npm run build:electron && node --test --test-force-exit tests/codex-responses-bridge.test.mjs
```

19/19 通过，其中新增 4 个回归用例覆盖请求映射、流式/非流式 `tool_search_call`、以及 namespace 回写。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c97680d5-ec01-4e67-a364-d63ce222235d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c97680d5-ec01-4e67-a364-d63ce222235d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

