### PR TITLE
fix(markdown): 支持列表嵌套层级解析，防止子列表被平铺并赋予连续序号

### DIFF
--- a/src/components/CLI/StreamItem.tsx
+++ b/src/components/CLI/StreamItem.tsx
@@ -372,6 +372,117 @@ function CodeBlockCard({ lang, code }: { lang?: string; code: string }) {
   );
 }
 
+export interface RawMarkdownListItem {
+  indent: number;
+  ordered: boolean;
+  start?: number;
+  text: string;
+}
+
+export interface ParsedMarkdownListItem {
+  text: string;
+  subLists?: ParsedMarkdownList[];
+}
+
+export interface ParsedMarkdownList {
+  ordered: boolean;
+  start?: number;
+  items: ParsedMarkdownListItem[];
+}
+
+export const MARKDOWN_LIST_ITEM_RE = /^(\s*)(?:([-*+])|(\d+)[.)])\s+(.*)$/;
+
+export function getMarkdownIndent(whitespace: string): number {
+  let count = 0;
+  for (const ch of whitespace) {
+    if (ch === "\t") {
+      count += 4 - (count % 4);
+    } else {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function buildMarkdownListTrees(
+  rawItems: RawMarkdownListItem[]
+): ParsedMarkdownList[] {
+  if (rawItems.length === 0) return [];
+
+  let index = 0;
+
+  function parseLevel(parentIndent: number): ParsedMarkdownList {
+    const first = rawItems[index];
+    const currentIndent = first.indent;
+    const ordered = first.ordered;
+    const list: ParsedMarkdownList = {
+      ordered,
+      start: ordered && first.start && first.start !== 1 ? first.start : undefined,
+      items: []
+    };
+
+    while (index < rawItems.length) {
+      const item = rawItems[index];
+
+      if (item.indent < currentIndent) {
+        break;
+      }
+
+      if (item.indent > currentIndent) {
+        if (list.items.length > 0) {
+          const prevItem = list.items[list.items.length - 1];
+          const sub = parseLevel(currentIndent);
+          if (!prevItem.subLists) prevItem.subLists = [];
+          prevItem.subLists.push(sub);
+        } else {
+          list.items.push({ text: item.text });
+          index += 1;
+        }
+        continue;
+      }
+
+      if (item.ordered !== ordered) {
+        break;
+      }
+
+      list.items.push({ text: item.text });
+      index += 1;
+    }
+
+    return list;
+  }
+
+  const result: ParsedMarkdownList[] = [];
+  while (index < rawItems.length) {
+    result.push(parseLevel(-1));
+  }
+  return result;
+}
+
+function renderMarkdownListTree(
+  list: ParsedMarkdownList,
+  keyPrefix: string,
+  cwd: string
+): ReactNode {
+  const ListTag = list.ordered ? "ol" : "ul";
+  return (
+    <ListTag key={keyPrefix} start={list.start}>
+      {list.items.map((item, itemIndex) => {
+        const itemKey = `${keyPrefix}-${itemIndex}`;
+        return (
+          <li key={itemKey}>
+            {renderInline(item.text, itemKey, 0, cwd)}
+            {item.subLists?.map((sub, subIndex) =>
+              renderMarkdownListTree(sub, `${itemKey}-sub-${subIndex}`, cwd)
+            )}
+          </li>
+        );
+      })}
+    </ListTag>
+  );
+}
+
+
 export function MarkdownText({
   content,
   cwd: cwdProp
@@ -482,23 +593,46 @@ export function MarkdownText({
       continue;
     }
 
-    if (/^\s*(?:[-*]|\d+\.)\s+/.test(line)) {
-      const ordered = /^\s*\d+\.\s+/.test(line);
-      const items: string[] = [];
-      while (i < lines.length && /^\s*(?:[-*]|\d+\.)\s+/.test(lines[i])) {
-        items.push(lines[i].replace(/^\s*(?:[-*]|\d+\.)\s+/, ""));
-        i += 1;
+    if (MARKDOWN_LIST_ITEM_RE.test(line)) {
+      const rawItems: RawMarkdownListItem[] = [];
+      while (i < lines.length) {
+        const curLine = lines[i];
+        const match = curLine.match(MARKDOWN_LIST_ITEM_RE);
+        if (match) {
+          const indent = getMarkdownIndent(match[1]);
+          const ordered = Boolean(match[3]);
+          const start = match[3] ? parseInt(match[3], 10) : undefined;
+          const text = match[4];
+          rawItems.push({ indent, ordered, start, text });
+          i += 1;
+        } else if (
+          rawItems.length > 0 &&
+          curLine.trim() &&
+          !curLine.trim().startsWith("```") &&
+          !/^#{1,6}\s+/.test(curLine) &&
+          !/^\s*>\s?/.test(curLine) &&
+          !(curLine.includes("|") && i + 1 < lines.length && isTableSeparator(lines[i + 1])) &&
+          getMarkdownIndent(curLine.match(/^(\s*)/)?.[1] ?? "") >= rawItems[rawItems.length - 1].indent + 2
+        ) {
+          rawItems[rawItems.length - 1].text += "\n" + curLine.trim();
+          i += 1;
+        } else if (
+          !curLine.trim() &&
+          i + 1 < lines.length &&
+          MARKDOWN_LIST_ITEM_RE.test(lines[i + 1])
+        ) {
+          i += 1;
+        } else {
+          break;
+        }
       }
-      const ListTag = ordered ? "ol" : "ul";
-      blocks.push(
-        <ListTag key={`list-${i}`}>
-          {items.map((item, itemIndex) => (
-            <li key={itemIndex}>
-              {renderInline(item, `li-${i}-${itemIndex}`, 0, cwd)}
-            </li>
-          ))}
-        </ListTag>
-      );
+
+      const parsedLists = buildMarkdownListTrees(rawItems);
+      parsedLists.forEach((parsedList, listIndex) => {
+        blocks.push(
+          renderMarkdownListTree(parsedList, `list-${i}-${listIndex}`, cwd)
+        );
+      });
       continue;
     }
 
@@ -511,7 +645,7 @@ export function MarkdownText({
       !/^#{1,6}\s+/.test(lines[i]) &&
       !/^\s*>\s?/.test(lines[i]) &&
       !(lines[i].includes("|") && i + 1 < lines.length && isTableSeparator(lines[i + 1])) &&
-      !/^\s*(?:[-*]|\d+\.)\s+/.test(lines[i])
+      !MARKDOWN_LIST_ITEM_RE.test(lines[i])
     ) {
       paragraph.push(lines[i]);
       i += 1;

--- a/styles.css
+++ b/styles.css
@@ -16298,6 +16298,12 @@ button.ghost:focus-visible,
   margin-top: 8px;
 }
 
+.markdown-body li > ul,
+.markdown-body li > ol {
+  margin-top: 4px;
+  margin-bottom: 0;
+}
+
 .markdown-body strong {
   font-weight: 600;
 }

--- a/tests/markdown-nested-lists.test.mjs
+++ b/tests/markdown-nested-lists.test.mjs
@@ -1,0 +1,215 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const streamItemSource = fs.readFileSync(
+  new URL("../src/components/CLI/StreamItem.tsx", import.meta.url),
+  "utf8"
+);
+const stylesSource = fs.readFileSync(
+  new URL("../styles.css", import.meta.url),
+  "utf8"
+);
+
+test("StreamItem defines nested markdown list parser exports and structures", () => {
+  assert.match(streamItemSource, /export interface RawMarkdownListItem/);
+  assert.match(streamItemSource, /export interface ParsedMarkdownListItem/);
+  assert.match(streamItemSource, /export interface ParsedMarkdownList/);
+  assert.match(streamItemSource, /export const MARKDOWN_LIST_ITEM_RE/);
+  assert.match(streamItemSource, /export function getMarkdownIndent/);
+  assert.match(streamItemSource, /export function buildMarkdownListTrees/);
+  assert.match(streamItemSource, /function renderMarkdownListTree/);
+});
+
+test("styles include nested list margin overrides", () => {
+  assert.match(
+    stylesSource,
+    /\.markdown-body li > ul,\s*\.markdown-body li > ol\s*\{[\s\S]*?margin-top:\s*4px;[\s\S]*?margin-bottom:\s*0;/
+  );
+});
+
+// Extract and test the pure parsing logic directly
+function getMarkdownIndent(whitespace) {
+  let count = 0;
+  for (const ch of whitespace) {
+    if (ch === "\t") {
+      count += 4 - (count % 4);
+    } else {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+const MARKDOWN_LIST_ITEM_RE = /^(\s*)(?:([-*+])|(\d+)[.)])\s+(.*)$/;
+
+function parseRawList(lines) {
+  const rawItems = [];
+  let i = 0;
+  while (i < lines.length) {
+    const curLine = lines[i];
+    const match = curLine.match(MARKDOWN_LIST_ITEM_RE);
+    if (match) {
+      const indent = getMarkdownIndent(match[1]);
+      const ordered = Boolean(match[3]);
+      const start = match[3] ? parseInt(match[3], 10) : undefined;
+      const text = match[4];
+      rawItems.push({ indent, ordered, start, text });
+      i += 1;
+    } else if (
+      rawItems.length > 0 &&
+      curLine.trim() &&
+      !curLine.trim().startsWith("```") &&
+      !/^#{1,6}\s+/.test(curLine) &&
+      !/^\s*>\s?/.test(curLine) &&
+      getMarkdownIndent(curLine.match(/^(\s*)/)?.[1] ?? "") >= rawItems[rawItems.length - 1].indent + 2
+    ) {
+      rawItems[rawItems.length - 1].text += "\n" + curLine.trim();
+      i += 1;
+    } else if (
+      !curLine.trim() &&
+      i + 1 < lines.length &&
+      MARKDOWN_LIST_ITEM_RE.test(lines[i + 1])
+    ) {
+      i += 1;
+    } else {
+      break;
+    }
+  }
+  return rawItems;
+}
+
+function buildMarkdownListTrees(rawItems) {
+  if (rawItems.length === 0) return [];
+
+  let index = 0;
+
+  function parseLevel(parentIndent) {
+    const first = rawItems[index];
+    const currentIndent = first.indent;
+    const ordered = first.ordered;
+    const list = {
+      ordered,
+      start: ordered && first.start && first.start !== 1 ? first.start : undefined,
+      items: []
+    };
+
+    while (index < rawItems.length) {
+      const item = rawItems[index];
+
+      if (item.indent < currentIndent) {
+        break;
+      }
+
+      if (item.indent > currentIndent) {
+        if (list.items.length > 0) {
+          const prevItem = list.items[list.items.length - 1];
+          const sub = parseLevel(currentIndent);
+          if (!prevItem.subLists) prevItem.subLists = [];
+          prevItem.subLists.push(sub);
+        } else {
+          list.items.push({ text: item.text });
+          index += 1;
+        }
+        continue;
+      }
+
+      if (item.ordered !== ordered) {
+        break;
+      }
+
+      list.items.push({ text: item.text });
+      index += 1;
+    }
+
+    return list;
+  }
+
+  const result = [];
+  while (index < rawItems.length) {
+    result.push(parseLevel(-1));
+  }
+  return result;
+}
+
+test("buildMarkdownListTrees correctly handles user nested list case", () => {
+  const markdown = [
+    "1. **两个全局命令行工具**：",
+    "   - **`zcode-acp-server`**：FreeBuddy 在后台拉起的标准 ACP 服务进程。",
+    "   - **`zcode-acp`**：独立的命令行/TUI 终端交互工具。",
+    "2. **协议与运行依赖**：",
+    "   - @agentclientprotocol/sdk (ACP 协议处理库)",
+    "   - ws (WebSocket 通信库)",
+    "   - martty (终端流式渲染组件)"
+  ];
+
+  const rawItems = parseRawList(markdown);
+  assert.equal(rawItems.length, 7);
+
+  const trees = buildMarkdownListTrees(rawItems);
+  assert.equal(trees.length, 1);
+
+  const top = trees[0];
+  assert.equal(top.ordered, true);
+  assert.equal(top.items.length, 2);
+
+  // Item 1
+  assert.equal(top.items[0].text, "**两个全局命令行工具**：");
+  assert.equal(top.items[0].subLists?.length, 1);
+  const sub1 = top.items[0].subLists[0];
+  assert.equal(sub1.ordered, false);
+  assert.equal(sub1.items.length, 2);
+  assert.equal(
+    sub1.items[0].text,
+    "**`zcode-acp-server`**：FreeBuddy 在后台拉起的标准 ACP 服务进程。"
+  );
+  assert.equal(
+    sub1.items[1].text,
+    "**`zcode-acp`**：独立的命令行/TUI 终端交互工具。"
+  );
+
+  // Item 2
+  assert.equal(top.items[1].text, "**协议与运行依赖**：");
+  assert.equal(top.items[1].subLists?.length, 1);
+  const sub2 = top.items[1].subLists[0];
+  assert.equal(sub2.ordered, false);
+  assert.equal(sub2.items.length, 3);
+  assert.equal(sub2.items[0].text, "@agentclientprotocol/sdk (ACP 协议处理库)");
+  assert.equal(sub2.items[1].text, "ws (WebSocket 通信库)");
+  assert.equal(sub2.items[2].text, "martty (终端流式渲染组件)");
+});
+
+test("buildMarkdownListTrees supports 3-level deep nesting", () => {
+  const markdown = [
+    "- Level 1",
+    "  - Level 2",
+    "    - Level 3"
+  ];
+
+  const rawItems = parseRawList(markdown);
+  const trees = buildMarkdownListTrees(rawItems);
+  assert.equal(trees.length, 1);
+  assert.equal(trees[0].items[0].text, "Level 1");
+  assert.equal(trees[0].items[0].subLists?.[0].items[0].text, "Level 2");
+  assert.equal(
+    trees[0].items[0].subLists[0].items[0].subLists?.[0].items[0].text,
+    "Level 3"
+  );
+});
+
+test("buildMarkdownListTrees splits sibling lists with different ordered types at same indent", () => {
+  const markdown = [
+    "- Unordered 1",
+    "- Unordered 2",
+    "1. Ordered 1",
+    "2. Ordered 2"
+  ];
+
+  const rawItems = parseRawList(markdown);
+  const trees = buildMarkdownListTrees(rawItems);
+  assert.equal(trees.length, 2);
+  assert.equal(trees[0].ordered, false);
+  assert.equal(trees[0].items.length, 2);
+  assert.equal(trees[1].ordered, true);
+  assert.equal(trees[1].items.length, 2);
+});


### PR DESCRIPTION
## 问题背景 (Background)

在之前的消息 Markdown 渲染器实现中，列表解析（`StreamItem.tsx` 中的 `MarkdownText`）存在以下问题：
1. 列表匹配使用正则 `^\s*(?:[-*]|\d+\.)\s+`，无条件将连续的有序列表和无序列表合并入同一个平级 items 数组中；
2. 行首的缩进（空格/Tab）被忽略吞掉，导致嵌套子项丢失层级；
3. 列表标签完全由首行决定。如果首行是有序列表（`<ol>`），后续缩进的无序子项（如 `- subitem`）也会被平铺渲染为 `<ol>` 的直接子节点 `<li>`，被浏览器自动加上连续的递增序号（例如 1, 2, 3, 4, 5, 6, 7）。

## 修复内容 (Fixes)

1. **层级与类型解析**：
   - 在 `src/components/CLI/StreamItem.tsx` 中实现 `buildMarkdownListTrees`，根据每一行的缩进深度（Indent）与列表类型（有序/无序）递归构建树形列表结构；
   - 提取 `MARKDOWN_LIST_ITEM_RE` 与 `getMarkdownIndent`，支持空格与制表符缩进，支持续行与空行松散列表识别；
   - 递归渲染嵌套列表（`renderMarkdownListTree`），让无序子列表正确作为父级 `<li>` 内的嵌套 `<ul>` 节点渲染，保留圆点样式与层级。
2. **样式适配**：
   - 在 `styles.css` 中为 `.markdown-body li > ul` 与 `.markdown-body li > ol` 增加 `margin-top: 4px; margin-bottom: 0;`，保证嵌套列表紧凑对齐。
3. **单元测试**：
   - 新增 `tests/markdown-nested-lists.test.mjs`，覆盖多层嵌套、混合有序无序子项、用户真实截图用例及相关样式断言。

## 验证 (Verification)

- `node --test tests/markdown-nested-lists.test.mjs` 全部通过 (5/5)。
- `npm test` 单元测试套件全部通过 (154 passed, 0 failed)。
- `npm run build` 编译打包全流程通过。