### PR TITLE
fix: 克隆 BYOK 模型透传 + 委派异常终态结构化 outcome

### DIFF
--- a/electron/cli/delegationDispatch.ts
+++ b/electron/cli/delegationDispatch.ts
@@ -91,14 +91,24 @@ const queuesByDeps = new WeakMap<
   DelegateConcurrencyQueue<DelegateExecArgs, DelegateExecResult>
 >();
 
+function delegateTargetLabel(
+  repository: ReturnType<typeof electronDelegationRepository>,
+  childEventId: string
+): string {
+  const event = repository.getEvent(childEventId);
+  const label = event?.roleLabel?.trim() || event?.agentName?.trim();
+  return label ? `「${label}」` : "该角色";
+}
+
 function queueFor(deps: DelegateActionDeps): DelegateConcurrencyQueue<
   DelegateExecArgs,
   DelegateExecResult
 > {
   let q = queuesByDeps.get(deps);
   if (!q) {
+    const repository = electronDelegationRepository();
     q = new DelegateConcurrencyQueue<DelegateExecArgs, DelegateExecResult>({
-      repository: electronDelegationRepository(),
+      repository,
       getPolicy: (runId) => deps.contextProvider(runId)?.policy,
       executor: async (args) => deps.executor(args),
       onResult: (childEventId, result) => {
@@ -119,18 +129,33 @@ function queueFor(deps: DelegateActionDeps): DelegateConcurrencyQueue<
           }
         );
       },
-      onTimeout: (childEventId) => {
-        transitionDelegationEvent(childEventId, "timeout", "委派超时");
+      onTimeout: (childEventId, info) => {
+        const minutes = Math.max(1, Math.round(info.timeoutMs / 60_000));
+        const summary =
+          `委派超时：${delegateTargetLabel(repository, childEventId)}执行超过团队策略时限` +
+          `（${minutes} 分钟，仅计活跃时间，等待其下级委派时暂停计时）。`;
+        transitionDelegationEvent(childEventId, "timeout", summary, {
+          result: buildDelegationResult({ status: "timeout", summary })
+        });
       },
       onError: (childEventId, err) => {
-        transitionDelegationEvent(
-          childEventId,
-          "failed",
-          (err as Error)?.message ?? String(err)
-        );
+        const message = (err as Error)?.message ?? String(err);
+        transitionDelegationEvent(childEventId, "failed", message, {
+          result: buildDelegationResult({
+            status: "failed",
+            summary: message,
+            errorMessage: message
+          })
+        });
       },
       onCancelled: (childEventId, reason) => {
-        transitionDelegationEvent(childEventId, "cancelled", reason);
+        transitionDelegationEvent(childEventId, "cancelled", reason, {
+          result: buildDelegationResult({
+            status: "cancelled",
+            summary: reason,
+            errorMessage: reason
+          })
+        });
       },
       onSettled: (childEventId) => {
         deps.onSettle?.(childEventId);

--- a/packages/delegation-core/src/protocol/text.ts
+++ b/packages/delegation-core/src/protocol/text.ts
@@ -208,13 +208,27 @@ export function buildDelegateWakePrompt(
 ): string {
   const summary = info.resultSummary?.trim() || "(无输出)";
   const verdict = info.verdict ?? null;
-  const verdictLine =
-    verdict === null
+  // A failed/timeout/cancelled child never produced a usable outcome. Reporting it
+  // as "needs_changes" would tell the parent to fix + re-delegate review, trapping
+  // it in a re-review loop that can never reach verdict=pass.
+  const abnormal =
+    info.status === "failed" ||
+    info.status === "timeout" ||
+    info.status === "cancelled";
+  const verdictLine = abnormal
+    ? `结构化结论：本子任务以 ${info.status} 结束，未产出可用结论。`
+    : verdict === null
       ? "结构化结论：未提交 verdict（按 needs_changes 保守处理）。"
       : `结构化结论：verdict=${verdict}${info.verdictSummary ? `；摘要：${info.verdictSummary}` : ""}`;
 
   let nextSteps: string;
-  if (verdict === "pass") {
+  if (abnormal) {
+    nextSteps = [
+      "该子任务没有正常返回结果，这不等于「需要修改」。",
+      "按兜底规则处理：可直接重试同一角色、改派其他角色，或由你自己完成。",
+      "不要把它当作已完成产出，也不要因此宣布整体收尾。"
+    ].join("");
+  } else if (verdict === "pass") {
     nextSteps =
       "评审已通过（pass）。若无新待办可以收尾；不要无故再开一轮复审。";
   } else {

--- a/packages/delegation-runtime/src/concurrency.ts
+++ b/packages/delegation-runtime/src/concurrency.ts
@@ -14,14 +14,14 @@ export interface ConcurrencyDeps<TExecArgs, TResult> {
   getPolicy: (runId: string) => DelegationPolicy | undefined;
   executor: (args: TExecArgs) => Promise<TResult>;
   onResult: (childEventId: string, result: TResult) => void;
-  onTimeout: (childEventId: string) => void;
+  onTimeout: (childEventId: string, info: { timeoutMs: number }) => void;
   onError: (childEventId: string, err: unknown) => void;
   onCancelled: (childEventId: string, reason: string) => void;
   onSettled: (childEventId: string, runId: string) => void;
 }
 
 export class DelegateTimeout extends Error {
-  constructor() {
+  constructor(readonly timeoutMs?: number) {
     super("delegate exceeded timeout");
     this.name = "DelegateTimeout";
   }
@@ -35,7 +35,7 @@ export function withActiveTimeTimeout<T>(
 ): Promise<T> {
   const tickMs = opts?.tickMs ?? 50;
   if (ms <= 0) {
-    return Promise.reject(new DelegateTimeout());
+    return Promise.reject(new DelegateTimeout(ms));
   }
   return new Promise<T>((resolve, reject) => {
     let remaining = ms;
@@ -50,7 +50,7 @@ export function withActiveTimeTimeout<T>(
       remaining -= elapsed;
       if (remaining <= 0) {
         cleanup();
-        reject(new DelegateTimeout());
+        reject(new DelegateTimeout(ms));
       }
     }, tickMs);
     const cleanup = () => {
@@ -148,8 +148,10 @@ export class DelegateConcurrencyQueue<TExecArgs, TResult> {
             reason instanceof Error ? reason.message : String(reason ?? "cancelled")
           );
         } else if (err instanceof DelegateTimeout) {
-          q.abortController.abort(new DelegateTimeout());
-          this.deps.onTimeout(q.childEventId);
+          q.abortController.abort(err);
+          this.deps.onTimeout(q.childEventId, {
+            timeoutMs: err.timeoutMs ?? q.timeoutMs
+          });
         } else {
           this.deps.onError(q.childEventId, err);
         }

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -485,6 +485,21 @@ function buildConversationMembers(
   return [...builtinMembers, ...customMembers];
 }
 
+/**
+ * A cloned adapter keeps its base adapter id in `member.cli.adapter` (see
+ * {@link buildConversationMembers}), so resolving that id returns the *base*
+ * adapter's override. The clone's own override id is encoded in the `cli-`
+ * prefixed member id; resolve that instead so a clone's BYOK config — and the
+ * model list that seeds its session — is used rather than the base adapter's.
+ */
+function resolveMemberExecutor(member: CLIMember) {
+  const store = useCliExecutorStore.getState();
+  const resolved = store.resolve(member.cli.adapter);
+  const overrideId = member.id.startsWith("cli-") ? member.id.slice(4) : "";
+  if (!overrideId || overrideId === member.cli.adapter) return resolved;
+  return store.resolve(overrideId) ?? resolved;
+}
+
 function defaultTitleForAgentName(agentName: string, cwd?: string): string {
   const tail = cwd
     ? cwd.split(/[/\\]/).filter(Boolean).slice(-1)[0]
@@ -877,9 +892,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     skillIds
   }) {
     const id = nanoid();
-    const resolvedExecutor = useCliExecutorStore
-      .getState()
-      .resolve(member.cli.adapter);
+    const resolvedExecutor = resolveMemberExecutor(member);
     const defaultCodexByokModel =
       member.cli.adapter === "codex-acp" && resolvedExecutor?.codexByok?.enabled
         ? resolvedExecutor.codexByok.models?.[0]?.id?.trim()
@@ -1248,6 +1261,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     const resolved = useCliExecutorStore
       .getState()
       .resolve(member.cli.adapter);
+    // BYOK defaults must come from the member's own override; `resolved` points
+    // at the base adapter for clones (see resolveMemberExecutor).
+    const memberExecutor = resolveMemberExecutor(member);
     const binary = member.cli.binary || resolved?.binary;
     const extraArgs = [
       ...(resolved?.extraArgs ?? []),
@@ -1298,8 +1314,8 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       configOptions
     );
     const combinedOverrides = {
-      ...(member.cli.adapter === "codex-acp" && resolved?.codexByok?.enabled
-        ? { model: resolved.codexByok.models?.[0]?.id?.trim() }
+      ...(member.cli.adapter === "codex-acp" && memberExecutor?.codexByok?.enabled
+        ? { model: memberExecutor.codexByok.models?.[0]?.id?.trim() }
         : {}),
       ...(overridesToSend ?? {}),
       ...(configOptionOverrides ?? {})

--- a/tests/delegation-dispatch.test.mjs
+++ b/tests/delegation-dispatch.test.mjs
@@ -289,6 +289,41 @@ test("delegate executor failure -> pending now, poll -> failed", async (t) => {
   });
 });
 
+test("delegate timeout writes a structured outcome naming the role and deadline", async (t) => {
+  if (!bindingAvailable) { t.skip("better-sqlite3 unavailable"); return; }
+  await withDb(async () => {
+    const { createDelegationRun, listDelegationEvents } = await import("../dist-electron/cli/delegationRuns.js");
+    const { runDelegateAction } = await import("../dist-electron/cli/delegationDispatch.js");
+    const runId = createDelegationRun({ goal: "g", teamId: "team-1", teamSnapshotJson: "{}" });
+    const binding = makeBinding(runId);
+    const shortTimeout = {
+      roster,
+      policy: { ...policy, delegateTimeoutMs: 60 },
+      teamId: "team-1",
+      cwd: "/repo"
+    };
+    const res = await runDelegateAction(binding, "delegate", { teammate_id: "r-rev", task: "审" }, {
+      contextProvider: () => shortTimeout,
+      executor: () => new Promise(() => {}),
+      writeApproval: async () => true
+    });
+    assert.equal(res.status, "pending");
+    await tick(300);
+
+    const ev = listDelegationEvents(runId).find((e) => e.id === res.request_id);
+    assert.equal(ev.status, "timeout");
+    assert.match(ev.resultSummary, /委派超时/);
+    assert.match(ev.resultSummary, /「评审」/);
+    assert.match(ev.resultSummary, /团队策略时限/);
+    assert.match(ev.resultSummary, /1 分钟/);
+    assert.match(ev.resultSummary, /仅计活跃时间/);
+    assert.equal(ev.result?.schemaVersion, 1);
+    assert.equal(ev.result?.status, "timeout");
+    assert.equal(ev.result?.error?.code, "delegate_timeout");
+    assert.equal(ev.result?.error?.retryable, true);
+  });
+});
+
 test("delegate synchronous start failure becomes terminal and settles the parent", async (t) => {
   if (!bindingAvailable) { t.skip("better-sqlite3 unavailable"); return; }
   await withDb(async () => {


### PR DESCRIPTION
关联 issue：Refs #157，Refs #159。

## 1. 克隆适配器的 BYOK 默认模型不再覆盖会话模型选择（#157 第 1 项）

**根因**：克隆成员（`cli-codex-acp-clone-*`）的 `member.cli.adapter` 存的是基础适配器 id（`codex-acp`），所以 `useCliExecutorStore.resolve()` 返回的是**基础适配器**的 override：

- `newConversation` 会把基础 BYOK 的首个模型写进新会话的 `config_option_overrides`
- `sendMessage` 也用它作兜底模型

于是原生 `codex-acp` 配了 `gpt-5.6-terra`、克隆配的是 `deepseek-v4-pro` 时，克隆会话仍被强制下发 `session/set_config_option model=gpt-5.6-terra`，界面选择的模型从未透传，上游以「模型不存在」失败。

**修复**：新增 `resolveMemberExecutor()`（`src/store/conversationStore.ts`），按成员 id 的 `cli-` 前缀解析克隆自身的 override，解析不到时才回退基础适配器。内置成员与 ButlerBuddy 行为不变。

**验证**：数据库核实原生 `codex-acp` BYOK = `gpt-5.6-terra`、克隆 `codex-acp-clone-eODkjjkT` = `deepseek-v4-pro`；失败会话 `z257M0D12e3bVolvLOh0a` 持久化了 `{"model":"gpt-5.6-terra"}`。修复后新会话写入克隆自身的 BYOK 模型。

## 2. 委派超时/失败/取消写入结构化 outcome（#159 第 2 项）

- `DelegateTimeout` 携带 `timeoutMs`，`onTimeout` 透传到分发层
- 超时摘要带上角色、团队策略时限与「仅计活跃时间」语义，不再只有「委派超时」四个字
- `onError` / `onCancelled` 补 `buildDelegationResult`，`error.code` 与 `retryable` 落库
- 唤醒提示不再把 `failed`/`timeout`/`cancelled` 当作 `needs_changes`：原文案要求主 agent「改完必须再 delegate 复审」，会让超时任务陷入无法收敛的复审循环

## 本次未包含（相关 issue 仍 open）

- #157 第 2 项：请求 `availableModels` 之外的 `gpt-5.6-luna`（疑似 `readCachedCodexModelSlugs()` 把全局 `~/.codex/models_cache.json` 的 slug 并入了每个 codex BYOK 目录）
- #157 第 3 项：`threadStatus === "systemError"` 被上报为 `end_turn`，原始错误码与用量丢失
- #159 第 1 项：「子 agent 不提交 verdict → 主 agent 停住」的降级唤醒与 park 恢复对账
- #159 第 3 项：团队编辑页 capability / instructions / sharedInstructions 说明（v0.9.20 已存在）

## 测试

- `npm run typecheck` 通过（packages + renderer + electron + preload）
- 委派测试子集 89/89 通过（含新增的超时结构化 outcome 用例 `tests/delegation-dispatch.test.mjs`）
- 全量 `npm run test`：1261 pass / 1 fail / 140 skipped。唯一失败是 `tests/release-workflow.test.mjs:154` 的 macOS 证书用例，在 Windows 上 `spawnSync("bash", ...)` 不可用导致，与本改动无关
