### PR TITLE
feat(cli): 支持通过 zcode-acp 接入智谱 ZCode + 修复 Markdown 嵌套列表渲染

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 .worktrees/
 .sessions/
 .agents/
+.zcode/

--- a/electron/cli/adapters.ts
+++ b/electron/cli/adapters.ts
@@ -30,6 +30,7 @@ export type CLIAdapterId =
   | "grok-acp"
   | "agy-acp"
   | "dsh-acp"
+  | "zcode-acp"
   | (string & {});
 
 export type CLIStreamMode =
@@ -265,6 +266,27 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     toolSessionArgPrefixes: [],
     installHint: dshAcpInstallCommand(),
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
+    protocol: "acp"
+  },
+  {
+    id: "zcode-acp",
+    label: "ZCode",
+    defaultBinary: "zcode-acp-server",
+    checkProbe: { args: ["--version"], versionOptional: false },
+    streamMode: "raw",
+    commandGroup: "zcode",
+    capabilities: {
+      toolSession: true,
+      skills: {
+        mode: "native",
+        nativeDirs: [".agents/skills", ".zcode/skills"],
+        reloadPolicy: "process-start"
+      }
+    },
+    toolSessionArgs: [],
+    toolSessionArgPrefixes: [],
+    installHint: "npm install -g zcode-acp-server",
+    docsUrl: "https://github.com/william0wang/zcode-acp",
     protocol: "acp"
   }
 ];
@@ -1470,6 +1492,15 @@ export function buildCommand(input: BuildCommandInput): BuiltCommand {
       };
     }
     case "agy-acp": {
+      const args: string[] = [...extra];
+      return {
+        bin,
+        args,
+        promptViaStdin: false,
+        protocol: "acp"
+      };
+    }
+    case "zcode-acp": {
       const args: string[] = [...extra];
       return {
         bin,

--- a/electron/cli/cliMemberBuiltins.ts
+++ b/electron/cli/cliMemberBuiltins.ts
@@ -90,5 +90,11 @@ export const builtinCliMembers: CLIMember[] = [
     name: "DeepSeek Harness",
     enabled: true,
     cli: { adapter: "dsh-acp", approvalMode: "auto", showStderr: true }
+  },
+  {
+    id: "cli-zcode-acp",
+    name: "ZCode",
+    enabled: true,
+    cli: { adapter: "zcode-acp", approvalMode: "auto", showStderr: true }
   }
 ];

--- a/electron/telemetryPrivacy.ts
+++ b/electron/telemetryPrivacy.ts
@@ -11,7 +11,8 @@ const KNOWN_ADAPTERS = new Set([
   "codebuddy-acp",
   "grok-acp",
   "agy-acp",
-  "dsh-acp"
+  "dsh-acp",
+  "zcode-acp"
 ]);
 
 export type TelemetryErrorCategory =

--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -372,6 +372,117 @@ function CodeBlockCard({ lang, code }: { lang?: string; code: string }) {
   );
 }
 
+export interface RawMarkdownListItem {
+  indent: number;
+  ordered: boolean;
+  start?: number;
+  text: string;
+}
+
+export interface ParsedMarkdownListItem {
+  text: string;
+  subLists?: ParsedMarkdownList[];
+}
+
+export interface ParsedMarkdownList {
+  ordered: boolean;
+  start?: number;
+  items: ParsedMarkdownListItem[];
+}
+
+export const MARKDOWN_LIST_ITEM_RE = /^(\s*)(?:([-*+])|(\d+)[.)])\s+(.*)$/;
+
+export function getMarkdownIndent(whitespace: string): number {
+  let count = 0;
+  for (const ch of whitespace) {
+    if (ch === "\t") {
+      count += 4 - (count % 4);
+    } else {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function buildMarkdownListTrees(
+  rawItems: RawMarkdownListItem[]
+): ParsedMarkdownList[] {
+  if (rawItems.length === 0) return [];
+
+  let index = 0;
+
+  function parseLevel(parentIndent: number): ParsedMarkdownList {
+    const first = rawItems[index];
+    const currentIndent = first.indent;
+    const ordered = first.ordered;
+    const list: ParsedMarkdownList = {
+      ordered,
+      start: ordered && first.start && first.start !== 1 ? first.start : undefined,
+      items: []
+    };
+
+    while (index < rawItems.length) {
+      const item = rawItems[index];
+
+      if (item.indent < currentIndent) {
+        break;
+      }
+
+      if (item.indent > currentIndent) {
+        if (list.items.length > 0) {
+          const prevItem = list.items[list.items.length - 1];
+          const sub = parseLevel(currentIndent);
+          if (!prevItem.subLists) prevItem.subLists = [];
+          prevItem.subLists.push(sub);
+        } else {
+          list.items.push({ text: item.text });
+          index += 1;
+        }
+        continue;
+      }
+
+      if (item.ordered !== ordered) {
+        break;
+      }
+
+      list.items.push({ text: item.text });
+      index += 1;
+    }
+
+    return list;
+  }
+
+  const result: ParsedMarkdownList[] = [];
+  while (index < rawItems.length) {
+    result.push(parseLevel(-1));
+  }
+  return result;
+}
+
+function renderMarkdownListTree(
+  list: ParsedMarkdownList,
+  keyPrefix: string,
+  cwd: string
+): ReactNode {
+  const ListTag = list.ordered ? "ol" : "ul";
+  return (
+    <ListTag key={keyPrefix} start={list.start}>
+      {list.items.map((item, itemIndex) => {
+        const itemKey = `${keyPrefix}-${itemIndex}`;
+        return (
+          <li key={itemKey}>
+            {renderInline(item.text, itemKey, 0, cwd)}
+            {item.subLists?.map((sub, subIndex) =>
+              renderMarkdownListTree(sub, `${itemKey}-sub-${subIndex}`, cwd)
+            )}
+          </li>
+        );
+      })}
+    </ListTag>
+  );
+}
+
+
 export function MarkdownText({
   content,
   cwd: cwdProp
@@ -482,23 +593,46 @@ export function MarkdownText({
       continue;
     }
 
-    if (/^\s*(?:[-*]|\d+\.)\s+/.test(line)) {
-      const ordered = /^\s*\d+\.\s+/.test(line);
-      const items: string[] = [];
-      while (i < lines.length && /^\s*(?:[-*]|\d+\.)\s+/.test(lines[i])) {
-        items.push(lines[i].replace(/^\s*(?:[-*]|\d+\.)\s+/, ""));
-        i += 1;
+    if (MARKDOWN_LIST_ITEM_RE.test(line)) {
+      const rawItems: RawMarkdownListItem[] = [];
+      while (i < lines.length) {
+        const curLine = lines[i];
+        const match = curLine.match(MARKDOWN_LIST_ITEM_RE);
+        if (match) {
+          const indent = getMarkdownIndent(match[1]);
+          const ordered = Boolean(match[3]);
+          const start = match[3] ? parseInt(match[3], 10) : undefined;
+          const text = match[4];
+          rawItems.push({ indent, ordered, start, text });
+          i += 1;
+        } else if (
+          rawItems.length > 0 &&
+          curLine.trim() &&
+          !curLine.trim().startsWith("```") &&
+          !/^#{1,6}\s+/.test(curLine) &&
+          !/^\s*>\s?/.test(curLine) &&
+          !(curLine.includes("|") && i + 1 < lines.length && isTableSeparator(lines[i + 1])) &&
+          getMarkdownIndent(curLine.match(/^(\s*)/)?.[1] ?? "") >= rawItems[rawItems.length - 1].indent + 2
+        ) {
+          rawItems[rawItems.length - 1].text += "\n" + curLine.trim();
+          i += 1;
+        } else if (
+          !curLine.trim() &&
+          i + 1 < lines.length &&
+          MARKDOWN_LIST_ITEM_RE.test(lines[i + 1])
+        ) {
+          i += 1;
+        } else {
+          break;
+        }
       }
-      const ListTag = ordered ? "ol" : "ul";
-      blocks.push(
-        <ListTag key={`list-${i}`}>
-          {items.map((item, itemIndex) => (
-            <li key={itemIndex}>
-              {renderInline(item, `li-${i}-${itemIndex}`, 0, cwd)}
-            </li>
-          ))}
-        </ListTag>
-      );
+
+      const parsedLists = buildMarkdownListTrees(rawItems);
+      parsedLists.forEach((parsedList, listIndex) => {
+        blocks.push(
+          renderMarkdownListTree(parsedList, `list-${i}-${listIndex}`, cwd)
+        );
+      });
       continue;
     }
 
@@ -511,7 +645,7 @@ export function MarkdownText({
       !/^#{1,6}\s+/.test(lines[i]) &&
       !/^\s*>\s?/.test(lines[i]) &&
       !(lines[i].includes("|") && i + 1 < lines.length && isTableSeparator(lines[i + 1])) &&
-      !/^\s*(?:[-*]|\d+\.)\s+/.test(lines[i])
+      !MARKDOWN_LIST_ITEM_RE.test(lines[i])
     ) {
       paragraph.push(lines[i]);
       i += 1;

--- a/src/config/agentIcon.tsx
+++ b/src/config/agentIcon.tsx
@@ -14,7 +14,8 @@ const defaultAgentIcon: Partial<Record<CLIAdapterId, string>> = {
   "codebuddy-acp": "CodeBuddy",
   "grok-acp": "Grok",
   "agy-acp": "Gemini",
-  "dsh-acp": "DeepSeek"
+  "dsh-acp": "DeepSeek",
+  "zcode-acp": "Zhipu"
 };
 
 /**

--- a/src/config/aiMembers.ts
+++ b/src/config/aiMembers.ts
@@ -129,5 +129,14 @@ export const builtinCliMembers: CLIMember[] = [
     source: "builtin",
     enabled: true,
     cli: { adapter: "dsh-acp", approvalMode: "auto", showStderr: true }
+  },
+  {
+    id: "cli-zcode-acp",
+    kind: "cli",
+    name: "ZCode",
+    description: "Local ZCode coding agent via ACP.",
+    source: "builtin",
+    enabled: true,
+    cli: { adapter: "zcode-acp", approvalMode: "auto", showStderr: true }
   }
 ];

--- a/src/config/cliAdapters.ts
+++ b/src/config/cliAdapters.ts
@@ -14,6 +14,7 @@ export type CLIAdapterId =
   | "grok-acp"
   | "agy-acp"
   | "dsh-acp"
+  | "zcode-acp"
   | (string & {});
 
 export type { CLIStreamMode } from "@freebuddy/protocol/cli";
@@ -172,6 +173,19 @@ export const cliAdapterDefinitions: CLIAdapterDefinition[] = [
     toolSessionArgPrefixes: [],
     installHint: "npm install -g deepseek-harness-acp",
     docsUrl: "https://github.com/deepseek-ai/deepseek-harness",
+    protocol: "acp"
+  },
+  {
+    id: "zcode-acp",
+    label: "ZCode",
+    defaultBinary: "zcode-acp-server",
+    streamMode: "raw",
+    commandGroup: "zcode",
+    capabilities: { toolSession: true },
+    toolSessionArgs: [],
+    toolSessionArgPrefixes: [],
+    installHint: "npm install -g zcode-acp-server",
+    docsUrl: "https://github.com/william0wang/zcode-acp",
     protocol: "acp"
   }
 ];

--- a/styles.css
+++ b/styles.css
@@ -16298,6 +16298,12 @@ button.ghost:focus-visible,
   margin-top: 8px;
 }
 
+.markdown-body li > ul,
+.markdown-body li > ol {
+  margin-top: 4px;
+  margin-bottom: 0;
+}
+
 .markdown-body strong {
   font-weight: 600;
 }

--- a/tests/acp.test.mjs
+++ b/tests/acp.test.mjs
@@ -163,7 +163,8 @@ test("visible adapter definitions are ACP-only with product names", () => {
       { id: "codebuddy-acp", label: "CodeBuddy", protocol: "acp" },
       { id: "grok-acp", label: "Grok", protocol: "acp" },
       { id: "agy-acp", label: "Antigravity", protocol: "acp" },
-      { id: "dsh-acp", label: "DeepSeek Harness", protocol: "acp" }
+      { id: "dsh-acp", label: "DeepSeek Harness", protocol: "acp" },
+      { id: "zcode-acp", label: "ZCode", protocol: "acp" }
     ]
   );
 });
@@ -182,6 +183,18 @@ test("buildCommand starts Codex and Claude ACP adapters", () => {
     buildCommand({ adapter: "claude-agent-acp", prompt: "hello" }),
     {
       bin: "claude-agent-acp",
+      args: [],
+      promptViaStdin: false,
+      protocol: "acp"
+    }
+  );
+});
+
+test("buildCommand starts ZCode ACP adapter", () => {
+  assert.deepEqual(
+    buildCommand({ adapter: "zcode-acp", prompt: "hello" }),
+    {
+      bin: "zcode-acp-server",
       args: [],
       promptViaStdin: false,
       protocol: "acp"

--- a/tests/cli-check.test.mjs
+++ b/tests/cli-check.test.mjs
@@ -55,6 +55,20 @@ test("agy-acp checks agy-acp binary probe", () => {
   });
 });
 
+test("zcode-acp checks zcode-acp-server binary probe", () => {
+  assert.deepEqual(getCliCheckProbe("zcode-acp"), {
+    args: ["--version"],
+    versionOptional: false
+  });
+});
+
+test("ZCode ACP install hint matches official package", () => {
+  assert.equal(
+    getAdapterDefinition("zcode-acp")?.installHint,
+    "npm install -g zcode-acp-server"
+  );
+});
+
 test("Windows fallback search includes the native Claude installer directory", () => {
   const source = fs.readFileSync(
     new URL("../electron/cli/check.ts", import.meta.url),

--- a/tests/markdown-nested-lists.test.mjs
+++ b/tests/markdown-nested-lists.test.mjs
@@ -1,0 +1,215 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const streamItemSource = fs.readFileSync(
+  new URL("../src/components/CLI/StreamItem.tsx", import.meta.url),
+  "utf8"
+);
+const stylesSource = fs.readFileSync(
+  new URL("../styles.css", import.meta.url),
+  "utf8"
+);
+
+test("StreamItem defines nested markdown list parser exports and structures", () => {
+  assert.match(streamItemSource, /export interface RawMarkdownListItem/);
+  assert.match(streamItemSource, /export interface ParsedMarkdownListItem/);
+  assert.match(streamItemSource, /export interface ParsedMarkdownList/);
+  assert.match(streamItemSource, /export const MARKDOWN_LIST_ITEM_RE/);
+  assert.match(streamItemSource, /export function getMarkdownIndent/);
+  assert.match(streamItemSource, /export function buildMarkdownListTrees/);
+  assert.match(streamItemSource, /function renderMarkdownListTree/);
+});
+
+test("styles include nested list margin overrides", () => {
+  assert.match(
+    stylesSource,
+    /\.markdown-body li > ul,\s*\.markdown-body li > ol\s*\{[\s\S]*?margin-top:\s*4px;[\s\S]*?margin-bottom:\s*0;/
+  );
+});
+
+// Extract and test the pure parsing logic directly
+function getMarkdownIndent(whitespace) {
+  let count = 0;
+  for (const ch of whitespace) {
+    if (ch === "\t") {
+      count += 4 - (count % 4);
+    } else {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+const MARKDOWN_LIST_ITEM_RE = /^(\s*)(?:([-*+])|(\d+)[.)])\s+(.*)$/;
+
+function parseRawList(lines) {
+  const rawItems = [];
+  let i = 0;
+  while (i < lines.length) {
+    const curLine = lines[i];
+    const match = curLine.match(MARKDOWN_LIST_ITEM_RE);
+    if (match) {
+      const indent = getMarkdownIndent(match[1]);
+      const ordered = Boolean(match[3]);
+      const start = match[3] ? parseInt(match[3], 10) : undefined;
+      const text = match[4];
+      rawItems.push({ indent, ordered, start, text });
+      i += 1;
+    } else if (
+      rawItems.length > 0 &&
+      curLine.trim() &&
+      !curLine.trim().startsWith("```") &&
+      !/^#{1,6}\s+/.test(curLine) &&
+      !/^\s*>\s?/.test(curLine) &&
+      getMarkdownIndent(curLine.match(/^(\s*)/)?.[1] ?? "") >= rawItems[rawItems.length - 1].indent + 2
+    ) {
+      rawItems[rawItems.length - 1].text += "\n" + curLine.trim();
+      i += 1;
+    } else if (
+      !curLine.trim() &&
+      i + 1 < lines.length &&
+      MARKDOWN_LIST_ITEM_RE.test(lines[i + 1])
+    ) {
+      i += 1;
+    } else {
+      break;
+    }
+  }
+  return rawItems;
+}
+
+function buildMarkdownListTrees(rawItems) {
+  if (rawItems.length === 0) return [];
+
+  let index = 0;
+
+  function parseLevel(parentIndent) {
+    const first = rawItems[index];
+    const currentIndent = first.indent;
+    const ordered = first.ordered;
+    const list = {
+      ordered,
+      start: ordered && first.start && first.start !== 1 ? first.start : undefined,
+      items: []
+    };
+
+    while (index < rawItems.length) {
+      const item = rawItems[index];
+
+      if (item.indent < currentIndent) {
+        break;
+      }
+
+      if (item.indent > currentIndent) {
+        if (list.items.length > 0) {
+          const prevItem = list.items[list.items.length - 1];
+          const sub = parseLevel(currentIndent);
+          if (!prevItem.subLists) prevItem.subLists = [];
+          prevItem.subLists.push(sub);
+        } else {
+          list.items.push({ text: item.text });
+          index += 1;
+        }
+        continue;
+      }
+
+      if (item.ordered !== ordered) {
+        break;
+      }
+
+      list.items.push({ text: item.text });
+      index += 1;
+    }
+
+    return list;
+  }
+
+  const result = [];
+  while (index < rawItems.length) {
+    result.push(parseLevel(-1));
+  }
+  return result;
+}
+
+test("buildMarkdownListTrees correctly handles user nested list case", () => {
+  const markdown = [
+    "1. **两个全局命令行工具**：",
+    "   - **`zcode-acp-server`**：FreeBuddy 在后台拉起的标准 ACP 服务进程。",
+    "   - **`zcode-acp`**：独立的命令行/TUI 终端交互工具。",
+    "2. **协议与运行依赖**：",
+    "   - @agentclientprotocol/sdk (ACP 协议处理库)",
+    "   - ws (WebSocket 通信库)",
+    "   - martty (终端流式渲染组件)"
+  ];
+
+  const rawItems = parseRawList(markdown);
+  assert.equal(rawItems.length, 7);
+
+  const trees = buildMarkdownListTrees(rawItems);
+  assert.equal(trees.length, 1);
+
+  const top = trees[0];
+  assert.equal(top.ordered, true);
+  assert.equal(top.items.length, 2);
+
+  // Item 1
+  assert.equal(top.items[0].text, "**两个全局命令行工具**：");
+  assert.equal(top.items[0].subLists?.length, 1);
+  const sub1 = top.items[0].subLists[0];
+  assert.equal(sub1.ordered, false);
+  assert.equal(sub1.items.length, 2);
+  assert.equal(
+    sub1.items[0].text,
+    "**`zcode-acp-server`**：FreeBuddy 在后台拉起的标准 ACP 服务进程。"
+  );
+  assert.equal(
+    sub1.items[1].text,
+    "**`zcode-acp`**：独立的命令行/TUI 终端交互工具。"
+  );
+
+  // Item 2
+  assert.equal(top.items[1].text, "**协议与运行依赖**：");
+  assert.equal(top.items[1].subLists?.length, 1);
+  const sub2 = top.items[1].subLists[0];
+  assert.equal(sub2.ordered, false);
+  assert.equal(sub2.items.length, 3);
+  assert.equal(sub2.items[0].text, "@agentclientprotocol/sdk (ACP 协议处理库)");
+  assert.equal(sub2.items[1].text, "ws (WebSocket 通信库)");
+  assert.equal(sub2.items[2].text, "martty (终端流式渲染组件)");
+});
+
+test("buildMarkdownListTrees supports 3-level deep nesting", () => {
+  const markdown = [
+    "- Level 1",
+    "  - Level 2",
+    "    - Level 3"
+  ];
+
+  const rawItems = parseRawList(markdown);
+  const trees = buildMarkdownListTrees(rawItems);
+  assert.equal(trees.length, 1);
+  assert.equal(trees[0].items[0].text, "Level 1");
+  assert.equal(trees[0].items[0].subLists?.[0].items[0].text, "Level 2");
+  assert.equal(
+    trees[0].items[0].subLists[0].items[0].subLists?.[0].items[0].text,
+    "Level 3"
+  );
+});
+
+test("buildMarkdownListTrees splits sibling lists with different ordered types at same indent", () => {
+  const markdown = [
+    "- Unordered 1",
+    "- Unordered 2",
+    "1. Ordered 1",
+    "2. Ordered 2"
+  ];
+
+  const rawItems = parseRawList(markdown);
+  const trees = buildMarkdownListTrees(rawItems);
+  assert.equal(trees.length, 2);
+  assert.equal(trees[0].ordered, false);
+  assert.equal(trees[0].items.length, 2);
+  assert.equal(trees[1].ordered, true);
+  assert.equal(trees[1].items.length, 2);
+});

--- a/tests/workflow-ipc-wiring.test.mjs
+++ b/tests/workflow-ipc-wiring.test.mjs
@@ -88,4 +88,5 @@ test("builtin members module exports the ACP agents", () => {
   assert.match(members, /cli-grok-acp/);
   assert.match(members, /cli-agy-acp/);
   assert.match(members, /cli-dsh-acp/);
+  assert.match(members, /cli-zcode-acp/);
 });


### PR DESCRIPTION
## 概述 (Summary)

1. 支持通过开源桥接器 `zcode-acp-server` 将智谱 ZCode 接入 FreeBuddy。
2. 修复消息流 Markdown 解析器中嵌套列表层级丢失、被父级 `<ol>` 强行平铺并产生递增序号的问题。

## 详细改动 (Changes)

### 一、ZCode ACP 适配器
- **适配器配置**：在 `src/config/cliAdapters.ts` 和 `electron/cli/adapters.ts` 中新增 `zcode-acp` 适配器定义（默认二进制 `zcode-acp-server`，协议 `acp`，流模式 `raw`，技能目录支持 `.agents/skills` 与 `.zcode/skills`）。
- **内置成员与 UI**：在 `src/config/aiMembers.ts` 与 `electron/cli/cliMemberBuiltins.ts` 中注册 `cli-zcode-acp` 内置成员，并在 `src/config/agentIcon.tsx` 映射智谱图标。
- **命令构建与遥测**：在 `electron/cli/adapters.ts` 中实现 `buildCommand`，并在 `electron/telemetryPrivacy.ts` 加入白名单。
- **忽略配置**：在 `.gitignore` 中加入 `.zcode/` 避免本地残留缓存。

### 二、Markdown 嵌套列表解析修复
- **树形结构解析**：在 `src/components/CLI/StreamItem.tsx` 中实现 `buildMarkdownListTrees`，根据每行缩进深度（Indent）与列表类型（有序/无序）构建树形结构，避免混入平级 items 数组。
- **递归渲染**：通过 `renderMarkdownListTree` 递归渲染子列表，使无序子项正确渲染为父级 `<li>` 内嵌套的 `<ul>`，保留圆点样式与缩进，不再被误编号。
- **样式适配**：在 `styles.css` 中为 `.markdown-body li > ul` 与 `.markdown-body li > ol` 补齐紧凑间距。

## 验证 (Verification)

- `npm test` 单元测试套件全部通过 (154 passed, 0 failed)，包含新增的 `tests/markdown-nested-lists.test.mjs`。
- `npm run build` 编译打包与 TypeScript 类型检查全部通过。